### PR TITLE
Fix LunaSlider fine control (Shift+drag) for all knob types (#20)

### DIFF
--- a/plugins/multi-comp/EnhancedCompressorEditor.cpp
+++ b/plugins/multi-comp/EnhancedCompressorEditor.cpp
@@ -51,7 +51,7 @@ EnhancedCompressorEditor::EnhancedCompressorEditor(UniversalCompressor& p)
     analogNoiseButton = std::make_unique<juce::ToggleButton>("Analog Noise");
 
     // Lookahead slider (not shown in header, but kept for parameter)
-    lookaheadSlider = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
+    lookaheadSlider = std::make_unique<LunaSlider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
     lookaheadSlider->setRange(0.0, 10.0, 0.1);
     lookaheadSlider->setTextValueSuffix(" ms");
     lookaheadSlider->setTextBoxStyle(juce::Slider::TextBoxLeft, false, 50, 18);
@@ -64,7 +64,7 @@ EnhancedCompressorEditor::EnhancedCompressorEditor(UniversalCompressor& p)
     oversamplingSelector->setSelectedId(2);  // Default to 2x
 
     // Sidechain HP filter vertical slider (Off to 500Hz)
-    sidechainHpSlider = std::make_unique<juce::Slider>(juce::Slider::LinearVertical, juce::Slider::TextBoxBelow);
+    sidechainHpSlider = std::make_unique<LunaSlider>(juce::Slider::LinearVertical, juce::Slider::TextBoxBelow);
     sidechainHpSlider->setRange(0.0, 500.0, 1.0);  // 0 = Off, up to 500Hz
     sidechainHpSlider->setTextBoxStyle(juce::Slider::TextBoxBelow, false, 50, 16);
     sidechainHpSlider->setSkewFactorFromMidPoint(80.0);  // Skew so useful range (20-200Hz) is more accessible
@@ -90,24 +90,24 @@ EnhancedCompressorEditor::EnhancedCompressorEditor(UniversalCompressor& p)
     };
 
     // Sidechain EQ controls (not in header - too complex, keep hidden for now)
-    scLowFreqSlider = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
+    scLowFreqSlider = std::make_unique<LunaSlider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
     scLowFreqSlider->setRange(60.0, 500.0, 1.0);
     scLowFreqSlider->setTextValueSuffix(" Hz");
     scLowFreqSlider->setTextBoxStyle(juce::Slider::TextBoxLeft, false, 45, 16);
     scLowFreqSlider->setSkewFactorFromMidPoint(150.0);
 
-    scLowGainSlider = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
+    scLowGainSlider = std::make_unique<LunaSlider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
     scLowGainSlider->setRange(-12.0, 12.0, 0.1);
     scLowGainSlider->setTextValueSuffix(" dB");
     scLowGainSlider->setTextBoxStyle(juce::Slider::TextBoxLeft, false, 45, 16);
 
-    scHighFreqSlider = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
+    scHighFreqSlider = std::make_unique<LunaSlider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
     scHighFreqSlider->setRange(2000.0, 16000.0, 10.0);
     scHighFreqSlider->setTextValueSuffix(" Hz");
     scHighFreqSlider->setTextBoxStyle(juce::Slider::TextBoxLeft, false, 50, 16);
     scHighFreqSlider->setSkewFactorFromMidPoint(6000.0);
 
-    scHighGainSlider = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
+    scHighGainSlider = std::make_unique<LunaSlider>(juce::Slider::LinearHorizontal, juce::Slider::TextBoxLeft);
     scHighGainSlider->setRange(-12.0, 12.0, 0.1);
     scHighGainSlider->setTextValueSuffix(" dB");
     scHighGainSlider->setTextBoxStyle(juce::Slider::TextBoxLeft, false, 45, 16);

--- a/plugins/multi-q/BandDetailPanel.cpp
+++ b/plugins/multi-q/BandDetailPanel.cpp
@@ -59,7 +59,7 @@ void BandDetailPanel::updateBandButtonColors()
 void BandDetailPanel::setupKnobs()
 {
     auto setupRotaryKnob = [this](std::unique_ptr<juce::Slider>& knob) {
-        knob = std::make_unique<juce::Slider>(juce::Slider::RotaryHorizontalVerticalDrag,
+        knob = std::make_unique<LunaSlider>(juce::Slider::RotaryHorizontalVerticalDrag,
                                                juce::Slider::NoTextBox);
         knob->setLookAndFeel(&f6KnobLookAndFeel);
         knob->setColour(juce::Slider::rotarySliderFillColourId, getBandColor(selectedBand));
@@ -90,7 +90,7 @@ void BandDetailPanel::setupKnobs()
 
     // Dynamics knobs (use orange for dynamics section)
     auto setupDynKnob = [this](std::unique_ptr<juce::Slider>& knob) {
-        knob = std::make_unique<juce::Slider>(juce::Slider::RotaryHorizontalVerticalDrag,
+        knob = std::make_unique<LunaSlider>(juce::Slider::RotaryHorizontalVerticalDrag,
                                                juce::Slider::NoTextBox);
         knob->setLookAndFeel(&f6KnobLookAndFeel);
         knob->setColour(juce::Slider::rotarySliderFillColourId, juce::Colour(0xFFff8844));

--- a/plugins/multi-q/BandDetailPanel.h
+++ b/plugins/multi-q/BandDetailPanel.h
@@ -2,6 +2,7 @@
 
 #include <JuceHeader.h>
 #include "EQBand.h"
+#include "../shared/LunaLookAndFeel.h"
 
 class MultiQ;
 


### PR DESCRIPTION
- Remove sync-back that discarded sub-interval accumulation during drag
- Reduce fine mode from 5x to 3x (600px vs 1000px) per industry standard
- Ensure all plugin knobs use LunaSlider (Multi-Q, Multi-Comp)

The sync-back line was resetting lastDragProportion each frame, which prevented fine control from working on parameters where per-pixel delta was less than half the interval step (input gain, saturation, frequency knobs at extreme positions).