### PR TITLE
Multi-Comp: per-band enable + true crossover collapse (issue #79)

### DIFF
--- a/plugins/multi-comp/ModernCompressorPanels.h
+++ b/plugins/multi-comp/ModernCompressorPanels.h
@@ -1127,12 +1127,20 @@ private:
 
     void drawDbScale(juce::Graphics& g)
     {
-        if (bandGRBounds[0].isEmpty()) return;
+        // Issue #79 — band 0 may be disabled (its bandGRBounds is empty in
+        // that case), so find the first enabled band's meter as the
+        // reference. All enabled bands share the same Y/height by
+        // construction in resized(), so any non-empty entry works.
+        const juce::Rectangle<int>* refBounds = nullptr;
+        for (int i = 0; i < 4; ++i)
+        {
+            if (! bandGRBounds[i].isEmpty()) { refBounds = &bandGRBounds[i]; break; }
+        }
+        if (refBounds == nullptr) return;
 
-        auto& refBounds = bandGRBounds[0];
         const float dbLevels[] = {0.0f, -3.0f, -6.0f, -10.0f, -15.0f, -20.0f};
-        const int meterTop = refBounds.getY();
-        const int meterHeight = refBounds.getHeight();
+        const int meterTop = refBounds->getY();
+        const int meterHeight = refBounds->getHeight();
 
         g.setFont(juce::FontOptions(9.0f * scaleFactor));
 
@@ -1354,6 +1362,14 @@ private:
     void selectBand(int band)
     {
         currentBand = juce::jlimit(0, 3, band);
+
+        // Sync the radio-group toggle state so programmatic callers
+        // (constructor's initialBand walk, timer-poll auto-walk to
+        // firstEnabled) move the visible tab highlight to match
+        // currentBand. For the user-click path the radio state is already
+        // correct by the time we get here, so this is a no-op.
+        for (int i = 0; i < 4; ++i)
+            bandButtons[i].setToggleState(i == currentBand, juce::dontSendNotification);
 
         const juce::String bandNames[] = {"low", "lowmid", "highmid", "high"};
         const juce::String& bandName = bandNames[currentBand];

--- a/plugins/multi-comp/ModernCompressorPanels.h
+++ b/plugins/multi-comp/ModernCompressorPanels.h
@@ -535,7 +535,8 @@ private:
 //==============================================================================
 // Multiband Compressor Panel - Modern digital design with per-band controls
 //==============================================================================
-class MultibandCompressorPanel : public juce::Component, private juce::Timer
+class MultibandCompressorPanel : public juce::Component,
+                                 private juce::Timer
 {
 public:
     // Band colors (matching modern multiband compressor aesthetics)
@@ -569,6 +570,20 @@ public:
             bandSoloButtons[i].setColour(juce::TextButton::textColourOnId, juce::Colours::black);
             bandSoloButtons[i].setTooltip("Solo " + getBandName(i) + " band");
             addAndMakeVisible(bandSoloButtons[i]);
+
+            // Per-band enable toggle (issue #79) — lives in the strip ABOVE
+            // GAIN REDUCTION. Click to disable; the band's tab + meter
+            // collapse out and the remaining bands fill the width.
+            // Always at fixed 1/4 positions in the strip so the user can
+            // re-enable a hidden band by clicking its toggle.
+            bandEnableButtons[i].setButtonText(getBandName(i));
+            bandEnableButtons[i].setClickingTogglesState(true);
+            bandEnableButtons[i].setColour(juce::TextButton::buttonColourId, juce::Colour(0xff2a2a2a));
+            bandEnableButtons[i].setColour(juce::TextButton::buttonOnColourId, juce::Colour(bandColors[i]));
+            bandEnableButtons[i].setColour(juce::TextButton::textColourOffId, juce::Colour(0xff888888));
+            bandEnableButtons[i].setColour(juce::TextButton::textColourOnId, juce::Colours::black);
+            bandEnableButtons[i].setTooltip("Enable / disable " + getBandName(i) + " band");
+            addAndMakeVisible(bandEnableButtons[i]);
         }
         bandButtons[0].setToggleState(true, juce::dontSendNotification);
 
@@ -613,12 +628,18 @@ public:
         setupKnob(bandRelease, " ms", 100.0);
         setupKnob(bandMakeup, " dB", 0.0);
 
-        // Per-band solo attachments
+        // Per-band solo + enable attachments
         const juce::String bandNames[] = {"low", "lowmid", "highmid", "high"};
         for (int i = 0; i < 4; ++i)
         {
             bandSoloAttachments[i] = std::make_unique<juce::AudioProcessorValueTreeState::ButtonAttachment>(
                 parameters, "mb_" + bandNames[i] + "_solo", bandSoloButtons[i]);
+            bandEnableAttachments[i] = std::make_unique<juce::AudioProcessorValueTreeState::ButtonAttachment>(
+                parameters, "mb_" + bandNames[i] + "_enabled", bandEnableButtons[i]);
+            // No parameterChanged listener — the timer at 30 Hz polls the
+            // mask and runs the layout update when it changes. Issue #79:
+            // listener-driven resized() hung Ardour during click event
+            // dispatch.
         }
 
         // Global controls
@@ -643,8 +664,13 @@ public:
             addAndMakeVisible(knobLabels[i]);
         }
 
-        // Initialize with first band
-        selectBand(0);
+        // Initialize with first band; updateEnableButtonStates seeds the
+        // ON-button lock state based on the current enabled-band count.
+        updateEnableButtonStates();
+        int initialBand = 0;
+        for (int i = 0; i < 4; ++i)
+            if (isBandEnabled(i)) { initialBand = i; break; }
+        selectBand(initialBand);
 
         // Start timer for crossover label updates
         startTimerHz(30);
@@ -737,6 +763,24 @@ public:
 
         topSection.reduce(margin, margin);
 
+        // === Issue #79 — Enable/disable strip at the very top ===
+        // Always 4 toggles at fixed 1/4 positions so disabled bands stay
+        // discoverable / re-enableable. Strip is a separate control zone;
+        // the meter section below collapses based on enabled count.
+        const int stripHeight = static_cast<int>(22 * scaleFactor);
+        auto stripRow = topSection.removeFromTop(stripHeight);
+        topSection.removeFromTop(static_cast<int>(2 * scaleFactor));  // gap
+
+        const int stripBandWidth = stripRow.getWidth() / 4;
+        const int stripGap = static_cast<int>(2 * scaleFactor);
+        for (int i = 0; i < 4; ++i)
+        {
+            auto toggleArea = stripRow.withX(stripRow.getX() + i * stripBandWidth)
+                                       .withWidth(stripBandWidth)
+                                       .reduced(stripGap, 1);
+            bandEnableButtons[i].setBounds(toggleArea);
+        }
+
         // Add "GAIN REDUCTION" label area at top
         topSection.removeFromTop(static_cast<int>(18 * scaleFactor));
         topSection.removeFromTop(static_cast<int>(4 * scaleFactor));
@@ -744,51 +788,74 @@ public:
         // Store meter section bounds for drawing
         meterSectionBounds = topSection;
 
-        // Calculate band widths
-        int bandWidth = topSection.getWidth() / 4;
+        // === Compute the collapsed layout — only enabled bands occupy slots ===
+        std::array<int, 4> enabledIdx{0, 0, 0, 0};
+        int numEnabled = 0;
+        for (int i = 0; i < 4; ++i)
+            if (isBandEnabled(i)) enabledIdx[static_cast<size_t>(numEnabled++)] = i;
+        if (numEnabled < 1) numEnabled = 1;  // safety; DSP guarantees >= 2 in practice
+
+        for (int i = 0; i < 4; ++i)
+            bandGRBounds[i] = {};
+
+        const int slotWidth = topSection.getWidth() / numEnabled;
+        const int buttonRowHeight = static_cast<int>(26 * scaleFactor);
+        const int soloWidth = static_cast<int>(24 * scaleFactor);
+        const int buttonGap = static_cast<int>(3 * scaleFactor);
+
+        // Hide disabled bands' tab + solo first; loop below makes enabled
+        // bands visible and lays them out in the collapsed slot.
         for (int i = 0; i < 4; ++i)
         {
-            auto bandArea = topSection.withX(topSection.getX() + i * bandWidth).withWidth(bandWidth).reduced(3, 0);
+            const bool enabled = isBandEnabled(i);
+            bandButtons[i].setVisible(enabled);
+            bandSoloButtons[i].setVisible(enabled);
+        }
 
-            // Calculate meter bounds first so we can align buttons to it
+        for (int slot = 0; slot < numEnabled; ++slot)
+        {
+            const int band = enabledIdx[static_cast<size_t>(slot)];
+            auto bandArea = topSection.withX(topSection.getX() + slot * slotWidth)
+                                       .withWidth(slotWidth)
+                                       .reduced(3, 0);
+
             auto meterArea = bandArea;
-            meterArea.removeFromTop(static_cast<int>(32 * scaleFactor));  // Space for buttons + gap
-            meterArea.removeFromBottom(static_cast<int>(22 * scaleFactor));  // Space for freq label
-            auto meterBounds = meterArea.reduced(static_cast<int>(4 * scaleFactor), static_cast<int>(2 * scaleFactor));
+            meterArea.removeFromTop(static_cast<int>(32 * scaleFactor));
+            meterArea.removeFromBottom(static_cast<int>(22 * scaleFactor));
+            auto meterBounds = meterArea.reduced(static_cast<int>(4 * scaleFactor),
+                                                  static_cast<int>(2 * scaleFactor));
 
-            // Top row: Band button and Solo button side by side, centered over meter
-            int buttonRowHeight = static_cast<int>(26 * scaleFactor);
-            int soloWidth = static_cast<int>(24 * scaleFactor);
-            int buttonGap = static_cast<int>(3 * scaleFactor);
-            int totalButtonWidth = meterBounds.getWidth();  // Match meter width
-            int minBandButtonWidth = static_cast<int>(30 * scaleFactor);
-            int requiredMinWidth = minBandButtonWidth + soloWidth + buttonGap;
+            int totalButtonWidth = meterBounds.getWidth();
+            int minBandButtonWidth = static_cast<int>(24 * scaleFactor);
+            int trailingWidth = soloWidth + buttonGap;
+            int bandButtonWidth = (totalButtonWidth >= minBandButtonWidth + trailingWidth)
+                ? totalButtonWidth - trailingWidth
+                : juce::jmax(static_cast<int>(20 * scaleFactor), totalButtonWidth - trailingWidth);
 
-            // Handle narrow meter edge case - allow smaller buttons if necessary
-            int bandButtonWidth = (totalButtonWidth >= requiredMinWidth)
-                ? totalButtonWidth - soloWidth - buttonGap
-                : juce::jmax(static_cast<int>(20 * scaleFactor), totalButtonWidth - soloWidth - buttonGap);
-
-            // Center buttons over the meter
             int buttonsX = meterBounds.getX();
             int buttonsY = bandArea.getY();
 
-            bandButtons[i].setBounds(buttonsX, buttonsY, bandButtonWidth, buttonRowHeight);
-            bandSoloButtons[i].setBounds(buttonsX + bandButtonWidth + buttonGap, buttonsY, soloWidth, buttonRowHeight);
+            bandButtons[band].setBounds(buttonsX, buttonsY, bandButtonWidth, buttonRowHeight);
+            bandSoloButtons[band].setBounds(buttonsX + bandButtonWidth + buttonGap, buttonsY,
+                                            soloWidth, buttonRowHeight);
 
-            // Store meter bounds
-            bandGRBounds[i] = meterBounds;
+            bandGRBounds[band] = meterBounds;
         }
 
-        // Store meter section info for handle positioning
-        // Use the actual meter bounds to align faders with meters
+        // Store meter section info for handle positioning. Use first enabled
+        // band's meter as reference (DSP guarantees >= 2 enabled, so this
+        // exists). Falls back to 0,0 only if everything is disabled (shouldn't
+        // happen).
         crossoverAreaLeft = topSection.getX();
         crossoverAreaWidth = topSection.getWidth();
-        // Align fader top with the top of the GR meters (after buttons + gap)
-        crossoverHandleTop = bandGRBounds[0].getY();
-        crossoverHandleHeight = bandGRBounds[0].getHeight();
+        const int refBand = enabledIdx[0];
+        if (! bandGRBounds[refBand].isEmpty())
+        {
+            crossoverHandleTop = bandGRBounds[refBand].getY();
+            crossoverHandleHeight = bandGRBounds[refBand].getHeight();
+        }
 
-        // Position crossover faders between bands
+        // Position crossover faders only between consecutive enabled bands.
         updateCrossoverFaderPositions();
 
         // === Layout knobs ===
@@ -832,11 +899,11 @@ public:
         // Draw band backgrounds (colored tint for each band region)
         drawBandBackgrounds(g);
 
-        // Draw band GR meters with LED-style segments
+        // Draw band GR meters with LED-style segments. drawBandMeter skips
+        // bands whose bandGRBounds is empty (= disabled, hidden by resized()
+        // per issue #79).
         for (int i = 0; i < 4; ++i)
-        {
             drawBandMeter(g, i);
-        }
 
         // Note: Crossover faders now draw their own frequency labels
 
@@ -846,6 +913,12 @@ public:
 
     void timerCallback() override
     {
+        // Issue #79 — poll the enabled mask and update layout if it changed.
+        // ~33 ms of latency between toggle click and visual update; that's
+        // imperceptible and avoids the parameter-listener path that was
+        // hanging Ardour during click event dispatch.
+        syncEnableLayoutIfChanged();
+
         // Update crossover fader positions whenever values change
         updateCrossoverFaderPositions();
 
@@ -897,6 +970,9 @@ private:
     DuskSlider bandThreshold, bandRatio, bandAttack, bandRelease, bandMakeup;
     std::array<juce::TextButton, 4> bandSoloButtons;
     std::array<std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment>, 4> bandSoloAttachments;
+    std::array<juce::TextButton, 4> bandEnableButtons;
+    std::array<std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment>, 4> bandEnableAttachments;
+    uint8_t lastSyncedMask_ = 0xF;
     std::array<juce::Label, 7> knobLabels;
 
     // Per-band parameter attachments (recreated when band changes)
@@ -910,6 +986,68 @@ private:
     DuskSlider globalOutput, globalMix;
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> outputAttachment;
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> mixAttachment;
+
+    // === Issue #79 — band-enable helpers + APVTS listener bridge ===
+
+    bool isBandEnabled(int band) const
+    {
+        const juce::String bandNames[] = {"low", "lowmid", "highmid", "high"};
+        if (band < 0 || band >= 4) return true;
+        if (auto* p = parameters.getRawParameterValue("mb_" + bandNames[band] + "_enabled"))
+            return p->load() > 0.5f;
+        return true;
+    }
+
+    int countEnabledBands() const
+    {
+        int n = 0;
+        for (int i = 0; i < 4; ++i)
+            if (isBandEnabled(i)) ++n;
+        return n;
+    }
+
+    // Lock the strip toggles when only 2 bands remain enabled (min-2
+    // invariant). Disabled bands' tab + solo are hidden by resized() —
+    // no alpha-dim is necessary here.
+    void updateEnableButtonStates()
+    {
+        const int enabledCount_ = countEnabledBands();
+        for (int i = 0; i < 4; ++i)
+        {
+            const bool enabled = isBandEnabled(i);
+            const bool atMinimum = (enabledCount_ <= 2 && enabled);
+            bandEnableButtons[i].setEnabled(! atMinimum);
+            bandEnableButtons[i].setTooltip(atMinimum
+                ? juce::String("Multiband requires at least 2 enabled bands")
+                : "Enable / disable " + getBandName(i) + " band");
+        }
+    }
+
+    // Issue #79 — poll the enabled mask in timerCallback (30 Hz). The
+    // timer always runs on the message thread, which avoids the
+    // parameter-listener path that was hanging Ardour when the layout
+    // pass overlapped with click event dispatch.
+    void syncEnableLayoutIfChanged()
+    {
+        uint8_t mask = 0;
+        for (int i = 0; i < 4; ++i)
+            if (isBandEnabled(i)) mask |= static_cast<uint8_t>(1 << i);
+        if (mask == lastSyncedMask_)
+            return;
+        lastSyncedMask_ = mask;
+
+        updateEnableButtonStates();
+        if (currentBand < 0 || currentBand >= 4 || ! isBandEnabled(currentBand))
+        {
+            int firstEnabled = -1;
+            for (int i = 0; i < 4; ++i)
+                if (isBandEnabled(i)) { firstEnabled = i; break; }
+            if (firstEnabled >= 0)
+                selectBand(firstEnabled);
+        }
+        resized();
+        repaint();
+    }
 
     // Convert frequency to normalized position (0-1) using logarithmic scale
     float frequencyToNormalizedPosition(double freq) const
@@ -931,25 +1069,58 @@ private:
     {
         if (crossoverAreaWidth <= 0) return;
 
-        // Faders are positioned between the band meters
-        int bandWidth = meterSectionBounds.getWidth() / 4;
-        int faderWidth = static_cast<int>(40 * scaleFactor);
-        // Extend fader height to include space for frequency label below meters
-        int faderHeight = crossoverHandleHeight + static_cast<int>(22 * scaleFactor);
+        // Issue #79 — show only the crossover faders that border two
+        // consecutive enabled bands; hide the rest. CRITICAL: this runs at
+        // 30 Hz from the timer, so it MUST be idempotent. The previous
+        // hide-all-then-show-some pattern was forcing setVisible(false)
+        // → setVisible(true) on each active fader every tick, queuing two
+        // paint events per fader per tick. That flood was hanging Ardour's
+        // compositor. Compute desired state once, only mutate when it
+        // differs from current.
+        std::array<int, 4> enabledIdx{0, 0, 0, 0};
+        int numEnabled = 0;
+        for (int i = 0; i < 4; ++i)
+            if (isBandEnabled(i)) enabledIdx[static_cast<size_t>(numEnabled++)] = i;
+
+        std::array<bool, 3> desiredVisible{false, false, false};
+        std::array<juce::Rectangle<int>, 3> desiredBounds{};
+
+        if (numEnabled >= 2)
+        {
+            const int slotWidth = meterSectionBounds.getWidth() / numEnabled;
+            const int faderWidth = static_cast<int>(40 * scaleFactor);
+            const int faderHeight = crossoverHandleHeight + static_cast<int>(22 * scaleFactor);
+
+            for (int slot = 0; slot < numEnabled - 1; ++slot)
+            {
+                const int upperBand = enabledIdx[static_cast<size_t>(slot + 1)];
+                const int boundaryIdx = upperBand - 1;  // 0..2
+                if (boundaryIdx < 0 || boundaryIdx > 2) continue;
+
+                const int boundaryX = meterSectionBounds.getX() + (slot + 1) * slotWidth;
+                desiredVisible[static_cast<size_t>(boundaryIdx)] = true;
+                desiredBounds[static_cast<size_t>(boundaryIdx)]
+                    = juce::Rectangle<int>(boundaryX - faderWidth / 2,
+                                           crossoverHandleTop,
+                                           faderWidth, faderHeight);
+            }
+        }
 
         for (int i = 0; i < 3; ++i)
         {
-            if (crossoverFaders[i])
-            {
-                // Position at the boundary between band i and band i+1
-                int boundaryX = meterSectionBounds.getX() + (i + 1) * bandWidth;
+            auto* fader = crossoverFaders[i].get();
+            if (! fader) continue;
 
-                crossoverFaders[i]->setBounds(
-                    boundaryX - faderWidth / 2,
-                    crossoverHandleTop,
-                    faderWidth,
-                    faderHeight
-                );
+            const bool wantVisible = desiredVisible[static_cast<size_t>(i)];
+            if (wantVisible)
+            {
+                // setBounds is idempotent (early-returns when bounds match).
+                fader->setBounds(desiredBounds[static_cast<size_t>(i)]);
+                if (! fader->isVisible()) fader->setVisible(true);
+            }
+            else
+            {
+                if (fader->isVisible()) fader->setVisible(false);
             }
         }
     }
@@ -984,19 +1155,26 @@ private:
 
     void drawBandBackgrounds(juce::Graphics& g)
     {
-        // Draw subtle colored backgrounds for each band
-        if (bandGRBounds[0].isEmpty()) return;
+        // Draw subtle colored backgrounds for each enabled band slot.
+        // Disabled bands collapse out entirely (issue #79), so we iterate
+        // only the enabled set and use the same 1/N positioning as resized().
+        if (meterSectionBounds.isEmpty()) return;
 
-        int bandWidth = meterSectionBounds.getWidth() / 4;
+        std::array<int, 4> enabledIdx{0, 0, 0, 0};
+        int numEnabled = 0;
         for (int i = 0; i < 4; ++i)
+            if (isBandEnabled(i)) enabledIdx[static_cast<size_t>(numEnabled++)] = i;
+        if (numEnabled < 1) return;
+
+        const int slotWidth = meterSectionBounds.getWidth() / numEnabled;
+        for (int slot = 0; slot < numEnabled; ++slot)
         {
-            auto bandArea = meterSectionBounds.withX(meterSectionBounds.getX() + i * bandWidth)
-                                              .withWidth(bandWidth);
+            const int band = enabledIdx[static_cast<size_t>(slot)];
+            auto bandArea = meterSectionBounds.withX(meterSectionBounds.getX() + slot * slotWidth)
+                                              .withWidth(slotWidth);
 
-            juce::Colour bandCol = juce::Colour(bandColors[i]);
-            bool isSelected = (currentBand == i);
-
-            // Very subtle band tint
+            juce::Colour bandCol = juce::Colour(bandColors[band]);
+            bool isSelected = (currentBand == band);
             g.setColour(bandCol.withAlpha(isSelected ? 0.08f : 0.03f));
             g.fillRect(bandArea.reduced(1, 0));
         }

--- a/plugins/multi-comp/UniversalCompressor.h
+++ b/plugins/multi-comp/UniversalCompressor.h
@@ -121,6 +121,27 @@ public:
     juce::AudioProcessorValueTreeState& getParameters() { return parameters; }
     CompressorMode getCurrentMode() const;
 
+    // Minimal-processing fast path. When enabled, processBlock skips
+    // sidechain HP/EQ filtering, true-peak detection, transient shaper,
+    // global lookahead, mix wet/dry crossfade, auto-makeup smoothing,
+    // bypass-fade crossfader, stereo linking, and INTERNAL OVERSAMPLING.
+    // The mode-specific process() is still called per-sample at NATIVE
+    // rate using the input as its own sidechain. Intended for per-channel
+    // mixer use (host applies its own bypass/mute/solo gating, no need
+    // for the bus-grade extras). Disabled by default to preserve the
+    // existing standalone-plugin behaviour.
+    void setMinimalProcessing (bool enabled) noexcept { minimalProcessingMode.store (enabled, std::memory_order_relaxed); }
+    bool getMinimalProcessing() const noexcept       { return minimalProcessingMode.load (std::memory_order_relaxed); }
+
+    // Internal oversampling enable. Default true (preserves the donor's
+    // historical behaviour for standalone-plugin users). When false, the
+    // standard processBlock path runs the mode at native sample rate. Has
+    // no effect on the minimal-processing fast path, which is already
+    // native-rate. Hosts that want per-effect 1x default with a global
+    // quality switch can flip this from outside.
+    void setInternalOversamplingEnabled (bool enabled) noexcept { internalOversamplingEnabled.store (enabled, std::memory_order_relaxed); }
+    bool getInternalOversamplingEnabled() const noexcept       { return internalOversamplingEnabled.load (std::memory_order_relaxed); }
+
     // Preset change listener for UI updates (called on message thread)
     class PresetChangeListener
     {
@@ -168,6 +189,11 @@ private:
     std::unique_ptr<LookaheadBuffer> lookaheadBuffer;  // Global lookahead for all modes
     std::unique_ptr<class SidechainEQ> sidechainEQ;    // Low/high shelf EQ for sidechain
     std::unique_ptr<TruePeakDetector> truePeakDetector; // True-peak detection for sidechain
+
+    // Per-channel mixer fast-path flag — see public setMinimalProcessing.
+    std::atomic<bool> minimalProcessingMode{false};
+    // Internal-oversampling flag — see public setInternalOversamplingEnabled.
+    std::atomic<bool> internalOversamplingEnabled{true};
 
     // Metering (combined L/R max for backwards compatibility)
     std::atomic<float> inputMeter{-60.0f};
@@ -230,6 +256,7 @@ private:
     float grSmoothCoeff = 0.0f;         // One-pole filter coefficient for GR smoothing (~200ms)
     bool primeGrAccumulator = true;     // Flag to instantly prime on mode change
     bool wasBypassedLastBlock = false;
+    bool wasMinimalLastBlock  = false;  // Track minimal→standard transition for PDC restore
 
     // Bypass crossfade state (smooth transition from bypass to active)
     int bypassFadeRemaining{0};

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -3635,6 +3635,46 @@ public:
         updateCrossoverFrequencies(200.0f, 2000.0f, 8000.0f);
     }
 
+    // Issue #79 — Phase 2: rebuild the active split chain from the enable
+    // mask. Each filter pool (lp1/hp1, lp2/hp2, lp3/hp3) keeps its
+    // assignment to its original boundary frequency (crossoverFreqs[0..2]).
+    // The splitter then walks ONLY the boundaries between consecutive
+    // enabled bands, addressing the matching filter pool by original
+    // boundary index. This way filter state survives a mask change because
+    // a given pool's coefficients never change just because the mask did.
+    void rebuildSplitChain(uint8_t mask)
+    {
+        currentMask = mask;
+        numEnabledBands = 0;
+        for (int i = 0; i < NUM_BANDS; ++i)
+        {
+            if (mask & (1 << i))
+                enabledIndices[static_cast<size_t>(numEnabledBands++)] = i;
+        }
+        // Defensive — caller's processBlock guarantees popcount >= 2, but
+        // if we ever land here with <2 bands, fall back to all-enabled so
+        // the splitter has a valid topology.
+        if (numEnabledBands < 2)
+        {
+            numEnabledBands = NUM_BANDS;
+            for (int i = 0; i < NUM_BANDS; ++i)
+                enabledIndices[static_cast<size_t>(i)] = i;
+            currentMask = static_cast<uint8_t>((1 << NUM_BANDS) - 1);
+        }
+        numActiveStages = numEnabledBands - 1;
+        topBandIndex = enabledIndices[static_cast<size_t>(numEnabledBands - 1)];
+
+        // Stage k uses the original boundary at the LOW edge of the
+        // (k+1)-th enabled band, which lives in crossoverFreqs[i_{k+1} - 1].
+        // We don't move filter coefficients between pools — we just record
+        // which pool index each stage uses so the splitter can route.
+        for (int stage = 0; stage < numActiveStages; ++stage)
+        {
+            const int upperEnabled = enabledIndices[static_cast<size_t>(stage + 1)];
+            stageBoundaryFilterIdx[static_cast<size_t>(stage)] = upperEnabled - 1;  // 0..2
+        }
+    }
+
     void updateCrossoverFrequencies(float freq1, float freq2, float freq3)
     {
         if (sampleRate <= 0.0)
@@ -3648,6 +3688,12 @@ public:
         crossoverFreqs[0] = freq1;
         crossoverFreqs[1] = freq2;
         crossoverFreqs[2] = freq3;
+
+        // Note (issue #79): no rebuildSplitChain call here. The topology
+        // (which boundary lives at which stage) is mask-driven and is set
+        // by processBlock when the mask changes. Filter pools' coefficients
+        // are assigned by ORIGINAL boundary index (xover_1/2/3 → pool
+        // 1/2/3), so updating frequencies here doesn't disturb the topology.
 
         // Create filter coefficients - Butterworth Q=0.707 for LR4 when cascaded
         auto lp1Coeffs = juce::dsp::IIR::Coefficients<float>::makeLowPass(sampleRate, freq1, 0.707f);
@@ -3703,6 +3749,7 @@ public:
                       const std::array<float, NUM_BANDS>& makeups,
                       const std::array<bool, NUM_BANDS>& bypasses,
                       const std::array<bool, NUM_BANDS>& solos,
+                      const std::array<bool, NUM_BANDS>& enableds,
                       float outputGain, float mixPercent,
                       const juce::AudioBuffer<float>* sidechainBuffer = nullptr,
                       bool hasExternalSidechain = false)
@@ -3712,6 +3759,29 @@ public:
 
         if (numSamples <= 0 || channels <= 0)
             return;
+
+        // Issue #79 — derive the active mask, enforce minimum-2 invariant,
+        // rebuild the split chain only when the mask changed (cheap; just
+        // updates a small lookup, doesn't move filter coefficients).
+        uint8_t desiredMask = 0;
+        int enabledCount = 0;
+        for (int b = 0; b < NUM_BANDS; ++b)
+        {
+            if (enableds[b]) { desiredMask |= static_cast<uint8_t>(1 << b); ++enabledCount; }
+        }
+        if (enabledCount < 2)
+        {
+            for (int b = 0; b < NUM_BANDS && enabledCount < 2; ++b)
+            {
+                if (! (desiredMask & (1 << b)))
+                {
+                    desiredMask |= static_cast<uint8_t>(1 << b);
+                    ++enabledCount;
+                }
+            }
+        }
+        if (desiredMask != currentMask)
+            rebuildSplitChain(desiredMask);
 
         // Check for any solo bands
         bool anySolo = false;
@@ -3753,12 +3823,31 @@ public:
                                        hasExternalSidechain ? &scBandBuffers[band] : nullptr,
                                        hasExternalSidechain);
             }
-            else if (!shouldProcess)
+            else
             {
-                // Mute non-soloed bands when solo is active
-                bandBuffers[band].clear();
+                // Bypassed bands (user-bypass, solo'd-out, or caller-disabled) do
+                // no compression — zero GR so getMaxGainReduction() and auto-makeup
+                // don't see stale values from when the band was last active.
+                bandGainReduction[band] = 0.0f;
+
+                // Reset the detector envelope when the band is removed from the
+                // active path (solo-muted or user-disabled). Without this, a
+                // band that was under heavy GR before being taken out resumes
+                // from its stale envelope state on reactivation and stays
+                // attenuated until the old release tail decays.
+                if (!shouldProcess || !enableds[band])
+                {
+                    for (int ch = 0; ch < channels; ++ch)
+                        bandEnvelopes[band][static_cast<size_t>(ch)] = 1.0f;
+                }
+
+                if (!shouldProcess)
+                {
+                    // Mute non-soloed bands when solo is active
+                    bandBuffers[band].clear();
+                }
+                // If bypassed but no solo, keep the band signal as-is (no compression)
             }
-            // If bypassed but no solo, keep the band signal as-is (no compression)
         }
 
         // Sum all bands back together
@@ -3849,107 +3938,127 @@ public:
 private:
     void splitIntoBands(const juce::AudioBuffer<float>& input, int numSamples, int channels)
     {
-        // Proper Linkwitz-Riley 4th order (LR4) crossover implementation
-        // LR4 = cascaded 2nd order Butterworth filters (applied twice)
+        // Issue #79 — topology-aware Linkwitz-Riley 4th order splitter.
+        // Walks the active boundary list (built by rebuildSplitChain) and
+        // sends LP into the corresponding enabled band buffer; HP cascades
+        // into the next stage. The final stage's HP feeds the highest
+        // enabled band. Disabled bands' buffers are cleared at the top so
+        // the recombination sum picks up zero from them.
         //
-        // Signal flow for 4 bands with 3 crossover points:
-        // Band 0 (Low):      Input -> LP1a -> LP1b
-        // Band 1 (Low-Mid):  Input -> HP1a -> HP1b -> LP2a -> LP2b
-        // Band 2 (High-Mid): Input -> HP1a -> HP1b -> HP2a -> HP2b -> LP3a -> LP3b
-        // Band 3 (High):     Input -> HP1a -> HP1b -> HP2a -> HP2b -> HP3a -> HP3b
-        //
-        // Each filter path needs its own filter instances to maintain correct state!
-        // The "a" and "b" filters are the two cascaded stages for LR4 response.
+        // Filter pools (lp1/hp1, lp2/hp2, lp3/hp3) keep their original
+        // boundary assignments (xover_1, xover_2, xover_3 respectively).
+        // stageBoundaryFilterIdx[stage] selects which pool the stage uses,
+        // so changing the mask doesn't invalidate filter state.
+
+        // Clear disabled bands so recombination sees zero from them.
+        for (int b = 0; b < NUM_BANDS; ++b)
+        {
+            if (! (currentMask & (1 << b)))
+                bandBuffers[b].clear(0, numSamples);
+        }
 
         for (int ch = 0; ch < channels; ++ch)
         {
             const float* in = input.getReadPointer(ch);
-            float* band0 = bandBuffers[0].getWritePointer(ch);
-            float* band1 = bandBuffers[1].getWritePointer(ch);
-            float* band2 = bandBuffers[2].getWritePointer(ch);
-            float* band3 = bandBuffers[3].getWritePointer(ch);
+            std::array<float*, NUM_BANDS> bandPtrs{};
+            for (int b = 0; b < NUM_BANDS; ++b)
+                bandPtrs[static_cast<size_t>(b)] = bandBuffers[b].getWritePointer(ch);
+
+            // Pre-resolve filter pointers per stage so the inner loop is
+            // pointer-chasing only.
+            std::array<juce::dsp::IIR::Filter<float>*, NUM_BANDS - 1> sLpA{}, sLpB{}, sHpA{}, sHpB{};
+            for (int stage = 0; stage < numActiveStages; ++stage)
+            {
+                const int idx = stageBoundaryFilterIdx[static_cast<size_t>(stage)];
+                sLpA[static_cast<size_t>(stage)] = &filterPool(idx, /*isLp*/true,  /*isB*/false)[ch];
+                sLpB[static_cast<size_t>(stage)] = &filterPool(idx, /*isLp*/true,  /*isB*/true) [ch];
+                sHpA[static_cast<size_t>(stage)] = &filterPool(idx, /*isLp*/false, /*isB*/false)[ch];
+                sHpB[static_cast<size_t>(stage)] = &filterPool(idx, /*isLp*/false, /*isB*/true) [ch];
+            }
 
             for (int i = 0; i < numSamples; ++i)
             {
-                float sample = in[i];
+                float running = in[i];
 
-                // === Band 0: Low (below crossover 1) ===
-                // LP1 applied twice for LR4
-                float lp1 = lp1_a[ch].processSample(sample);
-                lp1 = lp1_b[ch].processSample(lp1);
-                band0[i] = lp1;
+                for (int stage = 0; stage < numActiveStages; ++stage)
+                {
+                    float lp = sLpA[static_cast<size_t>(stage)]->processSample(running);
+                    lp = sLpB[static_cast<size_t>(stage)]->processSample(lp);
+                    bandPtrs[static_cast<size_t>(enabledIndices[static_cast<size_t>(stage)])][i] = lp;
 
-                // === HP1 for bands 1-3 (above crossover 1) ===
-                float hp1 = hp1_a[ch].processSample(sample);
-                hp1 = hp1_b[ch].processSample(hp1);
+                    float hp = sHpA[static_cast<size_t>(stage)]->processSample(running);
+                    hp = sHpB[static_cast<size_t>(stage)]->processSample(hp);
+                    running = hp;
+                }
 
-                // === Band 1: Low-Mid (between crossover 1 and 2) ===
-                // HP1 output -> LP2 applied twice
-                float lp2 = lp2_a[ch].processSample(hp1);
-                lp2 = lp2_b[ch].processSample(lp2);
-                band1[i] = lp2;
-
-                // === HP2 for bands 2-3 (above crossover 2) ===
-                float hp2 = hp2_a[ch].processSample(hp1);
-                hp2 = hp2_b[ch].processSample(hp2);
-
-                // === Band 2: High-Mid (between crossover 2 and 3) ===
-                // HP2 output -> LP3 applied twice
-                float lp3 = lp3_a[ch].processSample(hp2);
-                lp3 = lp3_b[ch].processSample(lp3);
-                band2[i] = lp3;
-
-                // === Band 3: High (above crossover 3) ===
-                // HP2 output -> HP3 applied twice
-                float hp3 = hp3_a[ch].processSample(hp2);
-                hp3 = hp3_b[ch].processSample(hp3);
-                band3[i] = hp3;
+                bandPtrs[static_cast<size_t>(topBandIndex)][i] = running;
             }
         }
     }
 
+    // Pool selector for the audio splitter. boundaryIdx ∈ {0,1,2}.
+    std::vector<juce::dsp::IIR::Filter<float>>& filterPool(int boundaryIdx, bool isLp, bool isB)
+    {
+        if (boundaryIdx == 0)
+            return isLp ? (isB ? lp1_b : lp1_a) : (isB ? hp1_b : hp1_a);
+        if (boundaryIdx == 1)
+            return isLp ? (isB ? lp2_b : lp2_a) : (isB ? hp2_b : hp2_a);
+        return isLp ? (isB ? lp3_b : lp3_a) : (isB ? hp3_b : hp3_a);
+    }
+
+    // Pool selector for the sidechain splitter (parallel filter set).
+    std::vector<juce::dsp::IIR::Filter<float>>& scFilterPool(int boundaryIdx, bool isLp, bool isB)
+    {
+        if (boundaryIdx == 0)
+            return isLp ? (isB ? sc_lp1_b : sc_lp1_a) : (isB ? sc_hp1_b : sc_hp1_a);
+        if (boundaryIdx == 1)
+            return isLp ? (isB ? sc_lp2_b : sc_lp2_a) : (isB ? sc_hp2_b : sc_hp2_a);
+        return isLp ? (isB ? sc_lp3_b : sc_lp3_a) : (isB ? sc_hp3_b : sc_hp3_a);
+    }
+
     void splitSidechainIntoBands(const juce::AudioBuffer<float>& scInput, int numSamples, int channels)
     {
-        // Same LR4 crossover as splitIntoBands() but using separate sc_ filter instances
+        // Same LR4 crossover as splitIntoBands() but using separate sc_ filter instances.
+        // Topology mirrors the audio path; see splitIntoBands for the rule.
+        for (int b = 0; b < NUM_BANDS; ++b)
+        {
+            if (! (currentMask & (1 << b)))
+                scBandBuffers[b].clear(0, numSamples);
+        }
+
         for (int ch = 0; ch < channels; ++ch)
         {
             const float* in = scInput.getReadPointer(juce::jmin(ch, scInput.getNumChannels() - 1));
-            float* band0 = scBandBuffers[0].getWritePointer(ch);
-            float* band1 = scBandBuffers[1].getWritePointer(ch);
-            float* band2 = scBandBuffers[2].getWritePointer(ch);
-            float* band3 = scBandBuffers[3].getWritePointer(ch);
+            std::array<float*, NUM_BANDS> bandPtrs{};
+            for (int b = 0; b < NUM_BANDS; ++b)
+                bandPtrs[static_cast<size_t>(b)] = scBandBuffers[b].getWritePointer(ch);
+
+            std::array<juce::dsp::IIR::Filter<float>*, NUM_BANDS - 1> sLpA{}, sLpB{}, sHpA{}, sHpB{};
+            for (int stage = 0; stage < numActiveStages; ++stage)
+            {
+                const int idx = stageBoundaryFilterIdx[static_cast<size_t>(stage)];
+                sLpA[static_cast<size_t>(stage)] = &scFilterPool(idx, /*isLp*/true,  /*isB*/false)[ch];
+                sLpB[static_cast<size_t>(stage)] = &scFilterPool(idx, /*isLp*/true,  /*isB*/true) [ch];
+                sHpA[static_cast<size_t>(stage)] = &scFilterPool(idx, /*isLp*/false, /*isB*/false)[ch];
+                sHpB[static_cast<size_t>(stage)] = &scFilterPool(idx, /*isLp*/false, /*isB*/true) [ch];
+            }
 
             for (int i = 0; i < numSamples; ++i)
             {
-                float sample = in[i];
+                float running = in[i];
 
-                // Band 0: Low (below crossover 1)
-                float lp1 = sc_lp1_a[ch].processSample(sample);
-                lp1 = sc_lp1_b[ch].processSample(lp1);
-                band0[i] = lp1;
+                for (int stage = 0; stage < numActiveStages; ++stage)
+                {
+                    float lp = sLpA[static_cast<size_t>(stage)]->processSample(running);
+                    lp = sLpB[static_cast<size_t>(stage)]->processSample(lp);
+                    bandPtrs[static_cast<size_t>(enabledIndices[static_cast<size_t>(stage)])][i] = lp;
 
-                // HP1 for bands 1-3
-                float hp1 = sc_hp1_a[ch].processSample(sample);
-                hp1 = sc_hp1_b[ch].processSample(hp1);
+                    float hp = sHpA[static_cast<size_t>(stage)]->processSample(running);
+                    hp = sHpB[static_cast<size_t>(stage)]->processSample(hp);
+                    running = hp;
+                }
 
-                // Band 1: Low-Mid (between crossover 1 and 2)
-                float lp2 = sc_lp2_a[ch].processSample(hp1);
-                lp2 = sc_lp2_b[ch].processSample(lp2);
-                band1[i] = lp2;
-
-                // HP2 for bands 2-3
-                float hp2 = sc_hp2_a[ch].processSample(hp1);
-                hp2 = sc_hp2_b[ch].processSample(hp2);
-
-                // Band 2: High-Mid (between crossover 2 and 3)
-                float lp3 = sc_lp3_a[ch].processSample(hp2);
-                lp3 = sc_lp3_b[ch].processSample(lp3);
-                band2[i] = lp3;
-
-                // Band 3: High (above crossover 3)
-                float hp3 = sc_hp3_a[ch].processSample(hp2);
-                hp3 = sc_hp3_b[ch].processSample(hp3);
-                band3[i] = hp3;
+                bandPtrs[static_cast<size_t>(topBandIndex)][i] = running;
             }
         }
     }
@@ -4076,6 +4185,21 @@ private:
 
     // Crossover frequencies
     std::array<float, 3> crossoverFreqs{200.0f, 2000.0f, 8000.0f};
+
+    // Issue #79 — active topology state. currentMask is the bitmask of
+    // enabled bands (LSB = band 0). enabledIndices is the ordered list of
+    // those band indices; numActiveStages = numEnabledBands - 1 is how
+    // many LP/HP splits the splitter actually runs. stageBoundaryFilterIdx
+    // maps stage k → original boundary index (0..2) which selects the
+    // filter pool to reuse (lp1/hp1 vs lp2/hp2 vs lp3/hp3). This decoupling
+    // keeps filter state valid across mask changes since a given pool's
+    // coefficients never depend on the mask, only on its boundary frequency.
+    uint8_t currentMask = 0xF;
+    std::array<int, NUM_BANDS> enabledIndices{0, 1, 2, 3};
+    int numEnabledBands = NUM_BANDS;
+    int numActiveStages = NUM_BANDS - 1;
+    int topBandIndex = NUM_BANDS - 1;
+    std::array<int, NUM_BANDS - 1> stageBoundaryFilterIdx{0, 1, 2};
 
     double sampleRate = 0.0;
     int numChannels = 2;
@@ -4415,6 +4539,14 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
         // Band solo
         layout.add(std::make_unique<juce::AudioParameterBool>(
             "mb_" + name + "_solo", label + " Solo", false));
+
+        // Band enabled — when false, the band is removed from the multiband
+        // chain entirely (issue #79). Default true so existing presets are
+        // unaffected. The UI enforces a minimum of 2 enabled bands; the DSP
+        // layer also defends against <2 in case the param is driven by host
+        // automation.
+        layout.add(std::make_unique<juce::AudioParameterBool>(
+            "mb_" + name + "_enabled", label + " Enabled", true));
     }
 
     // Global multiband output
@@ -4923,6 +5055,106 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         return;
     }
 
+    // ─────────────────────────────────────────────────────────────────────
+    // Minimal-processing fast path (per-channel mixer use). Skips everything
+    // that earns its keep on a master/bus but is wasted CPU on a track strip:
+    //   - sidechain HP filter / shelf EQ
+    //   - true-peak detection
+    //   - transient shaper
+    //   - global lookahead
+    //   - mix wet/dry crossfade (always 100% wet here)
+    //   - auto-makeup smoother
+    //   - bypass-fade crossfader
+    //   - stereo linking (per-channel comp is mono)
+    //   - INTERNAL OVERSAMPLING (the big one — saves a 2x-4x multiplier on
+    //     mode-process() invocations for every channel-block)
+    // The mode-specific per-sample process() is still called with the same
+    // params at native rate, using the input as its own sidechain. Mode
+    // switching, GR meter update, and Multiband fallback are preserved.
+    if (minimalProcessingMode.load (std::memory_order_relaxed))
+    {
+        const int numCh = juce::jmin (buffer.getNumChannels(), 2);
+
+        // Cache active mode params once (mirrors the switch below in the
+        // standard path but only reads what THIS mode needs).
+        const CompressorMode fastMode = getCurrentMode();
+        float p0 = 0.0f, p1 = 0.0f, p2 = 0.0f, p3 = 0.0f, p4 = 0.0f, p5 = 0.0f, p6 = 0.0f;
+        switch (fastMode)
+        {
+            case CompressorMode::Opto:
+                if (auto* a = parameters.getRawParameterValue ("opto_peak_reduction")) p0 = juce::jlimit (0.0f, 100.0f, a->load());
+                if (auto* a = parameters.getRawParameterValue ("opto_gain"))           p1 = juce::jlimit (-40.0f, 40.0f, (juce::jlimit (0.0f, 100.0f, a->load()) - 50.0f) * 0.8f);
+                if (auto* a = parameters.getRawParameterValue ("opto_limit"))          p2 = a->load();
+                break;
+            case CompressorMode::FET:
+                if (auto* a = parameters.getRawParameterValue ("fet_input"))    p0 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("fet_output"))   p1 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("fet_attack"))   p2 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("fet_release")) p3 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("fet_ratio"))    p4 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("fet_curve_mode"))      p5 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("fet_transient"))       p6 = a->load();
+                break;
+            case CompressorMode::VCA:
+                if (auto* a = parameters.getRawParameterValue ("vca_threshold")) p0 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("vca_ratio"))     p1 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("vca_attack"))    p2 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("vca_release"))  p3 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("vca_output"))    p4 = a->load();
+                if (auto* a = parameters.getRawParameterValue ("vca_overeasy"))  p5 = a->load();
+                break;
+            default:
+                // Bus / Studio / Digital / Multiband fall through to the
+                // standard path — minimal mode targets the three modes used
+                // on per-channel strips.
+                goto fastPathFallthrough;
+        }
+
+        // Process each channel in place at native rate. Pass input as its
+        // own sidechain (same as standard path's "internal sidechain" =
+        // input pre-filter, but with the HP filter skipped — see comment
+        // on the fast-path at top).
+        {
+            int numSamples = buffer.getNumSamples();
+            float maxGrDb = 0.0f;
+            for (int ch = 0; ch < numCh; ++ch)
+            {
+                float* data = buffer.getWritePointer (ch);
+                switch (fastMode)
+                {
+                    case CompressorMode::Opto:
+                        for (int i = 0; i < numSamples; ++i)
+                            data[i] = optoCompressor->process (data[i], ch, p0, p1, p2 > 0.5f, false, data[i], false);
+                        break;
+                    case CompressorMode::FET:
+                        for (int i = 0; i < numSamples; ++i)
+                            data[i] = fetCompressor->process (data[i], ch, p0, p1, p2, p3, static_cast<int>(p4), false,
+                                                                lookupTables.get(), transientShaper.get(),
+                                                                p5 > 0.5f, p6, data[i], false);
+                        break;
+                    case CompressorMode::VCA:
+                        for (int i = 0; i < numSamples; ++i)
+                            data[i] = vcaCompressor->process (data[i], ch, p0, p1, p2, p3, p4, p5 > 0.5f, false, data[i], false);
+                        break;
+                    default: break;  // already filtered out above
+                }
+            }
+
+            // GR meter — read whichever mode just ran.
+            switch (fastMode)
+            {
+                case CompressorMode::Opto: maxGrDb = optoCompressor->getGainReduction(0); break;
+                case CompressorMode::FET:  maxGrDb = fetCompressor ->getGainReduction(0); break;
+                case CompressorMode::VCA:  maxGrDb = vcaCompressor ->getGainReduction(0); break;
+                default: break;
+            }
+            grMeter.store (maxGrDb, std::memory_order_relaxed);
+        }
+        return;
+    }
+    fastPathFallthrough:;
+    // ─────────────────────────────────────────────────────────────────────
+
     // Restore latency on bypass→active transition with smooth crossfade
     if (wasBypassedLastBlock)
     {
@@ -5054,8 +5286,10 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         return;
     }
 
-    // Internal oversampling is always enabled for better quality
-    bool oversample = true; // Always use oversampling internally
+    // Internal oversampling — default true, but hosts that want a 1x default
+    // (and an external/global quality switch) can flip it off via
+    // setInternalOversamplingEnabled(false).
+    bool oversample = internalOversamplingEnabled.load (std::memory_order_relaxed);
     CompressorMode mode = getCurrentMode();
 
     // Reset auto-gain state on mode change
@@ -5603,6 +5837,7 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         std::array<float, kBands> thresholds, ratios, attacks, releases, makeups;
         std::array<bool, kBands> bypasses, solos;
 
+        std::array<bool, kBands> enableds;
         for (int band = 0; band < kBands; ++band)
         {
             const juce::String& name = bandNames[band];
@@ -5613,6 +5848,7 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             auto* makeup = parameters.getRawParameterValue("mb_" + name + "_makeup");
             auto* bypass = parameters.getRawParameterValue("mb_" + name + "_bypass");
             auto* solo = parameters.getRawParameterValue("mb_" + name + "_solo");
+            auto* enabled = parameters.getRawParameterValue("mb_" + name + "_enabled");
 
             thresholds[band] = thresh ? thresh->load() : -20.0f;
             ratios[band] = ratio ? ratio->load() : 4.0f;
@@ -5621,11 +5857,25 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             makeups[band] = makeup ? makeup->load() : 0.0f;
             bypasses[band] = bypass ? (bypass->load() > 0.5f) : false;
             solos[band] = solo ? (solo->load() > 0.5f) : false;
+            enableds[band] = enabled ? (enabled->load() > 0.5f) : true;
         }
 
-        // Process through multiband compressor (pass sidechain for external SC detection)
+        // Issue #79 — Phase 2: the splitter inside MultibandCompressor now
+        // collapses disabled bands' frequency ranges into their nearest
+        // enabled neighbour, so disabled bands' buffers come out cleared.
+        // Force-bypass disabled bands here too so processBandCompression
+        // doesn't waste cycles compressing zero (the envelope would just
+        // sit at unity, but skipping is free and clearer in intent).
+        for (int band = 0; band < kBands; ++band)
+            if (!enableds[band])
+                bypasses[band] = true;
+
+        // Process through multiband compressor (pass sidechain for external SC detection).
+        // The multiband compressor enforces its own minimum-2 invariant on
+        // enableds[] before deriving the splitter mask.
         multibandCompressor->processBlock(buffer, thresholds, ratios, attacks, releases,
-                                          makeups, bypasses, solos, mbOutput, mbMix,
+                                          makeups, bypasses, solos, enableds,
+                                          mbOutput, mbMix,
                                           &filteredSidechain, hasExternalSidechain);
 
         // Update per-band GR meters for UI

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -3644,6 +3644,24 @@ public:
     // a given pool's coefficients never change just because the mask did.
     void rebuildSplitChain(uint8_t mask)
     {
+        // Snapshot the previous active-pool set BEFORE we mutate currentMask,
+        // so we can detect pools that transition 0→1 (re-enabled) and reset
+        // their filter state. Without this, a pool that sat idle while the
+        // user had a band disabled would resume from frozen z-1/z-2 history
+        // and produce a small click on reactivation.
+        std::array<bool, 3> oldActivePools{false, false, false};
+        {
+            std::array<int, NUM_BANDS> oldEnabled{};
+            int n = 0;
+            for (int i = 0; i < NUM_BANDS; ++i)
+                if (currentMask & (1 << i)) oldEnabled[static_cast<size_t>(n++)] = i;
+            for (int s = 0; s < n - 1; ++s)
+            {
+                const int idx = oldEnabled[static_cast<size_t>(s + 1)] - 1;
+                if (idx >= 0 && idx <= 2) oldActivePools[static_cast<size_t>(idx)] = true;
+            }
+        }
+
         currentMask = mask;
         numEnabledBands = 0;
         for (int i = 0; i < NUM_BANDS; ++i)
@@ -3667,11 +3685,38 @@ public:
         // Stage k uses the original boundary at the LOW edge of the
         // (k+1)-th enabled band, which lives in crossoverFreqs[i_{k+1} - 1].
         // We don't move filter coefficients between pools — we just record
-        // which pool index each stage uses so the splitter can route.
+        // which pool index each stage uses so the splitter can route. While
+        // we're here, mark which pools are now active so we can compare to
+        // oldActivePools and reset only the newly-activated ones.
+        std::array<bool, 3> newActivePools{false, false, false};
         for (int stage = 0; stage < numActiveStages; ++stage)
         {
             const int upperEnabled = enabledIndices[static_cast<size_t>(stage + 1)];
-            stageBoundaryFilterIdx[static_cast<size_t>(stage)] = upperEnabled - 1;  // 0..2
+            const int idx = upperEnabled - 1;  // 0..2
+            stageBoundaryFilterIdx[static_cast<size_t>(stage)] = idx;
+            if (idx >= 0 && idx <= 2) newActivePools[static_cast<size_t>(idx)] = true;
+        }
+
+        // Reset filter state for pools that transitioned 0→1. RT-safe: just
+        // zeroes the IIR state vectors, no allocation. Pools that were
+        // already active keep their state so audio processing isn't
+        // disrupted when the mask change doesn't affect them.
+        for (int p = 0; p < 3; ++p)
+        {
+            if (newActivePools[static_cast<size_t>(p)] && ! oldActivePools[static_cast<size_t>(p)])
+            {
+                for (int ch = 0; ch < numChannels; ++ch)
+                {
+                    filterPool(p, true,  false)[static_cast<size_t>(ch)].reset();
+                    filterPool(p, true,  true) [static_cast<size_t>(ch)].reset();
+                    filterPool(p, false, false)[static_cast<size_t>(ch)].reset();
+                    filterPool(p, false, true) [static_cast<size_t>(ch)].reset();
+                    scFilterPool(p, true,  false)[static_cast<size_t>(ch)].reset();
+                    scFilterPool(p, true,  true) [static_cast<size_t>(ch)].reset();
+                    scFilterPool(p, false, false)[static_cast<size_t>(ch)].reset();
+                    scFilterPool(p, false, true) [static_cast<size_t>(ch)].reset();
+                }
+            }
         }
     }
 
@@ -3830,12 +3875,12 @@ public:
                 // don't see stale values from when the band was last active.
                 bandGainReduction[band] = 0.0f;
 
-                // Reset the detector envelope when the band is removed from the
-                // active path (solo-muted or user-disabled). Without this, a
-                // band that was under heavy GR before being taken out resumes
-                // from its stale envelope state on reactivation and stays
-                // attenuated until the old release tail decays.
-                if (!shouldProcess || !enableds[band])
+                // Reset the detector envelope on ANY bypass path (user-bypass,
+                // solo-muted, or caller-disabled). Without this, a band that
+                // was under heavy GR before being taken out resumes from its
+                // stale envelope state on reactivation and the band comes
+                // back already attenuated until the old release tail decays.
+                if (isBypassed || !enableds[band])
                 {
                     for (int ch = 0; ch < channels; ++ch)
                         bandEnvelopes[band][static_cast<size_t>(ch)] = 1.0f;
@@ -5110,6 +5155,55 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                 goto fastPathFallthrough;
         }
 
+        // We're committed to the minimal path now (the switch above
+        // already routed unsupported modes to fastPathFallthrough). Force
+        // host PDC to 0 since this path skips global lookahead AND
+        // internal oversampling — otherwise the host applies a phantom
+        // delay offset that doesn't match actual output and causes phase
+        // issues on parallel buses.
+        if (getLatencySamples() != 0)
+            setLatencySamples(0);
+
+        // Keep the global-lookahead ring + the bypass-fade delay line warm
+        // by feeding raw input through them, even though we don't use
+        // their output here. Without this, the first block of the
+        // standard path on minimal→standard transition would read cold /
+        // stale samples from those buffers and glitch until they refill.
+        // Mirrors the bypass-path warming pattern. Done BEFORE in-place
+        // processing so we feed unprocessed input.
+        {
+            const int nc = buffer.getNumChannels();
+            const int ns = buffer.getNumSamples();
+
+            if (lookaheadBuffer)
+            {
+                float lookaheadMs = 0.0f;
+                if (auto* laParam = parameters.getRawParameterValue("global_lookahead"))
+                    lookaheadMs = laParam->load();
+                if (lookaheadMs > 0.0f)
+                    for (int ch = 0; ch < nc; ++ch)
+                        for (int i = 0; i < ns; ++i)
+                            lookaheadBuffer->processSample(buffer.getSample(ch, i), ch, lookaheadMs);
+            }
+
+            // Digital lookahead is intentionally NOT warmed here — minimal
+            // path falls through to standard for Digital mode anyway, and
+            // its delay line runs at the oversampled rate.
+
+            if (bypassFadeDelaySize > 1)
+            {
+                for (int ch = 0; ch < nc; ++ch)
+                {
+                    int& wp = bypassFadeDelayWritePos[static_cast<size_t>(ch)];
+                    for (int i = 0; i < ns; ++i)
+                    {
+                        bypassFadeDelayBuf.setSample(ch, wp, buffer.getSample(ch, i));
+                        wp = (wp + 1) % bypassFadeDelaySize;
+                    }
+                }
+            }
+        }
+
         // Process each channel in place at native rate. Pass input as its
         // own sidechain (same as standard path's "internal sidechain" =
         // input pre-filter, but with the HP filter skipped — see comment
@@ -5150,10 +5244,21 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             }
             grMeter.store (maxGrDb, std::memory_order_relaxed);
         }
+        wasMinimalLastBlock = true;  // Standard path will restore latency on transition.
         return;
     }
     fastPathFallthrough:;
     // ─────────────────────────────────────────────────────────────────────
+
+    // Restore latency on minimal-mode → standard-path transition. Minimal
+    // mode forces latency to 0; standard path may need the lookahead /
+    // oversampling latency back. Mirrors the bypass-restoration pattern
+    // below but doesn't need the bypass-fade crossfade machinery.
+    if (wasMinimalLastBlock)
+    {
+        wasMinimalLastBlock = false;
+        updateLatencyReport();
+    }
 
     // Restore latency on bypass→active transition with smooth crossfade
     if (wasBypassedLastBlock)

--- a/plugins/shared/channel-comp/ChannelComp.h
+++ b/plugins/shared/channel-comp/ChannelComp.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// ChannelComp — streamlined per-channel mixer compressor for hosts that need
+// a lean Opto / FET / VCA path without the bus-grade extras of the full
+// UniversalCompressor (no internal oversampling, no sidechain HP/EQ/true-peak/
+// transient-shaper/lookahead, no mix wet-dry, no auto-makeup, no bypass-fade,
+// no stereo-link). Same per-sample mode DSP as UniversalCompressor — same
+// hardware emulation, same character — just stripped of features that would
+// run unconditionally in the standard path.
+//
+// Implementation strategy: own a UniversalCompressor instance and flip its
+// minimalProcessingMode flag at construction. processBlock() then takes the
+// fast-path branch in UniversalCompressor::processBlock that calls the mode's
+// process() per-sample at native rate. The host writes parameter atomics
+// directly via getParameters() (lock-free, notification-free) — same pattern
+// the donor plugin's audio thread uses internally.
+//
+// Header-only; sits in the Dusk plugins shared/ tree so any consumer (ADH DAW,
+// future internal tools) picks up algorithm changes the moment the donor is
+// rebuilt.
+
+#include "../../multi-comp/UniversalCompressor.h"
+
+#include <juce_audio_processors/juce_audio_processors.h>
+
+namespace dusk
+{
+class ChannelComp
+{
+public:
+    ChannelComp()
+    {
+        comp.setMinimalProcessing (true);
+    }
+
+    // Match the host's prepareToPlay contract. Channel count is fixed at 1
+    // per ChannelComp instance (one per mono channel strip); hosts that need
+    // stereo construct a left/right pair.
+    void prepare (double sampleRate, int blockSize, int numChannels = 1)
+    {
+        comp.setPlayConfigDetails (numChannels, numChannels, sampleRate, juce::jmax (1, blockSize));
+        comp.prepareToPlay (sampleRate, juce::jmax (1, blockSize));
+        midiScratch.clear();
+    }
+
+    // RT-safe: wraps host buffer pointers in a juce::AudioBuffer and calls the
+    // donor's processBlock. Fast-path branch is taken because the flag was set
+    // at construction.
+    void processBlock (juce::AudioBuffer<float>& buffer) noexcept
+    {
+        midiScratch.clear();
+        comp.processBlock (buffer, midiScratch);
+    }
+
+    // Direct access to the underlying APVTS so hosts can cache parameter
+    // atomic pointers and write SI-unit values via std::atomic::store. Same
+    // pattern the donor's audio thread uses to read params.
+    juce::AudioProcessorValueTreeState& getParameters() noexcept { return comp.getParameters(); }
+
+    // Most recent gain reduction (dB, negative = reduction) for metering.
+    float getGainReductionDb() const noexcept { return comp.getGainReduction(); }
+
+    UniversalCompressor& getUnderlying() noexcept { return comp; }
+
+private:
+    UniversalCompressor comp;
+    juce::MidiBuffer    midiScratch;
+};
+} // namespace dusk


### PR DESCRIPTION
## Summary
- Adds per-band `mb_<name>_enabled` toggles (default true) exposed as a strip of 4 buttons above the GR meters; disabled bands' columns collapse out of the UI.
- LR4 splitter is now topology-aware, disabled bands' frequency ranges are absorbed into the nearest active neighbour, delivering a real 2-band / 3-band feel rather than just bypassing compression.
- Min-2 invariant locks the last 2 enabled toggles so the chain always has at least 2 active bands.

Closes #79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-band enable/disable toggles with auto-selection and UI hiding of disabled bands
  * Minimal processing fast-path to reduce CPU in lightweight use
  * Toggle to control internal oversampling
  * New lightweight channel wrapper that uses the minimal processing path

* **Bug Fixes / Improvements**
  * Meters, band tabs and crossover controls now adapt to enabled-band layout and avoid stale meter/state when bands toggle
<!-- end of auto-generated comment: release notes by coderabbit.ai -->