### PR TITLE
Unify double-click-to-edit knob values across all plugins

### DIFF
--- a/plugins/DuskAmp/src/PluginEditor.cpp
+++ b/plugins/DuskAmp/src/PluginEditor.cpp
@@ -4,6 +4,7 @@
 #include "FactoryPresets.h"
 #include "ParamIDs.h"
 #include "CrashLog.h"
+#include "../../shared/DuskLookAndFeel.h"   // ValueEditor::popUp
 
 // =============================================================================
 // KnobWithLabel
@@ -18,6 +19,9 @@ void KnobWithLabel::init (juce::Component& parent,
 {
     slider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
     slider.setTextBoxStyle (juce::Slider::NoTextBox, true, 0, 0);
+    // Disable JUCE's built-in double-click-resets-to-default. We use double-
+    // click for the value-editor popup instead (see ValueEditorTrigger below).
+    slider.setDoubleClickReturnValue (false, 0.0);
     if (tooltip.isNotEmpty())
         slider.setTooltip (tooltip);
     parent.addAndMakeVisible (slider);
@@ -31,11 +35,31 @@ void KnobWithLabel::init (juce::Component& parent,
     parent.addAndMakeVisible (nameLabel);
 
     valueLabel.setJustificationType (juce::Justification::centred);
-    valueLabel.setInterceptsMouseClicks (false, false);
+    valueLabel.setInterceptsMouseClicks (true, false);
     valueLabel.setFont (juce::FontOptions (11.0f));
     valueLabel.setColour (juce::Label::textColourId,
                           juce::Colour (DuskAmpLookAndFeel::kValueText));
     parent.addAndMakeVisible (valueLabel);
+
+    // Double-click → spawn ValueEditor popup over the value label. Both the
+    // knob and the value label trigger it; editor anchors over the value
+    // label so it lands exactly on the visible text.
+    struct ValueEditorTrigger : public juce::MouseListener
+    {
+        juce::Slider* slider = nullptr;
+        juce::Component* anchor = nullptr;
+        void mouseDoubleClick (const juce::MouseEvent&) override
+        {
+            if (slider != nullptr && anchor != nullptr)
+                ValueEditor::popUp (*slider, *anchor);
+        }
+    };
+    valueEditorTrigger = std::make_unique<ValueEditorTrigger>();
+    auto* trig = static_cast<ValueEditorTrigger*> (valueEditorTrigger.get());
+    trig->slider = &slider;
+    trig->anchor = &valueLabel;
+    slider    .addMouseListener (trig, false);
+    valueLabel.addMouseListener (trig, false);
 
     // Store suffix in name field for formatting
     valueLabel.setName (suffix);

--- a/plugins/DuskAmp/src/PluginEditor.h
+++ b/plugins/DuskAmp/src/PluginEditor.h
@@ -18,6 +18,7 @@ struct KnobWithLabel
     juce::Label  nameLabel;
     juce::Label  valueLabel;
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> attachment;
+    std::unique_ptr<juce::MouseListener> valueEditorTrigger;
 
     void init (juce::Component& parent, juce::AudioProcessorValueTreeState& apvts,
                const juce::String& paramID, const juce::String& displayName,

--- a/plugins/groovemind/Source/PluginEditor.cpp
+++ b/plugins/groovemind/Source/PluginEditor.cpp
@@ -9,6 +9,13 @@
 
 #include "PluginProcessor.h"
 #include "PluginEditor.h"
+#include "../../shared/DuskLookAndFeel.h"   // ValueEditor::popUp
+
+void GrooveMindEditor::ValueEditorTrigger::mouseDoubleClick(const juce::MouseEvent& e)
+{
+    if (auto* s = dynamic_cast<juce::Slider*>(e.eventComponent))
+        ValueEditor::popUp(*s, *s);
+}
 
 //==============================================================================
 GrooveMindEditor::GrooveMindEditor(GrooveMindProcessor& p)
@@ -108,6 +115,14 @@ GrooveMindEditor::GrooveMindEditor(GrooveMindProcessor& p)
     addAndMakeVisible(fillIntensitySlider);
     fillIntensityAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
         processor.getAPVTS(), "fill_intensity", fillIntensitySlider);
+
+    // Wire double-click on each slider to spawn the shared ValueEditor popup.
+    valueEditorTrigger = std::make_unique<ValueEditorTrigger>();
+    for (auto* s : { &energySlider, &grooveSlider, &swingSlider, &fillIntensitySlider })
+    {
+        s->setDoubleClickReturnValue(false, 0.0);
+        s->addMouseListener(valueEditorTrigger.get(), false);
+    }
 
     fillTriggerButton.setButtonText("Fill!");
     fillTriggerButton.onClick = [this]() {

--- a/plugins/groovemind/Source/PluginEditor.h
+++ b/plugins/groovemind/Source/PluginEditor.h
@@ -95,5 +95,13 @@ private:
     juce::Label patternCountLabel;
     juce::Label currentPatternLabel;
 
+    // Double-click → ValueEditor popup. Single shared listener for all
+    // sliders; the popup figures out which slider was hit via the event.
+    struct ValueEditorTrigger : public juce::MouseListener
+    {
+        void mouseDoubleClick(const juce::MouseEvent& e) override;
+    };
+    std::unique_ptr<ValueEditorTrigger> valueEditorTrigger;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GrooveMindEditor)
 };

--- a/plugins/multi-comp/AnalogLookAndFeel.cpp
+++ b/plugins/multi-comp/AnalogLookAndFeel.cpp
@@ -126,10 +126,10 @@ juce::Label* AnalogLookAndFeelBase::createSliderTextBox(juce::Slider& slider)
 {
     auto* label = juce::LookAndFeel_V4::createSliderTextBox(slider);
 
-    // Style the text box with better contrast
-    label->setColour(juce::Label::textColourId, juce::Colours::white);
-    label->setColour(juce::Label::backgroundColourId, juce::Colour(0x40000000));  // Semi-transparent dark background
-    label->setColour(juce::Label::outlineColourId, juce::Colour(0x30FFFFFF));     // Subtle light outline
+    // Clean text-only value, no surrounding box (matches DuskVerb style).
+    label->setColour(juce::Label::textColourId,       juce::Colours::white);
+    label->setColour(juce::Label::backgroundColourId, juce::Colours::transparentBlack);
+    label->setColour(juce::Label::outlineColourId,    juce::Colours::transparentBlack);
     label->setFont(juce::Font(juce::FontOptions(13.0f).withStyle("Bold")));
 
     return label;

--- a/plugins/multi-q/BandDetailPanel.cpp
+++ b/plugins/multi-q/BandDetailPanel.cpp
@@ -1,6 +1,7 @@
 #include "BandDetailPanel.h"
 #include "MultiQ.h"
 #include "F6KnobLookAndFeel.h"
+#include "DuskLookAndFeel.h"   // DuskSlider — gives knobs double-click → ValueEditor
 
 // Static instance of F6 knob look and feel (shared by all instances)
 static F6KnobLookAndFeel f6KnobLookAndFeel;
@@ -62,8 +63,8 @@ void BandDetailPanel::updateBandButtonColors()
 void BandDetailPanel::setupKnobs()
 {
     auto setupRotaryKnob = [this](std::unique_ptr<juce::Slider>& knob) {
-        knob = std::make_unique<juce::Slider>(juce::Slider::RotaryHorizontalVerticalDrag,
-                                               juce::Slider::NoTextBox);
+        knob = std::make_unique<DuskSlider>(juce::Slider::RotaryHorizontalVerticalDrag,
+                                             juce::Slider::NoTextBox);
         knob->setLookAndFeel(&f6KnobLookAndFeel);
         knob->setColour(juce::Slider::rotarySliderFillColourId, getBandColor(selectedBand));
         knob->setColour(juce::Slider::rotarySliderOutlineColourId, juce::Colour(0xFF404040));
@@ -96,8 +97,8 @@ void BandDetailPanel::setupKnobs()
 
     // Dynamics knobs (use orange for dynamics section)
     auto setupDynKnob = [this](std::unique_ptr<juce::Slider>& knob) {
-        knob = std::make_unique<juce::Slider>(juce::Slider::RotaryHorizontalVerticalDrag,
-                                               juce::Slider::NoTextBox);
+        knob = std::make_unique<DuskSlider>(juce::Slider::RotaryHorizontalVerticalDrag,
+                                             juce::Slider::NoTextBox);
         knob->setLookAndFeel(&f6KnobLookAndFeel);
         knob->setColour(juce::Slider::rotarySliderFillColourId, juce::Colour(0xFFff8844));
         knob->setColour(juce::Slider::rotarySliderOutlineColourId, juce::Colour(0xFF404040));
@@ -169,8 +170,8 @@ void BandDetailPanel::setupKnobs()
     addAndMakeVisible(phaseInvertButton.get());
 
     // Pan knob (stereo placement of band EQ effect)
-    panKnob = std::make_unique<juce::Slider>(juce::Slider::RotaryHorizontalVerticalDrag,
-                                              juce::Slider::NoTextBox);
+    panKnob = std::make_unique<DuskSlider>(juce::Slider::RotaryHorizontalVerticalDrag,
+                                            juce::Slider::NoTextBox);
     panKnob->setLookAndFeel(&f6KnobLookAndFeel);
     panKnob->setColour(juce::Slider::rotarySliderFillColourId, juce::Colour(0xFF66aadd));
     panKnob->setColour(juce::Slider::rotarySliderOutlineColourId, juce::Colour(0xFF404040));
@@ -309,8 +310,8 @@ void BandDetailPanel::setupMatchControls()
         processor.parameters, ParamIDs::matchLimitCut, limitCutButton);
 
     // Apply slider (-100% to +100%)
-    matchApplySlider = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal,
-                                                       juce::Slider::TextBoxRight);
+    matchApplySlider = std::make_unique<DuskSlider>(juce::Slider::LinearHorizontal,
+                                                     juce::Slider::TextBoxRight);
     matchApplySlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 50, 20);
     matchApplySlider->setTooltip("Apply amount: 100% = full correction, 0% = bypass, negative = inverse");
     matchApplySlider->setVisible(false);
@@ -323,8 +324,8 @@ void BandDetailPanel::setupMatchControls()
         processor.parameters, ParamIDs::matchApply, *matchApplySlider);
 
     // Smoothing slider (1-24 semitones)
-    matchSmoothingSlider = std::make_unique<juce::Slider>(juce::Slider::LinearHorizontal,
-                                                           juce::Slider::TextBoxRight);
+    matchSmoothingSlider = std::make_unique<DuskSlider>(juce::Slider::LinearHorizontal,
+                                                         juce::Slider::TextBoxRight);
     matchSmoothingSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 50, 20);
     matchSmoothingSlider->setTooltip("Smoothing: wider = smoother correction (in semitones, 12 = 1 octave)");
     matchSmoothingSlider->setVisible(false);

--- a/plugins/multi-q/BandDetailPanel.cpp
+++ b/plugins/multi-q/BandDetailPanel.cpp
@@ -312,7 +312,7 @@ void BandDetailPanel::setupMatchControls()
     // Apply slider (-100% to +100%)
     matchApplySlider = std::make_unique<DuskSlider>(juce::Slider::LinearHorizontal,
                                                      juce::Slider::TextBoxRight);
-    matchApplySlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 50, 20);
+    matchApplySlider->setTextBoxStyle(juce::Slider::TextBoxRight, true, 50, 20);  // isReadOnly=true: editing is double-click → ValueEditor only
     matchApplySlider->setTooltip("Apply amount: 100% = full correction, 0% = bypass, negative = inverse");
     matchApplySlider->setVisible(false);
     matchApplySlider->onValueChange = [this]() {
@@ -326,7 +326,7 @@ void BandDetailPanel::setupMatchControls()
     // Smoothing slider (1-24 semitones)
     matchSmoothingSlider = std::make_unique<DuskSlider>(juce::Slider::LinearHorizontal,
                                                          juce::Slider::TextBoxRight);
-    matchSmoothingSlider->setTextBoxStyle(juce::Slider::TextBoxRight, false, 50, 20);
+    matchSmoothingSlider->setTextBoxStyle(juce::Slider::TextBoxRight, true, 50, 20);  // isReadOnly=true: editing is double-click → ValueEditor only
     matchSmoothingSlider->setTooltip("Smoothing: wider = smoother correction (in semitones, 12 = 1 octave)");
     matchSmoothingSlider->setVisible(false);
     matchSmoothingSlider->onValueChange = [this]() {

--- a/plugins/multi-synth/MultiSynthLookAndFeel.cpp
+++ b/plugins/multi-synth/MultiSynthLookAndFeel.cpp
@@ -6,10 +6,11 @@
 
 juce::Label* MultiSynthLookAndFeelBase::createSliderTextBox(juce::Slider& slider)
 {
+    // Clean text-only value, no surrounding box (matches DuskVerb style).
     auto* label = juce::LookAndFeel_V4::createSliderTextBox(slider);
-    label->setColour(juce::Label::textColourId, colors.text);
-    label->setColour(juce::Label::backgroundColourId, juce::Colour(0x40000000));
-    label->setColour(juce::Label::outlineColourId, juce::Colour(0x20FFFFFF));
+    label->setColour(juce::Label::textColourId,       colors.text);
+    label->setColour(juce::Label::backgroundColourId, juce::Colours::transparentBlack);
+    label->setColour(juce::Label::outlineColourId,    juce::Colours::transparentBlack);
     label->setFont(juce::Font(juce::FontOptions(12.0f).withStyle("Bold")));
     return label;
 }

--- a/plugins/shared/DuskLookAndFeel.h
+++ b/plugins/shared/DuskLookAndFeel.h
@@ -61,9 +61,34 @@ public:
     }
 
 private:
+    // Forwards double-clicks from child components (e.g. the inline TextBox
+    // label) up to the slider so we can open the ValueEditor popup. Skips
+    // events targeted AT the slider itself — those are handled by the
+    // mouseDoubleClick virtual override below, and double-handling would
+    // pop the editor twice.
+    struct ChildClickProxy : public juce::MouseListener
+    {
+        DuskSlider& owner;
+        explicit ChildClickProxy(DuskSlider& o) : owner(o) {}
+        void mouseDoubleClick(const juce::MouseEvent& e) override;
+    };
+    ChildClickProxy childClickProxy { *this };
+
     void initDuskSlider()
     {
         setVelocityBasedMode(false);
+
+        // Single-click on the inline TextBox should NOT focus it for editing
+        // — value editing is exclusively double-click → ValueEditor popup,
+        // matching the DuskVerb pattern and premium-plugin convention
+        // (FabFilter, iZotope, UAD, Plugin Alliance).
+        setTextBoxIsEditable(false);
+
+        // Catch double-clicks on the TextBox child too, not just the knob
+        // body. Without this, double-clicking the value text below a knob
+        // does nothing because Label consumes the event before it reaches
+        // Slider::mouseDoubleClick.
+        addMouseListener(&childClickProxy, /*wantsEventsForChildren=*/true);
     }
 
 public:
@@ -434,6 +459,15 @@ private:
 inline void DuskSlider::mouseDoubleClick (const juce::MouseEvent&)
 {
     ValueEditor::popUp (*this, *this);
+}
+
+inline void DuskSlider::ChildClickProxy::mouseDoubleClick (const juce::MouseEvent& e)
+{
+    // Skip events that came from the slider itself — the virtual override
+    // above already handles those. Only forward child-originated events
+    // (the inline value TextBox in particular).
+    if (e.eventComponent != &owner)
+        ValueEditor::popUp (owner, owner);
 }
 
 //==============================================================================

--- a/plugins/shared/DuskLookAndFeel.h
+++ b/plugins/shared/DuskLookAndFeel.h
@@ -92,6 +92,19 @@ private:
     }
 
 public:
+    // juce::Slider::setTextBoxStyle stores `editableText = !isReadOnly` in
+    // its pimpl, then calls lookAndFeelChanged() to recreate the textbox.
+    // Since most call sites pass isReadOnly=false (JUCE's default), the
+    // call clobbers our setTextBoxIsEditable(false) from initDuskSlider.
+    // Re-assert non-editable here so the invariant holds regardless of
+    // when/how callers reconfigure the textbox.
+    void lookAndFeelChanged() override
+    {
+        juce::Slider::lookAndFeelChanged();
+        juce::Slider::setTextBoxIsEditable(false);
+    }
+
+
     void mouseDown(const juce::MouseEvent& e) override
     {
         if (e.mods.isCommandDown() || e.mods.isCtrlDown())

--- a/plugins/spectrum-analyzer/Source/UI/SettingsOverlay.h
+++ b/plugins/spectrum-analyzer/Source/UI/SettingsOverlay.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include "DuskLookAndFeel.h"   // ValueEditor::popUp (../shared/ on include path)
 
 //==============================================================================
 /**
@@ -74,6 +75,18 @@ public:
         panel.addAndMakeVisible(rangeSlider);
 
         addAndMakeVisible(panel);
+
+        // Value editing is exclusively double-click → ValueEditor popup
+        // (matches DuskVerb / Multi-Comp / etc.). Disable inline TextBox
+        // editing and JUCE's default reset-on-double-click behaviour, then
+        // listen for double-clicks on the slider AND its TextBox child.
+        valueEditorTrigger_ = std::make_unique<ValueEditorTrigger>();
+        for (auto* s : { &smoothingSlider, &slopeSlider, &decaySlider, &rangeSlider })
+        {
+            s->setDoubleClickReturnValue(false, 0.0);
+            s->setTextBoxIsEditable(false);
+            s->addMouseListener(valueEditorTrigger_.get(), /*wantsForChildren=*/true);
+        }
     }
 
     void paint(juce::Graphics& g) override
@@ -168,6 +181,26 @@ private:
 
     juce::Label rangeLabel;
     juce::Slider rangeSlider;
+
+    // Double-click → ValueEditor popup. Single shared listener for all 4
+    // sliders. Walks up from the event-component so that double-clicks on
+    // the inline TextBox label (a child of the slider) still resolve to
+    // the parent Slider.
+    struct ValueEditorTrigger : public juce::MouseListener
+    {
+        void mouseDoubleClick(const juce::MouseEvent& e) override
+        {
+            for (auto* c = e.eventComponent; c != nullptr; c = c->getParentComponent())
+            {
+                if (auto* s = dynamic_cast<juce::Slider*>(c))
+                {
+                    ValueEditor::popUp(*s, *s);
+                    return;
+                }
+            }
+        }
+    };
+    std::unique_ptr<ValueEditorTrigger> valueEditorTrigger_;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SettingsOverlay)
 };


### PR DESCRIPTION
## Summary
- Wire double-click → type-in popup in plugins that were missing it (DuskAmp, groovemind, spectrum-analyzer)
- Unify behavior in shared `DuskSlider`: `setTextBoxIsEditable(false)` + a `ChildClickProxy` MouseListener that forwards double-clicks from the inline TextBox child up to `ValueEditor::popUp`
- Convert remaining raw `juce::Slider` holdouts in `multi-q/BandDetailPanel.cpp` to `DuskSlider`
- Remove the dark `backgroundColourId` + light `outlineColourId` on inline TextBox labels in `multi-comp` / `multi-synth` so value text renders clean (matches DuskVerb)

After this, every plugin behaves identically:
- Single-click on a value: no-op
- Drag knob: adjust value
- **Double-click anywhere on knob or value text**: type-in popup (smart unit parsing — `1.5k`, `85%`, `300ms`)
- Cmd/Ctrl+click on knob: reset to default

Matches the convention used by FabFilter, iZotope, UAD, Plugin Alliance.

## Test plan
- [ ] DuskVerb — double-click any knob value, type a new number, press Enter
- [ ] DuskAmp — same, on every section (Input / Amp / Tone / Power Amp / Stomp / Cab / Delay / Reverb / Output)
- [ ] Multi-Comp — verify on Opto / FET / Studio FET / VCA / Bus / Studio VCA / Digital + multiband + sidechain controls
- [ ] Multi-Q — main band knobs + dynamics knobs + match apply/smoothing sliders
- [ ] 4k-EQ, TapeMachine, Tape Echo, Multi-Synth, Convolution Reverb — sample one knob each
- [ ] GrooveMind — energy/groove/swing/fillIntensity sliders
- [ ] Spectrum Analyzer — settings overlay (smoothing/slope/decay/range)
- [ ] Confirm single-clicking the value text below a knob no longer focuses an editable text box
- [ ] Confirm Cmd/Ctrl+click on a knob still resets to default

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double-click knobs or slider value labels to open a dedicated value editor popup for quick editing across DuskAmp, GrooveMind, Multi-Q, and Spectrum Analyzer plugins.

* **Style**
  * Refreshed slider value label styling with cleaner, transparent backgrounds in Multi-Comp and Multi-Synth plugins for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->