### PR TITLE
TapeMachine autoComp: fix high-drive undercompensation (#92)

### DIFF
--- a/plugins/TapeMachine/CMakeLists.txt
+++ b/plugins/TapeMachine/CMakeLists.txt
@@ -121,3 +121,9 @@ endif()
 set_target_properties(TapeMachine PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
+# Opt-in unity-contract harness for GH issue #92 (autoComp undercompensation).
+option(BUILD_TAPEMACHINE_TESTS "Build TapeMachine standalone test harness" OFF)
+if(BUILD_TAPEMACHINE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/plugins/TapeMachine/Source/PluginProcessor.cpp
+++ b/plugins/TapeMachine/Source/PluginProcessor.cpp
@@ -626,24 +626,28 @@ void TapeMachineAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, 
 
     if (autoCompEnabled)
     {
-        // VTM-style: Output compensates for input + tape compression
-        // The tape emulation has nonlinear level-dependent behavior:
-        //   - At -12dB to 0dB: ~0.5dB loss (0.95 calibration factor)
-        //   - At +6dB: ~3.5dB loss (moderate compression)
-        //   - At +12dB: ~7dB loss (heavy compression)
-        // Use piecewise compensation: constant for negative, quadratic for positive
+        // VTM-style: Output compensates for input + tape compression.
+        // compressionCompensation is the negation of the tape's own (input-gain-
+        // removed) transfer, so applying -inputGainDB + comp drives net output to
+        // ~unity. Coefficients re-derived from the measured raw transfer curve
+        // (autoComp OFF, -6 dBFS / 1 kHz sine, 48k/512, OS=4x). The tape-alone
+        // gain delta at each drive point is:
+        //   -12dB -> +0.19   -6dB -> -0.20   0dB -> -2.45   +6dB -> -5.03   +12dB -> -11.09
+        // comp(d) = -tapeAlone(d), fitted as two quadratics meeting at d=0 (c=2.45):
+        //   d <= 0: through (-12,-0.19) (-6,+0.20) (0,+2.45)
+        //   d >  0: through (0,+2.45)  (+6,+5.03) (+12,+11.09)
         float compressionCompensation;
         if (inputGainDB <= 0.0f)
         {
-            // Low input: minimal compression, just compensate for 0.95 factor
-            compressionCompensation = 0.5f;
+            compressionCompensation = 0.025833f * inputGainDB * inputGainDB
+                                    + 0.53f     * inputGainDB
+                                    + 2.45f;
         }
         else
         {
-            // High input: compression increases quadratically
-            // At +12dB we need ~7dB compensation, at 0dB we need ~0.5dB
-            float normalizedInput = inputGainDB / 12.0f;  // 0 to 1
-            compressionCompensation = 0.5f + 6.5f * normalizedInput * normalizedInput;
+            compressionCompensation = 0.048333f * inputGainDB * inputGainDB
+                                    + 0.14f     * inputGainDB
+                                    + 2.45f;
         }
         targetOutputGain = juce::Decibels::decibelsToGain(-inputGainDB + compressionCompensation);
     }

--- a/plugins/TapeMachine/tests/AutoCompSweep.cpp
+++ b/plugins/TapeMachine/tests/AutoCompSweep.cpp
@@ -1,0 +1,131 @@
+// AutoCompSweep — standalone unity-contract harness for GH issue #92.
+//
+// Feeds a -6 dBFS / 1 kHz sine through TapeMachineAudioProcessor::processBlock,
+// sweeps inputGain across {-12,-6,0,+6,+12} dB with Auto Compensation ON, and
+// reports the post-tape peak delta vs input. The fix re-derives the
+// compressionCompensation curve from the measured raw transfer so |delta| must
+// stay within +/- 0.5 dB at every drive point. The sweep is run at both 2x and
+// 4x oversampling to confirm the curve does not drift across OS factors.
+//
+// Exit code 0 = all points within tolerance, 1 = failure.
+
+#include "PluginProcessor.h"
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+namespace
+{
+constexpr double kSampleRate   = 48000.0;
+constexpr int    kBlockSize    = 512;
+constexpr double kSineHz       = 1000.0;
+// Pre-tape peak the issue's raw-transfer curve was measured at: a -6 dBFS sine
+// through a -3 dB pan-center law -> 0.3544 (-9.01 dBFS). The tape saturation is
+// level-dependent, so the compensation curve is only valid at this input level;
+// feed the same level here so the harness mirrors Focal's measurement chain.
+constexpr double kInputPeak    = 0.3544; // -9.01 dBFS (post pan-center)
+constexpr int    kWarmupBlocks = 24;
+constexpr int    kMeasureBlocks = 8;
+constexpr double kTolDb        = 0.5;
+
+// Set an APVTS parameter by its 0..1 normalised value.
+void setNorm(juce::AudioProcessorValueTreeState& apvts, const char* id, float norm)
+{
+    if (auto* p = apvts.getParameter(id))
+        p->setValueNotifyingHost(norm);
+}
+
+// Normalised value for a choice param: index / (numChoices - 1).
+float choiceNorm(int index, int numChoices)
+{
+    return static_cast<float>(index) / static_cast<float>(numChoices - 1);
+}
+
+// Run the sweep at one oversampling setting; returns true if all points pass.
+bool runSweep(int osIndex, const char* osLabel)
+{
+    const double drives[] = { -12.0, -6.0, 0.0, 6.0, 12.0 };
+    bool allPass = true;
+
+    std::printf("\n=== Oversampling: %s ===\n", osLabel);
+    std::printf("  drive(dB)   outPeak     outdBFS    delta(dB)   verdict\n");
+
+    for (double driveDb : drives)
+    {
+        TapeMachineAudioProcessor proc;
+        auto& apvts = proc.getAPVTS();
+
+        // autoComp choice {Off,On} -> On = index 1
+        setNorm(apvts, "autoComp", choiceNorm(1, 2));
+        // oversampling choice {1x,2x,4x}
+        setNorm(apvts, "oversampling", choiceNorm(osIndex, 3));
+        // inputGain float -12..+12
+        setNorm(apvts, "inputGain", static_cast<float>((driveDb + 12.0) / 24.0));
+
+        proc.setPlayConfigDetails(2, 2, kSampleRate, kBlockSize);
+        proc.prepareToPlay(kSampleRate, kBlockSize);
+
+        juce::AudioBuffer<float> buffer(2, kBlockSize);
+        juce::MidiBuffer midi;
+
+        double phase = 0.0;
+        const double phaseInc = 2.0 * juce::MathConstants<double>::pi * kSineHz / kSampleRate;
+        float outPeak = 0.0f;
+
+        const int totalBlocks = kWarmupBlocks + kMeasureBlocks;
+        for (int b = 0; b < totalBlocks; ++b)
+        {
+            for (int n = 0; n < kBlockSize; ++n)
+            {
+                const float s = static_cast<float>(kInputPeak * std::sin(phase));
+                phase += phaseInc;
+                if (phase > 2.0 * juce::MathConstants<double>::pi)
+                    phase -= 2.0 * juce::MathConstants<double>::pi;
+                buffer.setSample(0, n, s);
+                buffer.setSample(1, n, s);
+            }
+
+            proc.processBlock(buffer, midi);
+
+            if (b >= kWarmupBlocks)
+            {
+                for (int ch = 0; ch < 2; ++ch)
+                    for (int n = 0; n < kBlockSize; ++n)
+                        outPeak = std::max(outPeak, std::abs(buffer.getSample(ch, n)));
+            }
+        }
+
+        const double outDbfs = 20.0 * std::log10(std::max(1.0e-9f, outPeak));
+        const double inDbfs  = 20.0 * std::log10(kInputPeak);
+        const double deltaDb = outDbfs - inDbfs;
+        const bool   pass    = std::abs(deltaDb) <= kTolDb;
+        allPass = allPass && pass;
+
+        std::printf("  %+7.1f    %8.4f   %+8.2f   %+8.2f    %s\n",
+                    driveDb, outPeak, outDbfs, deltaDb, pass ? "OK" : "FAIL");
+    }
+
+    return allPass;
+}
+} // namespace
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI juceInit; // some JUCE DSP paths expect this
+
+    std::printf("TapeMachine autoComp unity-contract sweep (GH #92)\n");
+    std::printf("  %.4f peak (%.2f dBFS) 1 kHz sine, %g/%d, %d warmup + %d measure blocks\n",
+                kInputPeak, 20.0 * std::log10(kInputPeak),
+                kSampleRate, kBlockSize, kWarmupBlocks, kMeasureBlocks);
+    std::printf("  PASS criterion: |delta| <= %.1f dB at every drive point\n", kTolDb);
+
+    bool pass2x = runSweep(1, "2x");
+    bool pass4x = runSweep(2, "4x");
+
+    const bool allPass = pass2x && pass4x;
+    std::printf("\nRESULT: %s (2x %s, 4x %s)\n",
+                allPass ? "PASS" : "FAIL",
+                pass2x ? "ok" : "fail",
+                pass4x ? "ok" : "fail");
+    return allPass ? 0 : 1;
+}

--- a/plugins/TapeMachine/tests/CMakeLists.txt
+++ b/plugins/TapeMachine/tests/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Standalone unity-contract harness for GH issue #92.
+# Opt-in: configure the top-level build with -DBUILD_TAPEMACHINE_TESTS=ON.
+# Reuses the TapeMachine shared-code target (compiled plugin DSP) so the harness
+# drives the real processBlock, not a copy.
+
+juce_add_console_app(AutoCompSweep PRODUCT_NAME "AutoCompSweep")
+
+juce_generate_juce_header(AutoCompSweep)
+
+target_sources(AutoCompSweep PRIVATE AutoCompSweep.cpp)
+
+target_compile_features(AutoCompSweep PRIVATE cxx_std_17)
+
+# Pull in the plugin's source dir so PluginProcessor.h resolves, and the same
+# JucePlugin_* compile defs the plugin is built with.
+target_include_directories(AutoCompSweep PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/../Source")
+
+target_compile_definitions(AutoCompSweep PRIVATE
+    JUCE_WEB_BROWSER=0
+    JUCE_USE_CURL=0
+    JUCE_DISPLAY_SPLASH_SCREEN=0
+    JUCE_REPORT_APP_USAGE=0
+    JUCE_STRICT_REFCOUNTEDPOINTER=1
+    JUCE_FORCE_USE_LEGACY_PARAM_IDS=1)
+
+# Link the compiled plugin shared code + the JUCE modules it needs.
+target_link_libraries(AutoCompSweep PRIVATE
+    TapeMachine
+    juce::juce_audio_basics
+    juce::juce_audio_devices
+    juce::juce_audio_formats
+    juce::juce_audio_processors
+    juce::juce_audio_utils
+    juce::juce_core
+    juce::juce_data_structures
+    juce::juce_dsp
+    juce::juce_events
+    juce::juce_graphics
+    juce::juce_gui_basics
+    juce::juce_gui_extra
+    juce::juce_recommended_config_flags
+    juce::juce_recommended_warning_flags)
+
+set_target_properties(AutoCompSweep PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")


### PR DESCRIPTION
## Problem
TapeMachine's Auto Compensation undercompensated by 2-4 dB at high drive — autoComp ON did not hold unity as `inputGain` increased. The `compressionCompensation` formula constants and its doc table were stale relative to the actual tape DSP transfer.

## Fix
Re-derive `compressionCompensation` as the negation of the tape's own (input-gain-removed) transfer, measured with autoComp OFF (-6 dBFS / 1 kHz sine, 48k/512, OS=4x). Tape-alone gain delta per drive point:

```
-12dB +0.19   -6dB -0.20   0dB -2.45   +6dB -5.03   +12dB -11.09
```

Fitted as two quadratics meeting at d=0 (c=2.45). Comment block updated with real values.

## Result (autoComp ON net delta vs unity)
| drive | before | after |
|---|---|---|
| -12 | +0.65 | +0.03 |
| -6 | +0.30 | +0.07 |
| 0 | -1.86 | +0.13 |
| +6 | -2.93 | +0.17 |
| +12 | -4.09 | +0.19 |

Within ±0.20 dB across -12..+12 dB at both 2x and 4x oversampling.

## Verification
- New opt-in standalone harness `tests/AutoCompSweep.cpp` (behind `-DBUILD_TAPEMACHINE_TESTS=ON`) drives the real `processBlock`, sweeps `inputGain`, asserts |delta| < 0.5 dB at every point on 2x and 4x. **PASS.**
- DuskStudio host self-test (`testMasterTapeAddsGain`) built against this branch: **[PASS]**, worst |delta| 0.19 dB, full suite 10/10. Selftest tolerance tightened to ±0.5 in a companion PR on dusk-studio.

## Constraints honored
No parameter names/ranges/defaults/order changed — APVTS wire format identical, saved presets still load. autoComp default stays On.

Fixes #92