### PR TITLE
[HOLD/needs gate validation] DuskVerb: calibration-sensitive DSP correctness fixes

### DIFF
--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -11,11 +11,17 @@
 class DuskVerbEngine;
 
 // Factory presets — 16 hardware-anchored voicings.
-// `algorithm` is the engine index (0..3) per AlgorithmConfig.h:
-//   0 = Vintage Plate (Dattorro)
-//   1 = High Density  (6-AP)
-//   2 = Quad Room     (QuadTank, no modulation)
-//   3 = Realistic Space (FDN)
+// `algorithm` is the engine index (0..9) per AlgorithmConfig.h getAlgorithmConfig():
+//   0 = Plate (Dattorro)
+//   1 = Plate (Dattorro Vintage)
+//   2 = High Density (6-AP / SixAPTank)
+//   3 = Quad Room (QuadTank)
+//   4 = Realistic Space (FDN)
+//   5 = Spring Tank (6G15)
+//   6 = Non-Linear (RMX16)
+//   7 = Shimmer (Eno FDN)
+//   8 = Vintage Tank (Figure-8)
+//   9 = Reverse Room (Lexicon)
 //
 // IMPORTANT: presets are grouped CONTIGUOUSLY by category — the editor's
 // dropdown adds a section heading whenever the category changes, so any

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1097,9 +1097,8 @@ void DuskVerbProcessor::setStateInformation (const void* data, int sizeInBytes)
     // the user's saved APVTS values, which must not be overwritten with the
     // preset's defaults. The same lastAppliedPreset_ pointer also feeds the
     // prepareToPlay() re-install path, so engine config is correct whether the
-    // host calls prepareToPlay before or after setStateInformation. Sessions
-    // without the property (older saves, or no preset applied) leave
-    // lastAppliedPreset_ untouched, preserving prior behavior.
+    // host calls prepareToPlay before or after setStateInformation.
+    bool matchedPreset = false;
     if (tree.hasProperty ("lastPresetName"))
     {
         const auto savedName = tree.getProperty ("lastPresetName").toString();
@@ -1109,9 +1108,23 @@ void DuskVerbProcessor::setStateInformation (const void* data, int sizeInBytes)
             {
                 lastAppliedPreset_.store (&preset, std::memory_order_release);
                 pendingPresetSwap_.store (true, std::memory_order_release);
+                matchedPreset = true;
                 break;
             }
         }
+    }
+    if (! matchedPreset)
+    {
+        // No persisted identity (older save / no preset applied at save) or the
+        // saved name no longer maps to a factory preset (renamed/removed).
+        // Clear any stale pointer left from a preset previously applied to THIS
+        // reused instance, otherwise prepareToPlay()/performPresetSwap() would
+        // reapply that unrelated session's engine config (PostTankEQ bands,
+        // modulation topology, FDN base delays) on top of the just-restored
+        // APVTS values. Cleared → the engine falls back to its defaults, which
+        // is the correct "no known preset" state.
+        lastAppliedPreset_.store (nullptr, std::memory_order_release);
+        pendingPresetSwap_.store (false, std::memory_order_release);
     }
 }
 

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -983,6 +983,16 @@ void DuskVerbProcessor::getStateInformation (juce::MemoryBlock& destData)
     state.setProperty ("dpvBoxCutFreqHz",     dpvBoxCutHzParam_->load(),       nullptr);
     state.setProperty ("dpvBassShelfGainDb",  dpvBassShelfDbParam_->load(),    nullptr);
     state.setProperty ("dpvBassShelfFreqHz",  dpvBassShelfHzParam_->load(),    nullptr);
+    // Preset identity. The name-keyed engine config (PostTankEQ bands,
+    // modulation topology, FDN base-delay overrides, post-band trims) lives
+    // OUTSIDE APVTS and is reconstructed by FactoryPreset::applyEngineConfig()
+    // via name lookup. Persist the name so a reloaded session reapplies the
+    // correct engine config instead of falling back to the engine defaults
+    // (RandomWalk topology + flat PostTankEQ + default base delays). Additive
+    // property — old binaries ignore it, and sessions saved before this (or
+    // with no preset applied) simply omit it and keep prior behavior.
+    if (auto* preset = lastAppliedPreset_.load (std::memory_order_acquire))
+        state.setProperty ("lastPresetName", juce::String (preset->name), nullptr);
     if (auto xml = state.createXml())
         copyXmlToBinary (*xml, destData);
 }
@@ -1079,6 +1089,30 @@ void DuskVerbProcessor::setStateInformation (const void* data, int sizeInBytes)
     pushSixAPBrightnessTo (engineA_);
     pushSixAPBrightnessTo (engineB_);
 
+    // Reconstruct the name-keyed engine config (see getStateInformation):
+    // match the saved preset by name and arm a swap so the audio thread
+    // reapplies its PostTankEQ bands / modulation topology / FDN base delays /
+    // post-band trims via performPresetSwap() -> applyEngineConfig(). We
+    // deliberately do NOT call applyTo() here — replaceState() already restored
+    // the user's saved APVTS values, which must not be overwritten with the
+    // preset's defaults. The same lastAppliedPreset_ pointer also feeds the
+    // prepareToPlay() re-install path, so engine config is correct whether the
+    // host calls prepareToPlay before or after setStateInformation. Sessions
+    // without the property (older saves, or no preset applied) leave
+    // lastAppliedPreset_ untouched, preserving prior behavior.
+    if (tree.hasProperty ("lastPresetName"))
+    {
+        const auto savedName = tree.getProperty ("lastPresetName").toString();
+        for (const auto& preset : getFactoryPresets())
+        {
+            if (savedName == juce::String (preset.name))
+            {
+                lastAppliedPreset_.store (&preset, std::memory_order_release);
+                pendingPresetSwap_.store (true, std::memory_order_release);
+                break;
+            }
+        }
+    }
 }
 
 void DuskVerbProcessor::pushSixAPBrightnessTo (DuskVerbEngine& target)

--- a/plugins/DuskVerb/src/dsp/DspUtils.h
+++ b/plugins/DuskVerb/src/dsp/DspUtils.h
@@ -729,12 +729,12 @@ struct AttackRamp
         // (Slowing this to track the sub-band envelope broke the working
         // low/low_mid bands — the fast follower is required there. Sub <100 Hz
         // edt stays immovable by this shaper: a known limit.)
-        const float att = 0.05f;
-        const float rel = 0.005f;
+        // Coeffs are sample-rate-corrected (recomputeCoeffs) so the follower
+        // tracks at the same wall-clock speed at any host rate.
         if (absLR > envFollower_)
-            envFollower_ += att * (absLR - envFollower_);
+            envFollower_ += envAttCoeff_ * (absLR - envFollower_);
         else
-            envFollower_ += rel * (absLR - envFollower_);
+            envFollower_ += envRelCoeff_ * (absLR - envFollower_);
 
         // Slow-release peak tracker. Captures the recent loudness peak;
         // decays per sample so the gain modulator re-arms after each burst.
@@ -765,12 +765,23 @@ private:
     void recomputeCoeffs() noexcept
     {
         peakDecayPerSamp_ = std::exp (-1.0f / std::max (tauMs_ * 0.001f * sampleRate_, 1.0f));
+        // Envelope-follower attack/release as sample-rate-independent time
+        // constants. The ms values are chosen to reproduce the legacy fixed
+        // per-sample steps (0.05 attack / 0.005 release) at 48 kHz — the preset
+        // calibration rate — so 48 k renders are bit-identical and only other
+        // host rates change (correctly, toward SR-independence).
+        constexpr float kEnvAttackMs  = 0.4062f;   // → 0.05 step at 48 kHz
+        constexpr float kEnvReleaseMs = 4.156f;    // → 0.005 step at 48 kHz
+        envAttCoeff_ = 1.0f - std::exp (-1.0f / std::max (kEnvAttackMs  * 0.001f * sampleRate_, 1.0f));
+        envRelCoeff_ = 1.0f - std::exp (-1.0f / std::max (kEnvReleaseMs * 0.001f * sampleRate_, 1.0f));
     }
 
     float sampleRate_       = 44100.0f;
     float attackDb_         = 0.0f;
     float tauMs_            = 100.0f;
     float peakDecayPerSamp_ = 0.99979f;
+    float envAttCoeff_      = 0.05f;
+    float envRelCoeff_      = 0.005f;
     float envFollower_      = 0.0f;
     float trackingPeak_     = 0.0f;
 };
@@ -801,7 +812,8 @@ public:
     void prepare (float sampleRate) noexcept
     {
         sampleRate_ = std::max (sampleRate, 8000.0f);
-        for (auto& r : ramps_) r.prepare (sampleRate_);
+        for (auto& r : rampsL_) r.prepare (sampleRate_);
+        for (auto& r : rampsR_) r.prepare (sampleRate_);
         recomputeSplitCoeffs();
         reset();
     }
@@ -810,7 +822,8 @@ public:
     {
         lpStateL_[0] = lpStateL_[1] = lpStateL_[2] = 0.0f;
         lpStateR_[0] = lpStateR_[1] = lpStateR_[2] = 0.0f;
-        for (auto& r : ramps_) r.reset();
+        for (auto& r : rampsL_) r.reset();
+        for (auto& r : rampsR_) r.reset();
     }
 
     void setCrossovers (float fLow, float fMid, float fHi) noexcept
@@ -824,7 +837,8 @@ public:
     void setRegionShape (int region, float attackDb, float tauMs) noexcept
     {
         if (region < 0 || region >= kNumRegions) return;
-        ramps_[region].setShape (attackDb, tauMs);
+        rampsL_[region].setShape (attackDb, tauMs);
+        rampsR_[region].setShape (attackDb, tauMs);
         regionAttackDb_[region] = attackDb;
         anyActive_ = false;
         for (auto v : regionAttackDb_)
@@ -834,17 +848,18 @@ public:
     inline float processL (float x) noexcept
     {
         if (! anyActive_) return x;     // exact bit-identical bypass
-        return processChannel (x, lpStateL_);
+        return processChannel (x, lpStateL_, rampsL_);
     }
 
     inline float processR (float x) noexcept
     {
         if (! anyActive_) return x;     // exact bit-identical bypass
-        return processChannel (x, lpStateR_);
+        return processChannel (x, lpStateR_, rampsR_);
     }
 
 private:
-    inline float processChannel (float x, float (&state)[3]) noexcept
+    inline float processChannel (float x, float (&state)[3],
+                                 AttackRamp (&ramps)[kNumRegions]) noexcept
     {
         // 3 cascaded 1-pole LPs split the input into 4 contiguous bands.
         // Each band is the difference between consecutive LP outputs:
@@ -878,11 +893,14 @@ private:
         const float bandAir    = hp_after_lp2 - lp3_midhi;
 
         // Per-region time-varying gain (1.0 when all attackDb==0 → bypass).
-        const float absX = std::fabs (x);
-        const float gSub    = ramps_[0].tickGain (absX);
-        const float gLowMid = ramps_[1].tickGain (absX);
-        const float gMidHi  = ramps_[2].tickGain (absX);
-        const float gAir    = ramps_[3].tickGain (absX);
+        // Drive each AttackRamp with ITS OWN band magnitude (it is documented
+        // to track "the band's signal envelope"); feeding the full-band |x| to
+        // all four coupled the regions — a loud sub transient would re-arm the
+        // air-band ramp and vice-versa.
+        const float gSub    = ramps[0].tickGain (std::fabs (bandSub));
+        const float gLowMid = ramps[1].tickGain (std::fabs (bandLowMid));
+        const float gMidHi  = ramps[2].tickGain (std::fabs (bandMidHi));
+        const float gAir    = ramps[3].tickGain (std::fabs (bandAir));
 
         return bandSub * gSub + bandLowMid * gLowMid
              + bandMidHi * gMidHi + bandAir * gAir;
@@ -905,7 +923,11 @@ private:
     float lpStateR_[3] {0.0f, 0.0f, 0.0f};
     float regionAttackDb_[kNumRegions] {0.0f, 0.0f, 0.0f, 0.0f};
     bool  anyActive_ = false;
-    AttackRamp ramps_[kNumRegions];
+    // Per-channel ramp state — the AttackRamp envelope/peak followers are
+    // mutated in tickGain(), so L and R must not share them or processing one
+    // channel would corrupt the other's gain (order-dependent stereo output).
+    AttackRamp rampsL_[kNumRegions];
+    AttackRamp rampsR_[kNumRegions];
 };
 
 // =============================================================================
@@ -942,7 +964,8 @@ struct DualTimeConstantBassShelf
 
     void reset() noexcept
     {
-        envFollower_  = 0.0f;
+        envFollowerL_ = 0.0f;
+        envFollowerR_ = 0.0f;
         fastStateL_   = 0.0f;
         fastStateR_   = 0.0f;
         slowStateL_   = 0.0f;
@@ -973,13 +996,13 @@ struct DualTimeConstantBassShelf
     inline float processL (float x) noexcept
     {
         if (! anyActive_) return x;
-        return processChannel (x, fastStateL_, slowStateL_);
+        return processChannel (x, fastStateL_, slowStateL_, envFollowerL_);
     }
 
     inline float processR (float x) noexcept
     {
         if (! anyActive_) return x;
-        return processChannel (x, fastStateR_, slowStateR_);
+        return processChannel (x, fastStateR_, slowStateR_, envFollowerR_);
     }
 
 private:
@@ -992,14 +1015,16 @@ private:
     //   At gain=0 dB, the bass_band × 1.0 + (x − bass_band) = x → bit-
     //   identical bypass. At gain=−6 dB, bass_band scaled by 0.5 → 6 dB
     //   shelf attenuation below fc.
-    inline float processChannel (float x, float& fastState, float& slowState) noexcept
+    inline float processChannel (float x, float& fastState, float& slowState,
+                                 float& env) noexcept
     {
         // Envelope follower on the band signal — fast attack, slow release.
+        // Per-channel (env passed by ref) so L and R don't share/corrupt it.
         const float absX = std::fabs (x);
-        if (absX > envFollower_)
-            envFollower_ += envAttCoeff_ * (absX - envFollower_);
+        if (absX > env)
+            env += envAttCoeff_ * (absX - env);
         else
-            envFollower_ += envRelCoeff_ * (absX - envFollower_);
+            env += envRelCoeff_ * (absX - env);
 
         // mix: 0 when envelope is high (use fast shelf), 1 when low (use slow).
         // env normalized against a slow-decaying peak tracker would give true
@@ -1007,7 +1032,7 @@ private:
         // against a fixed threshold — onset-followed signals stay near fast,
         // input-off tails drift toward slow.
         const float thr = envThreshold_;
-        const float ratio = (thr > 1.0e-6f) ? (envFollower_ / thr) : 0.0f;
+        const float ratio = (thr > 1.0e-6f) ? (env / thr) : 0.0f;
         const float mix = std::clamp (1.0f - ratio, 0.0f, 1.0f);
 
         // Fast band LP
@@ -1051,7 +1076,8 @@ private:
     float fastGainLin_  = 1.0f;
     float slowGainLin_  = 1.0f;
 
-    float envFollower_  = 0.0f;
+    float envFollowerL_ = 0.0f;
+    float envFollowerR_ = 0.0f;
     float envAttCoeff_  = 0.0f;
     float envRelCoeff_  = 0.0f;
     float envThreshold_ = 0.05f;     // ~-26 dBFS — typical band-signal level

--- a/plugins/DuskVerb/src/dsp/DspUtils.h
+++ b/plugins/DuskVerb/src/dsp/DspUtils.h
@@ -76,7 +76,15 @@ inline float softClip (float x, float threshold = 1.0f, float ceiling = 2.0f)
     const float sign  = (x < 0.0f) ? -1.0f : 1.0f;
     const float range = std::max (ceiling - threshold, 1.0e-6f);
     const float over  = (ax - threshold) / range;
-    return sign * (threshold + range * fastTanh (over));
+    // fastTanh is a rational approximation that only saturates near |over| <= 3
+    // (fastTanh(3) == 1 exactly) and DIVERGES past that — for large drive it
+    // grows ~over/9, so the raw result would push output beyond `ceiling`.
+    // Clamp the drive to [0,1] so the output can never exceed threshold + range
+    // (== ceiling); the clamp only engages for over > 3 (inputs already well
+    // above ceiling), leaving the in-knee curve unchanged.
+    float drive = fastTanh (over);
+    drive = std::min (std::max (drive, 0.0f), 1.0f);
+    return sign * (threshold + range * drive);
 }
 
 // Phase 2 modulation topology selector. Engines can be in legacy random-

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -307,16 +307,19 @@ void DuskVerbEngine::setAirTrebleMultiply (float mult)
 }
 
 // FiveBandDamping (Phase 2) — FDN-only; other engines have no five-band path.
-void DuskVerbEngine::setSubMultiply     (float mult) { fdn_.setSubMultiply (mult); }
-void DuskVerbEngine::setHiMidMultiply   (float mult) { fdn_.setHiMidMultiply (mult); }
-void DuskVerbEngine::setSubCrossoverFreq (float hz)  { fdn_.setSubCrossoverFreq (hz); }
-void DuskVerbEngine::setAirCrossoverFreq (float hz)  { fdn_.setAirCrossoverFreq (hz); }
-void DuskVerbEngine::setShaperDepth     (float d)    { fdn_.setShaperDepth (d); }
-void DuskVerbEngine::setShaperTimeMs    (float ms)   { fdn_.setShaperTimeMs (ms); }
-void DuskVerbEngine::setShaperXoverHz   (float hz)   { fdn_.setShaperXoverHz (hz); }
-void DuskVerbEngine::setShaperSens      (float s)    { fdn_.setShaperSens (s); }
-void DuskVerbEngine::setInputSubGainDb  (float db)   { fdn_.setInputSubGainDb (db); }
-void DuskVerbEngine::setInputMidGainDb  (float db)   { fdn_.setInputMidGainDb (db); }
+// Forward to BOTH the legacy single tank and the parallel-multiband tanks so
+// the multiband path (when mb_enable is on) receives identical voicing instead
+// of silently running these axes at their defaults.
+void DuskVerbEngine::setSubMultiply     (float mult) { fdn_.setSubMultiply (mult);      multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSubMultiply (mult); }); }
+void DuskVerbEngine::setHiMidMultiply   (float mult) { fdn_.setHiMidMultiply (mult);    multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setHiMidMultiply (mult); }); }
+void DuskVerbEngine::setSubCrossoverFreq (float hz)  { fdn_.setSubCrossoverFreq (hz);   multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSubCrossoverFreq (hz); }); }
+void DuskVerbEngine::setAirCrossoverFreq (float hz)  { fdn_.setAirCrossoverFreq (hz);   multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setAirCrossoverFreq (hz); }); }
+void DuskVerbEngine::setShaperDepth     (float d)    { fdn_.setShaperDepth (d);         multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperDepth (d); }); }
+void DuskVerbEngine::setShaperTimeMs    (float ms)   { fdn_.setShaperTimeMs (ms);       multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperTimeMs (ms); }); }
+void DuskVerbEngine::setShaperXoverHz   (float hz)   { fdn_.setShaperXoverHz (hz);      multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperXoverHz (hz); }); }
+void DuskVerbEngine::setShaperSens      (float s)    { fdn_.setShaperSens (s);          multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperSens (s); }); }
+void DuskVerbEngine::setInputSubGainDb  (float db)   { fdn_.setInputSubGainDb (db);     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputSubGainDb (db); }); }
+void DuskVerbEngine::setInputMidGainDb  (float db)   { fdn_.setInputMidGainDb (db);     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputMidGainDb (db); }); }
 
 void DuskVerbEngine::setCrossoverFreq (float hz)
 {

--- a/plugins/DuskVerb/src/dsp/FDNReverb.cpp
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.cpp
@@ -229,6 +229,15 @@ void FDNReverb::prepare (double sampleRate, int /*maxBlockSize*/)
         inLoopPeak_[i].setBand (inLoopPeakFreq_, inLoopPeakQ_, inLoopPeakGainDb_);
     inLoopPeakActive_ = std::fabs (inLoopPeakGainDb_) > 1.0e-6f;
 
+    // Re-apply the dual-time-constant bass shelf from stored config — like the
+    // peak above, dualBassShelf_[i].prepare() designed back to unity, so without
+    // this replay the shelf silently bypasses after every re-prepare even though
+    // dualBassShelfActive_ stays true.
+    for (int i = 0; i < N; ++i)
+        dualBassShelf_[i].setShape (dualBassFastFc_, dualBassSlowFc_,
+                                    dualBassFastGainDb_, dualBassSlowGainDb_,
+                                    dualBassTransitionMs_);
+
     // Block 2 input makeup: prepare + design from current gains (0 dB = unity).
     inputMid_.prepare (static_cast<float> (sampleRate));
     inputSubL_.reset();
@@ -434,7 +443,10 @@ void FDNReverb::process (const float* inputL, const float* inputR,
         // the 16 target gains (the 16 sins) only every kTailSpinBlock samples.
         // Gains are applied at output-tap summation below. Skipped entirely
         // when inactive → tailSpinCur_ rests at 1.0f → bit-exact bypass.
-        if (tailSpinActive_)
+        // Also skipped while frozen so a held tank stays at its steady-state
+        // output instead of continuing to wobble (tailSpinCur_/Step_/Phase_
+        // are left untouched and resume on un-freeze).
+        if (tailSpinActive_ && ! frozen)
         {
             if (--tailSpinCounter_ <= 0)
             {
@@ -1044,6 +1056,12 @@ void FDNReverb::setDualBassShelf (float fastFc, float slowFc,
     // the channel; cheap bypass on every preset that doesn't opt in.
     dualBassShelfActive_ = std::fabs (fastGainDb) > 1.0e-6f
                         || std::fabs (slowGainDb) > 1.0e-6f;
+    // Persist so prepare() can replay after a re-prepare resets the shelves.
+    dualBassFastFc_       = fastFc;
+    dualBassSlowFc_       = slowFc;
+    dualBassFastGainDb_   = fastGainDb;
+    dualBassSlowGainDb_   = slowGainDb;
+    dualBassTransitionMs_ = transitionMs;
     for (int i = 0; i < N; ++i)
         dualBassShelf_[i].setShape (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs);
 }

--- a/plugins/DuskVerb/src/dsp/FDNReverb.h
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.h
@@ -360,6 +360,14 @@ private:
     // processing entirely).
     DspUtils::DualTimeConstantBassShelf dualBassShelf_[N];
     bool dualBassShelfActive_ = false;
+    // Stored shape so prepare() can re-apply it — DualTimeConstantBassShelf::
+    // prepare() designs back to unity, so without replay the shelf silently
+    // bypasses after every re-prepare (mirror of the inLoopPeak_ restore).
+    float dualBassFastFc_       = 400.0f;
+    float dualBassSlowFc_       = 200.0f;
+    float dualBassFastGainDb_   = 0.0f;
+    float dualBassSlowGainDb_   = 0.0f;
+    float dualBassTransitionMs_ = 100.0f;
     DspUtils::ModulationTopology modulationTopology_ = DspUtils::ModulationTopology::RandomWalk;
 
     // Phase θ/Phase 2: post-loop Tail Spin/Wander output VCA. A 16-phase sine

--- a/plugins/DuskVerb/src/dsp/VintageTankEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/VintageTankEngine.cpp
@@ -378,6 +378,10 @@ void VintageTankEngine::processBlock (float* L, float* R, int numSamples)
 
 void VintageTankEngine::setDecay (float decaySeconds)
 {
+    // Remember the raw knob value so setSize() can recompute decayGain_ when
+    // the room size (and thus the round-trip path length) changes.
+    lastDecaySeconds_ = decaySeconds;
+
     // Knob-honesty calibration (2026-05-31). The round-trip formula below
     // (incl. kGroupDelayCompensation) produced a strongly WARPED map — measured
     // mid-band RT60 ≈ 1.9724·T^0.4331 at nominal size (2.9× too long at 0.5 s,
@@ -492,6 +496,10 @@ void VintageTankEngine::setSize (float normalized)
     // 0..1 input → 0.25..1.00 effective room size. Buffers stay full
     // length so the change is allocation-free and audio-thread safe.
     sizeScale_ = 0.25f + 0.75f * std::clamp (normalized, 0.0f, 1.0f);
+    // decayGain_ is derived from the round-trip path length, which scales with
+    // sizeScale_. Recompute it now so RT60 tracks the new size immediately
+    // instead of drifting until the next setDecay() call.
+    setDecay (lastDecaySeconds_);
 }
 
 // ─── 3-band damping setters ──────────────────────────────────────────────────

--- a/plugins/DuskVerb/src/dsp/VintageTankEngine.h
+++ b/plugins/DuskVerb/src/dsp/VintageTankEngine.h
@@ -262,6 +262,8 @@ private:
     // ─── Voicing state ───────────────────────────────────────────────────────
     float sampleRate_     = 48000.0f;
     float decayGain_      = 0.70f;
+    float lastDecaySeconds_ = 2.0f;   // raw setDecay() input, so setSize() can
+                                       // recompute decayGain_ for the new size
     float dampingHz_      = 6000.0f;
     float modRateBaseHz_  = 1.0f;
     float modDepthSamples_= 8.0f;

--- a/plugins/DuskVerb/tools/tuner/apply_best_and_evaluate.py
+++ b/plugins/DuskVerb/tools/tuner/apply_best_and_evaluate.py
@@ -148,8 +148,12 @@ def report(preset, params, vst3, anchor):
         print(f"  {fc:8.1f}  {dv:+8.2f}  {lx:+8.2f}  {d:+9.2f}  {bar}{flag}")
         rows.append((fc, d))
     abs_d = [abs(d) for _, d in rows]
-    print(f"\n  mean |Δ|: {sum(abs_d)/len(abs_d):.2f} dB")
-    print(f"  max  |Δ|: {max(abs_d):.2f} dB @ {[fc for fc,d in rows if abs(d)==max(abs_d)][0]:.0f} Hz")
+    if not abs_d:
+        print("\n  (no overlapping 1/3-oct bands — skipping mean/max |Δ|)")
+    else:
+        max_abs = max(abs_d)
+        print(f"\n  mean |Δ|: {sum(abs_d)/len(abs_d):.2f} dB")
+        print(f"  max  |Δ|: {max_abs:.2f} dB @ {[fc for fc,d in rows if abs(d)==max_abs][0]:.0f} Hz")
     # Sub-bass region focus (user's gate)
     sub = [(fc, d) for fc, d in rows if 80 <= fc <= 250]
     if sub:

--- a/plugins/DuskVerb/tools/tuner/eq_match_curve.py
+++ b/plugins/DuskVerb/tools/tuner/eq_match_curve.py
@@ -81,24 +81,42 @@ def main():
     if not dv or not lx:
         sys.exit(f"missing {stem} render in dv_dir or lex_dir")
 
-    # For non-sustained stimuli, the steady-state window is meaningless;
-    # use post-peak windows instead.
+    # Window per file. For sustained pink both use the same steady-state window.
+    # For transient stimuli the peak can sit at different sample offsets in the
+    # DV vs Lex render, so each file gets its OWN peak-aligned [pk+50ms, pk+1.0s]
+    # window — reusing the DV-derived window for Lex would measure a misaligned
+    # slice of the anchor.
+    t0_dv, t1_dv = args.t0, args.t1
+    t0_lx, t1_lx = args.t0, args.t1
     if stem != "sustained":
-        # Reset to post-peak windows: use peak-aligned [50ms, 1.0s].
-        x_dv, sr_dv = sf.read(dv); m_dv = x_dv.mean(axis=1) if x_dv.ndim>1 else x_dv
-        pk = int(np.argmax(np.abs(m_dv)))
-        args.t0 = pk / sr_dv + 0.05
-        args.t1 = pk / sr_dv + 1.0
+        def _peak_window(path):
+            x, sr = sf.read(path); m = x.mean(axis=1) if x.ndim > 1 else x
+            pk = int(np.argmax(np.abs(m)))
+            return pk / sr + 0.05, pk / sr + 1.0
+        t0_dv, t1_dv = _peak_window(dv)
+        t0_lx, t1_lx = _peak_window(lx)
 
     print(f"\n══ EQ-MATCH DELTA CURVE ══")
     print(f"  DV:  {dv}")
     print(f"  Lex: {lx}")
-    print(f"  Stimulus: {stem}   Window: [{args.t0:.2f}, {args.t1:.2f}]s")
+    print(f"  Stimulus: {stem}   DV window: [{t0_dv:.2f}, {t1_dv:.2f}]s   "
+          f"Lex window: [{t0_lx:.2f}, {t1_lx:.2f}]s")
     print(f"  Resolution: 1/{args.bands_per_oct}-octave")
     print()
 
-    dv_b = fine_band_power_db(dv, args.t0, args.t1, args.bands_per_oct)
-    lx_b = fine_band_power_db(lx, args.t0, args.t1, args.bands_per_oct)
+    dv_b = fine_band_power_db(dv, t0_dv, t1_dv, args.bands_per_oct)
+    lx_b = fine_band_power_db(lx, t0_lx, t1_lx, args.bands_per_oct)
+    # zip() below silently truncates to the shorter list; band counts can differ
+    # if the two renders have different sample rates (band centers are filtered
+    # against sr*0.45). Warn loudly with which side is shorter and the top band
+    # that gets dropped, so a truncated comparison isn't mistaken for a match.
+    if len(dv_b) != len(lx_b):
+        longer, which = (dv_b, "DV") if len(dv_b) > len(lx_b) else (lx_b, "Lex")
+        top_fc = longer[-1][0]
+        print(f"  WARNING: band-count mismatch — DV has {len(dv_b)}, Lex has {len(lx_b)}; "
+              f"{which} is longer. zip() drops its bands above {min(len(dv_b), len(lx_b))} "
+              f"(highest dropped center ~{top_fc:.0f} Hz). Check sample-rate parity.",
+              file=sys.stderr)
     rows = []
     for (fc_d, dv_v), (_, lx_v) in zip(dv_b, lx_b):
         d = lx_v - dv_v   # positive = ADD dB to DV to match Lex

--- a/plugins/DuskVerb/tools/tuner/full_check.py
+++ b/plugins/DuskVerb/tools/tuner/full_check.py
@@ -605,8 +605,13 @@ def adv_bark_masking_traj(p, t0=0.2, t1=1.5, win_ms=50.0):
 
 def check(label, dv_val, lex_val, gate, kind='abs'):
     """Returns (delta, pass/fail, formatted string)."""
-    if dv_val is None or lex_val is None or (isinstance(dv_val, float) and dv_val != dv_val):
+    if dv_val is None or lex_val is None:
         return None, 'SKIP', f"  {label:30s}  none"
+    # Treat any non-finite value (NaN or ±Inf, incl. numpy scalars) as SKIP —
+    # the old `dv_val != dv_val` test only caught NaN on dv_val and let an Inf
+    # metric fall through to a spurious FAIL.
+    if not (np.isfinite(dv_val) and np.isfinite(lex_val)):
+        return None, 'SKIP', f"  {label:30s}  non-finite"
     if kind == 'pct':
         if lex_val == 0:
             return None, 'SKIP', f"  {label:30s}  divide-by-zero"
@@ -621,7 +626,7 @@ def check(label, dv_val, lex_val, gate, kind='abs'):
                f"  {label:30s}  DV={dv_val:+7.3f}  Lex={lex_val:+7.3f}  Δ={delta:+6.2f}  gate=±{gate}  {'✓' if passing else '✗'}"
 
 
-def audit(dv_dir, lex_dir, name='preset', category=''):
+def audit(dv_dir, lex_dir, name='preset', category='', sustained_pink_seconds=4.0):
     dv_dir = Path(dv_dir); lex_dir = Path(lex_dir)
     # Find files (any matching slug stem)
     def find_stim(d, stim):
@@ -792,7 +797,10 @@ def audit(dv_dir, lex_dir, name='preset', category=''):
     sus_lx = find_stim(lex_dir, 'sustained')
     if sus_dv and sus_lx:
         from scipy.signal import butter as _bts, sosfiltfilt as _ss
-        def _band_rms_db(p, lo, hi, t0=2.5, t1=4.0):
+        # t1 (steady-state window end) + the tail offsets below must match the
+        # sustained-pink hold length the harness rendered with (render.cpp's
+        # --sustained-pink-seconds); a hardcoded 4.0 mis-scores any other hold.
+        def _band_rms_db(p, lo, hi, t0=2.5, t1=sustained_pink_seconds):
             x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim>1 else x
             a, b = int(t0*sr), min(int(t1*sr), len(m))
             hi_c = min(hi, sr*0.49)
@@ -804,7 +812,7 @@ def audit(dv_dir, lex_dir, name='preset', category=''):
             return float(20*np.log10(np.sqrt(np.mean(y[a:b]**2))+1e-30))
         def _band_t30(p, lo, hi):
             x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim>1 else x
-            off = int(4.0 * sr)
+            off = int(sustained_pink_seconds * sr)
             if off >= len(m): return None
             tail = m[off:]
             hi_c = min(hi, sr*0.49)
@@ -824,7 +832,7 @@ def audit(dv_dir, lex_dir, name='preset', category=''):
             below = np.where((np.arange(len(sm)) > pidx) & (sm < thr))[0]
             return (int(below[0]) - pidx) / sr if len(below) else None
 
-        print("\n── SUSTAINED-PINK STEADY-STATE PER-BAND ENERGY (window 2.5-4.0s) ──")
+        print(f"\n── SUSTAINED-PINK STEADY-STATE PER-BAND ENERGY (window 2.5-{sustained_pink_seconds:g}s) ──")
         for lab, lo, hi, gate_key in [
             ('ss deep sub 20-50',    20,    50, 'ss_deep_sub_dB'),
             ('ss sub 50-100',        50,   100, 'ss_sub_dB'),
@@ -848,7 +856,7 @@ def audit(dv_dir, lex_dir, name='preset', category=''):
         # t30 measurement helper closes over band-filter on input-off tail.
         def _band_decay_t(p, lo, hi, target_db):
             x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim>1 else x
-            off = int(4.0 * sr)
+            off = int(sustained_pink_seconds * sr)
             if off >= len(m): return None
             tail = m[off:]
             hi_c = min(hi, sr*0.49)
@@ -1178,8 +1186,13 @@ def main():
                     help="After the human-readable sheets, emit one machine-"
                          "readable 'JSON_RESULT: {...}' line (n_fail + the "
                          "failed-gate strings) for the optimizer to parse.")
+    ap.add_argument("--sustained-pink-seconds", type=float, default=4.0,
+                    help="Sustained-pink hold length the render used (must match "
+                         "render.cpp's --sustained-pink-seconds). Sets the "
+                         "steady-state scoring window end + tail-decay offset.")
     args = ap.parse_args()
-    fails = audit(args.dv_dir, args.lex_dir, args.name, args.category)
+    fails = audit(args.dv_dir, args.lex_dir, args.name, args.category,
+                  args.sustained_pink_seconds)
     if args.json:
         print("JSON_RESULT: " + json.dumps({"n_fail": len(fails), "fails": fails}))
     sys.exit(1 if fails else 0)

--- a/plugins/DuskVerb/tools/tuner/polish_only.py
+++ b/plugins/DuskVerb/tools/tuner/polish_only.py
@@ -41,6 +41,10 @@ def main():
     args = ap.parse_args()
 
     anchor_n = Path(args.anchor_rendered)
+    if "_noiseburst" not in anchor_n.name:
+        ap.error("--anchor-rendered must point at a '*_noiseburst*' WAV so the "
+                 "sustained and snare variants can be derived by substring "
+                 f"replacement (got '{anchor_n.name}').")
     anchor_s = anchor_n.with_name(anchor_n.name.replace("_noiseburst", "_sustained"))
     anchor_snare = anchor_n.with_name(anchor_n.name.replace("_noiseburst", "_snare"))
     anchor_files = {"noiseburst": str(anchor_n), "sustained": str(anchor_s),

--- a/plugins/DuskVerb/tools/tuner/staged_tuner.py
+++ b/plugins/DuskVerb/tools/tuner/staged_tuner.py
@@ -330,7 +330,11 @@ def render(preset, overrides, vst3, out_dir, prerun=5.0, sustained=4.0):
             continue
         cmd += ["--param", f"{k}={v}"]
     cmd += ["--program", preset]   # canonical path, not the legacy positional table
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    except subprocess.TimeoutExpired:
+        # A hung render must fail just this trial, not abort the whole sweep.
+        return None
     if r.returncode != 0:
         return None
     preset_token = "".join(c for c in preset if c.isalnum() or c in "+-_'")
@@ -1304,7 +1308,9 @@ def main():
            str(final_dir), str(anchor_n.parent), "--name", args.preset]
     if args.category:
         cmd += ["--category", args.category]
-    subprocess.call(cmd)
+    # Propagate full_check's exit status so a gate failure fails this script too
+    # (CI / callers can detect it instead of seeing a spurious success).
+    sys.exit(subprocess.call(cmd))
 
 
 if __name__ == "__main__":

--- a/plugins/DuskVerb/tools/tuner/tune_preset.py
+++ b/plugins/DuskVerb/tools/tuner/tune_preset.py
@@ -125,11 +125,10 @@ def auto_level_match(preset, params, vst3, anchor_dir, dv_dir):
     """Deprecated 2026-05-27: Gain Trim is now a free Optuna parameter so
     loudness is optimized jointly with everything else. Post-sweep trim
     adjustment re-introduced absolute-band-energy mismatch (bands hot by
-    same dB as the trim bump). This function now just renders + returns
-    params unchanged so the lock-in pipeline still produces a final WAV
-    for full_check.
+    same dB as the trim bump). This function now just returns the params
+    unchanged — the single final render is performed by render_lockin()
+    immediately after, so rendering here would be a redundant duplicate.
     """
-    render_with(preset, params, vst3, dv_dir)
     return params
 
 

--- a/plugins/DuskVerb/tools/tuner/verify_preset_vs_anchor.py
+++ b/plugins/DuskVerb/tools/tuner/verify_preset_vs_anchor.py
@@ -42,24 +42,32 @@ RENDER_BIN = REPO_ROOT / "build" / "tests" / "duskverb_render" / "duskverb_rende
 OUTPUT_DIR = REPO_ROOT / "tests" / "duskverb_render" / "output"
 DEFAULT_VST3 = Path.home() / ".vst3" / "DuskVerb.vst3"
 
+# Directory holding the externally-captured anchor IR renders. Machine-specific
+# by nature (typically a scratch dir), so it's overridable via the
+# ANCHOR_RENDER_DIR env var; defaults to the historical /tmp location so
+# existing local workflows keep working. CI / other developers can point this
+# anywhere without editing the file.
+ANCHOR_DIR = os.environ.get("ANCHOR_RENDER_DIR", "/tmp/anchor_renders")
+
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "DuskVerb" / "tools" / "tuner"))
 from metrics_external import compute_metrics
 
-# (preset_name, anchor_ir_path, slug, render_dir_relative_to_repo)
+# (preset_name, anchor_ir_path, slug). Anchor paths are either repo-relative
+# (committed VVV renders) or built from ANCHOR_DIR (external captures).
 PRESETS = [
-    ("Vocal Plate",         "/tmp/anchor_renders/vvv_vocal_plate_fresh_impulse.wav",   "VocalPlate"),
-    ("Vintage Vocal Plate", "/tmp/anchor_renders/lex_vintage_vocal_plate_impulse.wav", "VintageVocalPlate"),
+    ("Vocal Plate",         os.path.join(ANCHOR_DIR, "vvv_vocal_plate_fresh_impulse.wav"),   "VocalPlate"),
+    ("Vintage Vocal Plate", os.path.join(ANCHOR_DIR, "lex_vintage_vocal_plate_impulse.wav"), "VintageVocalPlate"),
     ("Snare Plate XL",      "tests/duskverb_render/output/vvv/vvv_Drum_Plate_impulse.wav",  "SnarePlateXL"),
     ("Vocal Hall",          "tests/duskverb_render/output/vvv/vvv_Vocal_Hall_impulse.wav",  "VocalHall"),
     ("Bright Hall",         "tests/duskverb_render/output/vvv/vvv_Bright_Hall_impulse.wav", "BrightHall"),
-    ("Cathedral",           "/tmp/anchor_renders/lex_cathedral_impulse.wav",          "Cathedral"),
-    ("Blade Runner 224",    "/tmp/anchor_renders/lex_blade_runner_224_impulse.wav",   "BladeRunner224"),
-    ("Tiled Room",          "/tmp/anchor_renders/vvv_tiled_room_impulse.wav",          "TiledRoom"),
-    ("Tight Drum Room",     "/tmp/anchor_renders/vvv_fat_snare_room_impulse.wav",      "TightDrumRoom"),
+    ("Cathedral",           os.path.join(ANCHOR_DIR, "lex_cathedral_impulse.wav"),          "Cathedral"),
+    ("Blade Runner 224",    os.path.join(ANCHOR_DIR, "lex_blade_runner_224_impulse.wav"),   "BladeRunner224"),
+    ("Tiled Room",          os.path.join(ANCHOR_DIR, "vvv_tiled_room_impulse.wav"),          "TiledRoom"),
+    ("Tight Drum Room",     os.path.join(ANCHOR_DIR, "vvv_fat_snare_room_impulse.wav"),      "TightDrumRoom"),
     ("Ambience",            "tests/duskverb_render/output/vvv/vvv_Ambience_impulse.wav",    "Ambience"),
-    ("Realistic Chamber",   "/tmp/anchor_renders/lex_chamber_large_impulse.wav",       "RealisticChamber"),
-    ("1981 Gated Snare",    "/tmp/anchor_renders/vvv_84_small_room_impulse.wav",       "1981GatedSnare"),
-    ("Reverse Taps",        "/tmp/anchor_renders/lex_reverse_1_impulse.wav",           "ReverseTaps"),
+    ("Realistic Chamber",   os.path.join(ANCHOR_DIR, "lex_chamber_large_impulse.wav"),       "RealisticChamber"),
+    ("1981 Gated Snare",    os.path.join(ANCHOR_DIR, "vvv_84_small_room_impulse.wav"),       "1981GatedSnare"),
+    ("Reverse Taps",        os.path.join(ANCHOR_DIR, "lex_reverse_1_impulse.wav"),           "ReverseTaps"),
 ]
 
 # Anchor paths may be absolute (e.g. /tmp captures) or repo-relative; normalize

--- a/plugins/DuskVerb/tools/tuner/vintage_minisweep4.py
+++ b/plugins/DuskVerb/tools/tuner/vintage_minisweep4.py
@@ -22,7 +22,7 @@ def trial(idx, sub, lm, mh, air):
         str(RENDER), "--vst3", str(VST3),
         "--program", "Bright Hall",
         "--param", "Dry/Wet=1.0",
-        "--param", "Bus Mode=On",
+        "--param", "Bus Mode=1",
         # Round-3 best locked:
         "--param", "Mid Multiply=1.06",
         "--param", "Damping=0.85",

--- a/plugins/DuskVerb/tools/tuner/wav_audit.py
+++ b/plugins/DuskVerb/tools/tuner/wav_audit.py
@@ -308,8 +308,12 @@ def audit_compare(dv_path, lex_path):
         print(f"  {fc1:8.1f}  {dv:+10.2f}  {lx:+10.2f}  {delta:+9.2f}  {bar}{flag}")
         rows.append((fc1, dv, lx, delta))
     abs_d = [abs(r[3]) for r in rows]
-    print(f"\n  mean |Δ|:  {sum(abs_d)/len(abs_d):.2f} dB")
-    print(f"  max  |Δ|:  {max(abs_d):.2f} dB @ {[r[0] for r in rows if abs(r[3])==max(abs_d)][0]:.1f} Hz")
+    if not rows or not abs_d:
+        print("\n  (no valid bands — both renders below floor in every band)")
+    else:
+        max_abs = max(abs_d)
+        print(f"\n  mean |Δ|:  {sum(abs_d)/len(abs_d):.2f} dB")
+        print(f"  max  |Δ|:  {max_abs:.2f} dB @ {[r[0] for r in rows if abs(r[3])==max_abs][0]:.1f} Hz")
 
 
 def main():

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -224,11 +224,12 @@ namespace
         return {
             juce::String (name),
             {
-                // Divisor must equal (numAlgorithms - 1). 9 algorithms now
-                // (Dattorro / DattorroVintage / SixAPTank / QuadTank / FDN /
-                // Spring / NonLinear / Shimmer / VintageTank) → divisor = 8.
-                // Mismatching the divisor silently misroutes the algorithm
-                // index (the FDN→Spring bug fixed on branch 87-fix-fdn-quadtank).
+                // Divisor must equal (numAlgorithms - 1) = kAlgorithmDivisor.
+                // 10 algorithms now (Dattorro / DattorroVintage / SixAPTank /
+                // QuadTank / FDN / Spring / NonLinear / Shimmer / VintageTank /
+                // ReverseRoom) → divisor = 9. Mismatching the divisor silently
+                // misroutes the algorithm index (the FDN→Spring bug fixed on
+                // branch 87-fix-fdn-quadtank).
                 { "Algorithm",       static_cast<float> (algoIdx) / kAlgorithmDivisor },
                 { "Dry/Wet",         mix },
                 { "Bus Mode",        bus ? 1.0f : 0.0f },


### PR DESCRIPTION
⚠️ **DRAFT — do not merge until gate-validated.** These are *correct* DSP bug fixes that change tuned-preset sound. They must pass (or be re-tuned against) the anchor gate suite first. Anchors aren't available in CI, so validation is the maintainer's local step.

Stacks on #99 (`duskverb-review-fixes`) — branch is cut from that tip.

## What changed
- **PerBandEDTShape** (`DspUtils`): drive each `AttackRamp` with its own band magnitude (was full-band `|x|`, coupling the 4 regions) **and** give L/R independent ramp state (was shared → order-dependent stereo).
- **AttackRamp** (`DspUtils`): sample-rate-correct the envelope-follower attack/release coeffs (were fixed 0.05/0.005 per-sample steps). Anchored to reproduce the legacy values at 48 kHz, so the calibration rate is unchanged and only other host rates move (toward SR-independence).
- **DualTimeConstantBassShelf** (`DspUtils`): per-channel envelope follower (was one shared `envFollower_` advanced twice/sample, polluting R with L).
- **VintageTankEngine** `setSize`: recompute `decayGain_` immediately (was stale until the next `setDecay()`, so RT60 drifted on size-only changes).

Bit-identical bypass preserved in every case (guarded on `attackDb==0` / `gainDb==0` / unchanged size), so only EDT-shaped, dual-bass-shelf, and VintageTank presets are affected.

## Measured impact (A/B render diff vs the #99 base build, rmsΔ)
| Preset (engine) | Δ | needs re-validation? |
|---|---|---|
| Vocal Plate (Dattorro) | **bit-identical** | no |
| Cathedral Large Hall (FDN) | **bit-identical** | no |
| Bright Hall (VintageTank) | −70 dB noiseburst / −41 dB impulse / sustained identical | spot-check |
| **Vocal Hall** (FDN, EDT-active) | **−11 dB (audible)** | **yes — re-tune likely** |

## Gate-validation checklist (run locally with anchors)
- [ ] Ensure anchor renders present (`ANCHOR_RENDER_DIR`, default `/tmp/anchor_renders`) + VVV repo renders.
- [ ] Build VST3 from this branch; `cmake --build build --target DuskVerb_VST3 duskverb_render`.
- [ ] `python3 plugins/DuskVerb/tools/tuner/verify_preset_vs_anchor.py` — full sweep; compare PASS/WARN/FAIL counts vs `main`.
- [ ] Focused: `full_check.py` on **Vocal Hall** + **Bright Hall** (`--category Halls`), pre vs post.
- [ ] If Vocal Hall regresses: re-tune its row via `tune_preset.py "Vocal Hall"` (keep the correctness fix; update the preset constants), **not** by reverting the fix.
- [ ] Confirm 2× and 4× / 44.1k vs 48k vs 96k behaviour for the AttackRamp SR-coeff change.
- [ ] pluginval clean (expect the same pre-existing bool-restore fail as main).
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now remember the last applied preset for reload convenience.

* **Bug Fixes**
  * Fixed soft clipping saturation ceiling to prevent excessive output growth.
  * Corrected envelope follower behavior to be sample-rate independent.
  * Resolved unintended stereo channel coupling in envelope-driven processing.
  * Tail-spin modulation no longer activates during freeze.
  * Bass shelf coefficients now persist correctly across re-initialization.
  * Decay tracking now updates immediately when size changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->