### PR TITLE
#32 Fix version numbers not matching releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,18 +201,20 @@ jobs:
             mesa-common-dev
 
       - name: Configure CMake
-        env:
-          PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.plugin_version }}
         run: |
+          if [ -n "${{ needs.setup.outputs.plugin_version }}" ]; then
+            export PLUGIN_VERSION_OVERRIDE="${{ needs.setup.outputs.plugin_version }}"
+          fi
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DLUNA_COPY_AFTER_BUILD=OFF \
             -DJUCE_PATH=$(pwd)/JUCE
 
       - name: Build plugins
-        env:
-          PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.plugin_version }}
         run: |
+          if [ -n "${{ needs.setup.outputs.plugin_version }}" ]; then
+            export PLUGIN_VERSION_OVERRIDE="${{ needs.setup.outputs.plugin_version }}"
+          fi
           TARGET="${{ needs.setup.outputs.plugin_target }}"
           if [ -n "$TARGET" ]; then
             echo "Building specific target: $TARGET"
@@ -318,18 +320,20 @@ jobs:
           ref: 8.0.4  # Use JUCE 8.x for modern C++ features
 
       - name: Configure CMake
-        env:
-          PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.plugin_version }}
         run: |
+          if ("${{ needs.setup.outputs.plugin_version }}") {
+            $env:PLUGIN_VERSION_OVERRIDE = "${{ needs.setup.outputs.plugin_version }}"
+          }
           cmake -B build `
             -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} `
             -DLUNA_COPY_AFTER_BUILD=OFF `
             -DJUCE_PATH=${{ github.workspace }}/JUCE
 
       - name: Build plugins
-        env:
-          PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.plugin_version }}
         run: |
+          if ("${{ needs.setup.outputs.plugin_version }}") {
+            $env:PLUGIN_VERSION_OVERRIDE = "${{ needs.setup.outputs.plugin_version }}"
+          }
           $target = "${{ needs.setup.outputs.plugin_target }}"
           if ($target) {
             Write-Host "Building specific target: $target"
@@ -420,9 +424,10 @@ jobs:
           ref: 8.0.4  # Use JUCE 8.x for modern C++ features
 
       - name: Configure CMake (Universal Binary)
-        env:
-          PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.plugin_version }}
         run: |
+          if [ -n "${{ needs.setup.outputs.plugin_version }}" ]; then
+            export PLUGIN_VERSION_OVERRIDE="${{ needs.setup.outputs.plugin_version }}"
+          fi
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DLUNA_COPY_AFTER_BUILD=OFF \
@@ -431,9 +436,10 @@ jobs:
             -DJUCE_PATH=${{ github.workspace }}/JUCE
 
       - name: Build plugins
-        env:
-          PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.plugin_version }}
         run: |
+          if [ -n "${{ needs.setup.outputs.plugin_version }}" ]; then
+            export PLUGIN_VERSION_OVERRIDE="${{ needs.setup.outputs.plugin_version }}"
+          fi
           TARGET="${{ needs.setup.outputs.plugin_target }}"
           if [ -n "$TARGET" ]; then
             echo "Building specific target: $TARGET"

--- a/cmake/PluginVersion.cmake
+++ b/cmake/PluginVersion.cmake
@@ -17,7 +17,9 @@
 #   OUTPUT_VAR  - Variable to store the extracted version
 function(get_plugin_version PLUGIN_SLUG OUTPUT_VAR)
     # Priority 1: Check for version override from CI (most reliable for releases)
-    if(DEFINED ENV{PLUGIN_VERSION_OVERRIDE})
+    # Note: AND NOT STREQUAL "" guard prevents empty env vars (e.g. from workflow_dispatch)
+    # from short-circuiting the git tag detection in Priority 2
+    if(DEFINED ENV{PLUGIN_VERSION_OVERRIDE} AND NOT "$ENV{PLUGIN_VERSION_OVERRIDE}" STREQUAL "")
         set(${OUTPUT_VAR} $ENV{PLUGIN_VERSION_OVERRIDE} PARENT_SCOPE)
         message(STATUS "${PLUGIN_SLUG}: Using CI version override: $ENV{PLUGIN_VERSION_OVERRIDE}")
         return()


### PR DESCRIPTION
## Summary
- **Root cause**: GitHub Actions silently drops all push events when >3 tags are pushed in a single `git push` command. Batch releases of 4+ plugins would silently fail to trigger CI, producing releases with wrong version numbers baked into the binaries.
- Push tags one at a time in the `/release-plugin` skill (with 2s delay between each)
- Guard against empty `PLUGIN_VERSION_OVERRIDE` in `PluginVersion.cmake` so `workflow_dispatch` builds fall through to git tag detection
- Only set `PLUGIN_VERSION_OVERRIDE` env var in CI when there's an actual version value

## Post-merge: Re-release broken versions
After merging, delete and re-push these tags individually to trigger fresh CI builds:
- `4k-eq-v1.0.9` (current latest — wrong binary)
- `tapemachine-v1.0.4` (current latest — wrong binary)
- `multi-q-v0.9.0` (wrong binary)
- `multi-q-v0.9.1` (tag exists, no release)

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, re-push one tag and confirm CI triggers and produces correct version
- [ ] Do a batch release of 4+ plugins and confirm all tags trigger individual CI runs

Closes #32