### PR TITLE
78 remove a band in multi q when disabling it

### DIFF
--- a/plugins/multi-q/CMakeLists.txt
+++ b/plugins/multi-q/CMakeLists.txt
@@ -79,6 +79,7 @@ target_sources(MultiQ
         BritishEQCurveDisplay.cpp
         TubeEQCurveDisplay.cpp
         BandDetailPanel.cpp
+        BandStripComponent.cpp
         ../shared/LEDMeter.cpp
         ../4k-eq/FourKLookAndFeel.cpp
 )

--- a/plugins/multi-q/EQBand.h
+++ b/plugins/multi-q/EQBand.h
@@ -149,10 +149,14 @@ namespace BandColors
 inline const std::array<BandConfig, 8> DefaultBandConfigs = {{
     { BandType::HighPass,   juce::Colour(0xFFff5555),    20.0f,    20.0f, 20000.0f, "HPF" },         // Red
     { BandType::LowShelf,   juce::Colour(0xFFffaa00),   100.0f,    20.0f, 20000.0f, "Low Shelf" },   // Orange
-    { BandType::Parametric, juce::Colour(0xFFffee00),   200.0f,    20.0f, 20000.0f, "Para 1" },      // Yellow
-    { BandType::Parametric, juce::Colour(0xFF88ee44),   500.0f,    20.0f, 20000.0f, "Para 2" },      // Lime
-    { BandType::Parametric, juce::Colour(0xFF00ccff),  1000.0f,    20.0f, 20000.0f, "Para 3" },      // Cyan
-    { BandType::Parametric, juce::Colour(0xFF5588ff),  2000.0f,    20.0f, 20000.0f, "Para 4" },      // Blue
+    // Parametric bands named by their default frequency role rather than
+    // generic "Para 1..4" — matches the role-based naming used for HPF /
+    // Low Shelf / High Shelf / LPF and gives the user a useful hint about
+    // each band's intended job. Frequencies remain freely adjustable.
+    { BandType::Parametric, juce::Colour(0xFFffee00),   200.0f,    20.0f, 20000.0f, "Low" },         // Yellow
+    { BandType::Parametric, juce::Colour(0xFF88ee44),   500.0f,    20.0f, 20000.0f, "Low Mid" },     // Lime
+    { BandType::Parametric, juce::Colour(0xFF00ccff),  1000.0f,    20.0f, 20000.0f, "Mid" },         // Cyan
+    { BandType::Parametric, juce::Colour(0xFF5588ff),  2000.0f,    20.0f, 20000.0f, "High Mid" },    // Blue
     { BandType::HighShelf,  juce::Colour(0xFFaa66ff),  4000.0f,    20.0f, 20000.0f, "High Shelf" },  // Purple
     { BandType::LowPass,    juce::Colour(0xFFff66cc), 20000.0f,    20.0f, 20000.0f, "LPF" }          // Pink
 }};

--- a/plugins/multi-q/EQGraphicDisplay.cpp
+++ b/plugins/multi-q/EQGraphicDisplay.cpp
@@ -843,11 +843,20 @@ void EQGraphicDisplay::drawControlPoints(juce::Graphics& g)
         }
     }
 
-    // Then draw inactive bands as faint indicators
-    for (int i = 0; i < MultiQ::NUM_BANDS; ++i)
+    // Then draw inactive bands as faint indicators — except in Digital mode,
+    // where disabled bands disappear completely (issue #78). The faint
+    // indicators clutter the analyzer view; the user wants disabled bands
+    // gone entirely. British / Tube / Match modes keep the indicators so
+    // there's still a visual hint that the band exists and can be re-enabled
+    // by clicking the corresponding number.
+    const bool hideDisabled = processor.isDigitalMode();
+    if (! hideDisabled)
     {
-        if (!isBandEnabled(i))
-            drawInactiveBandIndicator(g, i);
+        for (int i = 0; i < MultiQ::NUM_BANDS; ++i)
+        {
+            if (!isBandEnabled(i))
+                drawInactiveBandIndicator(g, i);
+        }
     }
 
     // Finally draw active band nodes on top

--- a/plugins/multi-q/EQGraphicDisplay.cpp
+++ b/plugins/multi-q/EQGraphicDisplay.cpp
@@ -1276,7 +1276,12 @@ void EQGraphicDisplay::mouseDown(const juce::MouseEvent& e)
 
     int hitBand = hitTestControlPoint(point);
 
-    if (hitBand < 0)
+    // Fallback proximity scan for disabled bands (so the user can click a
+    // faint indicator to re-enable). Skip in Digital mode — disabled bands
+    // are hidden there (issue #78), so an invisible target must not be
+    // clickable. Re-enable in Digital mode goes through the band strip or
+    // double-click on a parametric region.
+    if (hitBand < 0 && !processor.isDigitalMode())
     {
         for (int i = 0; i < MultiQ::NUM_BANDS; ++i)
         {
@@ -1536,6 +1541,17 @@ void EQGraphicDisplay::mouseDoubleClick(const juce::MouseEvent& e)
             if (bandToEnable >= 0)
             {
                 setBandEnabled(bandToEnable, true);
+
+                // Reset shape to peaking (0) first — otherwise a band left in
+                // Notch / BandPass would make setBandGain() a no-op and the
+                // clicked gain would be silently dropped, producing the wrong
+                // filter type at the double-clicked location.
+                if (auto* shapeParam = processor.parameters.getParameter(ParamIDs::bandShape(bandToEnable + 1)))
+                {
+                    if (shapeParam->getNumSteps() > 1)
+                        shapeParam->setValueNotifyingHost(0.0f);
+                }
+
                 setBandFrequency(bandToEnable, clickFreq);
                 setBandGain(bandToEnable, juce::jlimit(-24.0f, 24.0f, clickGain));
                 setBandQ(bandToEnable, 0.71f);

--- a/plugins/multi-q/EQGraphicDisplay.cpp
+++ b/plugins/multi-q/EQGraphicDisplay.cpp
@@ -1494,42 +1494,54 @@ void EQGraphicDisplay::mouseDoubleClick(const juce::MouseEvent& e)
     }
     else
     {
-        // Double-click on empty area: spectrum grab — enable nearest disabled band
-        // and move it to the clicked frequency
+        // Double-click on empty area: spectrum grab — enable the disabled
+        // parametric band whose NATURAL HOME (default frequency from
+        // DefaultBandConfigs) is closest to the clicked frequency, then
+        // move it to that frequency. Each parametric band has a semantic
+        // role baked in by its default freq:
+        //   index 2: "Low"      → 200 Hz
+        //   index 3: "Low Mid"  → 500 Hz
+        //   index 4: "Mid"      → 1000 Hz
+        //   index 5: "High Mid" → 2000 Hz
+        // So clicking at 130 Hz wakes up Low, at 600 Hz Low Mid, etc.
+        // Matching by *default* (not current) freq makes the choice
+        // predictable: the band you get is the one whose name matches
+        // the area you clicked, regardless of where bands have been
+        // moved before.
+        // Shelves (Low Shelf / High Shelf) and HPF / LPF are excluded —
+        // those are special-purpose bands the user should engage via
+        // their explicit toggles in the band strip below.
         auto displayBounds = getDisplayBounds();
         if (displayBounds.contains(e.position))
         {
             float clickFreq = getFrequencyAtX(e.position.x);
             float clickGain = getDBAtY(e.position.y);
 
-            // Find nearest disabled parametric band (bands 2-7, indices 1-6)
-            int bestBand = -1;
-            float bestDist = std::numeric_limits<float>::max();
-            for (int i = 1; i <= 6; ++i)
+            int bandToEnable = -1;
+            float bestDist   = std::numeric_limits<float>::max();
+            for (int i = 2; i <= 5; ++i)   // parametric bands only
             {
-                if (!isBandEnabled(i))
+                if (! isBandEnabled(i))
                 {
-                    // Prefer bands closer to the clicked frequency
-                    float bandFreq = getBandFrequency(i);
-                    float dist = std::abs(std::log2(clickFreq) - std::log2(bandFreq));
+                    const float defaultFreq = DefaultBandConfigs[static_cast<size_t>(i)].defaultFreq;
+                    const float dist = std::abs(std::log2(clickFreq) - std::log2(defaultFreq));
                     if (dist < bestDist)
                     {
                         bestDist = dist;
-                        bestBand = i;
+                        bandToEnable = i;
                     }
                 }
             }
 
-            if (bestBand >= 0)
+            if (bandToEnable >= 0)
             {
-                setBandEnabled(bestBand, true);
-                setBandFrequency(bestBand, clickFreq);
-                if (bestBand > 0 && bestBand < 7)
-                    setBandGain(bestBand, juce::jlimit(-24.0f, 24.0f, clickGain));
-                setBandQ(bestBand, 0.71f);
-                selectedBand = bestBand;
+                setBandEnabled(bandToEnable, true);
+                setBandFrequency(bandToEnable, clickFreq);
+                setBandGain(bandToEnable, juce::jlimit(-24.0f, 24.0f, clickGain));
+                setBandQ(bandToEnable, 0.71f);
+                selectedBand = bandToEnable;
                 if (onBandSelected)
-                    onBandSelected(bestBand);
+                    onBandSelected(bandToEnable);
                 repaint();
             }
         }

--- a/plugins/multi-q/MultiQ.h
+++ b/plugins/multi-q/MultiQ.h
@@ -513,6 +513,11 @@ public:
         return static_cast<int>(safeGetParam(eqTypeParam, 0.0f)) == static_cast<int>(EQType::Match);
     }
 
+    bool isDigitalMode() const
+    {
+        return static_cast<int>(safeGetParam(eqTypeParam, 0.0f)) == static_cast<int>(EQType::Digital);
+    }
+
     // Spectrum data for display (thread-safe)
     void getMatchCurrentSpectrumDB(std::array<float, EQMatchProcessor::NUM_BINS>& out) const
     {

--- a/plugins/multi-q/MultiQEditor.cpp
+++ b/plugins/multi-q/MultiQEditor.cpp
@@ -16,6 +16,15 @@ MultiQEditor::MultiQEditor(MultiQ& p)
     bandDetailPanel->onMatchCleared = [this]() { if (graphicDisplay) graphicDisplay->repaint(); };
     addAndMakeVisible(bandDetailPanel.get());
 
+    // Always-visible 8-column band overview between the EQ graph and the
+    // BandDetailPanel. Each column has its own enable toggle + click-to-select
+    // behaviour, so the user can always see all 8 bands and re-enable any of
+    // them — even when every band is disabled and the EQ graph is otherwise
+    // empty (issue #78 + UX follow-up).
+    bandStrip = std::make_unique<BandStripComponent>(processor);
+    bandStrip->onBandSelected = [this](int band) { onBandSelected(band); };
+    addAndMakeVisible(bandStrip.get());
+
     // Create British mode curve display (4K-EQ style)
     britishCurveDisplay = std::make_unique<BritishEQCurveDisplay>(processor);
     britishCurveDisplay->setVisible(false);  // Hidden by default
@@ -820,7 +829,8 @@ void MultiQEditor::paint(juce::Graphics& g)
         if (selectedBand >= 0 && selectedBand < 8)
         {
             // Get band info for display
-            const char* bandTypeNames[] = {"HPF", "Low Shelf", "Para 1", "Para 2", "Para 3", "Para 4", "High Shelf", "LPF"};
+            // Mirrors EQBand.h DefaultBandConfigs[].name — keep in sync.
+            const char* bandTypeNames[] = {"HPF", "Low Shelf", "Low", "Low Mid", "Mid", "High Mid", "High Shelf", "LPF"};
 
             // Draw centered band indicator: "Band 3 - Para 1"
             juce::String bandText = "Band " + juce::String(selectedBand + 1) + " - " + bandTypeNames[selectedBand];
@@ -1283,6 +1293,15 @@ void MultiQEditor::resized()
         bandDetailPanel->setBounds(detailPanelArea);
         bandDetailPanel->setVisible(true);
         bandDetailPanel->setSelectedBand(selectedBand);
+
+        // ===== BAND STRIP (8-column overview, sits above BandDetailPanel) =====
+        // Placed BEFORE the meter areas are removed (below) so the strip
+        // spans the same horizontal extent as the EQ graph.
+        const int bandStripHeight = 56;
+        auto bandStripArea = bounds.removeFromBottom(bandStripHeight);
+        bandStrip->setBounds(bandStripArea);
+        bandStrip->setVisible(true);
+        bandStrip->setSelectedBand(selectedBand);
 
         // ===== METERS ON SIDES =====
         int meterWidth = 28;  // Wider meters for better visibility
@@ -1856,6 +1875,7 @@ void MultiQEditor::onBandSelected(int bandIndex)
     selectedBand = bandIndex;
     graphicDisplay->setSelectedBand(bandIndex);
     bandDetailPanel->setSelectedBand(bandIndex);
+    if (bandStrip) bandStrip->setSelectedBand(bandIndex);
     updateSelectedBandControls();
 
     if (!isBritishMode && !isTubeEQMode)
@@ -2113,6 +2133,7 @@ void MultiQEditor::updateEQModeVisibility()
 
     // BandDetailPanel - only in Digital mode
     bandDetailPanel->setVisible(isDigitalMode);
+    if (bandStrip) bandStrip->setVisible(isDigitalMode);
 
     // NOTE: A/B buttons, preset selectors, bypass, oversampling, and display scale
     // visibility is handled by layoutUnifiedToolbar() - DO NOT set visibility here!

--- a/plugins/multi-q/MultiQEditor.h
+++ b/plugins/multi-q/MultiQEditor.h
@@ -9,6 +9,7 @@
 #include "TubeEQLookAndFeel.h"
 #include "VintageTubeEQLookAndFeel.h"
 #include "BandDetailPanel.h"
+#include "BandStripComponent.h"
 #include "../shared/SupportersOverlay.h"
 #include "../shared/LEDMeter.h"
 #include "../shared/DuskLookAndFeel.h"
@@ -57,6 +58,7 @@ private:
 
     // Band detail panel (band selector + single-row controls)
     std::unique_ptr<BandDetailPanel> bandDetailPanel;
+    std::unique_ptr<BandStripComponent> bandStrip;   // 8-column band overview, sits above bandDetailPanel
 
     // British mode curve display (4K-EQ style)
     std::unique_ptr<BritishEQCurveDisplay> britishCurveDisplay;

--- a/plugins/multi-q/MultiQPresets.h
+++ b/plugins/multi-q/MultiQPresets.h
@@ -1283,7 +1283,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };
         p.bands[2] = { false, 1000.0f, 0.0f, 0.71f, 0 };
         p.bands[3] = { false, 3000.0f, 0.0f, 0.71f, 0 };
-        p.bands[4] = { false, 6000.0f, 0.0f, 2.0f, 0 };  // De-ess target
+        p.bands[4] = { true, 6000.0f, 0.0f, 2.0f, 0 };   // De-ess target (dynamics-active)
         p.bands[5] = { false, 10000.0f, 0.0f, 0.71f, 0 };
         p.bands[6] = { false, 14000.0f, 0.0f, 0.71f, 0 };
         p.bands[7] = { false, 20000.0f, 0.0f, 0.71f, 2 };
@@ -1300,7 +1300,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.hasPerBandDynamics = true;
         p.bands[0] = { true, 60.0f, 0.0f, 0.71f, 2 };   // HPF at 60Hz
-        p.bands[1] = { false, 100.0f, 0.0f, 1.0f, 0 };    // Dynamic low shelf
+        p.bands[1] = { true, 100.0f, 0.0f, 1.0f, 0 };     // Dynamic low shelf (dynamics-active)
         p.bands[2] = { false, 250.0f, 0.0f, 0.71f, 0 };
         p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };
         p.bands[4] = { false, 3000.0f, 0.0f, 0.71f, 0 };
@@ -1341,9 +1341,9 @@ inline std::vector<Preset> getFactoryPresets()
         p.hasPerBandDynamics = true;
         p.bands[0] = { false, 20.0f, 0.0f, 0.71f, 2 };
         p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };
-        p.bands[2] = { false, 400.0f, 0.0f, 4.0f, 0 };   // Narrow — resonance target
-        p.bands[3] = { false, 800.0f, 0.0f, 4.0f, 0 };   // Narrow — resonance target
-        p.bands[4] = { false, 2000.0f, 0.0f, 4.0f, 0 };  // Narrow — resonance target
+        p.bands[2] = { true, 400.0f, 0.0f, 4.0f, 0 };    // Narrow — resonance target (dynamics-active)
+        p.bands[3] = { true, 800.0f, 0.0f, 4.0f, 0 };    // Narrow — resonance target (dynamics-active)
+        p.bands[4] = { true, 2000.0f, 0.0f, 4.0f, 0 };   // Narrow — resonance target (dynamics-active)
         p.bands[5] = { false, 5000.0f, 0.0f, 0.71f, 0 };
         p.bands[6] = { false, 10000.0f, 0.0f, 0.71f, 0 };
         p.bands[7] = { false, 20000.0f, 0.0f, 0.71f, 2 };
@@ -1362,11 +1362,11 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.hasPerBandDynamics = true;
         p.bands[0] = { true, 30.0f, 0.0f, 0.71f, 2 };    // HPF
-        p.bands[1] = { false, 100.0f, 0.0f, 0.5f, 0 };     // Low band
-        p.bands[2] = { false, 400.0f, 0.0f, 0.5f, 0 };     // Low-mid
-        p.bands[3] = { false, 1000.0f, 0.0f, 0.5f, 0 };    // Mid
-        p.bands[4] = { false, 3000.0f, 0.0f, 0.5f, 0 };    // Hi-mid
-        p.bands[5] = { false, 8000.0f, 0.0f, 0.5f, 0 };    // High
+        p.bands[1] = { true, 100.0f, 0.0f, 0.5f, 0 };      // Low band (dynamics-active)
+        p.bands[2] = { true, 400.0f, 0.0f, 0.5f, 0 };      // Low-mid (dynamics-active)
+        p.bands[3] = { true, 1000.0f, 0.0f, 0.5f, 0 };     // Mid (dynamics-active)
+        p.bands[4] = { true, 3000.0f, 0.0f, 0.5f, 0 };     // Hi-mid (dynamics-active)
+        p.bands[5] = { true, 8000.0f, 0.0f, 0.5f, 0 };     // High (dynamics-active)
         p.bands[6] = { false, 14000.0f, 0.0f, 0.71f, 0 };  // Air
         p.bands[7] = { true, 18000.0f, 0.0f, 0.71f, 2 };  // LPF
         // Gentle dynamics on all main bands

--- a/plugins/multi-q/MultiQPresets.h
+++ b/plugins/multi-q/MultiQPresets.h
@@ -136,11 +136,11 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0; // Digital
         p.bands[0] = { true, 80.0f, 0.0f, 0.71f, 2 };       // HPF at 80Hz
         p.bands[1] = { true, 200.0f, -2.5f, 1.0f, 0 };      // Low shelf cut - reduce mud
-        p.bands[2] = { true, 800.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 800.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[3] = { true, 2500.0f, 2.0f, 1.2f, 0 };      // Presence boost
         p.bands[4] = { true, 5000.0f, 1.5f, 0.8f, 0 };      // Air/clarity
         p.bands[5] = { true, 10000.0f, 1.0f, 0.71f, 0 };    // Brilliance
-        p.bands[6] = { true, 12000.0f, 0.0f, 0.71f, 0 };    // High shelf (flat)
+        p.bands[6] = { false, 12000.0f, 0.0f, 0.71f, 0 };    // High shelf (flat)
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };   // LPF off
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         p.qCoupleMode = 2; // Light
@@ -156,10 +156,10 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[0] = { true, 100.0f, 0.0f, 0.71f, 2 };      // HPF
         p.bands[1] = { true, 250.0f, -3.0f, 1.5f, 0 };      // Low shelf - mud cut
         p.bands[2] = { true, 400.0f, -2.0f, 2.5f, 0 };      // Boxiness notch
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[4] = { true, 3000.0f, 1.0f, 1.0f, 0 };      // Slight presence
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
-        p.bands[6] = { true, 12000.0f, 0.0f, 0.71f, 0 };    // Flat
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[6] = { false, 12000.0f, 0.0f, 0.71f, 0 };    // Flat
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };   // LPF off
         p.qCoupleMode = 3; // Medium
         presets.push_back(p);
@@ -177,7 +177,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[3] = { true, 2000.0f, 1.5f, 1.5f, 0 };      // Clarity
         p.bands[4] = { true, 4500.0f, 2.5f, 1.0f, 0 };      // Presence
         p.bands[5] = { true, 8000.0f, 1.0f, 0.71f, 0 };     // Air
-        p.bands[6] = { true, 10000.0f, 0.0f, 0.71f, 0 };    // Flat
+        p.bands[6] = { false, 10000.0f, 0.0f, 0.71f, 0 };    // Flat
         p.bands[7] = { true, 15000.0f, 0.0f, 0.71f, 2 };    // LPF gentle
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         presets.push_back(p);
@@ -190,12 +190,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Vocals";
         p.eqType = 0;
         p.bands[0] = { true, 80.0f, 0.0f, 0.71f, 2 };       // HPF at 80Hz
-        p.bands[1] = { true, 200.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[2] = { true, 600.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[2] = { false, 600.0f, 0.0f, 0.71f, 0 };       // Flat
         p.bands[3] = { true, 2500.0f, 2.5f, 0.8f, 0 };       // Presence boost
         p.bands[4] = { true, 3500.0f, 2.0f, 0.9f, 0 };       // Upper presence
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[6] = { true, 12000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 12000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };    // LPF off
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         presets.push_back(p);
@@ -210,9 +210,9 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[0] = { true, 80.0f, 0.0f, 0.71f, 2 };       // HPF
         p.bands[1] = { true, 250.0f, -2.5f, 1.2f, 0 };       // Low mud cut
         p.bands[2] = { true, 350.0f, -3.0f, 1.8f, 0 };       // Mud center cut
-        p.bands[3] = { true, 800.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[4] = { true, 2000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[5] = { true, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[3] = { false, 800.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[4] = { false, 2000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[5] = { false, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[6] = { true, 12000.0f, 1.5f, 0.71f, 0 };     // Air boost
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };    // LPF off
         presets.push_back(p);
@@ -225,12 +225,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Vocals";
         p.eqType = 0;
         p.bands[0] = { true, 100.0f, 0.0f, 0.71f, 3 };      // HPF steep
-        p.bands[1] = { true, 200.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[2] = { true, 800.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[2] = { false, 800.0f, 0.0f, 0.71f, 0 };       // Flat
         p.bands[3] = { true, 2500.0f, 2.0f, 0.8f, 0 };       // Intelligibility
         p.bands[4] = { true, 4000.0f, 1.5f, 0.9f, 0 };       // Clarity
         p.bands[5] = { true, 5000.0f, 1.0f, 1.0f, 0 };       // Upper clarity
-        p.bands[6] = { true, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[7] = { true, 12000.0f, 0.0f, 0.71f, 2 };     // LPF
         presets.push_back(p);
     }
@@ -249,7 +249,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[3] = { true, 350.0f, -3.0f, 2.0f, 0 };      // Remove mud
         p.bands[4] = { true, 2500.0f, 2.5f, 2.0f, 0 };      // Click/attack
         p.bands[5] = { true, 5000.0f, 1.0f, 1.0f, 0 };      // Beater
-        p.bands[6] = { true, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[6] = { false, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[7] = { true, 12000.0f, 0.0f, 0.71f, 2 };    // LPF
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         presets.push_back(p);
@@ -264,7 +264,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[0] = { true, 80.0f, 0.0f, 0.71f, 2 };       // HPF
         p.bands[1] = { true, 150.0f, 1.0f, 1.0f, 0 };       // Body
         p.bands[2] = { true, 400.0f, -2.0f, 2.5f, 0 };      // Remove box
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[4] = { true, 2000.0f, 3.0f, 1.5f, 0 };      // Crack
         p.bands[5] = { true, 5000.0f, 2.0f, 1.2f, 0 };      // Snare wire
         p.bands[6] = { true, 10000.0f, 1.5f, 0.71f, 0 };    // High shelf air
@@ -280,7 +280,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 200.0f, 0.0f, 0.71f, 2 };      // HPF - remove kick bleed
         p.bands[1] = { true, 400.0f, -1.5f, 1.5f, 0 };      // Remove mud
-        p.bands[2] = { true, 800.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 800.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[3] = { true, 3000.0f, 1.5f, 1.2f, 0 };      // Stick definition
         p.bands[4] = { true, 6000.0f, 2.0f, 0.8f, 0 };      // Cymbal presence
         p.bands[5] = { true, 10000.0f, 2.5f, 0.71f, 0 };    // Air
@@ -298,11 +298,11 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 30.0f, 0.0f, 0.71f, 2 };       // HPF sub cleanup
         p.bands[1] = { true, 60.0f, 3.5f, 1.2f, 0 };         // Sub boost
-        p.bands[2] = { true, 150.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[2] = { false, 150.0f, 0.0f, 0.71f, 0 };       // Flat
         p.bands[3] = { true, 300.0f, -3.5f, 2.0f, 0 };       // Mud cut
-        p.bands[4] = { true, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[4] = { false, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[5] = { true, 3500.0f, 2.5f, 1.5f, 0 };       // Click/attack
-        p.bands[6] = { true, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[7] = { true, 10000.0f, 0.0f, 0.71f, 2 };     // LPF
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         presets.push_back(p);
@@ -315,9 +315,9 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Drums";
         p.eqType = 0;
         p.bands[0] = { true, 100.0f, 0.0f, 0.71f, 2 };      // HPF
-        p.bands[1] = { true, 200.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };       // Flat
         p.bands[2] = { true, 400.0f, -2.5f, 2.0f, 0 };       // Box cut
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[4] = { true, 2500.0f, 3.0f, 1.2f, 0 };       // Crack
         p.bands[5] = { true, 4000.0f, 2.0f, 1.0f, 0 };       // Snap
         p.bands[6] = { true, 8000.0f, 1.5f, 0.71f, 0 };      // Air
@@ -332,10 +332,10 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Drums";
         p.eqType = 0;
         p.bands[0] = { true, 200.0f, 0.0f, 0.71f, 2 };      // HPF remove lows
-        p.bands[1] = { true, 400.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[2] = { true, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[3] = { true, 3000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[4] = { true, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[1] = { false, 400.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[2] = { false, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[3] = { false, 3000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[4] = { false, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[5] = { true, 8000.0f, 2.0f, 0.5f, 0 };       // Brightness shelf
         p.bands[6] = { true, 12000.0f, 2.5f, 0.5f, 0 };      // Air shelf
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };    // LPF off
@@ -354,10 +354,10 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[0] = { true, 30.0f, 0.0f, 0.71f, 3 };       // HPF - sub cleanup
         p.bands[1] = { true, 80.0f, 2.0f, 1.0f, 0 };        // Low-end punch
         p.bands[2] = { true, 200.0f, -1.5f, 1.5f, 0 };      // Reduce mud
-        p.bands[3] = { true, 500.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[3] = { false, 500.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[4] = { true, 1200.0f, 2.5f, 1.5f, 0 };      // Growl/attack
         p.bands[5] = { true, 3000.0f, 1.0f, 1.0f, 0 };      // String noise
-        p.bands[6] = { true, 6000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[6] = { false, 6000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[7] = { true, 8000.0f, 0.0f, 0.71f, 2 };     // LPF
         presets.push_back(p);
     }
@@ -373,8 +373,8 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[2] = { true, 100.0f, 1.5f, 1.0f, 0 };       // Low punch
         p.bands[3] = { true, 300.0f, -2.0f, 1.5f, 0 };      // Clean up mud
         p.bands[4] = { true, 700.0f, -1.0f, 1.2f, 0 };      // Reduce honk
-        p.bands[5] = { true, 2000.0f, 0.0f, 0.71f, 0 };     // Flat
-        p.bands[6] = { true, 5000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[5] = { false, 2000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[6] = { false, 5000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[7] = { true, 6000.0f, 0.0f, 0.71f, 3 };     // LPF steep
         presets.push_back(p);
     }
@@ -406,7 +406,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 100.0f, 0.0f, 0.71f, 2 };      // HPF
         p.bands[1] = { true, 200.0f, -1.5f, 1.2f, 0 };      // Reduce boom
-        p.bands[2] = { true, 500.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 500.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[3] = { true, 2000.0f, 1.5f, 1.0f, 0 };      // Body
         p.bands[4] = { true, 5000.0f, 2.0f, 0.8f, 0 };      // Pick attack
         p.bands[5] = { true, 8000.0f, 2.5f, 0.71f, 0 };     // Shimmer
@@ -423,12 +423,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Guitars";
         p.eqType = 0;
         p.bands[0] = { true, 80.0f, 0.0f, 0.71f, 2 };       // HPF
-        p.bands[1] = { true, 150.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[1] = { false, 150.0f, 0.0f, 0.71f, 0 };       // Flat
         p.bands[2] = { true, 400.0f, -3.0f, 1.5f, 0 };       // Scoop
         p.bands[3] = { true, 800.0f, -1.0f, 1.0f, 0 };       // Slight dip
         p.bands[4] = { true, 2000.0f, 2.0f, 1.2f, 0 };       // Presence
         p.bands[5] = { true, 4000.0f, 2.5f, 1.0f, 0 };       // Bite
-        p.bands[6] = { true, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[7] = { true, 12000.0f, 0.0f, 0.71f, 2 };     // LPF
         presets.push_back(p);
     }
@@ -441,11 +441,11 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 80.0f, 0.0f, 0.71f, 2 };       // HPF
         p.bands[1] = { true, 200.0f, -1.5f, 1.0f, 0 };       // Reduce boom
-        p.bands[2] = { true, 500.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[3] = { true, 2000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 500.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[3] = { false, 2000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[4] = { true, 5000.0f, 2.0f, 0.8f, 0 };       // Sparkle
         p.bands[5] = { true, 8000.0f, 1.0f, 0.71f, 0 };      // Shimmer
-        p.bands[6] = { true, 12000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[6] = { false, 12000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };    // LPF off
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         presets.push_back(p);
@@ -461,9 +461,9 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[1] = { true, 80.0f, 3.0f, 1.0f, 0 };         // Low punch
         p.bands[2] = { true, 250.0f, -2.5f, 1.5f, 0 };       // Mud cut
         p.bands[3] = { true, 700.0f, 2.0f, 1.2f, 0 };        // Growl
-        p.bands[4] = { true, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[5] = { true, 3000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[6] = { true, 5000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[4] = { false, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[5] = { false, 3000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 5000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[7] = { true, 8000.0f, 0.0f, 0.71f, 2 };      // LPF
         presets.push_back(p);
     }
@@ -479,9 +479,9 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[0] = { true, 30.0f, 0.0f, 0.71f, 2 };       // HPF gentle
         p.bands[1] = { true, 60.0f, 1.0f, 0.71f, 0 };       // Low shelf warmth
         p.bands[2] = { true, 300.0f, -0.5f, 0.5f, 0 };      // Subtle mud cut
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[4] = { true, 3000.0f, 0.5f, 0.5f, 0 };      // Subtle presence
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[6] = { true, 12000.0f, 1.5f, 0.71f, 0 };    // High shelf air
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };   // LPF off
         p.hqEnabled = false;  // OS is user preference, not preset-driven
@@ -497,10 +497,10 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 25.0f, 0.0f, 0.71f, 2 };       // HPF
         p.bands[1] = { true, 80.0f, 2.0f, 0.71f, 0 };       // Low shelf boost
-        p.bands[2] = { true, 200.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 200.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[3] = { true, 800.0f, -0.5f, 0.5f, 0 };      // Subtle mid cut
-        p.bands[4] = { true, 2500.0f, 0.0f, 0.71f, 0 };     // Flat
-        p.bands[5] = { true, 6000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[4] = { false, 2500.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[5] = { false, 6000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[6] = { true, 10000.0f, 2.0f, 0.71f, 0 };    // High shelf boost
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };   // LPF off
         p.hqEnabled = false;  // OS is user preference, not preset-driven
@@ -515,10 +515,10 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 25.0f, 0.0f, 0.71f, 2 };       // HPF
         p.bands[1] = { true, 80.0f, 1.5f, 0.5f, 0 };         // Bass shelf boost
-        p.bands[2] = { true, 300.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[4] = { true, 3000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[5] = { true, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 300.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[4] = { false, 3000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[5] = { false, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[6] = { true, 10000.0f, 1.5f, 0.5f, 0 };      // HF shelf boost
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };    // LPF off
         p.hqEnabled = false;  // OS is user preference, not preset-driven
@@ -533,12 +533,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Mix Bus";
         p.eqType = 0;
         p.bands[0] = { true, 30.0f, 0.0f, 0.71f, 2 };       // HPF
-        p.bands[1] = { true, 100.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[2] = { true, 500.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[1] = { false, 100.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[2] = { false, 500.0f, 0.0f, 0.71f, 0 };       // Flat
         p.bands[3] = { true, 1500.0f, 1.0f, 0.6f, 0 };       // Lower mid boost
         p.bands[4] = { true, 2500.0f, 1.5f, 0.7f, 0 };       // Mid presence
         p.bands[5] = { true, 3500.0f, 1.0f, 0.8f, 0 };       // Upper mid
-        p.bands[6] = { true, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };    // LPF off
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         presets.push_back(p);
@@ -552,11 +552,11 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 30.0f, 0.0f, 0.71f, 3 };       // HPF at 30Hz steep
         p.bands[1] = { true, 60.0f, -1.5f, 1.5f, 0 };        // Tighten low end
-        p.bands[2] = { true, 200.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[3] = { true, 500.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[4] = { true, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[5] = { true, 4000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[6] = { true, 10000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[2] = { false, 200.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[3] = { false, 500.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[4] = { false, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[5] = { false, 4000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 10000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[7] = { false, 18000.0f, 0.0f, 0.71f, 2 };    // LPF off
         presets.push_back(p);
     }
@@ -572,9 +572,9 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[0] = { true, 25.0f, 0.0f, 0.71f, 3 };       // HPF steep
         p.bands[1] = { true, 50.0f, 0.5f, 0.5f, 0 };        // Subtle sub lift
         p.bands[2] = { true, 250.0f, -0.3f, 0.4f, 0 };      // Very gentle mud cut
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[4] = { true, 4000.0f, 0.3f, 0.4f, 0 };      // Subtle presence
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[6] = { true, 14000.0f, 0.8f, 0.71f, 0 };    // High shelf air
         p.bands[7] = { true, 20000.0f, 0.0f, 0.71f, 1 };    // LPF gentle
         p.hqEnabled = false;  // OS is user preference, not preset-driven
@@ -589,12 +589,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Mastering";
         p.eqType = 0;
         p.bands[0] = { true, 28.0f, 0.0f, 0.71f, 4 };       // HPF very steep
-        p.bands[1] = { true, 100.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[2] = { true, 300.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
-        p.bands[4] = { true, 3000.0f, 0.0f, 0.71f, 0 };     // Flat
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
-        p.bands[6] = { true, 12000.0f, 0.0f, 0.71f, 0 };    // Flat
+        p.bands[1] = { false, 100.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 300.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[4] = { false, 3000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[6] = { false, 12000.0f, 0.0f, 0.71f, 0 };    // Flat
         p.bands[7] = { true, 19500.0f, 0.0f, 0.71f, 2 };    // LPF near Nyquist
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         presets.push_back(p);
@@ -607,11 +607,11 @@ inline std::vector<Preset> getFactoryPresets()
         p.category = "Mastering";
         p.eqType = 0;
         p.bands[0] = { true, 25.0f, 0.0f, 0.71f, 3 };       // HPF steep
-        p.bands[1] = { true, 100.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[2] = { true, 500.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[3] = { true, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[4] = { true, 4000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[1] = { false, 100.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[2] = { false, 500.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[3] = { false, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[4] = { false, 4000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[6] = { true, 15000.0f, 1.5f, 0.4f, 0 };      // Air shelf
         p.bands[7] = { true, 20000.0f, 0.0f, 0.71f, 1 };     // LPF gentle
         p.hqEnabled = false;  // OS is user preference, not preset-driven
@@ -627,11 +627,11 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 25.0f, 0.0f, 0.71f, 3 };       // HPF steep
         p.bands[1] = { true, 100.0f, 1.0f, 0.4f, 0 };        // Warm shelf
-        p.bands[2] = { true, 300.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 300.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[4] = { true, 3000.0f, -0.5f, 0.8f, 0 };      // Gentle dip
-        p.bands[5] = { true, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[6] = { true, 12000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[5] = { false, 6000.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[6] = { false, 12000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[7] = { true, 20000.0f, 0.0f, 0.71f, 1 };     // LPF gentle
         p.hqEnabled = false;  // OS is user preference, not preset-driven
         p.qCoupleMode = 1; // Proportional
@@ -694,7 +694,7 @@ inline std::vector<Preset> getFactoryPresets()
         p.bands[3] = { true, 2000.0f, 4.0f, 1.2f, 0 };      // Presence
         p.bands[4] = { true, 3500.0f, 2.0f, 1.0f, 0 };      // Upper mid
         p.bands[5] = { true, 4500.0f, -6.0f, 0.71f, 0 };    // High cut
-        p.bands[6] = { true, 5000.0f, 0.0f, 0.71f, 0 };     // Transition
+        p.bands[6] = { false, 5000.0f, 0.0f, 0.71f, 0 };     // Transition
         p.bands[7] = { true, 5500.0f, 0.0f, 0.71f, 4 };     // LPF steep
         presets.push_back(p);
     }
@@ -724,8 +724,8 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { false, 30.0f, 0.0f, 0.71f, 2 };      // HPF off
         p.bands[1] = { true, 100.0f, -2.0f, 0.71f, 0 };     // Cut sides in low
-        p.bands[2] = { true, 300.0f, 0.0f, 0.71f, 0 };      // Flat
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
+        p.bands[2] = { false, 300.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };     // Flat
         p.bands[4] = { true, 4000.0f, 2.0f, 0.8f, 0 };      // Boost upper mids
         p.bands[5] = { true, 8000.0f, 3.0f, 0.71f, 0 };     // Boost highs
         p.bands[6] = { true, 12000.0f, 2.0f, 0.71f, 0 };    // Air
@@ -982,8 +982,8 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.bands[0] = { true, 200.0f, 0.0f, 0.71f, 2 };      // HPF
         p.bands[1] = { true, 250.0f, 2.0f, 2.5f, 0 };        // Resonant bump at HPF
-        p.bands[2] = { true, 600.0f, 0.0f, 0.71f, 0 };       // Flat
-        p.bands[3] = { true, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
+        p.bands[2] = { false, 600.0f, 0.0f, 0.71f, 0 };       // Flat
+        p.bands[3] = { false, 1500.0f, 0.0f, 0.71f, 0 };      // Flat
         p.bands[4] = { true, 3000.0f, -1.0f, 0.71f, 0 };     // Slight dip
         p.bands[5] = { true, 5500.0f, 2.0f, 2.5f, 0 };       // Resonant bump at LPF
         p.bands[6] = { true, 6000.0f, -3.0f, 0.71f, 0 };     // Rolloff
@@ -1280,12 +1280,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;  // Digital
         p.hasPerBandDynamics = true;
         p.bands[0] = { false, 20.0f, 0.0f, 0.71f, 2 };
-        p.bands[1] = { true, 200.0f, 0.0f, 0.71f, 0 };
-        p.bands[2] = { true, 1000.0f, 0.0f, 0.71f, 0 };
-        p.bands[3] = { true, 3000.0f, 0.0f, 0.71f, 0 };
-        p.bands[4] = { true, 6000.0f, 0.0f, 2.0f, 0 };  // De-ess target
-        p.bands[5] = { true, 10000.0f, 0.0f, 0.71f, 0 };
-        p.bands[6] = { true, 14000.0f, 0.0f, 0.71f, 0 };
+        p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };
+        p.bands[2] = { false, 1000.0f, 0.0f, 0.71f, 0 };
+        p.bands[3] = { false, 3000.0f, 0.0f, 0.71f, 0 };
+        p.bands[4] = { false, 6000.0f, 0.0f, 2.0f, 0 };  // De-ess target
+        p.bands[5] = { false, 10000.0f, 0.0f, 0.71f, 0 };
+        p.bands[6] = { false, 14000.0f, 0.0f, 0.71f, 0 };
         p.bands[7] = { false, 20000.0f, 0.0f, 0.71f, 2 };
         // Dynamic on band 5 (6kHz sibilance)
         p.bandDynamics[4] = { true, -24.0f, 1.0f, 50.0f, 8.0f, 6.0f };
@@ -1300,12 +1300,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.hasPerBandDynamics = true;
         p.bands[0] = { true, 60.0f, 0.0f, 0.71f, 2 };   // HPF at 60Hz
-        p.bands[1] = { true, 100.0f, 0.0f, 1.0f, 0 };    // Dynamic low shelf
-        p.bands[2] = { true, 250.0f, 0.0f, 0.71f, 0 };
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.71f, 0 };
-        p.bands[4] = { true, 3000.0f, 0.0f, 0.71f, 0 };
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.71f, 0 };
-        p.bands[6] = { true, 12000.0f, 0.0f, 0.71f, 0 };
+        p.bands[1] = { false, 100.0f, 0.0f, 1.0f, 0 };    // Dynamic low shelf
+        p.bands[2] = { false, 250.0f, 0.0f, 0.71f, 0 };
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.71f, 0 };
+        p.bands[4] = { false, 3000.0f, 0.0f, 0.71f, 0 };
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.71f, 0 };
+        p.bands[6] = { false, 12000.0f, 0.0f, 0.71f, 0 };
         p.bands[7] = { false, 20000.0f, 0.0f, 0.71f, 2 };
         // Dynamic cut on band 2 (low shelf - tighten lows when loud)
         p.bandDynamics[1] = { true, -18.0f, 5.0f, 80.0f, 6.0f, 4.0f };
@@ -1320,12 +1320,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.hasPerBandDynamics = true;
         p.bands[0] = { false, 20.0f, 0.0f, 0.71f, 2 };
-        p.bands[1] = { true, 200.0f, 0.0f, 0.71f, 0 };
-        p.bands[2] = { true, 500.0f, 0.0f, 0.71f, 0 };
-        p.bands[3] = { true, 1500.0f, 0.0f, 0.71f, 0 };
+        p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };
+        p.bands[2] = { false, 500.0f, 0.0f, 0.71f, 0 };
+        p.bands[3] = { false, 1500.0f, 0.0f, 0.71f, 0 };
         p.bands[4] = { true, 3000.0f, 2.0f, 1.5f, 0 };   // Static boost at 3kHz
-        p.bands[5] = { true, 5000.0f, 0.0f, 0.71f, 0 };
-        p.bands[6] = { true, 10000.0f, 0.0f, 0.71f, 0 };
+        p.bands[5] = { false, 5000.0f, 0.0f, 0.71f, 0 };
+        p.bands[6] = { false, 10000.0f, 0.0f, 0.71f, 0 };
         p.bands[7] = { false, 20000.0f, 0.0f, 0.71f, 2 };
         // Dynamic cut on band 5 (presence — duck when too harsh)
         p.bandDynamics[4] = { true, -15.0f, 3.0f, 80.0f, 6.0f, 3.0f };
@@ -1340,12 +1340,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.hasPerBandDynamics = true;
         p.bands[0] = { false, 20.0f, 0.0f, 0.71f, 2 };
-        p.bands[1] = { true, 200.0f, 0.0f, 0.71f, 0 };
-        p.bands[2] = { true, 400.0f, 0.0f, 4.0f, 0 };   // Narrow — resonance target
-        p.bands[3] = { true, 800.0f, 0.0f, 4.0f, 0 };   // Narrow — resonance target
-        p.bands[4] = { true, 2000.0f, 0.0f, 4.0f, 0 };  // Narrow — resonance target
-        p.bands[5] = { true, 5000.0f, 0.0f, 0.71f, 0 };
-        p.bands[6] = { true, 10000.0f, 0.0f, 0.71f, 0 };
+        p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };
+        p.bands[2] = { false, 400.0f, 0.0f, 4.0f, 0 };   // Narrow — resonance target
+        p.bands[3] = { false, 800.0f, 0.0f, 4.0f, 0 };   // Narrow — resonance target
+        p.bands[4] = { false, 2000.0f, 0.0f, 4.0f, 0 };  // Narrow — resonance target
+        p.bands[5] = { false, 5000.0f, 0.0f, 0.71f, 0 };
+        p.bands[6] = { false, 10000.0f, 0.0f, 0.71f, 0 };
         p.bands[7] = { false, 20000.0f, 0.0f, 0.71f, 2 };
         // Dynamic narrow cuts on resonant bands
         p.bandDynamics[2] = { true, -20.0f, 2.0f, 60.0f, 10.0f, 8.0f };
@@ -1362,12 +1362,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.eqType = 0;
         p.hasPerBandDynamics = true;
         p.bands[0] = { true, 30.0f, 0.0f, 0.71f, 2 };    // HPF
-        p.bands[1] = { true, 100.0f, 0.0f, 0.5f, 0 };     // Low band
-        p.bands[2] = { true, 400.0f, 0.0f, 0.5f, 0 };     // Low-mid
-        p.bands[3] = { true, 1000.0f, 0.0f, 0.5f, 0 };    // Mid
-        p.bands[4] = { true, 3000.0f, 0.0f, 0.5f, 0 };    // Hi-mid
-        p.bands[5] = { true, 8000.0f, 0.0f, 0.5f, 0 };    // High
-        p.bands[6] = { true, 14000.0f, 0.0f, 0.71f, 0 };  // Air
+        p.bands[1] = { false, 100.0f, 0.0f, 0.5f, 0 };     // Low band
+        p.bands[2] = { false, 400.0f, 0.0f, 0.5f, 0 };     // Low-mid
+        p.bands[3] = { false, 1000.0f, 0.0f, 0.5f, 0 };    // Mid
+        p.bands[4] = { false, 3000.0f, 0.0f, 0.5f, 0 };    // Hi-mid
+        p.bands[5] = { false, 8000.0f, 0.0f, 0.5f, 0 };    // High
+        p.bands[6] = { false, 14000.0f, 0.0f, 0.71f, 0 };  // Air
         p.bands[7] = { true, 18000.0f, 0.0f, 0.71f, 2 };  // LPF
         // Gentle dynamics on all main bands
         p.bandDynamics[1] = { true, -18.0f, 10.0f, 100.0f, 6.0f, 2.0f };
@@ -1387,12 +1387,12 @@ inline std::vector<Preset> getFactoryPresets()
         p.hasPerBandDynamics = false;
         p.processingMode = 4;  // Side processing
         p.bands[0] = { true, 80.0f, 0.0f, 0.71f, 3 };    // HPF (mono bass)
-        p.bands[1] = { true, 200.0f, 0.0f, 0.71f, 0 };
-        p.bands[2] = { true, 800.0f, 0.0f, 0.71f, 0 };
+        p.bands[1] = { false, 200.0f, 0.0f, 0.71f, 0 };
+        p.bands[2] = { false, 800.0f, 0.0f, 0.71f, 0 };
         p.bands[3] = { true, 2000.0f, 2.0f, 0.71f, 0 };   // Boost sides at 2kHz
         p.bands[4] = { true, 5000.0f, 3.0f, 0.71f, 0 };   // Boost sides at 5kHz
         p.bands[5] = { true, 10000.0f, 2.0f, 0.71f, 0 };  // Boost sides at 10kHz
-        p.bands[6] = { true, 14000.0f, 0.0f, 0.71f, 0 };
+        p.bands[6] = { false, 14000.0f, 0.0f, 0.71f, 0 };
         p.bands[7] = { false, 20000.0f, 0.0f, 0.71f, 2 };
         presets.push_back(p);
     }


### PR DESCRIPTION
- **Multi-Q: hide disabled bands entirely in Digital mode (issue #78)**
- **Multi-Q: BandStripComponent + UX follow-ups for issue #78**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added band strip component providing a visual 8-column overview of all bands for quick editing and selection.
  * Enhanced double-click functionality on the EQ graph to automatically create and configure parametric bands at clicked frequencies.
  * Expanded factory preset library with new M/S variants, British/UK-themed presets, and updated drum, vocal, guitar, and mastering presets.

* **Changes**
  * Renamed parametric bands with semantic labels: Low, Low Mid, Mid, and High Mid.
  * Improved band visibility handling in Digital mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->