### PR TITLE
37: Add preset dropdown for DAWs like Ableton and Fender Studio to UI

### DIFF
--- a/plugins/TapeMachine/Source/PluginEditor.cpp
+++ b/plugins/TapeMachine/Source/PluginEditor.cpp
@@ -12,6 +12,25 @@ TapeMachineAudioProcessorEditor::TapeMachineAudioProcessorEditor(TapeMachineAudi
 {
     setLookAndFeel(&tapeMachineLookAndFeel);
 
+    // Preset selector
+    presetLabel.setText("PRESET", juce::dontSendNotification);
+    presetLabel.setJustificationType(juce::Justification::centredRight);
+    presetLabel.setColour(juce::Label::textColourId, juce::Colour(textPrimary));
+    presetLabel.setFont(juce::Font(10.0f, juce::Font::bold));
+    addAndMakeVisible(presetLabel);
+
+    for (int i = 0; i < audioProcessor.getNumPrograms(); ++i)
+        presetSelector.addItem(audioProcessor.getProgramName(i), i + 1);
+    presetSelector.setSelectedId(audioProcessor.getCurrentProgram() + 1, juce::dontSendNotification);
+    presetSelector.onChange = [this]()
+    {
+        int presetIndex = presetSelector.getSelectedId() - 1;
+        if (presetIndex >= 0 && presetIndex < audioProcessor.getNumPrograms())
+            audioProcessor.setCurrentProgram(presetIndex);
+    };
+    presetSelector.setTooltip("Select factory preset");
+    addAndMakeVisible(presetSelector);
+
     // Setup combo boxes
     setupComboBox(tapeMachineSelector, tapeMachineLabel, "MACHINE");
     tapeMachineSelector.addItem("Swiss 800", 1);
@@ -317,7 +336,16 @@ void TapeMachineAudioProcessorEditor::resized()
     auto area = getLocalBounds();
 
     // Header - scaled
-    area.removeFromTop(resizeHelper.scaled(50));
+    auto headerArea = area.removeFromTop(resizeHelper.scaled(50));
+    {
+        // Preset label + selector on the right side of header
+        auto presetArea = headerArea.removeFromRight(resizeHelper.scaled(260));
+        presetArea.removeFromRight(resizeHelper.scaled(10)); // right margin
+        auto labelArea = presetArea.removeFromLeft(resizeHelper.scaled(60));
+        presetArea.removeFromLeft(resizeHelper.scaled(4)); // gap between label and dropdown
+        presetLabel.setBounds(labelArea.withSizeKeepingCentre(labelArea.getWidth(), resizeHelper.scaled(20)));
+        presetSelector.setBounds(presetArea.withSizeKeepingCentre(presetArea.getWidth(), resizeHelper.scaled(26)));
+    }
 
     // Transport section - scaled
     auto transportArea = area.removeFromTop(resizeHelper.scaled(235));

--- a/plugins/TapeMachine/Source/PluginEditor.h
+++ b/plugins/TapeMachine/Source/PluginEditor.h
@@ -27,6 +27,10 @@ private:
     TapeMachineAudioProcessor& audioProcessor;
     TapeMachineLookAndFeel tapeMachineLookAndFeel;
 
+    // Preset selector
+    juce::ComboBox presetSelector;
+    juce::Label presetLabel;
+
     // Combo boxes
     juce::ComboBox tapeMachineSelector;
     juce::ComboBox tapeSpeedSelector;

--- a/plugins/TapeMachine/Source/PluginProcessor.cpp
+++ b/plugins/TapeMachine/Source/PluginProcessor.cpp
@@ -262,8 +262,8 @@ void TapeMachineAudioProcessor::setCurrentProgram (int index)
 
     if (index == 0)
     {
-        // Default preset - keeps current values
-        // User can manually adjust parameters from here
+        // Reset all parameters to defaults
+        TapeMachinePresets::applyPreset(TapeMachinePresets::Preset{}, apvts);
         return;
     }
 

--- a/plugins/TapeMachine/Source/TapeMachinePresets.h
+++ b/plugins/TapeMachine/Source/TapeMachinePresets.h
@@ -35,7 +35,7 @@ struct Preset
     // Character
     float wowAmount = 7.0f;      // 0-100%
     float flutterAmount = 3.0f;  // 0-100%
-    float noiseAmount = 5.0f;    // 0-100%
+    float noiseAmount = 0.0f;    // 0-100%
     bool noiseEnabled = false;
 };
 


### PR DESCRIPTION
Add preset dropdown for DAWs that do not have it built in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preset selector dropdown to the plugin editor interface, enabling users to quickly browse, select, and apply different presets from the available collection.

* **Changes**
  * The default preset now fully resets all parameters to their default values when selected.
  * Updated the default noise amount setting for improved defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->