### PR TITLE
Chord Analyzer MIDI: VST3 subcategory Fx|Instrument for Cubase MIDI I…

### DIFF
--- a/plugins/chord-analyzer/CMakeLists.txt
+++ b/plugins/chord-analyzer/CMakeLists.txt
@@ -155,6 +155,7 @@ juce_add_plugin(ChordAnalyzerMIDI
     PRODUCT_NAME "Chord Analyzer MIDI"
     VST3_CAN_REPLACE_VST2 FALSE
     VST3_AUTO_MANIFEST FALSE
+    VST3_CATEGORIES "Fx" "Instrument"
 )
 
 juce_generate_juce_header(ChordAnalyzerMIDI)


### PR DESCRIPTION
JUCE's default VST3 subcategory for IS_MIDI_EFFECT plugins is bare "Fx", which Cubase 12+ routes to FX Inserts. Steinberg's documented MIDI-effect subcategory is "Fx|Instrument" (PlugType::kFxInstrument, "mainly for MIDI Effects"); Cubase routes that to MIDI Inserts. Applied only to the MIDI variant, the main instrument variant is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VST3 plugin categorization for the Chord Analyzer MIDI plugin to properly identify it as both an effects and instrument plugin.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dusk-audio/dusk-audio-plugins/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->