### PR TITLE
Fix syntax error in website update workflow step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -806,7 +806,8 @@ jobs:
           git add _data/plugins.yml
           if [ -f "_plugins/${PLUGIN_SLUG}.md" ] && ! git diff --quiet "_plugins/${PLUGIN_SLUG}.md"; then
             git add "_plugins/${PLUGIN_SLUG}.md"
-          fi          git commit -m "Update $RELEASE_NAME to v$PLUGIN_VERSION
+          fi
+          git commit -m "Update $RELEASE_NAME to v$PLUGIN_VERSION
 
           Automated update from release workflow."
           git push


### PR DESCRIPTION
## Summary
- Fixed bash syntax error where `fi` and `git commit` were on the same line
- This broke the "Update Website Version" step in the release workflow

## What happened
The 4k-eq v1.0.6 release workflow failed at the website update step with:
```
syntax error near unexpected token 'git'
```

## Fix
Added newline between `fi` and `git commit` on line 809.

---
🤖 Generated with [Claude Code](https://claude.ai/code)