### PR TITLE
Chord Analyzer: add FX variant for Reaper/Bitwig/Logic/LV2

### DIFF
--- a/plugins/chord-analyzer/CMakeLists.txt
+++ b/plugins/chord-analyzer/CMakeLists.txt
@@ -43,7 +43,7 @@ juce_add_plugin(ChordAnalyzer
     BUNDLE_ID "com.DuskAudio.ChordAnalyzer"
     IS_SYNTH TRUE
     NEEDS_MIDI_INPUT TRUE
-    NEEDS_MIDI_OUTPUT FALSE
+    NEEDS_MIDI_OUTPUT TRUE
     IS_MIDI_EFFECT FALSE
     EDITOR_WANTS_KEYBOARD_FOCUS FALSE
     COPY_PLUGIN_AFTER_BUILD ${DUSK_COPY_AFTER_BUILD}
@@ -128,5 +128,83 @@ target_compile_definitions(ChordAnalyzerTest PRIVATE
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(ChordAnalyzer PRIVATE -O3 -ffast-math -fno-finite-math-only)
+    endif()
+endif()
+
+# ===== FX variant (audio effect with MIDI input/output) =====
+# For Reaper, Bitwig, Logic, LV2, Cubase — sits in FX chain, passes audio and MIDI through.
+# Same source code as the instrument variant, with CHORD_ANALYZER_FX_MODE=1 to control
+# bus layout (audio pass-through instead of silence) and plugin classification.
+juce_add_plugin(ChordAnalyzerFX
+    COMPANY_NAME "Dusk Audio"
+    BUNDLE_ID "com.DuskAudio.ChordAnalyzerFX"
+    IS_SYNTH FALSE
+    NEEDS_MIDI_INPUT TRUE
+    NEEDS_MIDI_OUTPUT TRUE
+    IS_MIDI_EFFECT FALSE
+    EDITOR_WANTS_KEYBOARD_FOCUS FALSE
+    COPY_PLUGIN_AFTER_BUILD ${DUSK_COPY_AFTER_BUILD}
+    PLUGIN_MANUFACTURER_CODE Dusk
+    PLUGIN_CODE ChFx
+    FORMATS ${PLUGIN_FORMATS}
+    LV2URI "https://dusk-audio.github.io/plugins/chord-analyzer-fx"
+    PRODUCT_NAME "Chord Analyzer FX"
+    VST3_CAN_REPLACE_VST2 FALSE
+    VST3_AUTO_MANIFEST FALSE
+)
+
+juce_generate_juce_header(ChordAnalyzerFX)
+
+target_sources(ChordAnalyzerFX
+    PRIVATE
+        Source/PluginProcessor.cpp
+        Source/PluginProcessor.h
+        Source/PluginEditor.cpp
+        Source/PluginEditor.h
+        Source/ChordAnalyzer.cpp
+        Source/ChordAnalyzer.h
+        Source/ChordRecorder.cpp
+        Source/ChordRecorder.h
+        Source/TheoryTooltips.h
+        Source/ChordAnalyzerLookAndFeel.h
+)
+
+target_include_directories(ChordAnalyzerFX
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/Source
+        ${CMAKE_CURRENT_SOURCE_DIR}/../shared
+)
+
+target_compile_definitions(ChordAnalyzerFX
+    PUBLIC
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+        JUCE_DISPLAY_SPLASH_SCREEN=0
+        JUCE_FORCE_USE_LEGACY_PARAM_IDS=1
+        CHORD_ANALYZER_FX_MODE=1
+)
+
+target_link_libraries(ChordAnalyzerFX
+    PRIVATE
+        juce::juce_audio_basics
+        juce::juce_audio_devices
+        juce::juce_audio_formats
+        juce::juce_audio_plugin_client
+        juce::juce_audio_processors
+        juce::juce_audio_utils
+        juce::juce_core
+        juce::juce_data_structures
+        juce::juce_events
+        juce::juce_graphics
+        juce::juce_gui_basics
+        juce::juce_gui_extra
+    PUBLIC
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_warning_flags
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(ChordAnalyzerFX PRIVATE -O3 -ffast-math -fno-finite-math-only)
     endif()
 endif()

--- a/plugins/chord-analyzer/Source/PluginEditor.cpp
+++ b/plugins/chord-analyzer/Source/PluginEditor.cpp
@@ -189,8 +189,13 @@ void ChordAnalyzerEditor::paint(juce::Graphics& g)
 
     // Header
     auto headerArea = bounds.removeFromTop(45);
+#if CHORD_ANALYZER_FX_MODE
+    ChordAnalyzerLookAndFeel::drawPluginHeader(g, headerArea,
+                                                "CHORD ANALYZER FX", "Dusk Audio");
+#else
     ChordAnalyzerLookAndFeel::drawPluginHeader(g, headerArea,
                                                 "CHORD ANALYZER", "Dusk Audio");
+#endif
     titleClickArea = headerArea.reduced(10, 5).withWidth(180);
 
     // Main chord display section - taller for better spacing
@@ -557,7 +562,11 @@ void ChordAnalyzerEditor::showSupportersPanel()
 {
     if (!supportersOverlay)
     {
+#if CHORD_ANALYZER_FX_MODE
+        supportersOverlay = std::make_unique<SupportersOverlay>("Chord Analyzer FX", JucePlugin_VersionString);
+#else
         supportersOverlay = std::make_unique<SupportersOverlay>("Chord Analyzer", JucePlugin_VersionString);
+#endif
         supportersOverlay->onDismiss = [this]() { hideSupportersPanel(); };
         addAndMakeVisible(supportersOverlay.get());
     }

--- a/plugins/chord-analyzer/Source/PluginProcessor.cpp
+++ b/plugins/chord-analyzer/Source/PluginProcessor.cpp
@@ -150,8 +150,12 @@ void ChordAnalyzerProcessor::releaseResources()
 void ChordAnalyzerProcessor::processBlock(juce::AudioBuffer<float>& buffer,
                                            juce::MidiBuffer& midiMessages)
 {
-    // Clear audio buffer - this is a MIDI effect
+#if CHORD_ANALYZER_FX_MODE
+    // FX mode: pass audio through unchanged (acts as an insert effect)
+#else
+    // Instrument mode: produce silence (no audio to generate)
     buffer.clear();
+#endif
 
     // Process MIDI input
     processMidiInput(midiMessages);

--- a/plugins/chord-analyzer/Source/PluginProcessor.h
+++ b/plugins/chord-analyzer/Source/PluginProcessor.h
@@ -22,7 +22,7 @@ public:
     //==========================================================================
     // MIDI effect characteristics
     bool acceptsMidi() const override { return true; }
-    bool producesMidi() const override { return false; }
+    bool producesMidi() const override { return true; }  // MIDI pass-through
     bool isMidiEffect() const override { return false; }
     double getTailLengthSeconds() const override { return 0.0; }
 


### PR DESCRIPTION
Program is now two separate binaries

- Add ChordAnalyzerFX target (IS_SYNTH=FALSE, audio effect with MIDI I/O)
- Enable MIDI pass-through on both variants (NEEDS_MIDI_OUTPUT=TRUE)
- FX mode passes audio through; instrument mode clears buffer (silence)
- UI header shows 'CHORD ANALYZER FX' to differentiate variants
- Compile-time CHORD_ANALYZER_FX_MODE flag controls behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced ChordAnalyzerFX audio effect plugin variant with MIDI input and output support
  * Added MIDI output capability to ChordAnalyzer for enhanced host integration

* **Changes**
  * Updated audio signal processing to support passthrough behavior in effect mode
  * Added differentiated UI branding between ChordAnalyzer and ChordAnalyzerFX variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->