### PR TITLE
Chord Analyzer: respect MIDI sustain pedal (CC 64) for transcription …

### DIFF
--- a/plugins/chord-analyzer/Source/PluginProcessor.cpp
+++ b/plugins/chord-analyzer/Source/PluginProcessor.cpp
@@ -20,12 +20,16 @@ ChordAnalyzerProcessor::ChordAnalyzerProcessor()
     parameters.addParameterListener(PARAM_KEY_MODE, this);
     parameters.addParameterListener(PARAM_SUGGESTION_LEVEL, this);
     parameters.addParameterListener(PARAM_SHOW_INVERSIONS, this);
+    parameters.addParameterListener(PARAM_RESPECT_SUSTAIN, this);
 
     // Initialize from current parameter values
     keyRoot.store(static_cast<int>(*parameters.getRawParameterValue(PARAM_KEY_ROOT)));
     keyMinor.store(*parameters.getRawParameterValue(PARAM_KEY_MODE) > 0.5f);
     suggestionLevel.store(static_cast<int>(*parameters.getRawParameterValue(PARAM_SUGGESTION_LEVEL)));
     showInversions.store(*parameters.getRawParameterValue(PARAM_SHOW_INVERSIONS) > 0.5f);
+    respectSustain.store(*parameters.getRawParameterValue(PARAM_RESPECT_SUSTAIN) > 0.5f);
+
+    sustainedReleasedNotes.reserve(16);
 
     analyzer.setKey(keyRoot.load(), keyMinor.load());
 
@@ -82,6 +86,7 @@ ChordAnalyzerProcessor::~ChordAnalyzerProcessor()
     parameters.removeParameterListener(PARAM_KEY_MODE, this);
     parameters.removeParameterListener(PARAM_SUGGESTION_LEVEL, this);
     parameters.removeParameterListener(PARAM_SHOW_INVERSIONS, this);
+    parameters.removeParameterListener(PARAM_RESPECT_SUSTAIN, this);
 }
 
 //==============================================================================
@@ -116,6 +121,14 @@ juce::AudioProcessorValueTreeState::ParameterLayout ChordAnalyzerProcessor::crea
         juce::ParameterID(PARAM_SHOW_INVERSIONS, 1),
         "Show Inversions",
         true));  // Default to showing inversions
+
+    // Respect sustain pedal — when on, MIDI CC 64 holds the detected chord
+    // until the pedal is released (matches piano hardware behaviour, useful
+    // for transcription workflows where players want to lift their hands).
+    params.push_back(std::make_unique<juce::AudioParameterBool>(
+        juce::ParameterID(PARAM_RESPECT_SUSTAIN, 1),
+        "Respect Sustain",
+        true));
 
     // NOTE: detection-output parameters are added directly to the processor
     // (not APVTS-managed) in the constructor body — see ctor for rationale.
@@ -152,6 +165,10 @@ void ChordAnalyzerProcessor::parameterChanged(const juce::String& parameterID, f
     else if (parameterID == PARAM_SHOW_INVERSIONS)
     {
         showInversions.store(newValue > 0.5f);
+    }
+    else if (parameterID == PARAM_RESPECT_SUSTAIN)
+    {
+        respectSustain.store(newValue > 0.5f);
     }
 }
 
@@ -232,6 +249,7 @@ void ChordAnalyzerProcessor::processBlock(juce::AudioBuffer<float>& buffer,
 void ChordAnalyzerProcessor::processMidiInput(const juce::MidiBuffer& midi)
 {
     bool notesChanged = false;
+    const bool sustainEnabled = respectSustain.load();
 
     for (const auto metadata : midi)
     {
@@ -239,10 +257,15 @@ void ChordAnalyzerProcessor::processMidiInput(const juce::MidiBuffer& midi)
 
         if (msg.isNoteOn())
         {
-            int noteNumber = msg.getNoteNumber();
+            const int noteNumber = msg.getNoteNumber();
             const juce::SpinLock::ScopedLockType lock(notesLock);
 
-            // Add note if not already present
+            // Re-pressing a sustained-released note cancels its deferred release
+            auto sustainedIt = std::find(sustainedReleasedNotes.begin(),
+                                         sustainedReleasedNotes.end(), noteNumber);
+            if (sustainedIt != sustainedReleasedNotes.end())
+                sustainedReleasedNotes.erase(sustainedIt);
+
             if (std::find(activeNotes.begin(), activeNotes.end(), noteNumber) == activeNotes.end())
             {
                 activeNotes.push_back(noteNumber);
@@ -251,10 +274,21 @@ void ChordAnalyzerProcessor::processMidiInput(const juce::MidiBuffer& midi)
         }
         else if (msg.isNoteOff())
         {
-            int noteNumber = msg.getNoteNumber();
-            const juce::SpinLock::ScopedLockType lock(notesLock);
+            const int noteNumber = msg.getNoteNumber();
 
-            // Remove note
+            if (sustainEnabled && sustainPedalDown)
+            {
+                // Defer the release: keep the note in activeNotes until the pedal lifts
+                if (std::find(sustainedReleasedNotes.begin(),
+                              sustainedReleasedNotes.end(), noteNumber)
+                    == sustainedReleasedNotes.end())
+                {
+                    sustainedReleasedNotes.push_back(noteNumber);
+                }
+                continue;
+            }
+
+            const juce::SpinLock::ScopedLockType lock(notesLock);
             auto it = std::find(activeNotes.begin(), activeNotes.end(), noteNumber);
             if (it != activeNotes.end())
             {
@@ -262,10 +296,34 @@ void ChordAnalyzerProcessor::processMidiInput(const juce::MidiBuffer& midi)
                 notesChanged = true;
             }
         }
+        else if (msg.isController() && msg.getControllerNumber() == 64)
+        {
+            // Sustain pedal: MIDI convention is value >= 64 → down, < 64 → up
+            const bool wasDown   = sustainPedalDown;
+            const bool nowDown   = msg.getControllerValue() >= 64;
+            sustainPedalDown     = nowDown;
+
+            if (wasDown && ! nowDown && sustainEnabled)
+            {
+                // Pedal release: drop every note that was released-while-sustained
+                const juce::SpinLock::ScopedLockType lock(notesLock);
+                for (int sustainedNote : sustainedReleasedNotes)
+                {
+                    auto it = std::find(activeNotes.begin(), activeNotes.end(), sustainedNote);
+                    if (it != activeNotes.end())
+                    {
+                        activeNotes.erase(it);
+                        notesChanged = true;
+                    }
+                }
+                sustainedReleasedNotes.clear();
+            }
+        }
         else if (msg.isAllNotesOff() || msg.isAllSoundOff())
         {
             const juce::SpinLock::ScopedLockType lock(notesLock);
             activeNotes.clear();
+            sustainedReleasedNotes.clear();
             notesChanged = true;
         }
     }

--- a/plugins/chord-analyzer/Source/PluginProcessor.cpp
+++ b/plugins/chord-analyzer/Source/PluginProcessor.cpp
@@ -303,9 +303,13 @@ void ChordAnalyzerProcessor::processMidiInput(const juce::MidiBuffer& midi)
             const bool nowDown   = msg.getControllerValue() >= 64;
             sustainPedalDown     = nowDown;
 
-            if (wasDown && ! nowDown && sustainEnabled)
+            if (wasDown && ! nowDown)
             {
-                // Pedal release: drop every note that was released-while-sustained
+                // Pedal release: drop every note whose note-off was deferred.
+                // We always flush regardless of the current sustainEnabled state —
+                // those entries reflect real player-released note-offs from when
+                // sustain was on, and would otherwise stay stuck in activeNotes
+                // if the user toggled "Respect Sustain" off while pedalling.
                 const juce::SpinLock::ScopedLockType lock(notesLock);
                 for (int sustainedNote : sustainedReleasedNotes)
                 {

--- a/plugins/chord-analyzer/Source/PluginProcessor.h
+++ b/plugins/chord-analyzer/Source/PluginProcessor.h
@@ -86,6 +86,7 @@ public:
     static constexpr const char* PARAM_KEY_MODE = "keyMode";
     static constexpr const char* PARAM_SUGGESTION_LEVEL = "suggestionLevel";
     static constexpr const char* PARAM_SHOW_INVERSIONS = "showInversions";
+    static constexpr const char* PARAM_RESPECT_SUSTAIN = "respectSustain";
 
     // Output (read-only) parameters — populated by the processor so headless
     // hosts (e.g. Zynthian, generic Reaper view) can display detection results
@@ -119,6 +120,12 @@ private:
     std::atomic<bool> keyMinor{false};
     std::atomic<int> suggestionLevel{2};  // 0=Basic, 1=+Inter, 2=All
     std::atomic<bool> showInversions{true};
+    std::atomic<bool> respectSustain{true};
+
+    //==========================================================================
+    // Sustain pedal (CC 64) state — audio-thread only, mutated in processMidiInput.
+    bool sustainPedalDown = false;
+    std::vector<int> sustainedReleasedNotes;  // notes released while pedal was down
 
     //==========================================================================
     // Timing

--- a/plugins/chord-analyzer/lv2/chord-analyzer-headless.ttl
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-headless.ttl
@@ -192,4 +192,14 @@
                        [ rdfs:label "1st"  ; rdf:value 2 ] ,
                        [ rdfs:label "2nd"  ; rdf:value 3 ] ,
                        [ rdfs:label "3rd"  ; rdf:value 4 ]
+    ] , [
+        a lv2:InputPort , lv2:ControlPort ;
+        lv2:index 10 ;
+        lv2:symbol "respect_sustain" ;
+        lv2:name "Respect Sustain" ;
+        lv2:default 1 ;
+        lv2:minimum 0 ;
+        lv2:maximum 1 ;
+        lv2:portProperty lv2:integer , lv2:toggled ;
+        rdfs:comment "When on, MIDI CC 64 (sustain pedal) holds the detected chord until the pedal is released."
     ] .

--- a/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
@@ -40,6 +40,9 @@ enum PortIndex : uint32_t
     PORT_DETECTED_QUALITY   = 7,
     PORT_DETECTED_BASS      = 8,
     PORT_DETECTED_INVERSION = 9,
+    PORT_RESPECT_SUSTAIN    = 10,  // appended after detection ports to keep
+                                    // existing port indices stable for hosts
+                                    // that already cached the v1.1.0 layout
 };
 
 struct ChordAnalyzerLV2
@@ -54,6 +57,7 @@ struct ChordAnalyzerLV2
     const float* keyMode         = nullptr;
     const float* suggestionLevel = nullptr;
     const float* showInversions  = nullptr;
+    const float* respectSustain  = nullptr;
 
     float* detectedRoot      = nullptr;
     float* detectedQuality   = nullptr;
@@ -63,6 +67,10 @@ struct ChordAnalyzerLV2
     ChordAnalyzer    analyzer;
     std::vector<int> activeNotes;
     ChordInfo        currentChord;
+
+    // Sustain pedal (CC 64) state — single audio thread, no synchronisation needed.
+    bool             sustainPedalDown = false;
+    std::vector<int> sustainedReleasedNotes;  // notes released while pedal was down
 };
 
 void publishDetectedChord (ChordAnalyzerLV2& self, const ChordInfo& chord)
@@ -107,6 +115,7 @@ LV2_Handle instantiate (const LV2_Descriptor*,
 
     self->midiEventURID = self->map->map (self->map->handle, LV2_MIDI__MidiEvent);
     self->activeNotes.reserve (16);
+    self->sustainedReleasedNotes.reserve (16);
 
     return static_cast<LV2_Handle> (self);
 }
@@ -127,6 +136,7 @@ void connect_port (LV2_Handle instance, uint32_t port, void* data)
         case PORT_DETECTED_QUALITY:   self->detectedQuality   = static_cast<float*>                   (data); break;
         case PORT_DETECTED_BASS:      self->detectedBass      = static_cast<float*>                   (data); break;
         case PORT_DETECTED_INVERSION: self->detectedInversion = static_cast<float*>                   (data); break;
+        case PORT_RESPECT_SUSTAIN:    self->respectSustain    = static_cast<const float*>             (data); break;
     }
 }
 
@@ -152,7 +162,8 @@ void run (LV2_Handle instance, uint32_t /*nSamples*/)
     lv2_atom_sequence_clear (self->midiOut);
     self->midiOut->atom.type = self->midiIn->atom.type;
 
-    bool notesChanged = false;
+    bool       notesChanged    = false;
+    const bool sustainEnabled  = (self->respectSustain != nullptr) && (*self->respectSustain) > 0.5f;
 
     LV2_ATOM_SEQUENCE_FOREACH (self->midiIn, ev)
     {
@@ -167,25 +178,63 @@ void run (LV2_Handle instance, uint32_t /*nSamples*/)
             continue;
 
         const uint8_t status   = static_cast<uint8_t> (msg[0] & 0xF0);
-        const int     noteNum  = msg[1] & 0x7F;
-        const uint8_t velocity = msg[2] & 0x7F;
+        const int     data1    = msg[1] & 0x7F;
+        const uint8_t data2    = msg[2] & 0x7F;
 
-        if (status == LV2_MIDI_MSG_NOTE_ON && velocity > 0)
+        if (status == LV2_MIDI_MSG_NOTE_ON && data2 > 0)
         {
-            if (std::find (self->activeNotes.begin(), self->activeNotes.end(), noteNum) == self->activeNotes.end())
+            // Re-pressing a sustained-released note cancels its deferred release
+            auto sustainedIt = std::find (self->sustainedReleasedNotes.begin(),
+                                          self->sustainedReleasedNotes.end(), data1);
+            if (sustainedIt != self->sustainedReleasedNotes.end())
+                self->sustainedReleasedNotes.erase (sustainedIt);
+
+            if (std::find (self->activeNotes.begin(), self->activeNotes.end(), data1) == self->activeNotes.end())
             {
-                self->activeNotes.push_back (noteNum);
+                self->activeNotes.push_back (data1);
                 notesChanged = true;
             }
         }
         else if (status == LV2_MIDI_MSG_NOTE_OFF
-                 || (status == LV2_MIDI_MSG_NOTE_ON && velocity == 0))
+                 || (status == LV2_MIDI_MSG_NOTE_ON && data2 == 0))
         {
-            auto it = std::find (self->activeNotes.begin(), self->activeNotes.end(), noteNum);
+            if (sustainEnabled && self->sustainPedalDown)
+            {
+                if (std::find (self->sustainedReleasedNotes.begin(),
+                               self->sustainedReleasedNotes.end(), data1)
+                    == self->sustainedReleasedNotes.end())
+                {
+                    self->sustainedReleasedNotes.push_back (data1);
+                }
+                continue;
+            }
+
+            auto it = std::find (self->activeNotes.begin(), self->activeNotes.end(), data1);
             if (it != self->activeNotes.end())
             {
                 self->activeNotes.erase (it);
                 notesChanged = true;
+            }
+        }
+        else if (status == LV2_MIDI_MSG_CONTROLLER && data1 == 64)
+        {
+            // Sustain pedal: MIDI convention is value >= 64 → down, < 64 → up
+            const bool wasDown = self->sustainPedalDown;
+            const bool nowDown = data2 >= 64;
+            self->sustainPedalDown = nowDown;
+
+            if (wasDown && ! nowDown && sustainEnabled)
+            {
+                for (int sustainedNote : self->sustainedReleasedNotes)
+                {
+                    auto it = std::find (self->activeNotes.begin(), self->activeNotes.end(), sustainedNote);
+                    if (it != self->activeNotes.end())
+                    {
+                        self->activeNotes.erase (it);
+                        notesChanged = true;
+                    }
+                }
+                self->sustainedReleasedNotes.clear();
             }
         }
     }

--- a/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
@@ -223,8 +223,12 @@ void run (LV2_Handle instance, uint32_t /*nSamples*/)
             const bool nowDown = data2 >= 64;
             self->sustainPedalDown = nowDown;
 
-            if (wasDown && ! nowDown && sustainEnabled)
+            if (wasDown && ! nowDown)
             {
+                // Always flush deferred releases on pedal-up regardless of
+                // sustainEnabled — entries here reflect real player note-offs
+                // captured while sustain was on, and would otherwise stay
+                // stuck in activeNotes if the user toggled the param off.
                 for (int sustainedNote : self->sustainedReleasedNotes)
                 {
                     auto it = std::find (self->activeNotes.begin(), self->activeNotes.end(), sustainedNote);


### PR DESCRIPTION
Closes #59. When the sustain pedal is held, defer note-offs so the detected chord stays displayed until the pedal is released — matches piano hardware behaviour and lets players take their hands off the keyboard while writing the chord down.

- Add "Respect Sustain" AudioParameterBool (default on) to JUCE processor
- Track CC 64 state and sustainedReleasedNotes in processMidiInput; flush on pedal-up; re-pressing a sustained-released note cancels its deferred release; All-Notes-Off resets all state
- Mirror the same logic in the native LV2 wrapper, with a new respect_sustain input ControlPort at index 10 (appended so existing detection-port indices stay stable for v1.1.0 saved Zynthian sessions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sustain pedal support to the chord analyzer. When enabled, the detected chord is held active while the sustain pedal is engaged, allowing continuous chord recognition without interruption across multiple note transitions. The chord releases when you lift the sustain pedal, providing better workflow control and analysis continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->