### PR TITLE
Chord Analyzer: MIDI + Headless variants for Zynthian (#62, partial #61)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
               NAME="DuskVerb"
               RELEASE_NAME="duskverb"
             elif [[ "$TAG" == chord-analyzer-v* ]]; then
-              TARGET="ChordAnalyzer_All ChordAnalyzerFX_All"
+              TARGET="ChordAnalyzer_All ChordAnalyzerMIDI_All ChordAnalyzerHeadless_LV2"
               NAME="Chord Analyzer"
               RELEASE_NAME="chord-analyzer"
             elif [[ "$TAG" == spectrum-analyzer-v* ]]; then
@@ -123,7 +123,7 @@ jobs:
               convolution-reverb) TARGET="ConvolutionReverb_All"; NAME="Convolution Reverb"; RELEASE_NAME="convolution-reverb" ;;
               groovemind) TARGET="GrooveMind_All"; NAME="GrooveMind"; RELEASE_NAME="groovemind" ;;
               duskverb) TARGET="DuskVerb_All"; NAME="DuskVerb"; RELEASE_NAME="duskverb" ;;
-              chord-analyzer) TARGET="ChordAnalyzer_All ChordAnalyzerFX_All"; NAME="Chord Analyzer"; RELEASE_NAME="chord-analyzer" ;;
+              chord-analyzer) TARGET="ChordAnalyzer_All ChordAnalyzerMIDI_All ChordAnalyzerHeadless_LV2"; NAME="Chord Analyzer"; RELEASE_NAME="chord-analyzer" ;;
               spectrum-analyzer) TARGET="SpectrumAnalyzer_All"; NAME="Spectrum Analyzer"; RELEASE_NAME="spectrum-analyzer" ;;
             esac
           fi
@@ -850,6 +850,22 @@ jobs:
           echo "Slug: $SLUG"
           echo "Version: $VERSION"
 
+          # Helper: when releasing chord-analyzer, carve out the headless LV2 bundle
+          # into its own zip so Zynthian users can grab a clean, self-contained
+          # download without the desktop variants. The headless bundle is the only
+          # one that ships native LV2 output ControlPorts for headless host UIs.
+          carve_headless() {
+            local release_dir="$1"
+            local out_zip="$2"
+            local bundle="$release_dir/LV2/Chord Analyzer Headless.lv2"
+            if [ -d "$bundle" ]; then
+              local headless_dir="${release_dir}-headless"
+              mkdir -p "$headless_dir/LV2"
+              mv "$bundle" "$headless_dir/LV2/"
+              ( cd "$headless_dir" && zip -r "../../${out_zip}" . )
+            fi
+          }
+
           # Linux: Create zip with VST3/ and LV2/ folders at root (not nested in plugins-linux/)
           # This allows users to extract directly and copy the appropriate format
           mkdir -p linux-release
@@ -859,6 +875,7 @@ jobs:
           if [ -d "plugins-linux/LV2" ]; then
             cp -r plugins-linux/LV2 linux-release/
           fi
+          carve_headless linux-release "${SLUG}-headless-linux.zip"
           cd linux-release
           zip -r "../../${SLUG}-linux.zip" .
           cd ..
@@ -871,6 +888,7 @@ jobs:
           if [ -d "plugins-linux-arm64/LV2" ]; then
             cp -r plugins-linux-arm64/LV2 linux-arm64-release/
           fi
+          carve_headless linux-arm64-release "${SLUG}-headless-linux-arm64.zip"
           cd linux-arm64-release
           zip -r "../../${SLUG}-linux-arm64.zip" .
           cd ..
@@ -967,6 +985,21 @@ jobs:
               echo "- Tape Echo - Vintage tape delay"
               echo "- Convolution Reverb - IR-based reverb"
               echo "- GrooveMind - ML drum generator"
+            fi
+
+            # Chord Analyzer ships three plugin variants — give users a quick map
+            if [ "$RELEASE_NAME" = "chord-analyzer" ]; then
+              echo ""
+              echo "### Chord Analyzer Variants"
+              echo ""
+              echo "The main \`chord-analyzer-*\` zips contain two variants:"
+              echo "- **Chord Analyzer** — instrument variant for FL Studio / Ableton"
+              echo "- **Chord Analyzer MIDI** — MIDI effect for Logic, Reaper, Bitwig, Cubase, Ardour, Carla (full UI)"
+              echo ""
+              echo "The separate \`chord-analyzer-headless-*\` zips contain:"
+              echo "- **Chord Analyzer Headless** — native LV2 with output ControlPorts for headless hosts (Zynthian)"
+              echo ""
+              echo "Most users want the main zip. If you're on Zynthian or another headless LV2 host, grab the \`-headless-\` zip instead."
             fi
           } > release_body.md
 

--- a/plugins/chord-analyzer/CMakeLists.txt
+++ b/plugins/chord-analyzer/CMakeLists.txt
@@ -87,6 +87,7 @@ target_compile_definitions(ChordAnalyzer
         JUCE_USE_CURL=0
         JUCE_DISPLAY_SPLASH_SCREEN=0
         JUCE_FORCE_USE_LEGACY_PARAM_IDS=1
+        JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS=0
 )
 
 # Link JUCE modules
@@ -131,31 +132,32 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     endif()
 endif()
 
-# ===== FX variant (audio effect with MIDI input/output) =====
-# For Reaper, Bitwig, Logic, LV2, Cubase — sits in FX chain, passes audio and MIDI through.
-# Same source code as the instrument variant, with CHORD_ANALYZER_FX_MODE=1 to control
-# bus layout (audio pass-through instead of silence) and plugin classification.
-juce_add_plugin(ChordAnalyzerFX
+# ===== MIDI variant (pure MIDI effect, no audio buses) =====
+# JUCE-built across all formats including LV2 — desktop LV2 hosts (Ardour, Carla)
+# get the full custom UI here. For Zynthian and other headless LV2 hosts that
+# need native lv2:OutputPort+ControlPort to display chord info in their own UI,
+# see the separate "Chord Analyzer Headless" native LV2 build below.
+juce_add_plugin(ChordAnalyzerMIDI
     COMPANY_NAME "Dusk Audio"
-    BUNDLE_ID "com.DuskAudio.ChordAnalyzerFX"
+    BUNDLE_ID "com.DuskAudio.ChordAnalyzerMIDI"
     IS_SYNTH FALSE
     NEEDS_MIDI_INPUT TRUE
     NEEDS_MIDI_OUTPUT TRUE
-    IS_MIDI_EFFECT FALSE
+    IS_MIDI_EFFECT TRUE
     EDITOR_WANTS_KEYBOARD_FOCUS FALSE
     COPY_PLUGIN_AFTER_BUILD ${DUSK_COPY_AFTER_BUILD}
     PLUGIN_MANUFACTURER_CODE Dusk
-    PLUGIN_CODE ChFx
+    PLUGIN_CODE ChMi
     FORMATS ${PLUGIN_FORMATS}
-    LV2URI "https://dusk-audio.github.io/plugins/chord-analyzer-fx"
-    PRODUCT_NAME "Chord Analyzer FX"
+    LV2URI "https://dusk-audio.github.io/plugins/chord-analyzer-midi"
+    PRODUCT_NAME "Chord Analyzer MIDI"
     VST3_CAN_REPLACE_VST2 FALSE
     VST3_AUTO_MANIFEST FALSE
 )
 
-juce_generate_juce_header(ChordAnalyzerFX)
+juce_generate_juce_header(ChordAnalyzerMIDI)
 
-target_sources(ChordAnalyzerFX
+target_sources(ChordAnalyzerMIDI
     PRIVATE
         Source/PluginProcessor.cpp
         Source/PluginProcessor.h
@@ -169,22 +171,23 @@ target_sources(ChordAnalyzerFX
         Source/ChordAnalyzerLookAndFeel.h
 )
 
-target_include_directories(ChordAnalyzerFX
+target_include_directories(ChordAnalyzerMIDI
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/Source
         ${CMAKE_CURRENT_SOURCE_DIR}/../shared
 )
 
-target_compile_definitions(ChordAnalyzerFX
+target_compile_definitions(ChordAnalyzerMIDI
     PUBLIC
         JUCE_WEB_BROWSER=0
         JUCE_USE_CURL=0
         JUCE_DISPLAY_SPLASH_SCREEN=0
         JUCE_FORCE_USE_LEGACY_PARAM_IDS=1
-        CHORD_ANALYZER_FX_MODE=1
+        JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS=0
+        CHORD_ANALYZER_MIDI_MODE=1
 )
 
-target_link_libraries(ChordAnalyzerFX
+target_link_libraries(ChordAnalyzerMIDI
     PRIVATE
         juce::juce_audio_basics
         juce::juce_audio_devices
@@ -205,6 +208,85 @@ target_link_libraries(ChordAnalyzerFX
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-        target_compile_options(ChordAnalyzerFX PRIVATE -O3 -ffast-math -fno-finite-math-only)
+        target_compile_options(ChordAnalyzerMIDI PRIVATE -O3 -ffast-math -fno-finite-math-only)
+    endif()
+endif()
+
+# ===== Headless variant (native LV2 only, for Zynthian + other headless LV2 hosts) =====
+# Hand-rolled because JUCE's LV2 wrapper can't emit lv2:OutputPort + lv2:ControlPort
+# for plugin parameters (everything goes through patch:Message). Zynthian only
+# renders values written to native output control ports, so we wrap ChordAnalyzer
+# in a thin LV2 plugin that declares the right ports. No GUI — host renders the
+# control ports in its own UI (this is the entire point: lets Zynthian display
+# the detected chord without our editor).
+if("LV2" IN_LIST PLUGIN_FORMATS)
+    set(LV2_SDK_DIR "${CMAKE_SOURCE_DIR}/../JUCE/modules/juce_audio_processors_headless/format_types/LV2_SDK/lv2")
+    if(NOT EXISTS "${LV2_SDK_DIR}/lv2/core/lv2.h")
+        # When JUCE_PATH is set explicitly the SDK lives under that path
+        set(LV2_SDK_DIR "${JUCE_PATH}/modules/juce_audio_processors_headless/format_types/LV2_SDK/lv2")
+    endif()
+
+    add_library(ChordAnalyzerHeadless_LV2 MODULE
+        lv2/chord-analyzer-lv2.cpp
+        Source/ChordAnalyzer.cpp
+    )
+
+    target_include_directories(ChordAnalyzerHeadless_LV2 PRIVATE
+        Source
+        "${LV2_SDK_DIR}"
+    )
+
+    target_link_libraries(ChordAnalyzerHeadless_LV2 PRIVATE
+        juce::juce_core
+    )
+
+    set_target_properties(ChordAnalyzerHeadless_LV2 PROPERTIES
+        PREFIX ""
+        SUFFIX ".so"           # LV2 convention: .so on every platform (incl. macOS)
+        OUTPUT_NAME "ChordAnalyzerHeadless"
+        POSITION_INDEPENDENT_CODE ON
+    )
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(ChordAnalyzerHeadless_LV2 PRIVATE -O3 -ffast-math -fno-finite-math-only)
+        endif()
+    endif()
+
+    # Assemble the .lv2 bundle (binary + manifest.ttl + chord-analyzer-headless.ttl)
+    set(CHORDANALYZER_HEADLESS_BUNDLE "${CMAKE_CURRENT_BINARY_DIR}/Chord Analyzer Headless.lv2")
+
+    add_custom_command(TARGET ChordAnalyzerHeadless_LV2 POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CHORDANALYZER_HEADLESS_BUNDLE}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:ChordAnalyzerHeadless_LV2>"
+            "${CHORDANALYZER_HEADLESS_BUNDLE}/ChordAnalyzerHeadless.so"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/lv2/manifest.ttl"
+            "${CHORDANALYZER_HEADLESS_BUNDLE}/manifest.ttl"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/lv2/chord-analyzer-headless.ttl"
+            "${CHORDANALYZER_HEADLESS_BUNDLE}/chord-analyzer-headless.ttl"
+        COMMENT "Assembling Chord Analyzer Headless.lv2 bundle"
+    )
+
+    if(DUSK_COPY_AFTER_BUILD)
+        if(APPLE)
+            set(LV2_INSTALL_DIR "$ENV{HOME}/Library/Audio/Plug-Ins/LV2")
+        elseif(UNIX)
+            set(LV2_INSTALL_DIR "$ENV{HOME}/.lv2")
+        elseif(WIN32)
+            set(LV2_INSTALL_DIR "$ENV{APPDATA}/LV2")
+        endif()
+
+        if(DEFINED LV2_INSTALL_DIR)
+            add_custom_command(TARGET ChordAnalyzerHeadless_LV2 POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${LV2_INSTALL_DIR}"
+                COMMAND ${CMAKE_COMMAND} -E copy_directory
+                    "${CHORDANALYZER_HEADLESS_BUNDLE}"
+                    "${LV2_INSTALL_DIR}/Chord Analyzer Headless.lv2"
+                COMMENT "Installing Chord Analyzer Headless.lv2 to ${LV2_INSTALL_DIR}"
+            )
+        endif()
     endif()
 endif()

--- a/plugins/chord-analyzer/Source/PluginEditor.cpp
+++ b/plugins/chord-analyzer/Source/PluginEditor.cpp
@@ -562,8 +562,8 @@ void ChordAnalyzerEditor::showSupportersPanel()
 {
     if (!supportersOverlay)
     {
-#if CHORD_ANALYZER_FX_MODE
-        supportersOverlay = std::make_unique<SupportersOverlay>("Chord Analyzer FX", JucePlugin_VersionString);
+#if CHORD_ANALYZER_MIDI_MODE
+        supportersOverlay = std::make_unique<SupportersOverlay>("Chord Analyzer MIDI", JucePlugin_VersionString);
 #else
         supportersOverlay = std::make_unique<SupportersOverlay>("Chord Analyzer", JucePlugin_VersionString);
 #endif

--- a/plugins/chord-analyzer/Source/PluginProcessor.cpp
+++ b/plugins/chord-analyzer/Source/PluginProcessor.cpp
@@ -3,9 +3,15 @@
 
 //==============================================================================
 ChordAnalyzerProcessor::ChordAnalyzerProcessor()
-    : AudioProcessor(BusesProperties()
-        .withInput("Input", juce::AudioChannelSet::stereo(), true)
-        .withOutput("Output", juce::AudioChannelSet::stereo(), true)),
+    : AudioProcessor(
+#if CHORD_ANALYZER_MIDI_MODE
+        BusesProperties()
+#else
+        BusesProperties()
+            .withInput("Input", juce::AudioChannelSet::stereo(), true)
+            .withOutput("Output", juce::AudioChannelSet::stereo(), true)
+#endif
+      ),
       parameters(*this, nullptr, juce::Identifier("ChordAnalyzerState"),
                  createParameterLayout())
 {
@@ -22,6 +28,52 @@ ChordAnalyzerProcessor::ChordAnalyzerProcessor()
     showInversions.store(*parameters.getRawParameterValue(PARAM_SHOW_INVERSIONS) > 0.5f);
 
     analyzer.setKey(keyRoot.load(), keyMinor.load());
+
+    // Output parameters (detection results) — added directly to the processor
+    // rather than via APVTS. APVTS's ValueTree sync was silently overwriting
+    // setValueNotifyingHost writes, so detected values never reached the host.
+    // Using ASCII "-" for the "no chord" label: Reaper's parameter strip renders
+    // multibyte UTF-8 (em-dash) as Latin-1 mojibake.
+    const juce::StringArray pitchClassChoices{
+        "-", "C", "C#/Db", "D", "D#/Eb", "E", "F",
+        "F#/Gb", "G", "G#/Ab", "A", "A#/Bb", "B" };
+
+    // Quality choices: index 0 = "-" (no chord). Indices 1..N follow ChordQuality
+    // enum order — keep these in sync if the enum is ever reordered.
+    const juce::StringArray qualityChoices{
+        "-",
+        "maj", "m", "dim", "aug",
+        "7", "maj7", "m7", "mMaj7", "dim7", "m7b5", "aug7", "augMaj7",
+        "sus2", "sus4", "7sus4",
+        "add9", "add11",
+        "6", "m6",
+        "maj9", "m9", "9",
+        "maj11", "m11", "11",
+        "maj13", "m13", "13",
+        "5",
+        "7b5", "7#5", "7b9", "7#9" };
+
+    const juce::StringArray inversionChoices{ "-", "Root", "1st", "2nd", "3rd" };
+
+    detectedRootParam = new juce::AudioParameterChoice(
+        juce::ParameterID(PARAM_DETECTED_ROOT, 1),
+        "Detected Root", pitchClassChoices, 0);
+    detectedQualityParam = new juce::AudioParameterChoice(
+        juce::ParameterID(PARAM_DETECTED_QUALITY, 1),
+        "Detected Quality", qualityChoices, 0);
+    detectedBassParam = new juce::AudioParameterChoice(
+        juce::ParameterID(PARAM_DETECTED_BASS, 1),
+        "Detected Bass", pitchClassChoices, 0);
+    detectedInversionParam = new juce::AudioParameterChoice(
+        juce::ParameterID(PARAM_DETECTED_INVERSION, 1),
+        "Detected Inversion", inversionChoices, 0);
+
+    addParameter(detectedRootParam);
+    addParameter(detectedQualityParam);
+    addParameter(detectedBassParam);
+    addParameter(detectedInversionParam);
+
+    startTimer(50);  // 20Hz publishing of detection results to host parameters
 }
 
 ChordAnalyzerProcessor::~ChordAnalyzerProcessor()
@@ -64,6 +116,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout ChordAnalyzerProcessor::crea
         juce::ParameterID(PARAM_SHOW_INVERSIONS, 1),
         "Show Inversions",
         true));  // Default to showing inversions
+
+    // NOTE: detection-output parameters are added directly to the processor
+    // (not APVTS-managed) in the constructor body — see ctor for rationale.
 
     return {params.begin(), params.end()};
 }
@@ -150,10 +205,11 @@ void ChordAnalyzerProcessor::releaseResources()
 void ChordAnalyzerProcessor::processBlock(juce::AudioBuffer<float>& buffer,
                                            juce::MidiBuffer& midiMessages)
 {
-#if CHORD_ANALYZER_FX_MODE
-    // FX mode: pass audio through unchanged (acts as an insert effect)
+#if CHORD_ANALYZER_MIDI_MODE
+    // MIDI-only mode: no audio buses (buffer is empty)
+    juce::ignoreUnused(buffer);
 #else
-    // Instrument mode: produce silence (no audio to generate)
+    // Instrument mode (synth): produce silence
     buffer.clear();
 #endif
 
@@ -253,6 +309,8 @@ void ChordAnalyzerProcessor::updateAnalysis()
             currentChord = newChord;
             chordChangedFlag.store(true);
 
+            stageDetectedChord(newChord);
+
             // Record the chord if recording
             const juce::SpinLock::ScopedLockType recLock(recorderLock);
             if (recorder.isRecording())
@@ -263,6 +321,39 @@ void ChordAnalyzerProcessor::updateAnalysis()
 
         currentSuggestions = std::move(newSuggestions);
     }
+}
+
+//==============================================================================
+void ChordAnalyzerProcessor::stageDetectedChord(const ChordInfo& chord)
+{
+    // Audio thread: stage detection results into atomics. The Timer publishes
+    // them on the message thread (where setValueNotifyingHost is host-safe).
+    // Choice index 0 always represents "no chord / unknown".
+    const int rootIndex      = (chord.isValid && chord.rootNote >= 0 && chord.rootNote < 12)
+                                  ? chord.rootNote + 1 : 0;
+    const int bassIndex      = (chord.isValid && chord.bassNote >= 0 && chord.bassNote < 12)
+                                  ? chord.bassNote + 1 : 0;
+    const int qualityIndex   = (chord.isValid && chord.quality != ChordQuality::Unknown)
+                                  ? static_cast<int>(chord.quality) + 1 : 0;
+    const int inversionIndex = chord.isValid
+                                  ? juce::jlimit(0, 4, chord.inversion + 1) : 0;
+
+    pendingRootIndex.store(rootIndex);
+    pendingQualityIndex.store(qualityIndex);
+    pendingBassIndex.store(bassIndex);
+    pendingInversionIndex.store(inversionIndex);
+    detectionDirty.store(true);
+}
+
+void ChordAnalyzerProcessor::timerCallback()
+{
+    if (! detectionDirty.exchange(false))
+        return;
+
+    if (detectedRootParam      != nullptr) *detectedRootParam      = pendingRootIndex.load();
+    if (detectedQualityParam   != nullptr) *detectedQualityParam   = pendingQualityIndex.load();
+    if (detectedBassParam      != nullptr) *detectedBassParam      = pendingBassIndex.load();
+    if (detectedInversionParam != nullptr) *detectedInversionParam = pendingInversionIndex.load();
 }
 
 //==============================================================================

--- a/plugins/chord-analyzer/Source/PluginProcessor.h
+++ b/plugins/chord-analyzer/Source/PluginProcessor.h
@@ -7,7 +7,8 @@
 
 //==============================================================================
 class ChordAnalyzerProcessor : public juce::AudioProcessor,
-                                public juce::AudioProcessorValueTreeState::Listener
+                                public juce::AudioProcessorValueTreeState::Listener,
+                                private juce::Timer
 {
 public:
     ChordAnalyzerProcessor();
@@ -23,7 +24,14 @@ public:
     // MIDI effect characteristics
     bool acceptsMidi() const override { return true; }
     bool producesMidi() const override { return true; }  // MIDI pass-through
-    bool isMidiEffect() const override { return false; }
+    bool isMidiEffect() const override
+    {
+       #if CHORD_ANALYZER_MIDI_MODE
+        return true;
+       #else
+        return false;
+       #endif
+    }
     double getTailLengthSeconds() const override { return 0.0; }
 
     //==========================================================================
@@ -79,6 +87,14 @@ public:
     static constexpr const char* PARAM_SUGGESTION_LEVEL = "suggestionLevel";
     static constexpr const char* PARAM_SHOW_INVERSIONS = "showInversions";
 
+    // Output (read-only) parameters — populated by the processor so headless
+    // hosts (e.g. Zynthian, generic Reaper view) can display detection results
+    // without instantiating the editor.
+    static constexpr const char* PARAM_DETECTED_ROOT      = "detectedRoot";
+    static constexpr const char* PARAM_DETECTED_QUALITY   = "detectedQuality";
+    static constexpr const char* PARAM_DETECTED_BASS      = "detectedBass";
+    static constexpr const char* PARAM_DETECTED_INVERSION = "detectedInversion";
+
 private:
     juce::AudioProcessorValueTreeState parameters;
 
@@ -118,6 +134,24 @@ private:
     //==========================================================================
     void processMidiInput(const juce::MidiBuffer& midi);
     void updateAnalysis();
+    void stageDetectedChord(const ChordInfo& chord);   // audio thread: store atomic snapshot
+    void timerCallback() override;                     // message thread: publish to host params
+
+    //==========================================================================
+    // Cached pointers to output parameters (populated in ctor).
+    juce::AudioParameterChoice* detectedRootParam = nullptr;
+    juce::AudioParameterChoice* detectedQualityParam = nullptr;
+    juce::AudioParameterChoice* detectedBassParam = nullptr;
+    juce::AudioParameterChoice* detectedInversionParam = nullptr;
+
+    // Atomic snapshot of detection results, written from the audio thread and
+    // published to the host on the message thread (Reaper and others don't
+    // refresh their parameter display from audio-thread setValueNotifyingHost).
+    std::atomic<int>  pendingRootIndex{0};
+    std::atomic<int>  pendingQualityIndex{0};
+    std::atomic<int>  pendingBassIndex{0};
+    std::atomic<int>  pendingInversionIndex{0};
+    std::atomic<bool> detectionDirty{false};
 
     static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
 

--- a/plugins/chord-analyzer/lv2/chord-analyzer-headless.ttl
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-headless.ttl
@@ -1,0 +1,195 @@
+@prefix atom: <http://lv2plug.in/ns/ext/atom#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix midi: <http://lv2plug.in/ns/ext/midi#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rsz:  <http://lv2plug.in/ns/ext/resize-port#> .
+@prefix urid: <http://lv2plug.in/ns/ext/urid#> .
+
+<https://dusk-audio.github.io/plugins/chord-analyzer-headless>
+    a lv2:Plugin , lv2:MIDIPlugin ;
+    doap:name "Chord Analyzer Headless" ;
+    doap:license <http://opensource.org/licenses/MIT> ;
+    doap:maintainer [
+        a foaf:Person ;
+        foaf:name "Dusk Audio" ;
+        foaf:homepage <https://dusk-audio.github.io/> ;
+    ] ;
+    lv2:requiredFeature urid:map ;
+    lv2:optionalFeature lv2:hardRTCapable ;
+
+    lv2:port [
+        a lv2:InputPort , atom:AtomPort ;
+        atom:bufferType atom:Sequence ;
+        atom:supports midi:MidiEvent ;
+        rsz:minimumSize 8192 ;
+        lv2:designation lv2:control ;
+        lv2:index 0 ;
+        lv2:symbol "midi_in" ;
+        lv2:name "MIDI In"
+    ] , [
+        a lv2:OutputPort , atom:AtomPort ;
+        atom:bufferType atom:Sequence ;
+        atom:supports midi:MidiEvent ;
+        rsz:minimumSize 8192 ;
+        lv2:designation lv2:control ;
+        lv2:index 1 ;
+        lv2:symbol "midi_out" ;
+        lv2:name "MIDI Out"
+    ] , [
+        a lv2:InputPort , lv2:ControlPort ;
+        lv2:index 2 ;
+        lv2:symbol "key_root" ;
+        lv2:name "Key Root" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 11 ;
+        lv2:portProperty lv2:integer , lv2:enumeration ;
+        lv2:scalePoint [ rdfs:label "C"     ; rdf:value 0 ] ,
+                       [ rdfs:label "C#/Db" ; rdf:value 1 ] ,
+                       [ rdfs:label "D"     ; rdf:value 2 ] ,
+                       [ rdfs:label "D#/Eb" ; rdf:value 3 ] ,
+                       [ rdfs:label "E"     ; rdf:value 4 ] ,
+                       [ rdfs:label "F"     ; rdf:value 5 ] ,
+                       [ rdfs:label "F#/Gb" ; rdf:value 6 ] ,
+                       [ rdfs:label "G"     ; rdf:value 7 ] ,
+                       [ rdfs:label "G#/Ab" ; rdf:value 8 ] ,
+                       [ rdfs:label "A"     ; rdf:value 9 ] ,
+                       [ rdfs:label "A#/Bb" ; rdf:value 10 ] ,
+                       [ rdfs:label "B"     ; rdf:value 11 ]
+    ] , [
+        a lv2:InputPort , lv2:ControlPort ;
+        lv2:index 3 ;
+        lv2:symbol "key_mode" ;
+        lv2:name "Key Mode" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:integer , lv2:enumeration ;
+        lv2:scalePoint [ rdfs:label "Major" ; rdf:value 0 ] ,
+                       [ rdfs:label "Minor" ; rdf:value 1 ]
+    ] , [
+        a lv2:InputPort , lv2:ControlPort ;
+        lv2:index 4 ;
+        lv2:symbol "suggestion_level" ;
+        lv2:name "Suggestion Level" ;
+        lv2:default 2 ;
+        lv2:minimum 0 ;
+        lv2:maximum 2 ;
+        lv2:portProperty lv2:integer , lv2:enumeration ;
+        lv2:scalePoint [ rdfs:label "Basic"                ; rdf:value 0 ] ,
+                       [ rdfs:label "Basic + Intermediate" ; rdf:value 1 ] ,
+                       [ rdfs:label "All (+ Advanced)"     ; rdf:value 2 ]
+    ] , [
+        a lv2:InputPort , lv2:ControlPort ;
+        lv2:index 5 ;
+        lv2:symbol "show_inversions" ;
+        lv2:name "Show Inversions" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:integer , lv2:toggled
+    ] , [
+        a lv2:OutputPort , lv2:ControlPort ;
+        lv2:index 6 ;
+        lv2:symbol "detected_root" ;
+        lv2:name "Detected Root" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 12 ;
+        lv2:portProperty lv2:integer , lv2:enumeration ;
+        lv2:scalePoint [ rdfs:label "-"     ; rdf:value 0 ] ,
+                       [ rdfs:label "C"     ; rdf:value 1 ] ,
+                       [ rdfs:label "C#/Db" ; rdf:value 2 ] ,
+                       [ rdfs:label "D"     ; rdf:value 3 ] ,
+                       [ rdfs:label "D#/Eb" ; rdf:value 4 ] ,
+                       [ rdfs:label "E"     ; rdf:value 5 ] ,
+                       [ rdfs:label "F"     ; rdf:value 6 ] ,
+                       [ rdfs:label "F#/Gb" ; rdf:value 7 ] ,
+                       [ rdfs:label "G"     ; rdf:value 8 ] ,
+                       [ rdfs:label "G#/Ab" ; rdf:value 9 ] ,
+                       [ rdfs:label "A"     ; rdf:value 10 ] ,
+                       [ rdfs:label "A#/Bb" ; rdf:value 11 ] ,
+                       [ rdfs:label "B"     ; rdf:value 12 ]
+    ] , [
+        a lv2:OutputPort , lv2:ControlPort ;
+        lv2:index 7 ;
+        lv2:symbol "detected_quality" ;
+        lv2:name "Detected Quality" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 33 ;
+        lv2:portProperty lv2:integer , lv2:enumeration ;
+        lv2:scalePoint [ rdfs:label "-"       ; rdf:value 0 ] ,
+                       [ rdfs:label "maj"     ; rdf:value 1 ] ,
+                       [ rdfs:label "m"       ; rdf:value 2 ] ,
+                       [ rdfs:label "dim"     ; rdf:value 3 ] ,
+                       [ rdfs:label "aug"     ; rdf:value 4 ] ,
+                       [ rdfs:label "7"       ; rdf:value 5 ] ,
+                       [ rdfs:label "maj7"    ; rdf:value 6 ] ,
+                       [ rdfs:label "m7"      ; rdf:value 7 ] ,
+                       [ rdfs:label "mMaj7"   ; rdf:value 8 ] ,
+                       [ rdfs:label "dim7"    ; rdf:value 9 ] ,
+                       [ rdfs:label "m7b5"    ; rdf:value 10 ] ,
+                       [ rdfs:label "aug7"    ; rdf:value 11 ] ,
+                       [ rdfs:label "augMaj7" ; rdf:value 12 ] ,
+                       [ rdfs:label "sus2"    ; rdf:value 13 ] ,
+                       [ rdfs:label "sus4"    ; rdf:value 14 ] ,
+                       [ rdfs:label "7sus4"   ; rdf:value 15 ] ,
+                       [ rdfs:label "add9"    ; rdf:value 16 ] ,
+                       [ rdfs:label "add11"   ; rdf:value 17 ] ,
+                       [ rdfs:label "6"       ; rdf:value 18 ] ,
+                       [ rdfs:label "m6"      ; rdf:value 19 ] ,
+                       [ rdfs:label "maj9"    ; rdf:value 20 ] ,
+                       [ rdfs:label "m9"      ; rdf:value 21 ] ,
+                       [ rdfs:label "9"       ; rdf:value 22 ] ,
+                       [ rdfs:label "maj11"   ; rdf:value 23 ] ,
+                       [ rdfs:label "m11"     ; rdf:value 24 ] ,
+                       [ rdfs:label "11"      ; rdf:value 25 ] ,
+                       [ rdfs:label "maj13"   ; rdf:value 26 ] ,
+                       [ rdfs:label "m13"     ; rdf:value 27 ] ,
+                       [ rdfs:label "13"      ; rdf:value 28 ] ,
+                       [ rdfs:label "5"       ; rdf:value 29 ] ,
+                       [ rdfs:label "7b5"     ; rdf:value 30 ] ,
+                       [ rdfs:label "7#5"     ; rdf:value 31 ] ,
+                       [ rdfs:label "7b9"     ; rdf:value 32 ] ,
+                       [ rdfs:label "7#9"     ; rdf:value 33 ]
+    ] , [
+        a lv2:OutputPort , lv2:ControlPort ;
+        lv2:index 8 ;
+        lv2:symbol "detected_bass" ;
+        lv2:name "Detected Bass" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 12 ;
+        lv2:portProperty lv2:integer , lv2:enumeration ;
+        lv2:scalePoint [ rdfs:label "-"     ; rdf:value 0 ] ,
+                       [ rdfs:label "C"     ; rdf:value 1 ] ,
+                       [ rdfs:label "C#/Db" ; rdf:value 2 ] ,
+                       [ rdfs:label "D"     ; rdf:value 3 ] ,
+                       [ rdfs:label "D#/Eb" ; rdf:value 4 ] ,
+                       [ rdfs:label "E"     ; rdf:value 5 ] ,
+                       [ rdfs:label "F"     ; rdf:value 6 ] ,
+                       [ rdfs:label "F#/Gb" ; rdf:value 7 ] ,
+                       [ rdfs:label "G"     ; rdf:value 8 ] ,
+                       [ rdfs:label "G#/Ab" ; rdf:value 9 ] ,
+                       [ rdfs:label "A"     ; rdf:value 10 ] ,
+                       [ rdfs:label "A#/Bb" ; rdf:value 11 ] ,
+                       [ rdfs:label "B"     ; rdf:value 12 ]
+    ] , [
+        a lv2:OutputPort , lv2:ControlPort ;
+        lv2:index 9 ;
+        lv2:symbol "detected_inversion" ;
+        lv2:name "Detected Inversion" ;
+        lv2:default 0 ;
+        lv2:minimum 0 ;
+        lv2:maximum 4 ;
+        lv2:portProperty lv2:integer , lv2:enumeration ;
+        lv2:scalePoint [ rdfs:label "-"    ; rdf:value 0 ] ,
+                       [ rdfs:label "Root" ; rdf:value 1 ] ,
+                       [ rdfs:label "1st"  ; rdf:value 2 ] ,
+                       [ rdfs:label "2nd"  ; rdf:value 3 ] ,
+                       [ rdfs:label "3rd"  ; rdf:value 4 ]
+    ] .

--- a/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
@@ -1,0 +1,229 @@
+// Native LV2 wrapper — "Chord Analyzer Headless".
+//
+// Why this exists: JUCE's LV2 wrapper exposes plugin parameters via the
+// LV2 patch:Message atom mechanism, not as native lv2:OutputPort + lv2:ControlPort.
+// Hosts like Zynthian only display values written to native output control ports
+// (the same pattern used by Ardour's a-comp.lv2). This wrapper bypasses JUCE's
+// LV2 layer entirely and emits proper output control ports for chord detection
+// results so headless LV2 hosts can render the detected chord in their own UI.
+//
+// Distinct from "Chord Analyzer MIDI" (JUCE-built across VST3/AU/LV2 with the
+// custom UI). Use the MIDI variant for desktop hosts that want the visualizer;
+// use this one for Zynthian and similar headless setups.
+
+#include <lv2/core/lv2.h>
+#include <lv2/atom/atom.h>
+#include <lv2/atom/util.h>
+#include <lv2/midi/midi.h>
+#include <lv2/urid/urid.h>
+
+#include <algorithm>
+#include <cstring>
+#include <new>
+#include <vector>
+
+#include "../Source/ChordAnalyzer.h"
+
+#define CHORD_ANALYZER_HEADLESS_URI "https://dusk-audio.github.io/plugins/chord-analyzer-headless"
+
+namespace
+{
+enum PortIndex : uint32_t
+{
+    PORT_MIDI_IN            = 0,
+    PORT_MIDI_OUT           = 1,
+    PORT_KEY_ROOT           = 2,
+    PORT_KEY_MODE           = 3,
+    PORT_SUGGESTION_LEVEL   = 4,
+    PORT_SHOW_INVERSIONS    = 5,
+    PORT_DETECTED_ROOT      = 6,
+    PORT_DETECTED_QUALITY   = 7,
+    PORT_DETECTED_BASS      = 8,
+    PORT_DETECTED_INVERSION = 9,
+};
+
+struct ChordAnalyzerLV2
+{
+    LV2_URID_Map* map           = nullptr;
+    LV2_URID      midiEventURID = 0;
+
+    const LV2_Atom_Sequence* midiIn  = nullptr;
+    LV2_Atom_Sequence*       midiOut = nullptr;
+
+    const float* keyRoot         = nullptr;
+    const float* keyMode         = nullptr;
+    const float* suggestionLevel = nullptr;
+    const float* showInversions  = nullptr;
+
+    float* detectedRoot      = nullptr;
+    float* detectedQuality   = nullptr;
+    float* detectedBass      = nullptr;
+    float* detectedInversion = nullptr;
+
+    ChordAnalyzer    analyzer;
+    std::vector<int> activeNotes;
+    ChordInfo        currentChord;
+};
+
+void publishDetectedChord (ChordAnalyzerLV2& self, const ChordInfo& chord)
+{
+    // Choice index 0 == "no chord / unknown". Indices 1..N follow the same
+    // order used by the JUCE-built variant for cross-format consistency.
+    const int rootIndex      = (chord.isValid && chord.rootNote >= 0 && chord.rootNote < 12)
+                                 ? chord.rootNote + 1 : 0;
+    const int bassIndex      = (chord.isValid && chord.bassNote >= 0 && chord.bassNote < 12)
+                                 ? chord.bassNote + 1 : 0;
+    const int qualityIndex   = (chord.isValid && chord.quality != ChordQuality::Unknown)
+                                 ? static_cast<int> (chord.quality) + 1 : 0;
+    const int inversionIndex = chord.isValid
+                                 ? std::clamp (chord.inversion + 1, 0, 4) : 0;
+
+    if (self.detectedRoot      != nullptr) *self.detectedRoot      = static_cast<float> (rootIndex);
+    if (self.detectedQuality   != nullptr) *self.detectedQuality   = static_cast<float> (qualityIndex);
+    if (self.detectedBass      != nullptr) *self.detectedBass      = static_cast<float> (bassIndex);
+    if (self.detectedInversion != nullptr) *self.detectedInversion = static_cast<float> (inversionIndex);
+}
+
+LV2_Handle instantiate (const LV2_Descriptor*,
+                        double /*sampleRate*/,
+                        const char* /*bundlePath*/,
+                        const LV2_Feature* const* features)
+{
+    auto* self = new (std::nothrow) ChordAnalyzerLV2();
+    if (self == nullptr)
+        return nullptr;
+
+    for (int i = 0; features[i] != nullptr; ++i)
+    {
+        if (std::strcmp (features[i]->URI, LV2_URID__map) == 0)
+            self->map = static_cast<LV2_URID_Map*> (features[i]->data);
+    }
+
+    if (self->map == nullptr)
+    {
+        delete self;
+        return nullptr;
+    }
+
+    self->midiEventURID = self->map->map (self->map->handle, LV2_MIDI__MidiEvent);
+    self->activeNotes.reserve (16);
+
+    return static_cast<LV2_Handle> (self);
+}
+
+void connect_port (LV2_Handle instance, uint32_t port, void* data)
+{
+    auto* self = static_cast<ChordAnalyzerLV2*> (instance);
+
+    switch (static_cast<PortIndex> (port))
+    {
+        case PORT_MIDI_IN:            self->midiIn            = static_cast<const LV2_Atom_Sequence*> (data); break;
+        case PORT_MIDI_OUT:           self->midiOut           = static_cast<LV2_Atom_Sequence*>       (data); break;
+        case PORT_KEY_ROOT:           self->keyRoot           = static_cast<const float*>             (data); break;
+        case PORT_KEY_MODE:           self->keyMode           = static_cast<const float*>             (data); break;
+        case PORT_SUGGESTION_LEVEL:   self->suggestionLevel   = static_cast<const float*>             (data); break;
+        case PORT_SHOW_INVERSIONS:    self->showInversions    = static_cast<const float*>             (data); break;
+        case PORT_DETECTED_ROOT:      self->detectedRoot      = static_cast<float*>                   (data); break;
+        case PORT_DETECTED_QUALITY:   self->detectedQuality   = static_cast<float*>                   (data); break;
+        case PORT_DETECTED_BASS:      self->detectedBass      = static_cast<float*>                   (data); break;
+        case PORT_DETECTED_INVERSION: self->detectedInversion = static_cast<float*>                   (data); break;
+    }
+}
+
+void activate (LV2_Handle) {}
+
+void run (LV2_Handle instance, uint32_t /*nSamples*/)
+{
+    auto* self = static_cast<ChordAnalyzerLV2*> (instance);
+
+    if (self->midiIn == nullptr || self->midiOut == nullptr)
+        return;
+
+    // Refresh key context from input control ports
+    if (self->keyRoot != nullptr && self->keyMode != nullptr)
+    {
+        const int keyRootInt = std::clamp (static_cast<int> (*self->keyRoot), 0, 11);
+        const bool isMinor   = (*self->keyMode) > 0.5f;
+        self->analyzer.setKey (keyRootInt, isMinor);
+    }
+
+    // Prepare output MIDI atom sequence — capacity is the size advertised by the host.
+    const uint32_t outCapacity = self->midiOut->atom.size;
+    lv2_atom_sequence_clear (self->midiOut);
+    self->midiOut->atom.type = self->midiIn->atom.type;
+
+    bool notesChanged = false;
+
+    LV2_ATOM_SEQUENCE_FOREACH (self->midiIn, ev)
+    {
+        // Forward every event so downstream synths still receive the MIDI stream
+        lv2_atom_sequence_append_event (self->midiOut, outCapacity, ev);
+
+        if (ev->body.type != self->midiEventURID)
+            continue;
+
+        const auto* msg = reinterpret_cast<const uint8_t*> (ev + 1);
+        if (ev->body.size < 3)
+            continue;
+
+        const uint8_t status   = static_cast<uint8_t> (msg[0] & 0xF0);
+        const int     noteNum  = msg[1] & 0x7F;
+        const uint8_t velocity = msg[2] & 0x7F;
+
+        if (status == LV2_MIDI_MSG_NOTE_ON && velocity > 0)
+        {
+            if (std::find (self->activeNotes.begin(), self->activeNotes.end(), noteNum) == self->activeNotes.end())
+            {
+                self->activeNotes.push_back (noteNum);
+                notesChanged = true;
+            }
+        }
+        else if (status == LV2_MIDI_MSG_NOTE_OFF
+                 || (status == LV2_MIDI_MSG_NOTE_ON && velocity == 0))
+        {
+            auto it = std::find (self->activeNotes.begin(), self->activeNotes.end(), noteNum);
+            if (it != self->activeNotes.end())
+            {
+                self->activeNotes.erase (it);
+                notesChanged = true;
+            }
+        }
+    }
+
+    if (! notesChanged)
+        return;
+
+    const ChordInfo newChord = self->analyzer.analyze (self->activeNotes);
+    if (newChord != self->currentChord)
+    {
+        self->currentChord = newChord;
+        publishDetectedChord (*self, newChord);
+    }
+}
+
+void deactivate (LV2_Handle) {}
+
+void cleanup (LV2_Handle instance)
+{
+    delete static_cast<ChordAnalyzerLV2*> (instance);
+}
+
+const void* extension_data (const char*) { return nullptr; }
+
+const LV2_Descriptor descriptor = {
+    CHORD_ANALYZER_HEADLESS_URI,
+    instantiate,
+    connect_port,
+    activate,
+    run,
+    deactivate,
+    cleanup,
+    extension_data,
+};
+} // namespace
+
+LV2_SYMBOL_EXPORT
+const LV2_Descriptor* lv2_descriptor (uint32_t index)
+{
+    return index == 0 ? &descriptor : nullptr;
+}

--- a/plugins/chord-analyzer/lv2/manifest.ttl
+++ b/plugins/chord-analyzer/lv2/manifest.ttl
@@ -1,0 +1,7 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://dusk-audio.github.io/plugins/chord-analyzer-headless>
+    a lv2:Plugin ;
+    lv2:binary <ChordAnalyzerHeadless.so> ;
+    rdfs:seeAlso <chord-analyzer-headless.ttl> .


### PR DESCRIPTION
## Summary
- Replace short-lived `Chord Analyzer FX` with `Chord Analyzer MIDI` (`IS_MIDI_EFFECT TRUE`, no audio buses) — fixes #62 by letting hosts (Zynthian, Logic, Reaper, Bitwig, Cubase) route it to their MIDI / Note FX chain. JUCE-built MIDI variant ships VST3 + AU + LV2 with the full visualizer UI.
- Add native LV2 wrapper **Chord Analyzer Headless** (`plugins/chord-analyzer/lv2/`) that declares `lv2:OutputPort + lv2:ControlPort` for detected root/quality/bass/inversion — same pattern as Ardour's a-comp.lv2 — so headless LV2 hosts (Zynthian) render the detected chord in their own UI. Distinct URI / bundle / binary so it coexists with the JUCE-built MIDI LV2.
- Add four read-only **Detected Root / Quality / Bass / Inversion** parameters (added directly to the processor, bypassing APVTS sync) plus a 20 Hz Timer that publishes results from the message thread so generic host UIs refresh. Disable `JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS` to suppress the 2048 phantom MIDI-CC parameters that cluttered Reaper's strip.
- CI: build target list updated; `carve_headless()` helper splits the headless bundle into a separate `chord-analyzer-headless-{linux,linux-arm64,macos}.zip` so Zynthian users can grab a clean, dedicated download.

Three resulting variants:

| Variant | URI / Bundle | Use |
|---|---|---|
| Chord Analyzer | `chord-analyzer` | FL Studio / Ableton (instrument slot) |
| Chord Analyzer MIDI | `chord-analyzer-midi` | Logic, Reaper, Bitwig, Cubase, Ardour, Carla (full UI in MIDI / Note FX slot) |
| Chord Analyzer Headless | `chord-analyzer-headless` | Zynthian + other headless LV2 hosts (no UI; output ControlPorts) |

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Chord Analyzer MIDI plugin variant for MIDI-only use cases.
  * Introduced headless LV2 plugin variant for standalone chord analysis without audio processing.
  * Exposed detection outputs as controllable parameters: Detected Root, Detected Quality, Detected Bass, and Detected Inversion.

* **Chores**
  * Updated release builds to generate three distinct plugin variants with separate distribution archives.
  * Updated release documentation to clarify when to download the headless LV2 variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->