### PR TITLE
DuskVerb: reset engine name-keyed config on identity-less state load + tuner nitpicks

### DIFF
--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1439,6 +1439,16 @@ void DuskVerbProcessor::performPresetSwap()
         // default freq/Q so the processBlock gain edge-detect stays consistent.
         newActive->reapplyNeutralEngineConfig();
         resolvePteqFreqQ ("", pteqBandFreq_, pteqBandQ_);
+        // reapplyNeutralEngineConfig() flattened the PostTankEQ, but the restored
+        // session still carries its own pteq_band*_gain_db in APVTS. Re-install
+        // those gains now (at the default freq/Q) — otherwise syncParameterCache-
+        // ToCurrent() below caches them as already-applied and the processBlock
+        // edge-detect (pushIfChanged) never fires, leaving the bands stuck flat
+        // despite non-zero restored gains.
+        newActive->setPostTankEQBand (0, pteqBandFreq_[0], pteqBandQ_[0], pteqBand0GainParam_->load());
+        newActive->setPostTankEQBand (1, pteqBandFreq_[1], pteqBandQ_[1], pteqBand1GainParam_->load());
+        newActive->setPostTankEQBand (2, pteqBandFreq_[2], pteqBandQ_[2], pteqBand2GainParam_->load());
+        newActive->setPostTankEQBand (3, pteqBandFreq_[3], pteqBandQ_[3], pteqBand3GainParam_->load());
     }
 
 

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1117,14 +1117,16 @@ void DuskVerbProcessor::setStateInformation (const void* data, int sizeInBytes)
     {
         // No persisted identity (older save / no preset applied at save) or the
         // saved name no longer maps to a factory preset (renamed/removed).
-        // Clear any stale pointer left from a preset previously applied to THIS
-        // reused instance, otherwise prepareToPlay()/performPresetSwap() would
-        // reapply that unrelated session's engine config (PostTankEQ bands,
-        // modulation topology, FDN base delays) on top of the just-restored
-        // APVTS values. Cleared → the engine falls back to its defaults, which
-        // is the correct "no known preset" state.
+        // Clear the pointer so prepareToPlay()/performPresetSwap() don't reapply
+        // an unrelated preset's config, AND arm a swap. Clearing alone is not
+        // enough: a reused instance's engine still holds the PREVIOUS preset's
+        // name-keyed config (PostTankEQ bands, modulation topology, FDN base
+        // delays — none of which forcePushAllParametersTo touches). The armed
+        // swap runs performPresetSwap()'s null branch → reapplyNeutralEngineConfig(),
+        // resetting those to defaults on the audio thread (so no message-thread
+        // biquad-coefficient write races process()).
         lastAppliedPreset_.store (nullptr, std::memory_order_release);
-        pendingPresetSwap_.store (false, std::memory_order_release);
+        pendingPresetSwap_.store (true, std::memory_order_release);
     }
 }
 
@@ -1427,6 +1429,16 @@ void DuskVerbProcessor::performPresetSwap()
         // detects in processBlock can re-issue setPostTankEQBand without
         // re-consulting the kPostTankEQByName map. Single source of truth.
         resolvePteqFreqQ (preset->name, pteqBandFreq_, pteqBandQ_);
+    }
+    else
+    {
+        // No known preset (session loaded with no/unknown identity). Reset the
+        // name-keyed engine config to defaults so a preset previously applied
+        // to this reused instance can't leak its PostTankEQ / topology / base
+        // delays onto the restored session. resolvePteqFreqQ("") yields the
+        // default freq/Q so the processBlock gain edge-detect stays consistent.
+        newActive->reapplyNeutralEngineConfig();
+        resolvePteqFreqQ ("", pteqBandFreq_, pteqBandQ_);
     }
 
 

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -416,6 +416,20 @@ void DuskVerbEngine::setFDNBaseDelays (const int* delays)
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setBaseDelays (delays); });
 }
 
+void DuskVerbEngine::reapplyNeutralEngineConfig()
+{
+    // PostTankEQ → all 4 bands flat (gain 0 → unity coefficients).
+    for (int b = 0; b < DspUtils::PostTankEQ::kNumBands; ++b)
+        postTankEQ_.setBand (b, 1000.0f, 1.0f, 0.0f);
+    // Modulation topology → legacy RandomWalk default.
+    setModulationTopology (DspUtils::ModulationTopology::RandomWalk);
+    // Per-line decay tilt → flat (1.0 / 1.0 = no tilt).
+    setPerLineDecayTilt (1.0f, 1.0f);
+    // FDN base delays → engine default log-spaced primes.
+    fdn_.resetBaseDelays();
+    multibandFdn_.forEachTank ([](FDNReverb& tk){ tk.resetBaseDelays(); });
+}
+
 void DuskVerbEngine::setFDNInLoopPeaking (float freqHz, float qFactor, float gainDb)
 {
     // Phase ε: only FDN has in-loop per-line peaking infrastructure.

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -210,6 +210,13 @@ public:
     // No-op for non-FDN engines. Pass nullptr to retain the engine default.
     void setFDNBaseDelays (const int* delays);
 
+    // Reset the name-keyed engine config (PostTankEQ bands, modulation topology,
+    // per-line decay tilt, FDN base delays) — the parts NOT carried by APVTS /
+    // forcePushAllParametersTo — back to engine defaults. Called when a session
+    // is loaded with no/unknown preset identity so a prior preset's config does
+    // not leak onto the restored session.
+    void reapplyNeutralEngineConfig();
+
     // Phase ε (2026-05-29): in-loop narrow-Q peaking band on the FDN per-
     // line feedback path. Designed to reinforce a specific frequency inside
     // the loop so steady-state input at that frequency builds extra gain

--- a/plugins/DuskVerb/src/dsp/FDNReverb.cpp
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.cpp
@@ -1078,6 +1078,19 @@ void FDNReverb::setBaseDelays (const int* delays)
     publishPending();
 }
 
+void FDNReverb::resetBaseDelays()
+{
+    // Restore the engine default (log-spaced primes) — used when a session is
+    // loaded with no/unknown preset identity so a prior preset's per-preset
+    // base-delay override (Phase β) doesn't leak onto the new session.
+    std::memcpy (baseDelays_, kDefaultDelays, sizeof (baseDelays_));
+    if (! prepared_) return;
+    LiveParams& p = pending();
+    computeDelayLengths (p);
+    computeDecayCoefficients (p);
+    publishPending();
+}
+
 void FDNReverb::setOutputTaps (const int* lt, const int* rt,
                                 const float* ls, const float* rs)
 {

--- a/plugins/DuskVerb/src/dsp/FDNReverb.h
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.h
@@ -49,6 +49,7 @@ public:
     void setTailSpinRate  (float hz);      // base rate of the master spin LFO
 
     void setBaseDelays (const int* delays);
+    void resetBaseDelays();   // restore the default log-spaced-prime table
     void setOutputTaps (const int* lt, const int* rt,
                         const float* ls, const float* rs);
     void setLateGainScale (float scale);

--- a/plugins/DuskVerb/tools/tuner/apply_best_and_evaluate.py
+++ b/plugins/DuskVerb/tools/tuner/apply_best_and_evaluate.py
@@ -153,7 +153,8 @@ def report(preset, params, vst3, anchor):
     else:
         max_abs = max(abs_d)
         print(f"\n  mean |Δ|: {sum(abs_d)/len(abs_d):.2f} dB")
-        print(f"  max  |Δ|: {max_abs:.2f} dB @ {[fc for fc,d in rows if abs(d)==max_abs][0]:.0f} Hz")
+        peak_fc = next((fc for fc, d in rows if abs(d) == max_abs), None)
+        print(f"  max  |Δ|: {max_abs:.2f} dB @ {peak_fc:.0f} Hz")
     # Sub-bass region focus (user's gate)
     sub = [(fc, d) for fc, d in rows if 80 <= fc <= 250]
     if sub:

--- a/plugins/DuskVerb/tools/tuner/eq_match_curve.py
+++ b/plugins/DuskVerb/tools/tuner/eq_match_curve.py
@@ -90,13 +90,14 @@ def main():
     t0_lx, t1_lx = args.t0, args.t1
     if stem != "sustained":
         def _peak_window(path):
-            x, sr = sf.read(path); m = x.mean(axis=1) if x.ndim > 1 else x
+            x, sr = sf.read(path)
+            m = x.mean(axis=1) if x.ndim > 1 else x
             pk = int(np.argmax(np.abs(m)))
             return pk / sr + 0.05, pk / sr + 1.0
         t0_dv, t1_dv = _peak_window(dv)
         t0_lx, t1_lx = _peak_window(lx)
 
-    print(f"\n══ EQ-MATCH DELTA CURVE ══")
+    print("\n══ EQ-MATCH DELTA CURVE ══")
     print(f"  DV:  {dv}")
     print(f"  Lex: {lx}")
     print(f"  Stimulus: {stem}   DV window: [{t0_dv:.2f}, {t1_dv:.2f}]s   "

--- a/plugins/DuskVerb/tools/tuner/wav_audit.py
+++ b/plugins/DuskVerb/tools/tuner/wav_audit.py
@@ -313,7 +313,8 @@ def audit_compare(dv_path, lex_path):
     else:
         max_abs = max(abs_d)
         print(f"\n  mean |Δ|:  {sum(abs_d)/len(abs_d):.2f} dB")
-        print(f"  max  |Δ|:  {max_abs:.2f} dB @ {[r[0] for r in rows if abs(r[3])==max_abs][0]:.1f} Hz")
+        peak_fc = next((r[0] for r in rows if abs(r[3]) == max_abs), None)
+        print(f"  max  |Δ|:  {max_abs:.2f} dB @ {peak_fc:.1f} Hz")
 
 
 def main():


### PR DESCRIPTION
## Main fix
Follow-up to the state-restore work in #99. When `setStateInformation()` loads a session with **no persisted preset name** (older saves) or an **unknown name**, clearing `lastAppliedPreset_` alone left a *reused* plugin instance's engine still holding the previous preset's **name-keyed config** — PostTankEQ bands, modulation topology, per-line decay tilt, FDN base delays. None of those are carried by APVTS / `forcePushAllParametersTo`. `prepare()` resets them, but a state-load without a following `prepare()` did not, so the restored session could inherit the prior preset's character.

Now that branch:
- arms a swap (`pendingPresetSwap_ = true`),
- `performPresetSwap()` gains a **null-preset branch** that calls the new `DuskVerbEngine::reapplyNeutralEngineConfig()` → PostTankEQ flat, modulation topology `RandomWalk`, decay tilt 1.0/1.0, FDN base delays back to the default log-spaced primes (new `FDNReverb::resetBaseDelays()`),
- runs entirely on the **audio thread** via the existing swap mechanism, so no message-thread biquad-coefficient write races `process()`.

**Scope:** this path only executes on an unknown/identity-less state load. `--program` renders always match a preset (`matchedPreset == true`), so factory-preset / gate renders are **completely unaffected**.

## Tuner nitpicks
- `apply_best_and_evaluate` / `wav_audit`: `next((...), None)` instead of building a throwaway list to find the max-|Δ| center frequency.
- `eq_match_curve`: PEP8-split the one-line `_peak_window` body; drop the `f` prefix on a placeholder-less `print`.

## Verification
- Builds clean on JUCE 8 (`DuskVerb_VST3`, `duskverb_render`), 0 errors; Python `py_compile` clean.
- pluginval exercises the new no-name path via its state roundtrip — 1/1/1 fails across 3 runs vs main's 2/2; the bool-param restore fail is **pre-existing** seed-noise (1–3), unrelated to this change. No regression.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions loaded with missing or unrecognized preset references now fully reset the reverb engine (neutral defaults, band frequencies/Qs, band gains and base delays) so prior preset state does not persist.

* **Chores**
  * Tuning utility scripts refactored for clearer output and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->