### PR TITLE
fix: JUCE 8 compat — replace removed Font::getStringWidth (#95)

### DIFF
--- a/plugins/multi-q/BritishEQCurveDisplay.cpp
+++ b/plugins/multi-q/BritishEQCurveDisplay.cpp
@@ -114,7 +114,7 @@ void BritishEQCurveDisplay::paint(juce::Graphics& g)
         juce::String frozenText = "FROZEN (F)";
         auto font = juce::FontOptions(11.0f, juce::Font::bold);
         g.setFont(font);
-        float textWidth = g.getCurrentFont().getStringWidth(frozenText) + 12.0f;
+        float textWidth = juce::GlyphArrangement::getStringWidth(g.getCurrentFont(), frozenText) + 12.0f;
         float textHeight = 18.0f;
         float badgeX = graphArea.getX() + 6.0f;
         float badgeY = graphArea.getY() + 6.0f;

--- a/plugins/multi-synth/MultiSynthEditor.cpp
+++ b/plugins/multi-synth/MultiSynthEditor.cpp
@@ -661,7 +661,7 @@ void MultiSynthEditor::paintOracle(juce::Graphics& g)
         int badgeY = b.getY() + scaled(kSectionTitleH) - 1;
         g.setColour(juce::Colour(0x50AA8040));
         g.drawHorizontalLine(badgeY, static_cast<float>(b.getX() + scaled(4)),
-                             static_cast<float>(b.getX() + scaled(4) + juce::Font(juce::FontOptions(10.0f * sf)).getStringWidthFloat(t) + scaled(8)));
+                             static_cast<float>(b.getX() + scaled(4) + juce::GlyphArrangement::getStringWidth(juce::Font(juce::FontOptions(10.0f * sf)), t) + scaled(8)));
     };
 
     psWithBadge(sections.oscillators, "POLY-MOD / OSC A / OSC B / MIXER");

--- a/plugins/spectrum-analyzer/Source/UI/SpectrumDisplay.cpp
+++ b/plugins/spectrum-analyzer/Source/UI/SpectrumDisplay.cpp
@@ -187,7 +187,7 @@ void SpectrumDisplay::drawHoverInfo(juce::Graphics& g)
 
     // Draw info box
     g.setFont(13.0f);
-    int textWidth = g.getCurrentFont().getStringWidth(infoStr) + 10;
+    int textWidth = juce::GlyphArrangement::getStringWidthInt(g.getCurrentFont(), infoStr) + 10;
 
     float boxX = hoverPosition.x + 10;
     float boxY = hoverPosition.y - 25;


### PR DESCRIPTION
## Problem
Building against a current JUCE submodule (8.x) fails:
```
plugins/multi-q/BritishEQCurveDisplay.cpp:117:46: error:
  'class juce::Font' has no member named 'getStringWidth'
```
JUCE 8 deprecated then **removed** `juce::Font::getStringWidth(const String&)` and `getStringWidthFloat(const String&)`. Reported on Debian Trixie via `./rebuild_all.sh` (#95).

## Fix
Replace all call sites with the `GlyphArrangement` static equivalents (present on both JUCE 7 and 8):

| old | new |
|---|---|
| `Font::getStringWidth(s)` | `GlyphArrangement::getStringWidthInt(font, s)` |
| `Font::getStringWidthFloat(s)` | `GlyphArrangement::getStringWidth(font, s)` |

Three call sites, all built by default (`BUILD_SPECTRUM_ANALYZER` / `BUILD_MULTI_SYNTH` are ON), so `rebuild_all.sh` would hit the same error right after MultiQ — fixed together:
- `multi-q/BritishEQCurveDisplay.cpp` (reported)
- `spectrum-analyzer/Source/UI/SpectrumDisplay.cpp`
- `multi-synth/MultiSynthEditor.cpp`

## Verification
MultiQ, SpectrumAnalyzer, and MultiSynth VST3 targets all build clean against local JUCE 8 — 0 errors.

Fixes #95
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text measurement accuracy for UI elements, including frozen status indicators, section title badges, and hover information tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->