### PR TITLE
DuskVerb: room/hall fleet calibration, added new engines and tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,6 @@ Algorithmic reverb with 53 factory presets:
 - Size, pre-delay, damping, modulation, and mix controls
 - Early reflections with configurable patterns
 
-### DuskAmp - IN DEVELOPMENT
-Guitar amp simulator:
-- Wave Digital Filter (WDF) circuit-modeled amp stages
-- Neural Amp Modeler (NAM) integration for loading community amp profiles
-- Procedural cabinet simulation
-
 ### Spectrum Analyzer - IN DEVELOPMENT
 Professional FFT spectrum analyzer with metering:
 - Real-time FFT spectrum display

--- a/plugins/DuskVerb/CMakeLists.txt
+++ b/plugins/DuskVerb/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(DuskVerb
         src/PluginProcessor.cpp
         src/PluginEditor.cpp
         src/dsp/FDNReverb.cpp
+        src/dsp/OctaveGEQDesign.cpp
         src/dsp/DattorroTank.cpp
         src/dsp/QuadTank.cpp
         src/dsp/SixAPTankEngine.cpp

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -657,8 +657,18 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // nine-octave T60 map; composite-exact GEQ made the 7.3 s anchor lows
         // reachable (the old leaky cascade diverged >190 s). A/B'd against
         // the VintageTank baseline (18) — ship the winner.
+        // AccurateHall32 (algo 12) migration 2026-06-11: 32-line dense mode-spread
+        // cuts the metallic tail and IMPROVES the gates. A joint n_fail+kurtosis
+        // sweep (joint_dense32_sweep.py, 90 trials, SQLite Pareto front) found a
+        // 32-delay set that, after per-set octave-T60 recalibration, scores
+        // full_check n_fail 13 vs the algo-10 baseline 16 (sustained-correct
+        // harness) AND drops the tail 2-14 kHz spectral kurtosis ~18 -> 14.9
+        // (anchor 12.0; the metallic ring). Worst sub-bands 4-6k 11.7->7.3,
+        // 6-9k 11.6->9.5. The earlier kurtosis-ONLY set (kurt 14.3) was rejected:
+        // it ignored the gates and cost n_fail 20. Delays in kBaseDelaysByName;
+        // octave T60 recalibrated for these delays in kAccurateHallT60ByName.
         { "Bright Hall",          "Halls",
-          10, 0.40f, false,  0.0f, 0,
+          12, 0.40f, false,  0.0f, 0,
           5.0580f, 0.93236f, 0.04761f, 1.45608f, 0.77929f, 0.93713f,  170.39f,
           0.90000f, 0.37f, 0.55f,  26.856f, 4554.46f, 1.00000f, false, -1.7407f,  // Diffusion 0.499->0.90 (manual 2026-06-07): scatters the 12.9k metallic modal ring (spec_L1 max 8.06->6.44), fixes cent_50 + sine1k loudness, halves pitch-chorus 7.5x->3.14x; n_fail 20->18. Width 0.944->1.00: closes residual global stereo_corr.
           /* mono */ 20.0f, /* mid */ 0.80743f, /* highX */ 6389.40f, /* sat */ 0.13963f,  // re-derived post Decay-calibration (honest Decay 5.06 s; was 10->17 fails on the recalibrated VintageTank)

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -1011,7 +1011,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Ambience",             "Rooms",
           10, 0.40f, false,  2.91f, 0,   // algo 10 = AccurateHall (2026-06-09): per-octave GEQ T60. QuadTank floored 33 (8/9 T60 fail); AccurateHall closes all T60 → gain-matched full_check 33->21. QuadTank+GEQ (AccurateChamber) was tested + rejected (tone-wrecked). Octave targets in kAccurateHallT60ByName.
           1.3875f, 0.26283f, 0.17870f, 0.17487f, 0.98911f, 0.96938f,  327.98f,
-          0.68861f, 0.89f, 0.56f,  30.214f, 15746.05f, 1.42044f, false, -0.29995f,
+          0.68861f, 0.89f, 0.56f,  30.214f, 15746.05f, 1.05000f, false, -0.29995f,
           /* mono */ 20.0f, /* mid */ 0.64948f, /* highX */ 5834.41f, /* sat */ 0.16156f },  // re-derived post Decay-calibration (honest Decay 1.39 s; was 18->20 fails)
         // ── 1981 Gated Snare ─────────────────────────────────────────────────
         // Engine: NonLinear v6 (algo 5) — TRUE STATIC FIR. The envelope

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -216,7 +216,8 @@ struct FactoryPreset
         // er_level + mono_below ARE row fields (0.79 / 20 for VH) → set by the row.
         struct FrontLoadOverride { float tankLevel, erBusLow, erBusHigh, erDecorr; };
         static const std::map<juce::String, FrontLoadOverride> kFrontLoadByName = {
-            { "Vocal Hall", { 0.42f, 5.0f, 2.6f, 0.60f } },  // er_bus_low 2.8->5.0: warm the cold low (front-load cut left it thin); low 100-250 + ss-low now match VVV. ER-bus low = EARLY low → no late boom-sub-hot (unlike a tank/PostBandTrim lift).
+            { "Vocal Hall", { 0.42f, 5.0f, 2.6f, 0.60f } },
+            { "Cathedral Large Hall", { 1.0f, 0.0f, 0.0f, 0.60f } },  // er_bus_low 2.8->5.0: warm the cold low (front-load cut left it thin); low 100-250 + ss-low now match VVV. ER-bus low = EARLY low → no late boom-sub-hot (unlike a tank/PostBandTrim lift).
         };
         if (auto it = kFrontLoadByName.find (juce::String (name)); it != kFrontLoadByName.end())
         {
@@ -326,7 +327,11 @@ struct FactoryPreset
             // Tiled Room (FDN) — scoreboard+warm-start vs VVV "Tiled Room", 47→28.
             { "Tiled Room", { 1.661f, 0.8853f, 43.26f, 10850.0f, 0.0346f, -1.87f, 0.0f, 0.223f } },
             { "Blade Runner 224", { 1.8467f, 0.2189f, 119.28f, 14310.79f, 1.6074f, 3.4473f, 0.0f, 0.1912f } },
-            { "Cathedral Large Hall", { 1.827f, 0.8574f, 104.8f, 8400.0f, 2.657f, 2.079f, 0.0f, 1.4f } },
+            // Cathedral (AccurateHall since 2026-06-09): in-loop peak 1.4 -> 0.
+            // Under the octave GEQ, in-loop gain at 1 kHz distorts that band's
+            // accurate-RT decay (the calibrator oscillated +228/-56% at 1k).
+            // Input makeup (pre-loop, level-only) kept.
+            { "Cathedral Large Hall", { 1.827f, 0.8574f, 104.8f, 8400.0f, 2.657f, 2.079f, 0.0f, 0.0f } },
             // Vocal Hall (FDN) — 2026-06-07 co-tune. Sub 1.615 (lengthen T60 63),
             // Hi-Mid 0.577 (shorten T60 8k + decay-hi). xSub 120 / xAir 8000 as
             // shipped. No input makeup / in-loop peak. Pairs w/ row Treble 1.091
@@ -787,8 +792,11 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // trebleMult can't bend (8k wants 1.79s, FDN gives 3.13s, +75%) + sub
         // energy/decay deficit. The FDN structural refactor targets exactly
         // this. See memory duskverb_tuning_method.
+        // Migrated FDN(4) -> AccurateHall(10) 2026-06-09: the composite-exact
+        // octave GEQ sets all nine octave T60s directly (kAccurateHallT60ByName),
+        // closing the 9-vs-5 decay-coupling block the comment above describes.
         { "Cathedral Large Hall", "Halls",
-          4,  0.45f, false, 20.88f, 0,
+          10, 0.45f, false, 20.88f, 0,
           3.00000f, 0.93880f, 0.38010f, 1.18680f, 1.40800f, 1.24610f,  223.90f,  // ACCURACY: Decay 3.315->3.00 matches anchor tail length (tail_t60 +26% -> ~0). ModDepth/Rate+BassMult prior.
           0.70090f, 0.48f, 0.36f,  40.730f, 4834.0f, 1.02400f, false, -7.90200f,
           /* mono */ 20.0f, /* mid */ 0.64240f, /* highX */ 5442.0f, /* sat */ 0.00126f,  // re-swept w/ FDN FiveBand+input-makeup axes 26->20 vs CathedralLargeHall (Decay->3.3s near ref 2.7)

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -186,6 +186,10 @@ struct FactoryPreset
             // paired with the tank-rebalance (tank_level 0.42) — the energy
             // front-load now comes from the tank/ER BALANCE, not raw ER boost.
             { "Vocal Hall", { 3.0f } },
+            // Medium Drum Room: anchor is a front-loaded room (first50 45%,
+            // attack 22 ms); the parallel ER supplies the early energy the
+            // FDN tank can't.
+            { "Medium Drum Room", { 7.0f } },
         };
         float erBoost = 1.0f;
         if (auto it = kERBoostByName.find (juce::String (name)); it != kERBoostByName.end())
@@ -198,6 +202,10 @@ struct FactoryPreset
             // Vocal Hall: 31.6→15 (front-load campaign) — closes attack_time +
             // onset_slope with the rebalanced early field.
             { "Vocal Hall", { 15.0f } },
+            // Medium Drum Room: ER peak alone fires at ~7 ms, the tank at
+            // ~68 ms — the anchor's 22 ms attack sits between the regimes;
+            // an 18 ms ER rise lands the combined peak on it.
+            { "Medium Drum Room", { 33.0f } },
         };
         float erRise = 0.0f;
         if (auto it = kERRiseByName.find (juce::String (name)); it != kERRiseByName.end())
@@ -227,6 +235,9 @@ struct FactoryPreset
             { "Vocal Hall", { 0.50f, 5.0f, 2.6f, 0.60f, 0.0f } },
             { "Cathedral Large Hall", { 1.0f, 0.0f, 0.0f, 0.60f, 0.0f } },
             { "Bright Hall", { 1.0f, 0.0f, 5.0f, 0.50f, 0.0f } },
+            // MDR: er_bus_low -6 — the 7x ER boost dumps decorrelated LOW
+            // energy (width-low -0.59, low/boom hot); cut it at the ER bus.
+            { "Medium Drum Room", { 1.0f, -6.0f, 0.0f, 0.0f, 0.0f } },
         };
         if (auto it = kFrontLoadByName.find (juce::String (name)); it != kFrontLoadByName.end())
         {
@@ -977,6 +988,19 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
           0.40083f, 0.32752f, 0.00430f, 0.23945f, 1.13952f, 1.12685f,  516.73f,
           0.84013f, 0.80f, 0.57f,  22.132f, 4799.3f, 1.00000f, false, 11.53915f,  // Width 1.125->1.00: was over-wide (bands -0.135 vs anchor ~0); 1.00 is local min (28->26).
           /* mono */ 20.0f, /* mid */ 1.21799f, /* highX */ 8771.6f, /* sat */ 0.06325f,  // Dattorro re-engine vs CORRECTED anchor (sustained-gate full_check) -> 23.
+          /* hiCutShelfGainDb */ -4.50f },
+        // ── Medium Drum Room (VVV anchor) ──────────────────────────────────
+        // Engine: Dattorro (algo 0, Small Drum Room sibling). Anchor: VVV
+        // "Fat Snare Room" (Room mode, eighties color, Decay 0.70 s, PreDelay
+        // 9 ms, Size 38.8%, HighCut 4.5 kHz) — re-captured 2026-06-10 via the
+        // saved .vstpreset XML replayed through --nparam (the May-30 render
+        // was the dry-only broken capture). Anchor profile: T60 0.66-0.99 s
+        // near-flat, t50 50 ms, first50 51% (front-loaded medium room).
+        { "Medium Drum Room",     "Rooms",
+          10, 0.30f, false,  9.00f, 0,
+          0.85000f, 0.45000f, 0.00500f, 0.30000f, 0.90000f, 1.10000f,  400.00f,
+          0.80000f, 0.70f, 0.50f,  25.000f, 4500.0f, 1.00000f, false, 0.00000f,  // hand row beats the capped Optuna winner on full_check (24 vs 27 — proxy-loss divergence again); Optuna best kept in /tmp/dv_optuna_3vd7jng7
+          /* mono */ 120.0f, /* mid */ 1.00000f, /* highX */ 8000.0f, /* sat */ 0.05000f,
           /* hiCutShelfGainDb */ -4.50f },
         // ── Tiled Room (VVV anchor) ────────────────────────────────────────
         // Engine: FDN. Anchor: VVV "Tiled Room" preset (Reverb Mode =

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -214,11 +214,19 @@ struct FactoryPreset
         // See memory duskverb_energy_arrival_gate_and_wall.
         // tank_level, er_bus shelves, er_decorr have NO row field → set here.
         // er_level + mono_below ARE row fields (0.79 / 20 for VH) → set by the row.
-        struct FrontLoadOverride { float tankLevel, erBusLow, erBusHigh, erDecorr; };
+        struct FrontLoadOverride { float tankLevel, erBusLow, erBusHigh, erDecorr, splitHz; };
         static const std::map<juce::String, FrontLoadOverride> kFrontLoadByName = {
-            { "Vocal Hall", { 0.42f, 5.0f, 2.6f, 0.60f } },
-            { "Cathedral Large Hall", { 1.0f, 0.0f, 0.0f, 0.60f } },
-            { "Bright Hall", { 1.0f, 0.0f, 5.0f, 0.50f } },  // er_bus_low 2.8->5.0: warm the cold low (front-load cut left it thin); low 100-250 + ss-low now match VVV. ER-bus low = EARLY low → no late boom-sub-hot (unlike a tank/PostBandTrim lift).
+            // VH split 300: the tank cut starved the LATE lows (boom/body 8
+            // gates quiet) — below 300 Hz the tank stays unity, mid/high keep
+            // the 0.42 front-load (attack/t50/first50 unaffected).
+            // VH tank 0.42->0.50 (2026-06-10) paired with the softened pteq
+            // 70 Hz cut: refills the boom/body late lows the deeper front-load
+            // starved, 20 -> 16. split_hz probed (300/250: lows-exempt tank cut
+            // over-corrects +7.5 dB and flips the tail dark via gain renorm —
+            // 26/22, reverted to broadband 0).
+            { "Vocal Hall", { 0.50f, 5.0f, 2.6f, 0.60f, 0.0f } },
+            { "Cathedral Large Hall", { 1.0f, 0.0f, 0.0f, 0.60f, 0.0f } },
+            { "Bright Hall", { 1.0f, 0.0f, 5.0f, 0.50f, 0.0f } },
         };
         if (auto it = kFrontLoadByName.find (juce::String (name)); it != kFrontLoadByName.end())
         {
@@ -226,22 +234,23 @@ struct FactoryPreset
             setIfExists ("er_bus_low_gain",  it->second.erBusLow);
             setIfExists ("er_bus_high_gain", it->second.erBusHigh);
             setIfExists ("er_decorr",        it->second.erDecorr);
+            setIfExists ("tank_split_hz",    it->second.splitHz);
         }
         else
         {
             // Reset to neutral so these don't latch across preset loads (only
-            // Vocal Hall sets them; the other name-keyed maps below already
-            // default-reset the same way). tank_level neutral is 1.0 (×1.0
-            // bypass) — NOT 0.0, which would mute the late tank.
+            // the mapped presets set them; the other name-keyed maps below
+            // already default-reset the same way). tank_level neutral is 1.0
+            // (×1.0 bypass) — NOT 0.0, which would mute the late tank.
             setIfExists ("tank_level",       1.0f);
             setIfExists ("er_bus_low_gain",  0.0f);
             setIfExists ("er_bus_high_gain", 0.0f);
             setIfExists ("er_decorr",        0.0f);
+            setIfExists ("tank_split_hz",    0.0f);
         }
-        // Companion front-load levers — every preset (including Vocal Hall)
-        // ships these neutral, so write them unconditionally on each load;
-        // otherwise a user tweak latches across preset changes.
-        setIfExists ("tank_split_hz",    0.0f);
+        // Companion front-load lever — every preset ships this neutral, so
+        // write it unconditionally on each load; otherwise a user tweak
+        // latches across preset changes.
         setIfExists ("er_stereo_neutral", 0.0f);
         // Phase 4 (Change 2): HF cross-talk decorrelation depth. 0 (unlisted) →
         // no cross-feed → bit-identical. Per-preset from the cross-talk sweep.

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -217,7 +217,8 @@ struct FactoryPreset
         struct FrontLoadOverride { float tankLevel, erBusLow, erBusHigh, erDecorr; };
         static const std::map<juce::String, FrontLoadOverride> kFrontLoadByName = {
             { "Vocal Hall", { 0.42f, 5.0f, 2.6f, 0.60f } },
-            { "Cathedral Large Hall", { 1.0f, 0.0f, 0.0f, 0.60f } },  // er_bus_low 2.8->5.0: warm the cold low (front-load cut left it thin); low 100-250 + ss-low now match VVV. ER-bus low = EARLY low → no late boom-sub-hot (unlike a tank/PostBandTrim lift).
+            { "Cathedral Large Hall", { 1.0f, 0.0f, 0.0f, 0.60f } },
+            { "Bright Hall", { 1.0f, 0.0f, 5.0f, 0.50f } },  // er_bus_low 2.8->5.0: warm the cold low (front-load cut left it thin); low 100-250 + ss-low now match VVV. ER-bus low = EARLY low → no late boom-sub-hot (unlike a tank/PostBandTrim lift).
         };
         if (auto it = kFrontLoadByName.find (juce::String (name)); it != kFrontLoadByName.end())
         {
@@ -629,12 +630,16 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         //   would push sine1k over gate (zero-sum boundary).
         //
         // Net session: BH 25 → 10 fails (-15).
+        // AccurateHall trial 2026-06-10 (P3): algo 8 -> 10 with a calibrated
+        // nine-octave T60 map; composite-exact GEQ made the 7.3 s anchor lows
+        // reachable (the old leaky cascade diverged >190 s). A/B'd against
+        // the VintageTank baseline (18) — ship the winner.
         { "Bright Hall",          "Halls",
-          8,  0.40f, false,  0.0f, 0,
+          10, 0.40f, false,  0.0f, 0,
           5.0580f, 0.93236f, 0.04761f, 1.45608f, 0.77929f, 0.93713f,  170.39f,
           0.90000f, 0.37f, 0.55f,  26.856f, 4554.46f, 1.00000f, false, 0.62933f,  // Diffusion 0.499->0.90 (manual 2026-06-07): scatters the 12.9k metallic modal ring (spec_L1 max 8.06->6.44), fixes cent_50 + sine1k loudness, halves pitch-chorus 7.5x->3.14x; n_fail 20->18. Width 0.944->1.00: closes residual global stereo_corr.
           /* mono */ 20.0f, /* mid */ 0.80743f, /* highX */ 6389.40f, /* sat */ 0.13963f,  // re-derived post Decay-calibration (honest Decay 5.06 s; was 10->17 fails on the recalibrated VintageTank)
-          /* hiCutShelfGainDb */ -6.0f },
+          /* hiCutShelfGainDb */ -6.0f },  // AccurateHall trial: -2 brightened LATE HF level too (bloom 8-12k +6 dB, gain==decay==level) — kept at -6; early-HF dark is compensated post-tank (pteq 10 kHz boost).
         // ── Deep Blue REMOVED 2026-05-31 ──────────────────────────────────────
         // The SixAP "massive concert hall" Deep Blue was redundant: the hall
         // niche is covered by Cathedral Large Hall / Bright Hall / Vocal Hall /

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -570,7 +570,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // old "T60-ceiling" verdict was an artifact of the leaky shelf cascade.
         { "Drum Plate",           "Plates",
           10, 0.42f, false, 12.0f, 0,
-          2.263f, 0.337f, 0.373f, 0.119f, 1.296f, 0.723f,  98.99f,
+          2.263f, 0.337f, 0.600f, 1.000f, 1.296f, 0.723f,  98.99f,
           0.441f, 0.30f, 0.55f,  20.68f, 10078.6f, 1.100f, false, -12.22f,  // Width 0.934->1.10: was too correlated (corr +0.107 vs anchor -0.097); 1.10 closes all 4 width/corr gates (27->23).
           /* mono */ 20.0f, /* mid */ 0.690f, /* highX */ 7762.3f, /* sat */ 0.214f },
         // ═══════════ SPRINGS ═══════════

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -189,7 +189,10 @@ struct FactoryPreset
             // Medium Drum Room: anchor is a front-loaded room (first50 45%,
             // attack 22 ms); the parallel ER supplies the early energy the
             // FDN tank can't.
-            { "Medium Drum Room", { 7.0f } },
+            { "Medium Drum Room", { 1.77390f } },
+            { "Ambience", { 3.09241f } },   // partial front-load (FDN back-load is structural)
+            { "Blade Runner 224", { 1.28774f } },   // ER on (was OFF) -> 107ms attack
+            { "Cathedral Large Hall", { 4.96275f } },   // strong ER for the 2.3ms attack
         };
         float erBoost = 1.0f;
         if (auto it = kERBoostByName.find (juce::String (name)); it != kERBoostByName.end())
@@ -205,7 +208,10 @@ struct FactoryPreset
             // Medium Drum Room: ER peak alone fires at ~7 ms, the tank at
             // ~68 ms — the anchor's 22 ms attack sits between the regimes;
             // an 18 ms ER rise lands the combined peak on it.
-            { "Medium Drum Room", { 33.0f } },
+            { "Medium Drum Room", { 24.38402f } },
+            { "Ambience", { 11.05449f } },
+            { "Blade Runner 224", { 28.35710f } },
+            { "Cathedral Large Hall", { 1.53405f } },
         };
         float erRise = 0.0f;
         if (auto it = kERRiseByName.find (juce::String (name)); it != kERRiseByName.end())
@@ -233,11 +239,16 @@ struct FactoryPreset
             // over-corrects +7.5 dB and flips the tail dark via gain renorm —
             // 26/22, reverted to broadband 0).
             { "Vocal Hall", { 0.50f, 5.0f, 2.6f, 0.60f, 0.0f } },
-            { "Cathedral Large Hall", { 1.0f, 0.0f, 0.0f, 0.60f, 0.0f } },
+            { "Cathedral Large Hall", { 0.90445f, 0.0f, 0.0f, 0.08057f, 0.0f } },  // tank rebalance + er_decorr (sweep 2026-06-11)
             { "Bright Hall", { 1.0f, 0.0f, 5.0f, 0.50f, 0.0f } },
             // MDR: er_bus_low -6 — the 7x ER boost dumps decorrelated LOW
             // energy (width-low -0.59, low/boom hot); cut it at the ER bus.
-            { "Medium Drum Room", { 1.0f, -6.0f, 0.0f, 0.0f, 0.0f } },
+            // MDR (r4 early-field sweep 2026-06-11): tank 0.556 front-load
+            // rebalance + ER-bus cuts — ER carries the attack, tank the tail.
+            { "Medium Drum Room", { 0.55587f, -7.99373f, -2.41836f, 0.0f, 0.0f } },
+            // Ambience: tank 0.633 front-load rebalance + er_decorr 0.323 (stereo).
+            { "Ambience", { 0.63322f, 0.0f, 0.0f, 0.32322f, 0.0f } },
+            { "Blade Runner 224", { 0.95209f, 0.0f, 0.0f, 0.57512f, 0.0f } },
         };
         if (auto it = kFrontLoadByName.find (juce::String (name)); it != kFrontLoadByName.end())
         {
@@ -279,6 +290,13 @@ struct FactoryPreset
         struct MultibandOverride { bool enable; float lowSec, midSec, highSec; };
         static const std::map<juce::String, MultibandOverride> kMultibandByName = {
             // Calibrated by the per-band decay sweep (2026-06-02).
+            // MDR multiband trial (2026-06-11) FALSIFIED: algo 4 + 3-band decays
+            // scored 29 vs the algo-10 AccurateHall baseline 25. The anchor's
+            // per-octave T60 is non-monotonic (63=0.75, 125=0.99, 500=0.93, 2k=0.73,
+            // 16k=0.66) — 3 decay knobs cannot fit a 6-octave curve, and algo 4
+            // loses AccurateHall's 9-octave GEQ darkening (cent_500 +81%) while the
+            // 3-tank sum worsens modal beating (osc P2P +12). Multiband is COARSER
+            // than the GEQ already in use. Reverted.
         };
         bool  mbEnable = false; float mbLo = 0.0f, mbMi = 0.0f, mbHi = 0.0f;
         if (auto it = kMultibandByName.find (juce::String (name)); it != kMultibandByName.end())
@@ -834,11 +852,11 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // octave GEQ sets all nine octave T60s directly (kAccurateHallT60ByName),
         // closing the 9-vs-5 decay-coupling block the comment above describes.
         { "Cathedral Large Hall", "Halls",
-          10, 0.45f, false, 20.88f, 0,
-          3.00000f, 0.93880f, 0.38010f, 1.18680f, 1.40800f, 1.24610f,  223.90f,  // ACCURACY: Decay 3.315->3.00 matches anchor tail length (tail_t60 +26% -> ~0). ModDepth/Rate+BassMult prior.
-          0.70090f, 0.48f, 0.36f,  40.730f, 4834.0f, 1.02400f, false, -6.232f,
-          /* mono */ 20.0f, /* mid */ 0.64240f, /* highX */ 5442.0f, /* sat */ 0.00126f,  // re-swept w/ FDN FiveBand+input-makeup axes 26->20 vs CathedralLargeHall (Decay->3.3s near ref 2.7)
-          /* hiCutShelfGainDb */ -14.5f },
+          10, 0.45f, false, 2.484f, 0,
+          3.44391f, 0.93880f, 0.38010f, 1.18680f, 1.28203f, 1.01074f,  223.90f,  // early-field+spectral sweep 2026-06-11: 19 -> 15.
+          0.74244f, 0.35840f, 0.44666f,  40.730f, 4834.0f, 1.00257f, false, -2.091f,  // PreDelay 20.88->2.48 + strong-fast ER (boost 4.96/rise 1.53 in maps) cracks the 147ms->2.3ms attack wall. gainTrim -2.09 = 100%-wet RMS match.
+          /* mono */ 20.0f, /* mid */ 0.51434f, /* highX */ 5442.0f, /* sat */ 0.00126f,  // edt+498% residual is octave-T60-locked (GEQ recal = next pass)
+          /* hiCutShelfGainDb */ -13.83844f },
         // ── Blade Runner 224 ─────────────────────────────────────────────────
         // Anchor: Vangelis on the late-1970s digital hall hardware (Hall A / Constellation) —
         // "Tears in Rain" / "Memories of Green". Validated against the
@@ -900,10 +918,10 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         //   PTEQ Band 3 -5.0 → -6.0 dB in PluginProcessor.cpp.
         { "Blade Runner 224",     "Halls",
           10, 0.45f, false, 25.0f, 0,    // algo 10 = AccurateHall (2026-06-09): per-octave GEQ T60. T60 8/9, gain-matched full_check 20->15 vs FDN. Extreme per-octave spread (9.8s low -> 1.3s 16k).
-          13.6421f, 0.91981f, 0.33084f, 2.64911f, 0.86140f, 1.05238f,  330.94f,
-          0.84476f, 0.00f, 0.50f, 56.210f, 14429.68f, 1.10000f, false, -1.6866f,  // HF damping re-swept (Treble/HiCut/FiveBand-HF): curb metallic 8k/16k ring, 21->19. Width 1.697->1.10: was over-wide/anti-phase (corr -0.37 vs anchor -0.149); 1.10 closes 3 width-band gates (26->23). Residual global stereo_corr is anchor's freq-dependent decorrelation, global Width can't match.
-          /* mono */ 20.0f, /* mid */ 0.73614f, /* highX */ 3980.22f, /* sat */ 0.17579f,
-          /* hiCutShelfGainDb */ -11.3f },  // RE-ANCHORED to VVV "Homestar Blade Runner" (Concert Hall, 10s, dark) — the prior lex-rhall-rhall4 anchor was WRONG (57->23 w/ FDN FiveBand+input-makeup axes)
+          11.07845f, 0.91981f, 0.33084f, 2.64911f, 0.98367f, 1.23893f,  330.94f,
+          0.72216f, 0.44324f, 0.84883f, 56.210f, 14429.68f, 1.03215f, false, -0.123f,  // tunable-cluster sweep 2026-06-11: 20 -> 17 (ER on 0->0.44 fixes 107ms attack; decay 13.6->11.1 tail_t60; damping/diffusion/spectral). gainTrim -0.12 = 100%-wet RMS match. edt+254% residual is octave-T60-locked (GEQ recal needed).
+          /* mono */ 20.0f, /* mid */ 0.79737f, /* highX */ 3980.22f, /* sat */ 0.17579f,
+          /* hiCutShelfGainDb */ -9.63168f },  // RE-ANCHORED to VVV "Homestar Blade Runner" (Concert Hall, 10s, dark)
         // ── 79 Vocal Chamber (VVV anchor) ──────────────────────────────────
         // Engine: QuadTank. Anchor: VVV "79 Vocal Chamber" preset (Reverb
         // Mode = Chamber1979) @ 100% wet.
@@ -1002,25 +1020,28 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // ── Medium Drum Room (VVV anchor) ──────────────────────────────────
         // Engine: Dattorro (algo 0, Small Drum Room sibling). Anchor: VVV
         // "Fat Snare Room" (Room mode, eighties color, Decay 0.70 s, PreDelay
-        // 9 ms, Size 38.8%, HighCut 4.5 kHz) — re-captured 2026-06-10 via the
-        // saved .vstpreset XML replayed through --nparam (the May-30 render
-        // was the dry-only broken capture). Anchor profile: T60 0.66-0.99 s
+        // 9 ms, Size 38.8%, HighCut 4.5 kHz). Anchor profile: T60 0.66-0.99 s
         // near-flat, t50 50 ms, first50 51% (front-loaded medium room).
-        // Medium Drum Room: kept on the FDN (algo 10). Two structural attempts
-        // 2026-06-11 — (1) composite ER + FDN tail, (2) "UltraRoom" decouple (ER +
-        // octave-GEQ decay + post-loop PostTankBandTrim level) — both FALSIFIED:
-        // best n_fail 24 vs FDN 25 (-1, noise-level). MDR is not behind one coupling
-        // wall but a STACK: decay-TIME (octave-GEQ-vs-band-gate mismatch + T60-gate
-        // coupling), within-band level/boom/body coupling (a static post trim can't
-        // separate), modulation (osc P2P / tail pitch-chorus), diffusion_flux, and
-        // spectral. No single lever (or ER+level-decouple together) reaches the low
-        // teens. Reverted; composite/decouple infra retained for Tiled Room.
+        // MIGRATED FDN(10) -> Dattorro(0) 2026-06-11 (cold-start Optuna sweep,
+        // --param-driven, full_check n_fail objective, 2 rounds): 25 -> 20. The FDN
+        // family structurally COULD NOT match this DARK room — multiband (3-band, 29)
+        // and AccurateHall32 (32-line, 32) both FAILED because ANY FDN recirculates
+        // input HF, leaving a 12.9 kHz metallic modal ring (spec_L1 max 7 dB @ 12902).
+        // The Dattorro allpass tank damps HF OUT of the loop: ring GONE (spec_L1 max
+        // resolved), cent_50 / decay low_mid+mid (+54/+22%) / osc P2P all CLOSED.
+        // Topology confirmed by RoomReverb/Freeverb3 (Moorer ER + Dattorro Progenitor
+        // = the textbook dark-room design). Residual 20 is coupling-walled (cent_500
+        // +130% <-> T60 <-> decay: cannot darken the mid-tail without cratering HF T60;
+        // Dattorro 3-band damping too coarse for the 9-octave anchor curve) + Phase-2
+        // features the tank lacks (pitch-chorus 6.2x -> aperiodic noise-mod; stereo_corr
+        // -> crossfeed). Voicing in the row + kERBoost/kERRise (ER front). gainTrim
+        // +12.77 (dark voicing runs quiet; sibling Small Drum Room is +11.54).
         { "Medium Drum Room",     "Rooms",
-          10, 0.30f, false,  9.00f, 0,
-          0.85000f, 0.45000f, 0.00500f, 0.30000f, 0.90000f, 1.10000f,  400.00f,
-          0.80000f, 0.70f, 0.50f,  25.000f, 4500.0f, 1.00000f, false, -0.81f,  // FDN algo 10 baseline (n_fail 25).
-          /* mono */ 120.0f, /* mid */ 1.00000f, /* highX */ 8000.0f, /* sat */ 0.05000f,
-          /* hiCutShelfGainDb */ -4.50f },
+          0, 0.30f, false,  12.71f, 0,
+          0.94601f, 0.40165f, 0.03176f, 0.62647f, 0.65776f, 0.84324f,  400.00f,
+          0.67800f, 0.27052f, 0.41204f,  25.000f, 4949.32f, 0.99109f, false, 18.01f,  // Dattorro algo 0; r3 tank + r4 early-field + anti-beating sweep (modal geometry to drop pitch-chorus 8.2x->3.65x): honest n_fail 18. gainTrim +18.01 = 100%-wet noiseburst RMS match.
+          /* mono */ 120.0f, /* mid */ 0.79808f, /* highX */ 4859.93f, /* sat */ 0.02480f,
+          /* hiCutShelfGainDb */ -3.77129f },
         // ── Tiled Room (VVV anchor) ────────────────────────────────────────
         // Engine: FDN. Anchor: VVV "Tiled Room" preset (Reverb Mode =
         // Chamber, Size 0.107, EarlyDiffusion 0.35, LateDiffusion 0.5).
@@ -1062,9 +1083,9 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // QuadTank topology vs VVV's Ambience modal character.
         { "Ambience",             "Rooms",
           10, 0.40f, false,  2.91f, 0,   // algo 10 = AccurateHall (2026-06-09): per-octave GEQ T60. QuadTank floored 33 (8/9 T60 fail); AccurateHall closes all T60 → gain-matched full_check 33->21. QuadTank+GEQ (AccurateChamber) was tested + rejected (tone-wrecked). Octave targets in kAccurateHallT60ByName.
-          1.3875f, 0.26283f, 0.17870f, 0.17487f, 0.98911f, 0.96938f,  327.98f,
-          0.68861f, 0.89f, 0.56f,  30.214f, 15746.05f, 1.05000f, false, -0.29995f,
-          /* mono */ 20.0f, /* mid */ 0.64948f, /* highX */ 5834.41f, /* sat */ 0.16156f },  // re-derived post Decay-calibration (honest Decay 1.39 s; was 18->20 fails)
+          1.51574f, 0.26283f, 0.17870f, 0.17487f, 0.64252f, 0.62992f,  327.98f,
+          0.49320f, 0.86847f, 0.56f,  30.214f, 15746.05f, 1.07315f, false, 3.277f,  // tunable-cluster sweep 2026-06-11: 23 -> 16 (bass-damp+bandtrim boom/640, partial front-load, edt). gainTrim +3.28 = 100%-wet noiseburst RMS match.
+          /* mono */ 20.0f, /* mid */ 0.70170f, /* highX */ 5834.41f, /* sat */ 0.16156f, /* hiCutShelfGainDb */ -5.41295f },
         // ── 1981 Gated Snare ─────────────────────────────────────────────────
         // Engine: NonLinear v6 (algo 5) — TRUE STATIC FIR. The envelope
         // (attack ramp → flat plateau → mathematical cliff) is baked into

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -529,7 +529,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // 300-trial warm-started re-sweep both floor at 21. Remaining (cent -29%
         // dark, sine1k +5 dB hot, small T60 tilt, 12.9k spike) is DPV-vs-Lexicon.
         { "Vintage Vocal Plate",  "Plates",
-          1,  0.5f,   true,  10.0f, 0,
+          1,  0.5f,   false, 10.0f, 0,  // busMode true->false (2026-06-10): calibration leftover — Mix 0.5 was dead under bus mode, and every other preset ships insert-friendly. Calibration renders force Bus Mode=1 via the harness, so gates are unaffected.
           0.80466f, 0.80357f, 0.29369f, 1.64421f, 1.30000f, 1.38104f,  522.55f,
           0.24230f, 0.00f, 0.30f,  42.811f, 15000.0f, 0.81121f, false, 9.01827f,  // ACCURACY: Treble 1.366->1.30 + HiCut 7366->15000 brightens to the bright Lex anchor (cent -29%->-11%)
           /* mono */ 20.0f, /* mid */ 1.42055f, /* highX */ 7049.45f, /* sat */ 0.12959f,

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -1006,10 +1006,19 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // saved .vstpreset XML replayed through --nparam (the May-30 render
         // was the dry-only broken capture). Anchor profile: T60 0.66-0.99 s
         // near-flat, t50 50 ms, first50 51% (front-loaded medium room).
+        // Medium Drum Room: kept on the FDN (algo 10). Two structural attempts
+        // 2026-06-11 — (1) composite ER + FDN tail, (2) "UltraRoom" decouple (ER +
+        // octave-GEQ decay + post-loop PostTankBandTrim level) — both FALSIFIED:
+        // best n_fail 24 vs FDN 25 (-1, noise-level). MDR is not behind one coupling
+        // wall but a STACK: decay-TIME (octave-GEQ-vs-band-gate mismatch + T60-gate
+        // coupling), within-band level/boom/body coupling (a static post trim can't
+        // separate), modulation (osc P2P / tail pitch-chorus), diffusion_flux, and
+        // spectral. No single lever (or ER+level-decouple together) reaches the low
+        // teens. Reverted; composite/decouple infra retained for Tiled Room.
         { "Medium Drum Room",     "Rooms",
           10, 0.30f, false,  9.00f, 0,
           0.85000f, 0.45000f, 0.00500f, 0.30000f, 0.90000f, 1.10000f,  400.00f,
-          0.80000f, 0.70f, 0.50f,  25.000f, 4500.0f, 1.00000f, false, -0.81f,  // hand row beats the capped Optuna winner on full_check (24 vs 27 — proxy-loss divergence again); Optuna best kept in /tmp/dv_optuna_3vd7jng7
+          0.80000f, 0.70f, 0.50f,  25.000f, 4500.0f, 1.00000f, false, -0.81f,  // FDN algo 10 baseline (n_fail 25).
           /* mono */ 120.0f, /* mid */ 1.00000f, /* highX */ 8000.0f, /* sat */ 0.05000f,
           /* hiCutShelfGainDb */ -4.50f },
         // ── Tiled Room (VVV anchor) ────────────────────────────────────────
@@ -1024,10 +1033,18 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // map; in-loop peak 0.223 zeroed (distorts accurate-RT decay —
         // Cathedral lesson). Won the A/B vs the FDN baseline 18 -> 17 plus
         // 9/9 octave decay accuracy.
+        // Tiled Room: migrated to the dedicated TiledRoomEngine (algo 13) 2026-06-11.
+        // A single-tank FDN (algo 10) structurally back-loaded + recirculated bright
+        // energy (n_fail 26: energy_first50 12.7% vs anchor 69%, cent_500 +196%, slow
+        // attack, over-modulation). Algo 13 welds a sparse tapped-delay ER front-end
+        // (front-loads the first ~50 ms) to a short frozen low-pass-terminated tail
+        // (~1.1 kHz dark loop). The FDN decay/size/damping/mod fields below are inert
+        // on this engine (it is self-contained, fixed-voiced); Dry/Wet, Pre-Delay,
+        // Width still apply (handled outside the tank).
         { "Tiled Room",           "Rooms",
-          10, 0.30f, false,  8.20f, 0,
-          0.5684f, 0.47940f, 0.43350f, 2.39800f, 0.68070f, 1.31900f,  173.10f,
-          0.41390f, 0.46f, 0.40f,  34.100f, 7090.39f, 1.00000f, false, 0.7701f,  // Width 0.535->1.00: the prior [0.35,0.60] sweep OVERSHOT corr -0.34 -> +0.50 (now anchor is +0.007, DV was too narrow/correlated). 1.00 closes width mid+hi (23->21). Residual corr/width-low is global-vs-per-band mismatch.
+          13, 0.30f, false,  8.20f, 0,
+          0.5684f, 0.47940f, 0.00000f, 2.39800f, 0.68070f, 1.31900f,  173.10f,   // modDepth 0.4335->0: frozen tail (composite engine; kills pitch wobble / osc P2P)
+          0.41390f, 0.46f, 0.40f,  34.100f, 7090.39f, 1.00000f, false, 2.2780f,  // gainTrim 0.7701->2.278 (2026-06-11): re-matched 100%-wet noiseburst RMS to the anchor after the algo-13 composite migration (+1.51 dB). Width 1.00 retained.
           /* mono */ 20.0f, /* mid */ 1.33500f, /* highX */ 4276.0f, /* sat */ 0.15320f },  // RE-TUNED vs CORRECTED anchor -> 21. The prior vvv-tiled-room anchor was BROKEN (dry-only render, no reverb) so the old "25" was gate-gamed degenerate (clipped, no tail). Real anchor = VVV Tiled Room (Chamber mode ~0.8s); sane makeup, honest 21.
         // ── Ambience (VVV anchor) ──────────────────────────────────────────
         // Engine: QuadTank. Anchor: Valhalla Vintage Verb "Ambience" preset

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -898,6 +898,10 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // near-mono +0.07 correlation. Result: dark character + correct stereo +
         // tail (tail_t60 -7%) at 22. Remaining (cent_500/air still bright, T60
         // tilt, comb ripple) is the QuadTank vs Chamber1979 modal-density gap.
+        // AccurateHall trial 2026-06-10 REJECTED: algo 10 + calibrated octave
+        // map scored 23 vs QuadTank's 10 — the FDN's late-heavy energy field
+        // (boom +4..+7.6 dB hot, t50 +98 ms) wrecks this tight near-mono
+        // chamber; 3 HF T60 gates aren't worth 13 regressions. QuadTank kept.
         { "79 Vocal Chamber",     "Chambers",
           3,  0.30f, false,  8.39f, 0,
           4.8190f, 0.76512f, 0.54685f, 1.74903f, 0.50150f, 0.94761f,  675.47f,

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -670,7 +670,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Bright Hall",          "Halls",
           12, 0.40f, false,  0.0f, 0,
           5.0580f, 0.93236f, 0.04761f, 1.45608f, 0.77929f, 0.93713f,  170.39f,
-          0.90000f, 0.37f, 0.55f,  26.856f, 4554.46f, 1.00000f, false, -1.7407f,  // Diffusion 0.499->0.90 (manual 2026-06-07): scatters the 12.9k metallic modal ring (spec_L1 max 8.06->6.44), fixes cent_50 + sine1k loudness, halves pitch-chorus 7.5x->3.14x; n_fail 20->18. Width 0.944->1.00: closes residual global stereo_corr.
+          0.90000f, 0.37f, 0.55f,  26.856f, 4554.46f, 1.00000f, false, -2.4947f,  // gainTrim -1.7407->-2.4947 (2026-06-11): re-matched 100%-wet noiseburst RMS to the VVV anchor after the AccurateHall32 migration shifted output level +0.754 dB. Diffusion 0.90 (manual 2026-06-07): scatters the 12.9k metallic modal ring, fixes cent_50 + sine1k loudness, halves pitch-chorus 7.5x->3.14x. Width 1.00: closes residual global stereo_corr.
           /* mono */ 20.0f, /* mid */ 0.80743f, /* highX */ 6389.40f, /* sat */ 0.13963f,  // re-derived post Decay-calibration (honest Decay 5.06 s; was 10->17 fails on the recalibrated VintageTank)
           /* hiCutShelfGainDb */ -6.0f },  // AccurateHall trial: -2 brightened LATE HF level too (bloom 8-12k +6 dB, gain==decay==level) — kept at -6; early-HF dark is compensated post-tank (pteq 10 kHz boost).
         // ── Deep Blue REMOVED 2026-05-31 ──────────────────────────────────────

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -335,7 +335,7 @@ struct FactoryPreset
             // peak fix that proved it can't be filled within stability).
             { "Drum Plate", { 0.5349f, 0.8907f, 67.45f, 15219.49f, 2.02f, 0.0f, 0.0f, 0.0f } },
             // Tiled Room (FDN) — scoreboard+warm-start vs VVV "Tiled Room", 47→28.
-            { "Tiled Room", { 1.661f, 0.8853f, 43.26f, 10850.0f, 0.0346f, -1.87f, 0.0f, 0.223f } },
+            { "Tiled Room", { 1.661f, 0.8853f, 43.26f, 10850.0f, 0.0346f, -1.87f, 0.0f, 0.0f } },
             { "Blade Runner 224", { 1.8467f, 0.2189f, 119.28f, 14310.79f, 1.6074f, 3.4473f, 0.0f, 0.1912f } },
             // Cathedral (AccurateHall since 2026-06-09): in-loop peak 1.4 -> 0.
             // Under the octave GEQ, in-loop gain at 1 kHz distorts that band's
@@ -982,8 +982,11 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // pipeline — FiveBand + input makeup + in-loop peak), 47→28 vs VVV
         // "Tiled Room". Extended params (Sub/Hi-Mid mult, crossovers, input
         // makeup, in-loop +1.32 dB) in kFiveBandByName above.
+        // AccurateHall trial 2026-06-10: algo 4 -> 10, calibrated octave map;
+        // in-loop peak 0.223 zeroed (distorts accurate-RT decay — Cathedral
+        // lesson). A/B'd vs the FDN baseline (18).
         { "Tiled Room",           "Rooms",
-          4,  0.30f, false,  8.20f, 0,
+          10, 0.30f, false,  8.20f, 0,
           0.5684f, 0.47940f, 0.43350f, 2.39800f, 0.68070f, 1.31900f,  173.10f,
           0.41390f, 0.46f, 0.40f,  34.100f, 7090.39f, 1.00000f, false, -0.39990f,  // Width 0.535->1.00: the prior [0.35,0.60] sweep OVERSHOT corr -0.34 -> +0.50 (now anchor is +0.007, DV was too narrow/correlated). 1.00 closes width mid+hi (23->21). Residual corr/width-low is global-vs-per-band mismatch.
           /* mono */ 20.0f, /* mid */ 1.33500f, /* highX */ 4276.0f, /* sat */ 0.15320f },  // RE-TUNED vs CORRECTED anchor -> 21. The prior vvv-tiled-room anchor was BROKEN (dry-only render, no reverb) so the old "25" was gate-gamed degenerate (clipped, no tail). Real anchor = VVV Tiled Room (Chamber mode ~0.8s); sane makeup, honest 21.

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -1010,9 +1010,10 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // pipeline — FiveBand + input makeup + in-loop peak), 47→28 vs VVV
         // "Tiled Room". Extended params (Sub/Hi-Mid mult, crossovers, input
         // makeup, in-loop +1.32 dB) in kFiveBandByName above.
-        // AccurateHall trial 2026-06-10: algo 4 -> 10, calibrated octave map;
-        // in-loop peak 0.223 zeroed (distorts accurate-RT decay — Cathedral
-        // lesson). A/B'd vs the FDN baseline (18).
+        // AccurateHall (SHIPPED 2026-06-10): algo 4 -> 10, calibrated octave
+        // map; in-loop peak 0.223 zeroed (distorts accurate-RT decay —
+        // Cathedral lesson). Won the A/B vs the FDN baseline 18 -> 17 plus
+        // 9/9 octave decay accuracy.
         { "Tiled Room",           "Rooms",
           10, 0.30f, false,  8.20f, 0,
           0.5684f, 0.47940f, 0.43350f, 2.39800f, 0.68070f, 1.31900f,  173.10f,

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -545,8 +545,11 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         // capped +2.0, broad input bell disturbs broadband) + mild sub-hot
         // (+3.1, the cost of the +2.02 makeup). Row params unchanged from the
         // 27 baseline; the +2.02 makeup is the only delta.
+        // Migrated FDN(4) -> AccurateHall(10) 2026-06-10: composite-exact octave
+        // GEQ sets all nine octave T60s directly (kAccurateHallT60ByName) — the
+        // old "T60-ceiling" verdict was an artifact of the leaky shelf cascade.
         { "Drum Plate",           "Plates",
-          4,  0.42f, false, 12.0f, 0,
+          10, 0.42f, false, 12.0f, 0,
           2.263f, 0.337f, 0.373f, 0.119f, 1.296f, 0.723f,  98.99f,
           0.441f, 0.30f, 0.55f,  20.68f, 10078.6f, 1.100f, false, -5.15f,  // Width 0.934->1.10: was too correlated (corr +0.107 vs anchor -0.097); 1.10 closes all 4 width/corr gates (27->23).
           /* mono */ 20.0f, /* mid */ 0.690f, /* highX */ 7762.3f, /* sat */ 0.214f },

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -478,7 +478,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Vocal Plate",          "Plates",
           10, 0.35f, false, 29.16f, 0,   // algo 10 = AccurateHall (2026-06-09): per-octave GEQ T60. T60 6/9->9/9, gain-matched full_check 25->14 vs FDN. Octave targets in kAccurateHallT60ByName.
           0.90f, 0.15f, 0.37f, 1.51f, 0.60f, 0.74f,  401.0f,  // T60 decay tune 2026-06-08 (gain-matched): Decay 1.02->0.90 + Treble 0.85->0.60 closes T60 6/9 (63/250/500/2k/4k/8k match VVV, tail_t60 within 3%). Hi-Mid PINNED 0.85 via kFiveBandByName so the air band isn't double-damped. Residual 125/1k/16k = single-octave anomalies (9-octave-vs-5-band wall).
-          0.58f, 0.25f, 0.76f,  30.0f, 16667.0f, 1.02f, false, -1.00f,  // GainTrim -1.74->-1.0 (re-gain-matched to anchor noiseburst after the decay cut). Lo Cut 30: restores 20-100Hz low-end.
+          0.58f, 0.25f, 0.76f,  30.0f, 16667.0f, 1.02f, false, -7.05f,  // GainTrim -1.74->-1.0 (re-gain-matched to anchor noiseburst after the decay cut). Lo Cut 30: restores 20-100Hz low-end.
           /* mono */ 20.0f, /* mid */ 0.72f, /* highX */ 3817.0f, /* sat */ 0.03f },
         // ═══════════ PLATES ═══════════
         // ── Vintage Vocal Plate ──────────────────────────────────────────────
@@ -571,7 +571,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Drum Plate",           "Plates",
           10, 0.42f, false, 12.0f, 0,
           2.263f, 0.337f, 0.373f, 0.119f, 1.296f, 0.723f,  98.99f,
-          0.441f, 0.30f, 0.55f,  20.68f, 10078.6f, 1.100f, false, -5.15f,  // Width 0.934->1.10: was too correlated (corr +0.107 vs anchor -0.097); 1.10 closes all 4 width/corr gates (27->23).
+          0.441f, 0.30f, 0.55f,  20.68f, 10078.6f, 1.100f, false, -12.22f,  // Width 0.934->1.10: was too correlated (corr +0.107 vs anchor -0.097); 1.10 closes all 4 width/corr gates (27->23).
           /* mono */ 20.0f, /* mid */ 0.690f, /* highX */ 7762.3f, /* sat */ 0.214f },
         // ═══════════ SPRINGS ═══════════
         // ── Surf '63 Spring ──────────────────────────────────────────────────
@@ -660,7 +660,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Bright Hall",          "Halls",
           10, 0.40f, false,  0.0f, 0,
           5.0580f, 0.93236f, 0.04761f, 1.45608f, 0.77929f, 0.93713f,  170.39f,
-          0.90000f, 0.37f, 0.55f,  26.856f, 4554.46f, 1.00000f, false, 0.62933f,  // Diffusion 0.499->0.90 (manual 2026-06-07): scatters the 12.9k metallic modal ring (spec_L1 max 8.06->6.44), fixes cent_50 + sine1k loudness, halves pitch-chorus 7.5x->3.14x; n_fail 20->18. Width 0.944->1.00: closes residual global stereo_corr.
+          0.90000f, 0.37f, 0.55f,  26.856f, 4554.46f, 1.00000f, false, -1.7407f,  // Diffusion 0.499->0.90 (manual 2026-06-07): scatters the 12.9k metallic modal ring (spec_L1 max 8.06->6.44), fixes cent_50 + sine1k loudness, halves pitch-chorus 7.5x->3.14x; n_fail 20->18. Width 0.944->1.00: closes residual global stereo_corr.
           /* mono */ 20.0f, /* mid */ 0.80743f, /* highX */ 6389.40f, /* sat */ 0.13963f,  // re-derived post Decay-calibration (honest Decay 5.06 s; was 10->17 fails on the recalibrated VintageTank)
           /* hiCutShelfGainDb */ -6.0f },  // AccurateHall trial: -2 brightened LATE HF level too (bloom 8-12k +6 dB, gain==decay==level) — kept at -6; early-HF dark is compensated post-tank (pteq 10 kHz boost).
         // ── Deep Blue REMOVED 2026-05-31 ──────────────────────────────────────
@@ -807,7 +807,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Vocal Hall",           "Halls",
           10, 0.35f, false, 22.0f, 0,    // algo 10 = AccurateHall (2026-06-09): per-octave GEQ T60. T60 9/9, gain-matched full_check 22->20 vs FDN. Front-load levers carry over (post-tank, engine-agnostic).
           3.50f, 0.76f, 0.50390f, 0.78820f, 1.0840f, 1.3570f,  850.0f,  // FRONT-LOAD CAMPAIGN 2026-06-08: Treble 1.091->1.084, Bass 1.3042->1.357 (co-tuned with tank-rebalance). Decay/ModDepth/LowX unchanged. er_level + mono now set by kFrontLoadByName (0.79 / 20).
-          0.77940f, 0.79000f, 0.44870f,  33.0f,  6000.0f, 0.96000f, false, 2.00f,  // erLevel 0.608->0.79 (front-load deck) + Width 0.995->0.96 + GainTrim -2.5->+2.0: with er_decorr 0.6 (kFrontLoadByName) the width family lands ~VVV; GainTrim + erLevel restore level/front-load after tank_level 0.42 cut.
+          0.77940f, 0.79000f, 0.44870f,  33.0f,  6000.0f, 0.96000f, false, -2.84f,  // erLevel 0.608->0.79 (front-load deck) + Width 0.995->0.96 + GainTrim -2.5->+2.0: with er_decorr 0.6 (kFrontLoadByName) the width family lands ~VVV; GainTrim + erLevel restore level/front-load after tank_level 0.42 cut.
           /* mono */ 20.0f, /* mid */ 0.7530f, /* highX */ 6000.0f, /* sat */ 0.0f },  // Mid 0.76->0.753. MonoBelow 150->20 (mono was correlating the low, fighting er_decorr's image fix). Sat 0.0 (clean highs).
         // ── Cathedral (VVV anchor) ─────────────────────────────────────────
         // Engine: FDN. Anchor: VVV "CathedralLargeHall" preset (Reverb Mode
@@ -826,7 +826,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Cathedral Large Hall", "Halls",
           10, 0.45f, false, 20.88f, 0,
           3.00000f, 0.93880f, 0.38010f, 1.18680f, 1.40800f, 1.24610f,  223.90f,  // ACCURACY: Decay 3.315->3.00 matches anchor tail length (tail_t60 +26% -> ~0). ModDepth/Rate+BassMult prior.
-          0.70090f, 0.48f, 0.36f,  40.730f, 4834.0f, 1.02400f, false, -7.90200f,
+          0.70090f, 0.48f, 0.36f,  40.730f, 4834.0f, 1.02400f, false, -6.232f,
           /* mono */ 20.0f, /* mid */ 0.64240f, /* highX */ 5442.0f, /* sat */ 0.00126f,  // re-swept w/ FDN FiveBand+input-makeup axes 26->20 vs CathedralLargeHall (Decay->3.3s near ref 2.7)
           /* hiCutShelfGainDb */ -14.5f },
         // ── Blade Runner 224 ─────────────────────────────────────────────────
@@ -891,7 +891,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Blade Runner 224",     "Halls",
           10, 0.45f, false, 25.0f, 0,    // algo 10 = AccurateHall (2026-06-09): per-octave GEQ T60. T60 8/9, gain-matched full_check 20->15 vs FDN. Extreme per-octave spread (9.8s low -> 1.3s 16k).
           13.6421f, 0.91981f, 0.33084f, 2.64911f, 0.86140f, 1.05238f,  330.94f,
-          0.84476f, 0.00f, 0.50f, 56.210f, 14429.68f, 1.10000f, false, -3.93657f,  // HF damping re-swept (Treble/HiCut/FiveBand-HF): curb metallic 8k/16k ring, 21->19. Width 1.697->1.10: was over-wide/anti-phase (corr -0.37 vs anchor -0.149); 1.10 closes 3 width-band gates (26->23). Residual global stereo_corr is anchor's freq-dependent decorrelation, global Width can't match.
+          0.84476f, 0.00f, 0.50f, 56.210f, 14429.68f, 1.10000f, false, -1.6866f,  // HF damping re-swept (Treble/HiCut/FiveBand-HF): curb metallic 8k/16k ring, 21->19. Width 1.697->1.10: was over-wide/anti-phase (corr -0.37 vs anchor -0.149); 1.10 closes 3 width-band gates (26->23). Residual global stereo_corr is anchor's freq-dependent decorrelation, global Width can't match.
           /* mono */ 20.0f, /* mid */ 0.73614f, /* highX */ 3980.22f, /* sat */ 0.17579f,
           /* hiCutShelfGainDb */ -11.3f },  // RE-ANCHORED to VVV "Homestar Blade Runner" (Concert Hall, 10s, dark) — the prior lex-rhall-rhall4 anchor was WRONG (57->23 w/ FDN FiveBand+input-makeup axes)
         // ── 79 Vocal Chamber (VVV anchor) ──────────────────────────────────
@@ -916,7 +916,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "79 Vocal Chamber",     "Chambers",
           3,  0.30f, false,  8.39f, 0,
           4.8190f, 0.76512f, 0.54685f, 1.74903f, 0.50150f, 0.94761f,  675.47f,
-          0.52932f, 0.20f, 0.44f,  26.022f, 8021.01f, 0.97000f, false, -7.39142f,  // Width 1.136->0.97: baked value went anti-phase (stereo_corr -0.11); 0.97 lands anchor's near-mono +0.07 across all 3 width bands, 26->23
+          0.52932f, 0.20f, 0.44f,  26.022f, 8021.01f, 0.97000f, false, -6.3314f,  // Width 1.136->0.97: baked value went anti-phase (stereo_corr -0.11); 0.97 lands anchor's near-mono +0.07 across all 3 width bands, 26->23
           /* mono */ 20.0f, /* mid */ 0.56053f, /* highX */ 5417.19f, /* sat */ 0.08377f,  // re-derived post Decay-calibration (honest Decay 4.82 s; was 22->24 fails)
           /* hiCutShelfGainDb */ -23.5f },
         // ═══════════ CHAMBERS ═══════════
@@ -999,7 +999,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Medium Drum Room",     "Rooms",
           10, 0.30f, false,  9.00f, 0,
           0.85000f, 0.45000f, 0.00500f, 0.30000f, 0.90000f, 1.10000f,  400.00f,
-          0.80000f, 0.70f, 0.50f,  25.000f, 4500.0f, 1.00000f, false, 0.00000f,  // hand row beats the capped Optuna winner on full_check (24 vs 27 — proxy-loss divergence again); Optuna best kept in /tmp/dv_optuna_3vd7jng7
+          0.80000f, 0.70f, 0.50f,  25.000f, 4500.0f, 1.00000f, false, -0.81f,  // hand row beats the capped Optuna winner on full_check (24 vs 27 — proxy-loss divergence again); Optuna best kept in /tmp/dv_optuna_3vd7jng7
           /* mono */ 120.0f, /* mid */ 1.00000f, /* highX */ 8000.0f, /* sat */ 0.05000f,
           /* hiCutShelfGainDb */ -4.50f },
         // ── Tiled Room (VVV anchor) ────────────────────────────────────────
@@ -1017,7 +1017,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Tiled Room",           "Rooms",
           10, 0.30f, false,  8.20f, 0,
           0.5684f, 0.47940f, 0.43350f, 2.39800f, 0.68070f, 1.31900f,  173.10f,
-          0.41390f, 0.46f, 0.40f,  34.100f, 7090.39f, 1.00000f, false, -0.39990f,  // Width 0.535->1.00: the prior [0.35,0.60] sweep OVERSHOT corr -0.34 -> +0.50 (now anchor is +0.007, DV was too narrow/correlated). 1.00 closes width mid+hi (23->21). Residual corr/width-low is global-vs-per-band mismatch.
+          0.41390f, 0.46f, 0.40f,  34.100f, 7090.39f, 1.00000f, false, 0.7701f,  // Width 0.535->1.00: the prior [0.35,0.60] sweep OVERSHOT corr -0.34 -> +0.50 (now anchor is +0.007, DV was too narrow/correlated). 1.00 closes width mid+hi (23->21). Residual corr/width-low is global-vs-per-band mismatch.
           /* mono */ 20.0f, /* mid */ 1.33500f, /* highX */ 4276.0f, /* sat */ 0.15320f },  // RE-TUNED vs CORRECTED anchor -> 21. The prior vvv-tiled-room anchor was BROKEN (dry-only render, no reverb) so the old "25" was gate-gamed degenerate (clipped, no tail). Real anchor = VVV Tiled Room (Chamber mode ~0.8s); sane makeup, honest 21.
         // ── Ambience (VVV anchor) ──────────────────────────────────────────
         // Engine: QuadTank. Anchor: Valhalla Vintage Verb "Ambience" preset
@@ -1128,7 +1128,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Reverse Taps",         "Rooms",
           9,  1.00f, false, 38.0f, 0,           // engine 9 = ReverseRoom; predelay 38ms (measured)
           6.9912f, 0.16498f, 0.13950f, 2.28741f, 0.79816f, 1.14756f,  566.85f,
-          0.18188f, 0.00f, 0.30f,  40.596f, 5367.38f, 1.17197f, false, 0.89119f,
+          0.18188f, 0.00f, 0.30f,  40.596f, 5367.38f, 1.17197f, false, 0.3712f,
           /* mono */ 20.0f, /* mid */ 0.51963f, /* highX */ 8201.39f, /* sat */ 0.25533f },  // RE-ENGINED NonLinear->ReverseRoom: causal rising-ER replicates Lexicon Room "Reverse 1" (reverse-engineered from data). 32->20 fails; env_p2p cliff +60->+15 (smooth swell); tail_t60/cent/env_shape/osc now MATCH the reference
         // ── Mobius Pad ───────────────────────────────────────────────────────
         // Named after the Möbius Twist DSP (sign-inverted cross-feedback —
@@ -1207,7 +1207,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Black Hole",           "Ambient",
           7,  0.50f, false,   0.0f, 0,
           10.8728f, 0.56922f, 0.50890f, 1.43860f, 1.16880f, 0.53601f,  372.24f,  // ModDepth/Rate re-tuned vs honest (sustained) mod gate: 25->21
-          0.85741f, 0.05f, 0.70f,  24.591f, 18926.8f, 1.26041f, false, 0.81969f,
+          0.85741f, 0.05f, 0.70f,  24.591f, 18926.8f, 1.26041f, false, 1.4597f,
           /* mono */ 60.0f, /* mid */ 0.75073f, /* highX */ 3390.34f, /* sat */ 0.38197f },
         // ── Cascading Heaven ─────────────────────────────────────────────
         // +24 semitones (two-octave stack) at ~57% feedback. No external reference factory
@@ -1241,7 +1241,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Deep Blue Day",        "Shimmer",
           7,  0.38f, false,  25.0f, 0,
           9.1423f, 0.59833f, 0.50f, 0.60458f, 1.40394f, 0.56879f,  408.59f,
-          0.80742f, 0.20f, 0.50f,  26.925f, 11000.0f, 1.69030f, false, 0.31973f,
+          0.80742f, 0.20f, 0.50f,  26.925f, 11000.0f, 1.69030f, false, 1.8697f,
           /* mono */ 20.0f, /* mid */ 1.18105f, /* highX */ 9800.46f, /* sat */ 0.23195f },  // 29->27->23: Shimmer 2nd pitch voice (+24, fills 12-24k) + Hi Cut 4521->11000 so its HF reaches output (matches Valhalla broadband octave; the dark 4521 was choking the new top band)
     };
     return presets;

--- a/plugins/DuskVerb/src/PluginEditor.cpp
+++ b/plugins/DuskVerb/src/PluginEditor.cpp
@@ -245,6 +245,101 @@ void DuskVerbLookAndFeel::drawToggleButton (juce::Graphics& g, juce::ToggleButto
 }
 
 // =============================================================================
+// Custom dark dropdown popup (preset / algorithm / sync menus). Replaces the
+// default LookAndFeel_V4 grey popup so every dropdown matches the plugin: dark
+// panel + border, rounded hover fill in the live engine accent, accent dot for
+// the selected item, slim submenu arrow.
+// =============================================================================
+
+juce::Font DuskVerbLookAndFeel::getPopupMenuFont()
+{
+    return juce::Font (juce::FontOptions (15.0f));
+}
+
+void DuskVerbLookAndFeel::drawPopupMenuBackground (juce::Graphics& g, int width, int height)
+{
+    auto bounds = juce::Rectangle<float> (0.0f, 0.0f, (float) width, (float) height);
+    g.setColour (juce::Colour (kBackground));
+    g.fillRoundedRectangle (bounds, 6.0f);
+    g.setColour (juce::Colour (kBorder));
+    g.drawRoundedRectangle (bounds.reduced (0.5f), 6.0f, 1.0f);
+}
+
+void DuskVerbLookAndFeel::getIdealPopupMenuItemSize (const juce::String& text, bool isSeparator,
+                                                     int standardMenuItemHeight,
+                                                     int& idealWidth, int& idealHeight)
+{
+    if (isSeparator)
+    {
+        idealWidth  = 60;
+        idealHeight = 8;
+        return;
+    }
+
+    const auto font = getPopupMenuFont();
+    juce::GlyphArrangement ga;
+    ga.addLineOfText (font, text, 0.0f, 0.0f);
+    const int textW = (int) std::ceil (ga.getBoundingBox (0, -1, true).getWidth());
+
+    idealHeight = standardMenuItemHeight > 0 ? juce::jmax (standardMenuItemHeight, 28) : 28;
+    idealWidth  = textW + 52;   // left tick gutter + right submenu-arrow padding
+}
+
+void DuskVerbLookAndFeel::drawPopupMenuItem (juce::Graphics& g, const juce::Rectangle<int>& area,
+                                             bool isSeparator, bool isActive, bool isHighlighted,
+                                             bool isTicked, bool hasSubMenu, const juce::String& text,
+                                             const juce::String& /*shortcutKeyText*/,
+                                             const juce::Drawable* /*icon*/, const juce::Colour* textColour)
+{
+    if (isSeparator)
+    {
+        auto line = area.toFloat().reduced (10.0f, 0.0f).withHeight (1.0f)
+                        .withY ((float) area.getCentreY());
+        g.setColour (juce::Colour (kSeparator));
+        g.fillRect (line);
+        return;
+    }
+
+    auto r = area.reduced (4, 1);
+    const auto accent = getCurrentAccent();
+
+    if (isHighlighted && isActive)
+    {
+        g.setColour (accent.withAlpha (0.22f));
+        g.fillRoundedRectangle (r.toFloat(), 4.0f);
+    }
+
+    juce::Colour col = isActive ? juce::Colour (kText) : juce::Colour (kDimText);
+    if (textColour != nullptr)        col = *textColour;
+    if (isHighlighted && isActive)    col = juce::Colour (kValueText);
+
+    auto content = r.reduced (10, 0);
+
+    if (isTicked)
+    {
+        const float d = 5.0f;
+        g.setColour (accent);
+        g.fillEllipse ((float) content.getX(), (float) content.getCentreY() - d * 0.5f, d, d);
+    }
+    content.removeFromLeft (16);   // tick gutter
+
+    g.setColour (col);
+    g.setFont (getPopupMenuFont());
+    g.drawFittedText (text, content, juce::Justification::centredLeft, 1);
+
+    if (hasSubMenu)
+    {
+        const float h = (float) r.getHeight() * 0.26f;
+        const float x = (float) r.getRight() - 12.0f;
+        const float yc = (float) r.getCentreY();
+        juce::Path arrow;
+        arrow.addTriangle (x, yc - h, x, yc + h, x + h, yc);
+        g.setColour (col.withAlpha (0.75f));
+        g.fillPath (arrow);
+    }
+}
+
+// =============================================================================
 // Value formatting (used by the timer to refresh the value label under each knob)
 // =============================================================================
 
@@ -1028,6 +1123,7 @@ void DuskVerbEditor::refreshPresetList()
 juce::PopupMenu DuskVerbEditor::buildPresetMenu()
 {
     juce::PopupMenu menu;
+    menu.setLookAndFeel (&lnf_);   // render the popup + submenus with our dark dropdown L&F
     const auto& presets = getFactoryPresets();
     const int currentId = presetBox_.getSelectedId();
 

--- a/plugins/DuskVerb/src/PluginEditor.cpp
+++ b/plugins/DuskVerb/src/PluginEditor.cpp
@@ -1554,8 +1554,8 @@ void EngineGlyph::paint (juce::Graphics& g)
         default:
         {
             // Generic engine cue for engines without a bespoke glyph
-            // (VintageTank / ReverseRoom / AccurateHall) — a centred ring so
-            // the header still shows an icon instead of empty space.
+            // (VintageTank / ReverseRoom / AccurateHall / SparseField) — a
+            // centred ring so the header still shows an icon instead of empty space.
             const float r = std::min (w, h) * 0.30f;
             g.drawEllipse (inner.getCentreX() - r, inner.getCentreY() - r,
                            r * 2.0f, r * 2.0f, 1.5f);

--- a/plugins/DuskVerb/src/PluginEditor.h
+++ b/plugins/DuskVerb/src/PluginEditor.h
@@ -31,6 +31,7 @@ inline juce::Colour getEngineAccent (EngineType engine)
         case EngineType::VintageTank:     return juce::Colour (0xff7da8e8);  // steel blue — vintage tank
         case EngineType::ReverseRoom:     return juce::Colour (0xff9b6dff);  // violet — reverse room
         case EngineType::AccurateHall:    return juce::Colour (0xffa8e84d);  // lime — accurate per-octave halls
+        case EngineType::SparseField:     return juce::Colour (0xff4de8d9);  // aqua — sparse early field
     }
     return juce::Colour (0xffff7a3d);
 }
@@ -279,10 +280,10 @@ private:
     KnobWithLabel modRate_;
     KnobWithLabel damping_;
     KnobWithLabel bassMult_;
-    KnobWithLabel midMult_;            // NEW: 3-band mid multiplier
+    KnobWithLabel midMult_;            // 3-band mid multiplier
     KnobWithLabel crossover_;
-    KnobWithLabel highCrossover_;      // NEW: 3-band high crossover
-    KnobWithLabel saturation_;         // NEW: drive softClip
+    KnobWithLabel highCrossover_;      // 3-band high crossover
+    KnobWithLabel saturation_;         // drive softClip
     KnobWithLabel diffusion_;
     KnobWithLabel erLevel_;
     KnobWithLabel erSize_;

--- a/plugins/DuskVerb/src/PluginEditor.h
+++ b/plugins/DuskVerb/src/PluginEditor.h
@@ -32,6 +32,7 @@ inline juce::Colour getEngineAccent (EngineType engine)
         case EngineType::ReverseRoom:     return juce::Colour (0xff9b6dff);  // violet — reverse room
         case EngineType::AccurateHall:    return juce::Colour (0xffa8e84d);  // lime — accurate per-octave halls
         case EngineType::SparseField:     return juce::Colour (0xff4de8d9);  // aqua — sparse early field
+        case EngineType::AccurateHall32:  return juce::Colour (0xff6ee87a);  // green — dense 32-line hall
     }
     return juce::Colour (0xffff7a3d);
 }

--- a/plugins/DuskVerb/src/PluginEditor.h
+++ b/plugins/DuskVerb/src/PluginEditor.h
@@ -33,6 +33,7 @@ inline juce::Colour getEngineAccent (EngineType engine)
         case EngineType::AccurateHall:    return juce::Colour (0xffa8e84d);  // lime — accurate per-octave halls
         case EngineType::SparseField:     return juce::Colour (0xff4de8d9);  // aqua — sparse early field
         case EngineType::AccurateHall32:  return juce::Colour (0xff6ee87a);  // green — dense 32-line hall
+        case EngineType::TiledRoom:       return juce::Colour (0xffe8c44d);  // amber — tight ceramic tiled room
     }
     return juce::Colour (0xffff7a3d);
 }

--- a/plugins/DuskVerb/src/PluginEditor.h
+++ b/plugins/DuskVerb/src/PluginEditor.h
@@ -52,6 +52,20 @@ public:
                            bool shouldDrawButtonAsHighlighted,
                            bool shouldDrawButtonAsDown) override;
 
+    // Custom dark dropdown popup — replaces JUCE's default V4 grey popup for the
+    // preset / algorithm / sync menus with the plugin palette + live engine accent
+    // (highlight + selected-tick). Applies to every PopupMenu shown under lnf_.
+    void drawPopupMenuBackground (juce::Graphics&, int width, int height) override;
+    void drawPopupMenuItem (juce::Graphics&, const juce::Rectangle<int>& area,
+                            bool isSeparator, bool isActive, bool isHighlighted,
+                            bool isTicked, bool hasSubMenu, const juce::String& text,
+                            const juce::String& shortcutKeyText,
+                            const juce::Drawable* icon, const juce::Colour* textColour) override;
+    juce::Font getPopupMenuFont() override;
+    void getIdealPopupMenuItemSize (const juce::String& text, bool isSeparator,
+                                    int standardMenuItemHeight,
+                                    int& idealWidth, int& idealHeight) override;
+
     // Live-mutable accent so we can recolour the entire UI when the user
     // switches engines. Defaults to the legacy orange so first paint matches.
     void          setCurrentAccent (juce::Colour c) { currentAccent_ = c; }

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1513,6 +1513,15 @@ namespace {
             //   Band 3 —10000 Hz Q=1.2 -6.0 dB: BR-9 deepens -5.0 → -6.0
             //                                    to clamp bloom 8-12k (was
             //                                    0.53 dB over gate).
+            // Drum Plate (AccurateHall migration 2026-06-10): 1 kHz steady-
+            // state lift — DV renders sine1k far below the anchor's plate
+            // resonance (-13 dB rel.); post-tank boost lifts it without
+            // touching the calibrated decay.
+            { "Drum Plate", {
+                {  150.0f, 1000.0f, 3000.0f,  8000.0f },
+                {   0.80f,   2.50f,   1.50f,    1.00f },
+                {  +3.50f,   +8.00f,   0.00f,    0.00f },
+            } },
             { "Blade Runner 224", {
                 {  350.0f, 3000.0f, 6000.0f, 10000.0f },
                 {   1.20f,   1.50f,   1.00f,    1.20f },
@@ -1741,6 +1750,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Ambience", {{ 1.5195f, 1.5053f, 1.1346f, 0.7328f, 0.7831f, 0.7861f, 0.7947f, 0.9030f, 0.9535f }} },
             { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
             { "Bright Hall", {{ 7.8074f, 7.0818f, 6.0995f, 5.6386f, 4.6386f, 4.2369f, 3.5919f, 3.0193f, 2.3286f }} },
+            { "Drum Plate", {{ 1.4801f, 1.4044f, 1.7830f, 1.7079f, 1.8507f, 1.7023f, 1.7860f, 1.8388f, 5.6775f }} },
             // END_OCTAVE_T60_MAP
         };
         auto it = kAccurateHallT60ByName.find (std::string_view (name));

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1506,9 +1506,9 @@ namespace {
             //                                   tilt is post-tank. Closes
             //                                   cent_50/cent_500/hi/spec.
             { "Bright Hall", {
-                {  60.0f, 1000.0f, 3500.0f, 10000.0f },
-                {   1.0f,    6.0f,    2.0f,     0.8f },
-                { -3.0f,   +2.0f,   -2.0f,    +2.0f },
+                {  60.0f, 1000.0f, 5000.0f, 10000.0f },
+                {   1.0f,    6.0f,    1.2f,     0.8f },
+                { -3.0f,   +2.0f,   +3.0f,    +4.0f },
             } },
             // Small Drum Room (SDR-NL3 on NonLinear algo=6, 2026-05-30):
             //   Band 0/1/3 — defaults / reserved.

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1487,17 +1487,25 @@ namespace {
                 {  3.00f,  4.00f,  1.00f,  1.50f },
                 { -5.00f, +3.50f, -3.00f, -4.50f },
             } },
-            // Blade Runner 224 (BR-9 on FDN algo=4, 2026-05-30):
-            //   Band 0 —  600 Hz Q=2.0 -2.0 dB: low-mid steady-state scoop.
+            // Blade Runner 224 (BR-9 2026-05-30; Band 0 re-tuned 2026-06-09
+            // with the composite-exact octave GEQ re-calibration):
+            //   Band 0 —  350 Hz Q=1.2 -3.0 dB: late low-mid decouple. The
+            //                                    accurate 250 Hz T60 target
+            //                                    (gain==decay==level coupling)
+            //                                    left 100-700 Hz late energy
+            //                                    ~+2.5 dB hot; this post-tank
+            //                                    cut closes sub-bass/boom-low/
+            //                                    spec_L1/mid without touching
+            //                                    decay. (Was 600 Hz Q=2 -2.0.)
             //   Band 1 — 3000 Hz Q=1.5 -3.5 dB: lower bloom suppressor.
             //   Band 2 — 6000 Hz Q=1.0 -5.0 dB: bloom 4-8k closed BR-8.
             //   Band 3 —10000 Hz Q=1.2 -6.0 dB: BR-9 deepens -5.0 → -6.0
             //                                    to clamp bloom 8-12k (was
             //                                    0.53 dB over gate).
             { "Blade Runner 224", {
-                {  600.0f, 3000.0f, 6000.0f, 10000.0f },
-                {   2.00f,   1.50f,   1.00f,    1.20f },
-                {  -2.00f,  -3.50f,  -5.00f,   -6.00f },
+                {  350.0f, 3000.0f, 6000.0f, 10000.0f },
+                {   1.20f,   1.50f,   1.00f,    1.20f },
+                {  -3.00f,  -3.50f,  -5.00f,   -6.00f },
             } },
         };
         return m;
@@ -1700,23 +1708,26 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
     {
         struct OctaveT60Override { float t60[9]; };
         static const std::map<std::string_view, OctaveT60Override> kAccurateHallT60ByName = {
-            // Per-octave T60 targets (63 Hz..16 kHz), shelf-interaction-corrected
-            // to land each octave within ±5% of the VVV anchor (Schroeder
-            // backward-int on the noiseburst tail). The 9-vs-5 coupling wall the
-            // FDN FiveBandDamping floored on; the octave GEQ sets each directly.
-            // Only the three MIGRATED AccurateHall presets (algo 10). Targets are
-            // shelf-interaction-corrected, NOT raw anchor T60 — the GEQ cascade
-            // loses gain (esp. HF vs structural/AA damping), so the target is
-            // inflated to land the MEASURED octave T60 on the anchor. SR-invariant
-            // (sr cancels in g=10^(-3·L/(T·sr)) since L∝sr). Drum Plate + Cathedral
-            // were evaluated and KEPT ON FDN — anchor T60 exceeds the GEQ ceiling
-            // (targets diverged >40 s, did not beat FDN). Tiled Room: T60 9/9 but
-            // traded into tonal gates (net wash) — kept on FDN.
+            // Per-octave T60 targets (63 Hz..16 kHz), calibrated to land each
+            // octave within ±5% of the VVV anchor (Schroeder backward-int on
+            // the noiseburst tail). The 9-vs-5 coupling wall the FDN
+            // FiveBandDamping floored on; the octave GEQ sets each directly.
+            // Since the composite-exact GEQ design (OctaveGEQDesign.cpp) the
+            // shelf cascade realizes its commanded gains AT the octave centres,
+            // so these targets are close to raw anchor T60 — the small residual
+            // compensates other in-loop losses (structural/AA HF damping,
+            // mod-interpolation). Mostly SR-invariant (sr cancels in
+            // g=10^(-3·L/(T·sr)) since L∝sr); the AA-loss share is not.
+            // Blade Runner 250 Hz is pinned at 27 s: measured T60 walls at
+            // ~8.8 s (anchor 9.7) regardless of target — per-line decay tilt
+            // blends fast lines into that band; higher targets only raise
+            // sine1k THD. Its late-250 level excess is decoupled by the
+            // 350 Hz PostTankEQ cut instead.
             // BEGIN_OCTAVE_T60_MAP (maintained by tools/tuner/calibrate_octave_t60.py)
-            { "Vocal Plate", {{ 0.7031f, 0.7489f, 0.7307f, 0.7363f, 0.7162f, 0.8189f, 0.7902f, 0.7798f, 0.9499f }} },
-            { "Vocal Hall", {{ 6.2734f, 5.9864f, 4.3580f, 5.0546f, 3.1917f, 2.6694f, 2.6226f, 2.3275f, 5.9068f }} },
-            { "Blade Runner 224", {{ 15.4166f, 12.0619f, 19.6892f, 10.9104f, 7.5872f, 8.2379f, 5.9153f, 2.6138f, 1.8789f }} },
-            { "Ambience", {{ 1.5016f, 1.6369f, 1.3395f, 0.6205f, 0.8263f, 0.7844f, 0.7676f, 0.9303f, 0.9500f }} },
+            { "Vocal Plate", {{ 0.7117f, 0.7373f, 0.7335f, 0.7337f, 0.7365f, 0.7926f, 0.7923f, 0.8018f, 0.9431f }} },
+            { "Vocal Hall", {{ 6.1854f, 5.6522f, 4.6678f, 4.4460f, 3.2748f, 2.7689f, 2.5910f, 2.5712f, 6.2021f }} },
+            { "Blade Runner 224", {{ 16.0236f, 12.3625f, 27.0000f, 9.6761f, 8.1305f, 7.4944f, 4.9930f, 2.7399f, 1.9333f }} },
+            { "Ambience", {{ 1.5195f, 1.5053f, 1.1346f, 0.7328f, 0.7831f, 0.7861f, 0.7947f, 0.9030f, 0.9535f }} },
             // END_OCTAVE_T60_MAP
         };
         auto it = kAccurateHallT60ByName.find (std::string_view (name));

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1121,6 +1121,29 @@ void DuskVerbProcessor::setStateInformation (const void* data, int sizeInBytes)
 
     parameters.replaceState (tree);
 
+    // Snap every parameter object to its restored tree value. JUCE's discrete
+    // parameters (AudioParameterBool/Choice) store the RAW normalized value
+    // from setValue() but the APVTS tree records the QUANTIZED denormalized
+    // value. If a host parked a discrete param at a fractional normalized
+    // value (pluginval's randomized state-restore test does exactly this),
+    // the restored tree value can EQUAL the tree's current record, so
+    // replaceState's ValueTree no-op suppression skips the parameter callback
+    // and the parameter object keeps the stale fractional value — "Bus Mode
+    // not restored on setStateInformation" at strictness 7+. Message thread,
+    // once per state load; the no-change guard keeps normal loads silent.
+    for (int i = 0; i < tree.getNumChildren(); ++i)
+    {
+        const auto child = tree.getChild (i);
+        if (! child.hasProperty ("id") || ! child.hasProperty ("value"))
+            continue;
+        if (auto* rp = parameters.getParameter (child.getProperty ("id").toString()))
+        {
+            const float norm = rp->convertTo0to1 (static_cast<float> (child.getProperty ("value")));
+            if (std::fabs (rp->getValue() - norm) > 1.0e-6f)
+                rp->setValueNotifyingHost (norm);
+        }
+    }
+
     // Reset SixAPTank brightness state to engine defaults BEFORE reading the
     // optional v2+ properties. Without this reset, loading a v1 state file
     // (no sixAP properties) AFTER having loaded a preset that sets brighter

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1513,6 +1513,16 @@ namespace {
             //   Band 3 —10000 Hz Q=1.2 -6.0 dB: BR-9 deepens -5.0 → -6.0
             //                                    to clamp bloom 8-12k (was
             //                                    0.53 dB over gate).
+            // Vocal Plate (AccurateHall, 2026-06-10): HF tilt for the bright
+            // late field (cent_500 +72%) — closes mid/bloom/snare via the
+            // renorm. A 1 kHz +6 lift for sine1k -12.4 was probed and is
+            // POISON here (15/19 vs 13) — VP's post-tank 1 kHz response is
+            // inconsistent (also documented in the FDN era); leave Band 1 flat.
+            { "Vocal Plate", {
+                {  150.0f, 1000.0f, 5000.0f, 10000.0f },
+                {   1.00f,   2.50f,   0.80f,    1.00f },
+                {   0.00f,    0.00f,  -3.50f,    0.00f },
+            } },
             // Tiled Room (AccurateHall trial 2026-06-10): dark post-tank tilt —
             // the calibrated octave T60s fixed decay but the tail LEVEL runs
             // bright (cent_500 +215%, blooms 2-12k +2..+4.4).

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1513,13 +1513,13 @@ namespace {
             //   Band 3 —10000 Hz Q=1.2 -6.0 dB: BR-9 deepens -5.0 → -6.0
             //                                    to clamp bloom 8-12k (was
             //                                    0.53 dB over gate).
-            // Medium Drum Room (AccurateHall, 2026-06-10): dark tilt — the FDN
-            // tail runs far brighter than the eighties-color anchor (blooms
-            // +5..+12 dB, cent_500 +124%); 1 kHz tames the hot sine1k.
+            // Medium Drum Room (AccurateHall, 2026-06-10): dark tilt — the
+            // tank tail runs far brighter than the eighties-color anchor
+            // (blooms +5..+12 dB, cent_500 +124%); 1 kHz tames the hot sine1k.
             { "Medium Drum Room", {
-                { 1000.0f, 3500.0f, 10000.0f,  150.0f },
-                {   2.50f,   0.70f,    1.00f,    1.00f },
-                {  -3.50f,  -5.50f,   -8.00f,    0.00f },
+                {  150.0f, 1000.0f, 3500.0f, 10000.0f },
+                {   1.00f,   2.50f,   0.70f,    1.00f },
+                {   0.00f,  -3.50f,  -5.50f,   -8.00f },
             } },
             // Vocal Plate (AccurateHall, 2026-06-10): HF tilt for the bright
             // late field (cent_500 +72%) — closes mid/bloom/snare via the
@@ -1535,9 +1535,9 @@ namespace {
             // the calibrated octave T60s fixed decay but the tail LEVEL runs
             // bright (cent_500 +215%, blooms 2-12k +2..+4.4).
             { "Tiled Room", {
-                {  150.0f, 3500.0f, 9000.0f,  1000.0f },
-                {   1.00f,   0.70f,   1.00f,    1.00f },
-                {   0.00f,   -5.00f,  -2.50f,    0.00f },
+                {  150.0f, 1000.0f, 3500.0f,  9000.0f },
+                {   1.00f,   1.00f,   0.70f,    1.00f },
+                {   0.00f,    0.00f,  -5.00f,   -2.50f },
             } },
             // Drum Plate (AccurateHall migration 2026-06-10): 1 kHz steady-
             // state lift — DV renders sine1k far below the anchor's plate

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1728,6 +1728,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Vocal Hall", {{ 6.1854f, 5.6522f, 4.6678f, 4.4460f, 3.2748f, 2.7689f, 2.5910f, 2.5712f, 6.2021f }} },
             { "Blade Runner 224", {{ 16.0236f, 12.3625f, 27.0000f, 9.6761f, 8.1305f, 7.4944f, 4.9930f, 2.7399f, 1.9333f }} },
             { "Ambience", {{ 1.5195f, 1.5053f, 1.1346f, 0.7328f, 0.7831f, 0.7861f, 0.7947f, 0.9030f, 0.9535f }} },
+            { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
             // END_OCTAVE_T60_MAP
         };
         auto it = kAccurateHallT60ByName.find (std::string_view (name));

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1464,17 +1464,28 @@ namespace {
                 {   1.2f,    1.0f,    2.5f,     1.2f },
                 {  -4.5f,   -1.5f,   -3.0f,    +1.0f },   // Front-load re-tune (2026-06-08): 70Hz -2.5->-4.5 (deeper boom cut for the boosted early field), 1kHz Q 2.5->1.0 gain -0.3->-1.5 (the front-load config ran sine1k +4.24 hot; wider post-tank cut, NOT in-loop, tames it without touching decay), 8kHz -2.5->+1.0 (restore air the tank cut dulled). 2560 modal notch unchanged.
             } },
-            // Bright Hall (BH-6 on VintageTank algo=8, 2026-05-30):
-            //   Band 0 —  60 Hz Q=1.0 -3.0 dB: BH-2 tight sub-bass scoop.
-            //   Band 1 — 1000 Hz Q=6.0 -5.5 dB: BH-4 hyper-narrow notch.
-            //   Band 2 — 3500 Hz Q=2.0 -2.0 dB: BH-6 deepens -1.5 → -2.0 dB
-            //                                   to push spec_L1 mean
-            //                                   off the 2.00 gate boundary.
-            //   Band 3 — 10000 Hz Q=0.8 0 dB:   unity, reserved.
+            // Bright Hall (BH-6 on VintageTank 2026-05-30; Bands 1+3 re-tuned
+            // 2026-06-10 for the AccurateHall migration):
+            //   Band 0 —  60 Hz Q=1.0 -3.0 dB: BH-2 tight sub-bass scoop
+            //                                   (still load-bearing on FDN —
+            //                                   removing it opened 5 boom
+            //                                   gates).
+            //   Band 1 — 1000 Hz Q=6.0 +2.0 dB: was -5.5 (VintageTank modal
+            //                                   ring, gone on FDN); +2 lifts
+            //                                   sine1k toward the anchor.
+            //   Band 2 — 3500 Hz Q=2.0 -2.0 dB: BH-6 spec_L1 mean trim.
+            //   Band 3 — 10000 Hz Q=0.8 +9.0 dB: post-tank early-HF restore.
+            //                                   The FDN loop (hiCutShelf -6)
+            //                                   runs darker than VintageTank;
+            //                                   brightening the LOOP lifted
+            //                                   late bloom 8-12k instead
+            //                                   (gain==decay==level), so the
+            //                                   tilt is post-tank. Closes
+            //                                   cent_50/cent_500/hi/spec.
             { "Bright Hall", {
                 {  60.0f, 1000.0f, 3500.0f, 10000.0f },
                 {   1.0f,    6.0f,    2.0f,     0.8f },
-                {  -3.0f,   -5.5f,   -2.0f,     0.0f },
+                {  -3.0f,   +2.0f,   -2.0f,    +9.0f },
             } },
             // Small Drum Room (SDR-NL3 on NonLinear algo=6, 2026-05-30):
             //   Band 0/1/3 — defaults / reserved.
@@ -1729,6 +1740,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Blade Runner 224", {{ 16.0236f, 12.3625f, 27.0000f, 9.6761f, 8.1305f, 7.4944f, 4.9930f, 2.7399f, 1.9333f }} },
             { "Ambience", {{ 1.5195f, 1.5053f, 1.1346f, 0.7328f, 0.7831f, 0.7861f, 0.7947f, 0.9030f, 0.9535f }} },
             { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
+            { "Bright Hall", {{ 7.8074f, 7.0818f, 6.0995f, 5.6386f, 4.6386f, 4.2369f, 3.5919f, 3.0193f, 2.3286f }} },
             // END_OCTAVE_T60_MAP
         };
         auto it = kAccurateHallT60ByName.find (std::string_view (name));

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1798,7 +1798,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Blade Runner 224", {{ 16.0236f, 12.3625f, 27.0000f, 9.6761f, 8.1305f, 7.4944f, 4.9930f, 2.7399f, 1.9333f }} },
             { "Ambience", {{ 1.3581f, 1.5841f, 1.1106f, 0.7022f, 0.8357f, 0.8101f, 0.8043f, 0.8688f, 0.9877f }} },
             { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
-            { "Bright Hall", {{ 7.8074f, 7.0818f, 6.0995f, 5.6386f, 4.6386f, 4.2369f, 3.5919f, 3.0193f, 2.3286f }} },
+            { "Bright Hall", {{ 8.2160f, 6.6804f, 6.4622f, 5.8494f, 4.6598f, 4.2287f, 3.5663f, 2.8808f, 2.3479f }} },
             { "Drum Plate", {{ 1.4806f, 1.7512f, 1.7059f, 1.8501f, 1.8154f, 1.6800f, 1.7348f, 1.8968f, 4.9167f }} },
             { "Tiled Room", {{ 0.6205f, 0.8945f, 0.7593f, 0.7463f, 0.7543f, 0.7503f, 0.6429f, 0.5625f, 0.4257f }} },
             { "Medium Drum Room", {{ 0.7283f, 1.0271f, 0.7906f, 1.0167f, 0.7691f, 0.7298f, 0.7645f, 0.7753f, 1.0098f }} },
@@ -1808,6 +1808,39 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         for (int b = 0; b < 9; ++b)
             engine.setAccurateHallOctaveT60 (
                 b, it != kAccurateHallT60ByName.end() ? it->second.t60[b] : 0.0f);
+    }
+
+    // ─── Per-preset post-tank OUTPUT diffusion (Bright Hall metallic-ring) ──
+    // The 16-line FDN leaves sparse, isolated HF tail modes above 4 kHz (tail
+    // spectral kurtosis ~19 vs the dense anchor ~12) that read as a metallic
+    // ring on a bright, long-HF preset. A 4-stage allpass cascade on the wet
+    // tail smears them into a denser wash. Unlisted presets → disabled (the
+    // process() call is skipped → bit-null). amount / lfoScale / delayScale
+    // tuned by tools/tuner/outdiff_kurtosis_sweep.py.
+    {
+        struct OutDiffConfig { float amount, lfoScale, delayScale; };
+        static const std::map<std::string_view, OutDiffConfig> kOutputDiffusionByName = {
+            // BEGIN_OUTDIFF_MAP (maintained by outdiff_kurtosis_sweep.py)
+            // END_OUTDIFF_MAP
+        };
+        // Sweep override: DUSKVERB_OUTDIFF="amount,lfoScale,delayScale" forces
+        // the diffuser ON for the preset being rendered (the kurtosis sweep
+        // drives it without a rebuild, like DUSKVERB_FDN_DELAYS).
+        if (const char* env = std::getenv ("DUSKVERB_OUTDIFF"); env != nullptr && env[0] != '\0')
+        {
+            juce::StringArray t; t.addTokens (juce::String (env), ",", "");
+            if (t.size() == 3)
+                engine.setOutputDiffusion (true, t[0].getFloatValue(),
+                                           t[1].getFloatValue(), t[2].getFloatValue());
+            else
+                engine.setOutputDiffusion (false, 0.0f, 0.0f, 1.0f);
+        }
+        else if (auto od = kOutputDiffusionByName.find (std::string_view (name));
+                 od != kOutputDiffusionByName.end())
+            engine.setOutputDiffusion (true, od->second.amount,
+                                       od->second.lfoScale, od->second.delayScale);
+        else
+            engine.setOutputDiffusion (false, 0.0f, 0.0f, 1.0f);   // bypass → bit-null
     }
 
     // Phase 3 (VH->0): per-line energy-following hi-shelf (TimeVaryingDamping).
@@ -1942,7 +1975,12 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
     //
     // Presets not in this map keep the engine default (log-spaced primes
     // 1151..6451 samples) — bit-identical to pre-Phase β behavior.
-    struct BaseDelaySet { int delays[16]; };
+    // 32 entries: the 16-line engines (fdn_/accurateHall_) read [0..15]; the
+    // 32-line accurateHall32_ reads all 32. setFDNBaseDelays forwards ONE pointer
+    // to every engine, so accurateHall32_.setBaseDelays always reads 32 — every
+    // entry MUST define all 32 (else OOB). 16-line presets pad [16..31] with the
+    // engine default tail primes (dormant: their active engine never reads them).
+    struct BaseDelaySet { int delays[32]; };
     static const std::unordered_map<std::string_view, BaseDelaySet> kBaseDelaysByName = {
         // Vocal Hall (Step 2 on v15 baseline, 2026-05-30): restored Phase β
         // sweep result. Without this override the engine's default log-
@@ -1956,28 +1994,41 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         //   lowmid 1.37 Hz (target 1.56, 12% err)
         //   high 2.56 Hz (target 2.47, 3.8% err)
         { "Vocal Hall", { { 1005, 1007, 1050, 1256, 1440, 1921, 2357, 2694,
-                            3069, 3253, 3588, 4086, 4178, 5043, 6014, 6414 } } },
-        // Bright Hall (Phase β sweep, 2026-05-29, 500 trials TPE):
-        // trial 27 — per-band Hilbert peaks bass 3.20Hz (target 3.02,
-        // 6.1% err), lowmid 1.74Hz (target 2.01, 13.5% err), mid 4.30Hz
-        // (target 4.76, 9.6% err), high 6.59Hz (target 7.23, 8.8% err).
-        // All 4 mod gates pass ±30%.
-        { "Bright Hall", { { 707, 814, 1594, 1613, 1791, 2767, 3212, 3692,
-                              4030, 4268, 4579, 4866, 5319, 5659, 5889, 5912 } } },
+                            3069, 3253, 3588, 4086, 4178, 5043, 6014, 6414,
+                            // [16..31] dormant (Vocal Hall is 16-line algo 10):
+                            1213, 1361, 1531, 1721, 1933, 2153, 2417, 2713,
+                            3041, 3413, 3833, 4297, 4817, 5417, 6079, 6469 } } },
+        // Bright Hall (AccurateHall32 algo 12, joint_dense32_sweep.py trial 76,
+        // 2026-06-11): 32 prime delays, mean 3128 ~ the 16-line baseline mean 3121
+        // (T60 held). Joint objective minimized full_check n_fail with a kurtosis
+        // hold; after per-set octave-T60 recalibration this set scores n_fail 13
+        // (baseline 16) AND tail 2-14k spectral kurtosis ~18 -> 14.9 (anchor 12.0,
+        // the metallic ring) — a strict improvement on both axes. All 32 lines
+        // active (AccurateHall32 reads all 32). Octave T60 in kAccurateHallT60ByName.
+        { "Bright Hall", { { 1103, 1249, 1327, 1361, 1531, 1543, 1549, 1637,
+                             1861, 1879, 2053, 2137, 2251, 2371, 2531, 2609,
+                             2741, 3109, 3163, 3371, 3659, 3761, 3943, 4153,
+                             4397, 4721, 4861, 5297, 5431, 5839, 6151, 6521 } } },
         // Ambience / Medium Drum Room (2026-06-10 ripple_delay_sweep): the
         // default log-spaced primes pushed the per-band envelope beats to
         // 4-8 Hz (high tail-mod-ripple std); these sets align the beats to
         // each anchor's slow rate, closing the ripple gate (Ambience high
         // +1.58->-0.04; MDR bass +2.56->-0.01) with all four bands passing.
         { "Ambience", { { 792, 970, 986, 1394, 1474, 2066, 2630, 2735,
-                          3245, 3881, 4084, 4771, 4802, 5151, 6083, 6164 } } },
+                          3245, 3881, 4084, 4771, 4802, 5151, 6083, 6164,
+                          1213, 1361, 1531, 1721, 1933, 2153, 2417, 2713,
+                          3041, 3413, 3833, 4297, 4817, 5417, 6079, 6469 } } },
         { "Medium Drum Room", { { 967, 1110, 1195, 1226, 2190, 2376, 2945, 3198,
-                                 3515, 3624, 4893, 5131, 5333, 5802, 6177, 6402 } } },
+                                 3515, 3624, 4893, 5131, 5333, 5802, 6177, 6402,
+                                 1213, 1361, 1531, 1721, 1933, 2153, 2417, 2713,
+                                 3041, 3413, 3833, 4297, 4817, 5417, 6079, 6469 } } },
         // Drum Plate (2026-06-10 ripple_delay_sweep, ss term off — no sustained
         // anchor, ss_ref would be noiseburst noise floor): closes lowmid +2.68
         // and high +3.57 (the failing bands) while holding bass/mid + octave T60.
         { "Drum Plate", { { 813, 1147, 1447, 1476, 2306, 2392, 2638, 3313,
-                           4055, 4594, 5184, 5202, 5808, 6246, 6423, 6678 } } },
+                           4055, 4594, 5184, 5202, 5808, 6246, 6423, 6678,
+                           1213, 1361, 1531, 1721, 1933, 2153, 2417, 2713,
+                           3041, 3413, 3833, 4297, 4817, 5417, 6079, 6469 } } },
     };
 
     // ─── Phase γ: per-preset post-tank band-trim region gains ────────────
@@ -2026,16 +2077,21 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
     // copyXmlToBinary drops root-XML attributes added after createXml — so
     // setAttribute injection from a host doesn't survive the deserialization
     // path inside setStateInformation).
+    // CSV of 16 (16-line engines) OR 32 (AccurateHall32) positive ints in
+    // samples. setFDNBaseDelays forwards to every engine; each copies its own
+    // line count (fdn_/accurateHall_ read the first 16, accurateHall32_ reads
+    // all 32). Zero-padded so a 16-token override leaves the 32-line tail
+    // defined (it is not the render target in that case).
     const char* envCsv = std::getenv ("DUSKVERB_FDN_DELAYS");
     if (envCsv != nullptr && envCsv[0] != '\0')
     {
         juce::StringArray tokens;
         tokens.addTokens (juce::String (envCsv), ",", "");
-        if (tokens.size() == 16)
+        if (tokens.size() == 16 || tokens.size() == 32)
         {
-            int parsed[16];
+            int parsed[32] = {};
             bool ok = true;
-            for (int i = 0; i < 16; ++i)
+            for (int i = 0; i < tokens.size(); ++i)
             {
                 const int v = tokens[i].trim().getIntValue();
                 if (v <= 0) { ok = false; break; }

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -9,6 +9,41 @@
 #include <string_view>
 #include <unordered_map>
 
+namespace
+{
+// Tuning-sweep env overrides (DUSKVERB_*) let the offline render harness drive
+// params without a rebuild. They are STATIC for the process lifetime (the sweep
+// exports them before the host loads the plugin), so read each EXACTLY ONCE and
+// cache the pointer. CRITICAL: FactoryPreset::applyEngineConfig() — which consumes
+// these — runs on the AUDIO THREAD (performPresetSwap), and std::getenv() is not
+// real-time-safe (reads the environ global, unguarded vs setenv). The cache is
+// primed from the processor constructor (message thread); applyEngineConfig only
+// ever reads the already-initialized pointers (a plain load).
+struct TuningEnv
+{
+    const char* pteq;
+    const char* outdiff;
+    const char* bandtrim;
+    const char* tankfeed;
+    const char* densjit;
+    const char* fdnDelays;
+    const char* tiledRoom;
+    TuningEnv()
+        : pteq      (std::getenv ("DUSKVERB_PTEQ")),
+          outdiff   (std::getenv ("DUSKVERB_OUTDIFF")),
+          bandtrim  (std::getenv ("DUSKVERB_BANDTRIM")),
+          tankfeed  (std::getenv ("DUSKVERB_TANKFEED")),
+          densjit   (std::getenv ("DUSKVERB_DENSJIT")),
+          fdnDelays (std::getenv ("DUSKVERB_FDN_DELAYS")),
+          tiledRoom (std::getenv ("DUSKVERB_TILEDROOM")) {}
+};
+const TuningEnv& tuningEnv()
+{
+    static const TuningEnv cache;   // C++11 thread-safe, one-time init
+    return cache;
+}
+} // namespace
+
 juce::AudioProcessorValueTreeState::ParameterLayout DuskVerbProcessor::createParameterLayout()
 {
     juce::AudioProcessorValueTreeState::ParameterLayout layout;
@@ -424,6 +459,11 @@ DuskVerbProcessor::DuskVerbProcessor()
                         .withOutput ("Output", juce::AudioChannelSet::stereo(), true)),
       parameters (*this, nullptr, juce::Identifier ("DuskVerb"), createParameterLayout())
 {
+    // Prime the tuning-env cache on the message thread (this ctor) so the
+    // one-time std::getenv() reads never land on the audio thread, where
+    // applyEngineConfig() later consumes the cached pointers.
+    tuningEnv();
+
     algorithmParam_     = parameters.getRawParameterValue ("algorithm");
     mixParam_           = parameters.getRawParameterValue ("mix");
     busModeParam_       = parameters.getRawParameterValue ("bus_mode");
@@ -1581,6 +1621,20 @@ namespace {
     }
     inline void resolvePteqFreqQ (const char* name, float fOut[4], float qOut[4])
     {
+        // Env sweep override (DUSKVERB_PTEQ = 12 CSV floats f,q,g per band x4)
+        // takes precedence — must match the freq/Q that applyEngineConfig()
+        // pushes to the engine, else performPresetSwap()/the pteq gain
+        // edge-detect would revert the bands to the preset/default centres.
+        if (const char* envPq = tuningEnv().pteq; envPq != nullptr && envPq[0] != '\0')
+        {
+            juce::StringArray t; t.addTokens (juce::String (envPq), ",", "");
+            if (t.size() == 12)
+            {
+                for (int b = 0; b < 4; ++b)
+                { fOut[b] = t[b * 3].getFloatValue(); qOut[b] = t[b * 3 + 1].getFloatValue(); }
+                return;
+            }
+        }
         auto& m = pteqByName();
         auto it = m.find (std::string_view (name));
         const float* fSrc = (it != m.end()) ? it->second.freq : kPteqDefaultFreq;
@@ -1761,6 +1815,21 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         const float* fSrc = (it != m.end()) ? it->second.freq : kPteqDefaultFreq;
         const float* qSrc = (it != m.end()) ? it->second.q    : kPteqDefaultQ;
         const float* gSrc = (it != m.end()) ? it->second.gain : kPteqZeroGain;
+        // Sweep override: DUSKVERB_PTEQ = 12 CSV floats (f,q,g per band x4).
+        // Direct-call path (same as the map), so it bypasses the APVTS desync
+        // that blinds --param pteq edits. Absent in normal sessions.
+        if (const char* envPq = tuningEnv().pteq; envPq != nullptr && envPq[0] != '\0')
+        {
+            juce::StringArray t; t.addTokens (juce::String (envPq), ",", "");
+            if (t.size() == 12)
+            {
+                for (int b = 0; b < 4; ++b)
+                    engine.setPostTankEQBand (b, t[b * 3].getFloatValue(),
+                                              t[b * 3 + 1].getFloatValue(),
+                                              t[b * 3 + 2].getFloatValue());
+            }
+        }
+        else
         for (int b = 0; b < 4; ++b)
             engine.setPostTankEQBand (b, fSrc[b], qSrc[b], gSrc[b]);
     }
@@ -1826,7 +1895,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // Sweep override: DUSKVERB_OUTDIFF="amount,lfoScale,delayScale" forces
         // the diffuser ON for the preset being rendered (the kurtosis sweep
         // drives it without a rebuild, like DUSKVERB_FDN_DELAYS).
-        if (const char* env = std::getenv ("DUSKVERB_OUTDIFF"); env != nullptr && env[0] != '\0')
+        if (const char* env = tuningEnv().outdiff; env != nullptr && env[0] != '\0')
         {
             juce::StringArray t; t.addTokens (juce::String (env), ",", "");
             if (t.size() == 3)
@@ -2054,6 +2123,16 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // at unity (no map entry) gives the cleanest current result.
         // (Medium Drum Room UltraRoom decouple FALSIFIED — the static post-loop
         // trim couples to boom/body within-band; best 24 vs FDN 25. Reverted.)
+        // Medium Drum Room (Dattorro re-engine, 2026-06-11): zeros = bit-null
+        // placeholder that OPTS the preset into the DUSKVERB_BANDTRIM sweep
+        // hook (the env override is gated on map membership). The post-loop
+        // trim is the orthogonal level lever vs the in-loop coupling wall.
+        { "Medium Drum Room", { 0.0f, 0.0f, 0.0f, 0.0f } },
+        // Ambience (2026-06-11): zeros = bit-null placeholder unlocking the
+        // DUSKVERB_BANDTRIM sweep hook for the boom-low post-loop cut.
+        { "Ambience",         { 0.27389f, -4.81217f, -0.51326f, -2.40095f } },  // boom-low cut + 640 (lowMid -4.8) + air
+        { "Blade Runner 224", { -1.05804f, -0.69518f, -1.16656f, -0.68592f } },  // mild broadband post-trim (sweep)
+        { "Cathedral Large Hall", { -3.42900f, -7.91777f, -0.35222f, -4.19473f } },  // ss low-mid/air cut (sweep)
     };
     PostBandTrimConfig pbt { 0.0f, 0.0f, 0.0f, 0.0f };
     auto pbtIt = kPostBandTrimByName.find (std::string_view (name));
@@ -2061,7 +2140,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         pbt = pbtIt->second;
     // Sweep override: DUSKVERB_BANDTRIM = "sub,lowMid,midHi,air" dB (the UltraRoom
     // decouple level lever). Rebuild-free; only the listed preset opts in.
-    const char* envBt = std::getenv ("DUSKVERB_BANDTRIM");
+    const char* envBt = tuningEnv().bandtrim;
     if (envBt != nullptr && envBt[0] != '\0' && pbtIt != kPostBandTrimByName.end())
     {
         juce::StringArray t; t.addTokens (juce::String (envBt), ",", "");
@@ -2075,6 +2154,55 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
     engine.setPostTankBandTrimGainDb (2, pbt.midHi);
     engine.setPostTankBandTrimGainDb (3, pbt.air);
 
+    // ─── Tank-feed EQ (Progenitor 'inputdamp', 2026-06-11) ────────────────
+    // Low+high shelves on the TANK FEED only (post-diffuser; the parallel ER
+    // taps earlier and stays bright). Feed-forward → per-band T60 untouched;
+    // moves the late-field spectrum the in-loop/post-sum levers couldn't.
+    // 0 dB gains (unlisted presets) → engine skips the branch → bit-identical.
+    // Direct engine call (no APVTS → no edge-detect desync). Sweep override:
+    // DUSKVERB_TANKFEED = "lowFc,lowDb,highFc,highDb".
+    {
+        struct TankFeedConfig { float lowFc, lowDb, highFc, highDb; };
+        static const std::unordered_map<std::string_view, TankFeedConfig> kTankFeedEQByName = {
+            // BEGIN_TANKFEED_MAP (maintained by tools/tuner/mdr_progenitor_sweep.py)
+            { "Medium Drum Room", { 250.0f, -0.16244f, 3736.08f, -0.84836f } },
+            // END_TANKFEED_MAP
+        };
+        TankFeedConfig tf { 200.0f, 0.0f, 2500.0f, 0.0f };
+        if (auto it = kTankFeedEQByName.find (std::string_view (name)); it != kTankFeedEQByName.end())
+            tf = it->second;
+        if (const char* envTf = tuningEnv().tankfeed; envTf != nullptr && envTf[0] != '\0')
+        {
+            juce::StringArray t; t.addTokens (juce::String (envTf), ",", "");
+            if (t.size() == 4)
+                tf = { t[0].getFloatValue(), t[1].getFloatValue(),
+                       t[2].getFloatValue(), t[3].getFloatValue() };
+        }
+        engine.setTankFeedEQ (tf.lowFc, tf.lowDb, tf.highFc, tf.highDb);
+    }
+
+    // ─── Dattorro density-AP jitter (per-preset, 2026-06-11) ──────────────
+    // The hardcoded 0.02 anti-ring wander is a time-varying in-loop element:
+    // it FM-scatters tail energy broadband every pass, creating a flat late-
+    // window HF plateau (~35 dB above a dark anchor's floor) that no static
+    // EQ can remove + driving tail pitch-chorus. Dark short rooms can reduce
+    // it. Unlisted presets keep 0.02 → bit-identical. Sweep override:
+    // DUSKVERB_DENSJIT = "<fraction>".
+    {
+        struct DensityJitterConfig { float fraction; };
+        static const std::unordered_map<std::string_view, DensityJitterConfig> kDensityJitterByName = {
+            // BEGIN_DENSJIT_MAP (maintained by tools/tuner/mdr_progenitor_sweep.py)
+            { "Medium Drum Room", { 0.00474f } },
+            // END_DENSJIT_MAP
+        };
+        float dj = 0.02f;
+        if (auto it = kDensityJitterByName.find (std::string_view (name)); it != kDensityJitterByName.end())
+            dj = it->second.fraction;
+        if (const char* envDj = tuningEnv().densjit; envDj != nullptr && envDj[0] != '\0')
+            dj = juce::String (envDj).getFloatValue();
+        engine.setDattorroDensityJitter (dj);
+    }
+
     // Sweep override: DUSKVERB_FDN_DELAYS env var wins over the map. CSV of
     // 16 positive ints in samples. Set by the sweep harness per trial; absent
     // in normal sessions. Bypasses state-blob roundtrip entirely (JUCE's
@@ -2086,7 +2214,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
     // line count (fdn_/accurateHall_ read the first 16, accurateHall32_ reads
     // all 32). Zero-padded so a 16-token override leaves the 32-line tail
     // defined (it is not the render target in that case).
-    const char* envCsv = std::getenv ("DUSKVERB_FDN_DELAYS");
+    const char* envCsv = tuningEnv().fdnDelays;
     if (envCsv != nullptr && envCsv[0] != '\0')
     {
         juce::StringArray tokens;
@@ -2129,7 +2257,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
     if (erIt != kCompositeERByName.end())
     {
         CompositeER c = erIt->second;
-        const char* envTr = std::getenv ("DUSKVERB_TILEDROOM");
+        const char* envTr = tuningEnv().tiledRoom;
         if (envTr != nullptr && envTr[0] != '\0')
         {
             juce::StringArray t;

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1513,6 +1513,14 @@ namespace {
             //   Band 3 —10000 Hz Q=1.2 -6.0 dB: BR-9 deepens -5.0 → -6.0
             //                                    to clamp bloom 8-12k (was
             //                                    0.53 dB over gate).
+            // Medium Drum Room (AccurateHall, 2026-06-10): dark tilt — the FDN
+            // tail runs far brighter than the eighties-color anchor (blooms
+            // +5..+12 dB, cent_500 +124%); 1 kHz tames the hot sine1k.
+            { "Medium Drum Room", {
+                { 1000.0f, 3500.0f, 10000.0f,  150.0f },
+                {   2.50f,   0.70f,    1.00f,    1.00f },
+                {  -3.50f,  -5.50f,   -8.00f,    0.00f },
+            } },
             // Vocal Plate (AccurateHall, 2026-06-10): HF tilt for the bright
             // late field (cent_500 +72%) — closes mid/bloom/snare via the
             // renorm. A 1 kHz +6 lift for sine1k -12.4 was probed and is
@@ -1770,6 +1778,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Bright Hall", {{ 7.8074f, 7.0818f, 6.0995f, 5.6386f, 4.6386f, 4.2369f, 3.5919f, 3.0193f, 2.3286f }} },
             { "Drum Plate", {{ 1.4801f, 1.4044f, 1.7830f, 1.7079f, 1.8507f, 1.7023f, 1.7860f, 1.8388f, 5.6775f }} },
             { "Tiled Room", {{ 0.6205f, 0.8945f, 0.7593f, 0.7463f, 0.7543f, 0.7503f, 0.6429f, 0.5625f, 0.4257f }} },
+            { "Medium Drum Room", {{ 0.6662f, 0.9294f, 0.8642f, 0.9537f, 0.8041f, 0.7135f, 0.7917f, 0.7769f, 0.9501f }} },
             // END_OCTAVE_T60_MAP
         };
         auto it = kAccurateHallT60ByName.find (std::string_view (name));

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1799,7 +1799,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Ambience", {{ 1.3581f, 1.5841f, 1.1106f, 0.7022f, 0.8357f, 0.8101f, 0.8043f, 0.8688f, 0.9877f }} },
             { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
             { "Bright Hall", {{ 7.8074f, 7.0818f, 6.0995f, 5.6386f, 4.6386f, 4.2369f, 3.5919f, 3.0193f, 2.3286f }} },
-            { "Drum Plate", {{ 1.4801f, 1.4044f, 1.7830f, 1.7079f, 1.8507f, 1.7023f, 1.7860f, 1.8388f, 5.6775f }} },
+            { "Drum Plate", {{ 1.4806f, 1.7512f, 1.7059f, 1.8501f, 1.8154f, 1.6800f, 1.7348f, 1.8968f, 4.9167f }} },
             { "Tiled Room", {{ 0.6205f, 0.8945f, 0.7593f, 0.7463f, 0.7543f, 0.7503f, 0.6429f, 0.5625f, 0.4257f }} },
             { "Medium Drum Room", {{ 0.7283f, 1.0271f, 0.7906f, 1.0167f, 0.7691f, 0.7298f, 0.7645f, 0.7753f, 1.0098f }} },
             // END_OCTAVE_T60_MAP
@@ -1973,6 +1973,11 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
                           3245, 3881, 4084, 4771, 4802, 5151, 6083, 6164 } } },
         { "Medium Drum Room", { { 967, 1110, 1195, 1226, 2190, 2376, 2945, 3198,
                                  3515, 3624, 4893, 5131, 5333, 5802, 6177, 6402 } } },
+        // Drum Plate (2026-06-10 ripple_delay_sweep, ss term off — no sustained
+        // anchor, ss_ref would be noiseburst noise floor): closes lowmid +2.68
+        // and high +3.57 (the failing bands) while holding bass/mid + octave T60.
+        { "Drum Plate", { { 813, 1147, 1447, 1476, 2306, 2392, 2638, 3313,
+                           4055, 4594, 5184, 5202, 5808, 6246, 6423, 6678 } } },
     };
 
     // ─── Phase γ: per-preset post-tank band-trim region gains ────────────

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1508,7 +1508,7 @@ namespace {
             { "Bright Hall", {
                 {  60.0f, 1000.0f, 3500.0f, 10000.0f },
                 {   1.0f,    6.0f,    2.0f,     0.8f },
-                {  -3.0f,   +2.0f,   -2.0f,    +9.0f },
+                { -3.0f,   +2.0f,   -2.0f,    +2.0f },
             } },
             // Small Drum Room (SDR-NL3 on NonLinear algo=6, 2026-05-30):
             //   Band 0/1/3 — defaults / reserved.
@@ -1569,7 +1569,7 @@ namespace {
             { "Drum Plate", {
                 {  150.0f, 1000.0f, 3000.0f,  8000.0f },
                 {   0.80f,   2.50f,   1.50f,    1.00f },
-                {  +3.50f,   +8.00f,   0.00f,    0.00f },
+                {  +3.50f,   +2.00f,   0.00f,   +4.00f },
             } },
             { "Blade Runner 224", {
                 {  350.0f, 3000.0f, 6000.0f, 10000.0f },
@@ -1870,7 +1870,13 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // extension only per-line decay scaling can deliver.
         { "Bright Hall",          DspUtils::ModulationTopology::ModulatedDamping },
         { "Cathedral Large Hall", DspUtils::ModulationTopology::ModulatedDamping },
-        { "Drum Plate",           DspUtils::ModulationTopology::ModulatedDamping },
+        // Drum Plate -> RandomWalk (2026-06-10, tail-cleanliness review): under
+        // ModulatedDamping the Mod Rate/Depth knobs are inert (fixed slow
+        // drift), so the tail could not smear its comb modes — ripple +3..+3.8
+        // dB rougher than the anchor and pitch wander 4.3 Hz vs the anchor
+        // plate's 16.5 Hz. RandomWalk enables real line modulation; depth/rate
+        // tuned to match the anchor's chorused-smooth tail.
+        { "Drum Plate",           DspUtils::ModulationTopology::RandomWalk },
         // Vocal Hall — REVERTED to RandomWalk default on 2026-05-29 with
         // the v15 preset-row rollback. ModulatedDamping was added as a
         // Phase 3 anti-Doppler fix layered on top of v18-manual params;

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1513,6 +1513,14 @@ namespace {
             //   Band 3 —10000 Hz Q=1.2 -6.0 dB: BR-9 deepens -5.0 → -6.0
             //                                    to clamp bloom 8-12k (was
             //                                    0.53 dB over gate).
+            // Tiled Room (AccurateHall trial 2026-06-10): dark post-tank tilt —
+            // the calibrated octave T60s fixed decay but the tail LEVEL runs
+            // bright (cent_500 +215%, blooms 2-12k +2..+4.4).
+            { "Tiled Room", {
+                {  150.0f, 3500.0f, 9000.0f,  1000.0f },
+                {   1.00f,   0.70f,   1.00f,    1.00f },
+                {   0.00f,   -5.00f,  -2.50f,    0.00f },
+            } },
             // Drum Plate (AccurateHall migration 2026-06-10): 1 kHz steady-
             // state lift — DV renders sine1k far below the anchor's plate
             // resonance (-13 dB rel.); post-tank boost lifts it without
@@ -1751,6 +1759,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
             { "Bright Hall", {{ 7.8074f, 7.0818f, 6.0995f, 5.6386f, 4.6386f, 4.2369f, 3.5919f, 3.0193f, 2.3286f }} },
             { "Drum Plate", {{ 1.4801f, 1.4044f, 1.7830f, 1.7079f, 1.8507f, 1.7023f, 1.7860f, 1.8388f, 5.6775f }} },
+            { "Tiled Room", {{ 0.6205f, 0.8945f, 0.7593f, 0.7463f, 0.7543f, 0.7503f, 0.6429f, 0.5625f, 0.4257f }} },
             // END_OCTAVE_T60_MAP
         };
         auto it = kAccurateHallT60ByName.find (std::string_view (name));

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1800,7 +1800,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
             { "Bright Hall", {{ 8.2160f, 6.6804f, 6.4622f, 5.8494f, 4.6598f, 4.2287f, 3.5663f, 2.8808f, 2.3479f }} },
             { "Drum Plate", {{ 1.4806f, 1.7512f, 1.7059f, 1.8501f, 1.8154f, 1.6800f, 1.7348f, 1.8968f, 4.9167f }} },
-            { "Tiled Room", {{ 0.6205f, 0.8945f, 0.7593f, 0.7463f, 0.7543f, 0.7503f, 0.6429f, 0.5625f, 0.4257f }} },
+            { "Tiled Room", {{ 0.6370f, 0.5615f, 0.6482f, 0.7510f, 0.6489f, 0.6736f, 0.6699f, 0.4520f, 0.1680f }} },
             { "Medium Drum Room", {{ 0.7283f, 1.0271f, 0.7906f, 1.0167f, 0.7691f, 0.7298f, 0.7645f, 0.7753f, 1.0098f }} },
             // END_OCTAVE_T60_MAP
         };
@@ -2052,24 +2052,28 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // helped. Under the new VintageTank row (baked round-3 axes), the
         // same cuts dropped 13 additional gates net. Leaving PostBandTrim
         // at unity (no map entry) gives the cleanest current result.
+        // (Medium Drum Room UltraRoom decouple FALSIFIED — the static post-loop
+        // trim couples to boom/body within-band; best 24 vs FDN 25. Reverted.)
     };
+    PostBandTrimConfig pbt { 0.0f, 0.0f, 0.0f, 0.0f };
     auto pbtIt = kPostBandTrimByName.find (std::string_view (name));
     if (pbtIt != kPostBandTrimByName.end())
+        pbt = pbtIt->second;
+    // Sweep override: DUSKVERB_BANDTRIM = "sub,lowMid,midHi,air" dB (the UltraRoom
+    // decouple level lever). Rebuild-free; only the listed preset opts in.
+    const char* envBt = std::getenv ("DUSKVERB_BANDTRIM");
+    if (envBt != nullptr && envBt[0] != '\0' && pbtIt != kPostBandTrimByName.end())
     {
-        engine.setPostTankBandTrimGainDb (0, pbtIt->second.sub);
-        engine.setPostTankBandTrimGainDb (1, pbtIt->second.lowMid);
-        engine.setPostTankBandTrimGainDb (2, pbtIt->second.midHi);
-        engine.setPostTankBandTrimGainDb (3, pbtIt->second.air);
+        juce::StringArray t; t.addTokens (juce::String (envBt), ",", "");
+        if (t.size() == 4)
+            pbt = { t[0].getFloatValue(), t[1].getFloatValue(),
+                    t[2].getFloatValue(), t[3].getFloatValue() };
     }
-    else
-    {
-        // Defensively zero — applyEngineConfig may run after APVTS has set
-        // non-zero post-band trims from a prior preset that opted in. Without
-        // this reset, switching from VH (opt-in) to e.g. Vocal Plate (no
-        // opt-in) would inherit VH's trim values.
-        for (int r = 0; r < 4; ++r)
-            engine.setPostTankBandTrimGainDb (r, 0.0f);
-    }
+    // Always set (defensive: don't inherit a prior opt-in preset's trims).
+    engine.setPostTankBandTrimGainDb (0, pbt.sub);
+    engine.setPostTankBandTrimGainDb (1, pbt.lowMid);
+    engine.setPostTankBandTrimGainDb (2, pbt.midHi);
+    engine.setPostTankBandTrimGainDb (3, pbt.air);
 
     // Sweep override: DUSKVERB_FDN_DELAYS env var wins over the map. CSV of
     // 16 positive ints in samples. Set by the sweep harness per trial; absent
@@ -2104,6 +2108,42 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             }
         }
     }
+
+    // Algo-13 COMPOSITE voicing (sparse ER front-end + 16-line AccurateHall tail).
+    // Per-preset ER config — only the ER + mix here; the tail (accurateHall_) is
+    // configured by the preset's octave-T60 map + frozen mod. DUSKVERB_TILEDROOM
+    // env (6 floats: erSize,onsetMs,erDecayMs,burst2Ms,sparseTailGain,spare)
+    // overrides for the rebuild-free tuning sweep (applies to whichever composite
+    // preset is loading).
+    // 6th field erGain: ER level in the mix (1.0 = full). Backs off the ER for a
+    // less-front-loaded room so it doesn't overshoot energy_first50.
+    struct CompositeER { float erSize, onsetMs, erDecayMs, burst2Ms, sparseTailGain, erGain; };
+    static const std::unordered_map<std::string_view, CompositeER> kCompositeERByName = {
+        // Tiled Room: tiledroom_voicing_sweep.py best (n_fail 26->16). Tight ER,
+        // fast onset, short discharge, micro-burst ~18 ms, ER/tail mix 0.49, full ER.
+        { "Tiled Room",       { 0.3248f, 1.4567f, 17.1838f, 17.749f, 0.4928f, 1.0000f } },
+        // (Medium Drum Room composite/decouple FALSIFIED — best 24 vs FDN 25;
+        // reverted to the FDN. See the FactoryPresets MDR comment.)
+    };
+    auto erIt = kCompositeERByName.find (std::string_view (name));
+    if (erIt != kCompositeERByName.end())
+    {
+        CompositeER c = erIt->second;
+        const char* envTr = std::getenv ("DUSKVERB_TILEDROOM");
+        if (envTr != nullptr && envTr[0] != '\0')
+        {
+            juce::StringArray t;
+            t.addTokens (juce::String (envTr), ",", "");
+            if (t.size() == 6)
+            {
+                c.erSize = t[0].getFloatValue(); c.onsetMs = t[1].getFloatValue();
+                c.erDecayMs = t[2].getFloatValue(); c.burst2Ms = t[3].getFloatValue();
+                c.sparseTailGain = t[4].getFloatValue(); c.erGain = t[5].getFloatValue();
+            }
+        }
+        engine.setTiledRoomVoicing (c.erSize, c.onsetMs, c.erDecayMs, c.burst2Ms, c.sparseTailGain, c.erGain);
+    }
+
     auto bdIt = kBaseDelaysByName.find (std::string_view (name));
     if (bdIt != kBaseDelaysByName.end())
         engine.setFDNBaseDelays (bdIt->second.delays);

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1796,12 +1796,12 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Vocal Plate", {{ 0.7117f, 0.7373f, 0.7335f, 0.7337f, 0.7365f, 0.7926f, 0.7923f, 0.8018f, 0.9431f }} },
             { "Vocal Hall", {{ 6.1854f, 5.6522f, 4.6678f, 4.4460f, 3.2748f, 2.7689f, 2.5910f, 2.5712f, 6.2021f }} },
             { "Blade Runner 224", {{ 16.0236f, 12.3625f, 27.0000f, 9.6761f, 8.1305f, 7.4944f, 4.9930f, 2.7399f, 1.9333f }} },
-            { "Ambience", {{ 1.5195f, 1.5053f, 1.1346f, 0.7328f, 0.7831f, 0.7861f, 0.7947f, 0.9030f, 0.9535f }} },
+            { "Ambience", {{ 1.3581f, 1.5841f, 1.1106f, 0.7022f, 0.8357f, 0.8101f, 0.8043f, 0.8688f, 0.9877f }} },
             { "Cathedral Large Hall", {{ 4.0341f, 4.2508f, 4.0282f, 3.3828f, 3.3917f, 2.7591f, 2.2539f, 2.1740f, 4.1189f }} },
             { "Bright Hall", {{ 7.8074f, 7.0818f, 6.0995f, 5.6386f, 4.6386f, 4.2369f, 3.5919f, 3.0193f, 2.3286f }} },
             { "Drum Plate", {{ 1.4801f, 1.4044f, 1.7830f, 1.7079f, 1.8507f, 1.7023f, 1.7860f, 1.8388f, 5.6775f }} },
             { "Tiled Room", {{ 0.6205f, 0.8945f, 0.7593f, 0.7463f, 0.7543f, 0.7503f, 0.6429f, 0.5625f, 0.4257f }} },
-            { "Medium Drum Room", {{ 0.6662f, 0.9294f, 0.8642f, 0.9537f, 0.8041f, 0.7135f, 0.7917f, 0.7769f, 0.9501f }} },
+            { "Medium Drum Room", {{ 0.7283f, 1.0271f, 0.7906f, 1.0167f, 0.7691f, 0.7298f, 0.7645f, 0.7753f, 1.0098f }} },
             // END_OCTAVE_T60_MAP
         };
         auto it = kAccurateHallT60ByName.find (std::string_view (name));
@@ -1964,6 +1964,15 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // All 4 mod gates pass ±30%.
         { "Bright Hall", { { 707, 814, 1594, 1613, 1791, 2767, 3212, 3692,
                               4030, 4268, 4579, 4866, 5319, 5659, 5889, 5912 } } },
+        // Ambience / Medium Drum Room (2026-06-10 ripple_delay_sweep): the
+        // default log-spaced primes pushed the per-band envelope beats to
+        // 4-8 Hz (high tail-mod-ripple std); these sets align the beats to
+        // each anchor's slow rate, closing the ripple gate (Ambience high
+        // +1.58->-0.04; MDR bass +2.56->-0.01) with all four bands passing.
+        { "Ambience", { { 792, 970, 986, 1394, 1474, 2066, 2630, 2735,
+                          3245, 3881, 4084, 4771, 4802, 5151, 6083, 6164 } } },
+        { "Medium Drum Room", { { 967, 1110, 1195, 1226, 2190, 2376, 2945, 3198,
+                                 3515, 3624, 4893, 5131, 5333, 5802, 6177, 6402 } } },
     };
 
     // ─── Phase γ: per-preset post-tank band-trim region gains ────────────

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -1462,7 +1462,7 @@ namespace {
             { "Vocal Hall", {
                 {  70.0f, 1000.0f, 2560.0f,  8000.0f },
                 {   1.2f,    1.0f,    2.5f,     1.2f },
-                {  -4.5f,   -1.5f,   -3.0f,    +1.0f },   // Front-load re-tune (2026-06-08): 70Hz -2.5->-4.5 (deeper boom cut for the boosted early field), 1kHz Q 2.5->1.0 gain -0.3->-1.5 (the front-load config ran sine1k +4.24 hot; wider post-tank cut, NOT in-loop, tames it without touching decay), 8kHz -2.5->+1.0 (restore air the tank cut dulled). 2560 modal notch unchanged.
+                {  -2.0f,   -1.5f,   -3.0f,    +1.0f },   // 70Hz -4.5->-2.0 (2026-06-10): the deep boom cut was tuned for tank_level 0.42; at the rebalanced 0.55 it starved boom/body 80-500. 1kHz Q1.0 -1.5 (sine1k tame), 8kHz +1.0 (air restore), 2560 modal notch unchanged.
             } },
             // Bright Hall (BH-6 on VintageTank 2026-05-30; Bands 1+3 re-tuned
             // 2026-06-10 for the AccurateHall migration):

--- a/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
+++ b/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
@@ -53,20 +53,26 @@ inline int getNumAlgorithms() { return 13; }
 
 inline const AlgorithmConfig& getAlgorithmConfig (int index)
 {
+    // User-facing engine names. Standardized 2026-06-11: clean musician-facing
+    // labels, no internal-algorithm jargon and no trademark references (was
+    // Lexicon / RMX16 / Eno / 6G15 / Figure-8 / Dattorro). ENUM ORDER IS FIXED —
+    // AudioParameterChoice stores the index, presets store the algorithm index,
+    // so these strings are display-only and must NOT be reordered or removed
+    // (that would shift indices and break saved state). Rename freely.
     static constexpr AlgorithmConfig kEngines[] = {
-        { "Plate (Dattorro)",         EngineType::Dattorro        },
-        { "Plate (Dattorro Vintage)", EngineType::DattorroVintage },
-        { "High Density (6-AP)",      EngineType::SixAPTank       },
-        { "Quad Room (QuadTank)",     EngineType::QuadTank        },
-        { "Realistic Space (FDN)",    EngineType::FDN             },
-        { "Spring Tank (6G15)",       EngineType::Spring          },
-        { "Non-Linear (RMX16)",       EngineType::NonLinear       },
-        { "Shimmer (Eno FDN)",        EngineType::Shimmer         },
-        { "Vintage Tank (Figure-8)",  EngineType::VintageTank     },
-        { "Reverse Room (Lexicon)",   EngineType::ReverseRoom     },
-        { "Accurate Hall (FDN-GEQ)",  EngineType::AccurateHall    },
-        { "Sparse Field (Early)",     EngineType::SparseField     },
-        { "Accurate Hall 32 (Dense)", EngineType::AccurateHall32  },
+        { "Plate",         EngineType::Dattorro        },
+        { "Vintage Plate", EngineType::DattorroVintage },
+        { "Smooth Plate",  EngineType::SixAPTank       },
+        { "Room",          EngineType::QuadTank        },
+        { "Studio",        EngineType::FDN             },
+        { "Spring",        EngineType::Spring          },
+        { "Gated",         EngineType::NonLinear       },
+        { "Shimmer",       EngineType::Shimmer         },
+        { "Vintage Hall",  EngineType::VintageTank     },
+        { "Reverse",       EngineType::ReverseRoom     },
+        { "Hall",          EngineType::AccurateHall    },
+        { "Sparse",        EngineType::SparseField     },
+        { "Concert Hall",  EngineType::AccurateHall32  },
     };
     if (index < 0 || index >= 13)
         index = 0;

--- a/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
+++ b/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
@@ -37,6 +37,9 @@ enum class EngineType : int
                             // with a reduced AccurateHall octave-GEQ tail. Closes the early-
                             // arrival wall (energy_t50/first50/attack/onset/diffusion_flux) the
                             // back-loading FDN/tank topologies structurally cannot.
+    AccurateHall32    = 12, // 32-line variant of AccurateHall (double the feedback lines +
+                            // order-32 Hadamard) for high-frequency modal density — kills the
+                            // metallic ring of the 16-line FDN. Bright Hall only.
 };
 
 // Per-engine descriptor surfaced in the algorithm dropdown.
@@ -46,7 +49,7 @@ struct AlgorithmConfig
     EngineType  engine;
 };
 
-inline int getNumAlgorithms() { return 12; }
+inline int getNumAlgorithms() { return 13; }
 
 inline const AlgorithmConfig& getAlgorithmConfig (int index)
 {
@@ -63,8 +66,9 @@ inline const AlgorithmConfig& getAlgorithmConfig (int index)
         { "Reverse Room (Lexicon)",   EngineType::ReverseRoom     },
         { "Accurate Hall (FDN-GEQ)",  EngineType::AccurateHall    },
         { "Sparse Field (Early)",     EngineType::SparseField     },
+        { "Accurate Hall 32 (Dense)", EngineType::AccurateHall32  },
     };
-    if (index < 0 || index >= 12)
+    if (index < 0 || index >= 13)
         index = 0;
     return kEngines[index];
 }

--- a/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
+++ b/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
@@ -40,6 +40,11 @@ enum class EngineType : int
     AccurateHall32    = 12, // 32-line variant of AccurateHall (double the feedback lines +
                             // order-32 Hadamard) for high-frequency modal density — kills the
                             // metallic ring of the 16-line FDN. Bright Hall only.
+    TiledRoom         = 13, // Sparse tapped-delay ER front-end (front-loads ~69% of energy in
+                            // the first 50 ms) welded to a SHORT, frozen, low-pass-terminated
+                            // 4-line FDN tail (~1.1 kHz loop -> dark late field). Tight ceramic
+                            // tiled room — the front-load + instant-dark character a single-tank
+                            // FDN structurally cannot express. Tiled Room only.
 };
 
 // Per-engine descriptor surfaced in the algorithm dropdown.
@@ -49,7 +54,7 @@ struct AlgorithmConfig
     EngineType  engine;
 };
 
-inline int getNumAlgorithms() { return 13; }
+inline int getNumAlgorithms() { return 14; }
 
 inline const AlgorithmConfig& getAlgorithmConfig (int index)
 {
@@ -73,8 +78,9 @@ inline const AlgorithmConfig& getAlgorithmConfig (int index)
         { "Hall",          EngineType::AccurateHall    },
         { "Sparse",        EngineType::SparseField     },
         { "Concert Hall",  EngineType::AccurateHall32  },
+        { "Tiled Room",    EngineType::TiledRoom       },
     };
-    if (index < 0 || index >= 13)
+    if (index < 0 || index >= 14)
         index = 0;
     return kEngines[index];
 }

--- a/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
+++ b/plugins/DuskVerb/src/dsp/AlgorithmConfig.h
@@ -33,6 +33,10 @@ enum class EngineType : int
     AccurateHall      = 10, // FDN + per-OCTAVE attenuation GEQ in the feedback loop (Jot/
                             // Schlecht accurate-RT control). Independent per-octave T60 — closes
                             // the 9-octave-vs-5-band damping wall the standard FDN can't.
+    SparseField       = 11, // Velvet-noise front-loaded sparse early field (to ~220ms) summed
+                            // with a reduced AccurateHall octave-GEQ tail. Closes the early-
+                            // arrival wall (energy_t50/first50/attack/onset/diffusion_flux) the
+                            // back-loading FDN/tank topologies structurally cannot.
 };
 
 // Per-engine descriptor surfaced in the algorithm dropdown.
@@ -42,7 +46,7 @@ struct AlgorithmConfig
     EngineType  engine;
 };
 
-inline int getNumAlgorithms() { return 11; }
+inline int getNumAlgorithms() { return 12; }
 
 inline const AlgorithmConfig& getAlgorithmConfig (int index)
 {
@@ -58,8 +62,9 @@ inline const AlgorithmConfig& getAlgorithmConfig (int index)
         { "Vintage Tank (Figure-8)",  EngineType::VintageTank     },
         { "Reverse Room (Lexicon)",   EngineType::ReverseRoom     },
         { "Accurate Hall (FDN-GEQ)",  EngineType::AccurateHall    },
+        { "Sparse Field (Early)",     EngineType::SparseField     },
     };
-    if (index < 0 || index >= 11)
+    if (index < 0 || index >= 12)
         index = 0;
     return kEngines[index];
 }

--- a/plugins/DuskVerb/src/dsp/DattorroTank.cpp
+++ b/plugins/DuskVerb/src/dsp/DattorroTank.cpp
@@ -153,7 +153,7 @@ void DattorroTank::prepare (double sampleRate, int /*maxBlockSize*/)
             // samples for cubic Hermite (reads intIdx-1 .. intIdx+2) plus
             // a safety margin. Without this, a worst-case jitter sample
             // could read into not-yet-written buffer positions.
-            const int extraSamples = static_cast<int> (std::ceil (baseMax * 0.02f));
+            const int extraSamples = static_cast<int> (std::ceil (baseMax * kMaxDensityJitterFraction));
             const int dapMax = static_cast<int> (std::ceil (baseMax))
                              + extraSamples + 4;
             tank.densityAP[i].allocate (dapMax);
@@ -169,7 +169,7 @@ void DattorroTank::prepare (double sampleRate, int /*maxBlockSize*/)
             // 28-30 ms comb teeth on the worst-case plates while keeping
             // the residual pitch wobble inaudible on sustained content
             // (3 % was perceptible as chorus on Rich Plate).
-            tank.densityAP[i].jitterDepthFraction = 0.02f;
+            tank.densityAP[i].jitterDepthFraction = densityJitterFraction_;
         }
 
         tank.damping.prepare (static_cast<float> (sampleRate));
@@ -699,6 +699,20 @@ void DattorroTank::setDecayBoost (float boost)
     decayBoost_ = std::clamp (boost, 0.3f, 2.0f);
     if (prepared_)
         updateDecayCoefficients();
+}
+
+void DattorroTank::setDensityJitter (float fraction)
+{
+    // Clamp to the 2 % the density-AP buffers allocate read headroom for.
+    densityJitterFraction_ = std::clamp (fraction, 0.0f, kMaxDensityJitterFraction);
+    const float sr = static_cast<float> (sampleRate_);
+    for (int i = 0; i < kNumDensityAPs; ++i)
+    {
+        leftTank_ .densityAP[i].jitterDepthFraction = densityJitterFraction_;
+        rightTank_.densityAP[i].jitterDepthFraction = densityJitterFraction_;
+        leftTank_ .densityAP[i].updateJitterDepth (sr);
+        rightTank_.densityAP[i].updateJitterDepth (sr);
+    }
 }
 
 void DattorroTank::setStructuralHFDamping (float hz)

--- a/plugins/DuskVerb/src/dsp/DattorroTank.h
+++ b/plugins/DuskVerb/src/dsp/DattorroTank.h
@@ -36,11 +36,11 @@ public:
 
     void setDecayTime (float seconds);
     void setBassMultiply (float mult);
-    void setMidMultiply (float mult);                  // NEW: 3-band mid mult (default 1.0)
+    void setMidMultiply (float mult);                  // 3-band mid mult (default 1.0)
     void setTrebleMultiply (float mult);
     void setCrossoverFreq (float hz);
     void setHighCrossoverFreq (float hz);
-    void setSaturation (float amount);                 // NEW: 0..1 drive-style softClip
+    void setSaturation (float amount);                 // 0..1 drive-style softClip
     void setModDepth (float depth);
     void setModRate (float hz);
     void setSize (float size);

--- a/plugins/DuskVerb/src/dsp/DattorroTank.h
+++ b/plugins/DuskVerb/src/dsp/DattorroTank.h
@@ -73,6 +73,16 @@ public:
     void setLimiter (float thresholdDb, float releaseMs);  // Peak limiter (0 thresholdDb = off)
     void setDecayBoost (float boost);
     void setStructuralHFDamping (float hz);
+    // Density-AP random-walk jitter depth (fraction of each AP's delay).
+    // Engine default 0.02 (the #87 anti-ring wander). The in-loop wander is
+    // a time-VARYING element: every pass FM-scatters tail energy broadband,
+    // which builds a flat late-window HF plateau (~35 dB above a dark
+    // anchor's floor) that NO static filter — feed, in-loop, or post — can
+    // remove, and drives the tail pitch-chorus metric. Dark/short room
+    // presets can trade the (mild, short-decay) comb risk for a clean dark
+    // tail. Clamped to [0, 0.02]: the AP buffers allocate headroom for
+    // exactly 2 % wander. 0.02 = bit-identical legacy.
+    void setDensityJitter (float fraction);
     void clearBuffers();
 
 private:
@@ -191,6 +201,12 @@ private:
     // Multiplies echo density ~8× per loop pass (each AP doubles mode count).
     // Delays are prime and coprime to all other elements.
     static constexpr int kNumDensityAPs = 3;
+
+    // Density-AP wander cap. The density-AP buffers allocate EXACTLY this much
+    // read-offset headroom (see prepare()), and setDensityJitter() clamps to it
+    // — one invariant, one constant, so the two can never drift out of sync and
+    // expose an out-of-bounds interpolated read.
+    static constexpr float kMaxDensityJitterFraction = 0.02f;
 
     // Left tank density AP delays (at 44100 Hz)
     static constexpr int kLeftDensityAPBase[kNumDensityAPs] = { 137, 199, 281 };
@@ -350,6 +366,9 @@ private:
     // earlier per-sample white-noise jitter; the smooth wander breaks modal
     // resonances without producing audible FM sidebands.
     float delayModDepthSamples_ = 4.0f;
+
+    // Density-AP wander depth fraction (see setDensityJitter). 0.02 = legacy.
+    float densityJitterFraction_ = 0.02f;
 
     void updateDelayLengths();
     void updateDecayCoefficients();

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -15,6 +15,13 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     sampleRate_ = sampleRate;
     maxBlockSize_ = maxBlockSize;
 
+    // SR-dependent shell coeffs are derived from stored corner freqs — recompute
+    // here so a sample-rate change can't leave them stale even if the caller
+    // doesn't re-install the preset config afterward (the sub-engines below
+    // already recompute their own coeffs in prepare()).
+    recomputeTankFeedCoeffs();
+    setTankSplitHz (tankSplitHz_);
+
     // All engines stay prepared so setAlgorithm() never has to allocate.
     dattorro_.prepare (sampleRate, maxBlockSize);
     sixAPTank_.prepare (sampleRate, maxBlockSize);
@@ -476,7 +483,7 @@ void DuskVerbEngine::setFDNBaseDelays (const int* delays)
 
 void DuskVerbEngine::resetFDNBaseDelays()
 {
-    fdn_.resetBaseDelays(); accurateHall_.resetBaseDelays();
+    fdn_.resetBaseDelays(); accurateHall_.resetBaseDelays(); accurateHall32_.resetBaseDelays();
     multibandFdn_.forEachTank ([](FDNReverb& tk){ tk.resetBaseDelays(); });
 }
 
@@ -510,6 +517,10 @@ void DuskVerbEngine::reapplyNeutralEngineConfig()
     setTankFeedEQ (200.0f, 0.0f, 2500.0f, 0.0f);
     // Dattorro density-AP jitter → engine default (0.02).
     setDattorroDensityJitter (0.02f);
+    // Output diffusion → disabled. applyEngineConfig's else-branch covers the
+    // with-preset path, but the null-preset swap calls THIS alone — without it,
+    // a prior preset's post-tank diffusion (e.g. Bright Hall) would leak.
+    setOutputDiffusion (false, 0.0f, 0.0f, 1.0f);
 }
 
 void DuskVerbEngine::setFDNInLoopPeaking (float freqHz, float qFactor, float gainDb)
@@ -691,12 +702,20 @@ void DuskVerbEngine::setTankFeedEQ (float lowFc, float lowGainDb, float highFc, 
     tankFeedHighFc_   = std::clamp (highFc, 500.0f, 16000.0f);
     tankFeedLowGain_  = std::pow (10.0f, std::clamp (lowGainDb,  -24.0f, 6.0f) / 20.0f);
     tankFeedHighGain_ = std::pow (10.0f, std::clamp (highGainDb, -24.0f, 6.0f) / 20.0f);
-    const float sr = static_cast<float> (sampleRate_);
-    tankFeedLowCoeff_  = std::exp (-2.0f * 3.14159265f * tankFeedLowFc_  / sr);
-    tankFeedHighCoeff_ = std::exp (-2.0f * 3.14159265f * tankFeedHighFc_ / sr);
+    recomputeTankFeedCoeffs();
     tankFeedActive_ = std::abs (lowGainDb) > 0.01f || std::abs (highGainDb) > 0.01f;
     if (! tankFeedActive_)
         tfLowStateL_ = tfLowStateR_ = tfHighStateL_ = tfHighStateR_ = 0.0f;
+}
+
+// One-pole shelf coeffs from the stored corner freqs at the current sampleRate_.
+// Called by setTankFeedEQ and by prepare() so an SR change can't leave them
+// stale (single source of truth — no duplicated formula).
+void DuskVerbEngine::recomputeTankFeedCoeffs()
+{
+    const float sr = static_cast<float> (sampleRate_);
+    tankFeedLowCoeff_  = std::exp (-2.0f * 3.14159265f * tankFeedLowFc_  / sr);
+    tankFeedHighCoeff_ = std::exp (-2.0f * 3.14159265f * tankFeedHighFc_ / sr);
 }
 
 void DuskVerbEngine::setERBusShelves (float lowGainDb, float highGainDb)

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -442,6 +442,7 @@ void DuskVerbEngine::setSparseFieldOnsetMs  (float ms)   { sparseField_.setOnset
 void DuskVerbEngine::setSparseFieldDecayMs  (float ms)   { sparseField_.setDecayMs (ms); }
 void DuskVerbEngine::setSparseFieldBurst2Ms (float ms)   { sparseField_.setBurst2Ms (ms); }
 void DuskVerbEngine::setSparseFieldTailGain (float gain) { sparseTailGain_ = std::clamp (gain, 0.0f, 1.0f); }
+void DuskVerbEngine::setSparseERGain        (float gain) { sparseERGain_   = std::clamp (gain, 0.0f, 2.0f); }
 
 void DuskVerbEngine::setOutputDiffusion (bool enable, float amount, float lfoScale, float delayScale)
 {
@@ -468,6 +469,21 @@ void DuskVerbEngine::resetFDNBaseDelays()
 {
     fdn_.resetBaseDelays(); accurateHall_.resetBaseDelays();
     multibandFdn_.forEachTank ([](FDNReverb& tk){ tk.resetBaseDelays(); });
+}
+
+void DuskVerbEngine::setTiledRoomVoicing (float erSize, float onsetMs, float erDecayMs,
+                                          float burst2Ms, float sparseTailGain, float erGain)
+{
+    // Composite voicing: sparse ER front-end + the ER/tail mix. The 16-line
+    // AccurateHall tail is configured separately via the preset's octave-T60 map
+    // + decay/mod (frozen). erGain backs off the ER level for less-front-loaded
+    // rooms (Tiled Room = 1.0; Medium Drum Room < 1.0 to hit first50 44.8%).
+    setSparseFieldSize     (erSize);
+    setSparseFieldOnsetMs  (onsetMs);
+    setSparseFieldDecayMs  (erDecayMs);
+    setSparseFieldBurst2Ms (burst2Ms);
+    setSparseFieldTailGain (sparseTailGain);
+    setSparseERGain        (erGain);
 }
 
 void DuskVerbEngine::reapplyNeutralEngineConfig()
@@ -972,13 +988,18 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
                                      tankOutL_.data(), tankOutR_.data(), numSamples);
             break;
         case EngineType::SparseField:
-            // Sparse front-loaded early field (owns 0-~150ms) + reduced
-            // AccurateHall octave-GEQ tail (late body only). The tail runs the
-            // preset's full config; sparseTailGain_ pulls its level down so the
-            // sparse field dominates early while the tail supplies decay/body.
-            // The early field and tail are independent, sidestepping the FDN's
-            // inseparable early-wash/late-body. Summed here; SparseField makes
-            // its own early field, so it's excluded from the smooth-ER bus below.
+        case EngineType::TiledRoom:
+            // COMPOSITE: sparse tapped-delay ER front-end (owns the front-loaded
+            // first ~50 ms) + the mature 16-line AccurateHall octave-GEQ tail
+            // (dense -> no flutter; per-octave GEQ -> correct bright-early/dark-
+            // late). sparseTailGain_ sets the tail/ER balance. The two stages are
+            // independent, sidestepping the FDN's inseparable early-wash/late-body.
+            //   - SparseField (algo 11): hall-voiced ER.
+            //   - TiledRoom  (algo 13): tight-room ER + dark, frozen tail (the
+            //     4-line hand-rolled tail was a kill-test: it conquered the front-
+            //     load but a sparse tail flutters [osc P2P +39] + inverts the
+            //     spectrum [cent] -> 39 fails. The 16-line FDN tail fixes both).
+            // Both make their own early field -> excluded from the smooth-ER bus.
             accurateHall_.process (tankInL_.data(), tankInR_.data(),
                                    tankOutL_.data(), tankOutR_.data(), numSamples);
             sparseField_.process (tankInL_.data(), tankInR_.data(),
@@ -986,9 +1007,9 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
             for (int i = 0; i < numSamples; ++i)
             {
                 tankOutL_[static_cast<size_t> (i)] =
-                    tankOutL_[static_cast<size_t> (i)] * sparseTailGain_ + sparseOutL_[static_cast<size_t> (i)];
+                    tankOutL_[static_cast<size_t> (i)] * sparseTailGain_ + sparseOutL_[static_cast<size_t> (i)] * sparseERGain_;
                 tankOutR_[static_cast<size_t> (i)] =
-                    tankOutR_[static_cast<size_t> (i)] * sparseTailGain_ + sparseOutR_[static_cast<size_t> (i)];
+                    tankOutR_[static_cast<size_t> (i)] * sparseTailGain_ + sparseOutR_[static_cast<size_t> (i)] * sparseERGain_;
             }
             break;
     }
@@ -1016,7 +1037,8 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
     // shared ER bus on top would double-count the onset. Exclude both.
     const bool useSmoothER = (currentEngine_ != EngineType::DattorroVintage
                            && currentEngine_ != EngineType::ReverseRoom
-                           && currentEngine_ != EngineType::SparseField);
+                           && currentEngine_ != EngineType::SparseField
+                           && currentEngine_ != EngineType::TiledRoom);
     for (int i = 0; i < numSamples; ++i)
     {
         float erL   = useSmoothER ? erOutL_[static_cast<size_t> (i)] : 0.0f;

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -19,8 +19,10 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     dattorro_.prepare (sampleRate, maxBlockSize);
     sixAPTank_.prepare (sampleRate, maxBlockSize);
     quad_.prepare (sampleRate, maxBlockSize);
-    fdn_.prepare (sampleRate, maxBlockSize); accurateHall_.prepare (sampleRate, maxBlockSize);
+    fdn_.prepare (sampleRate, maxBlockSize); accurateHall_.prepare (sampleRate, maxBlockSize); accurateHall32_.prepare (sampleRate, maxBlockSize);
     sparseField_.prepare (sampleRate, maxBlockSize);
+    accurateHall32_.prepare (sampleRate, maxBlockSize);
+    outputDiffusion_.prepare (sampleRate, maxBlockSize);
     multibandFdn_.prepare (sampleRate, maxBlockSize);
     multibandFdn_.setCrossovers (300.0f, 5000.0f);
     spring_.prepare (sampleRate, maxBlockSize);
@@ -113,6 +115,8 @@ void DuskVerbEngine::clearAllBuffers()
     fdn_      .clearBuffers();
     accurateHall_.clearBuffers();   // FDNReverbT<true> — was missing here (setAlgorithm clears it, but that early-returns when the algo is unchanged → AccurateHall state could leak across same-algo preset swaps).
     sparseField_.clear();           // algo 11 early-field tap buffers
+    accurateHall32_.clearBuffers(); // algo 12 (32-line)
+    outputDiffusion_.clear();       // per-preset post-tank diffuser (BH)
     multibandFdn_.clearBuffers();
     spring_   .clearBuffers();
     nonLinear_.clearBuffers();
@@ -193,7 +197,7 @@ void DuskVerbEngine::setAlgorithm (int index)
     dattorro_.clearBuffers();
     sixAPTank_.clearBuffers();
     quad_.clearBuffers();
-    fdn_.clearBuffers(); accurateHall_.clearBuffers (); sparseField_.clear();
+    fdn_.clearBuffers(); accurateHall_.clearBuffers (); accurateHall32_.clearBuffers (); accurateHall32_.clearBuffers(); sparseField_.clear(); outputDiffusion_.clear();
     multibandFdn_.clearBuffers();
     spring_.clearBuffers();
     nonLinear_.clearBuffers();
@@ -211,7 +215,7 @@ void DuskVerbEngine::setFreeze (bool frozen)
     dattorro_.setFreeze (frozen);
     sixAPTank_.setFreeze (frozen);
     quad_.setFreeze (frozen);
-    fdn_.setFreeze (frozen); accurateHall_.setFreeze (frozen);
+    fdn_.setFreeze (frozen); accurateHall_.setFreeze (frozen); accurateHall32_.setFreeze (frozen);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setFreeze (frozen); });
     spring_.setFreeze (frozen);
     nonLinear_.setFreeze (frozen);
@@ -231,7 +235,7 @@ void DuskVerbEngine::setDecayTime (float seconds)
     dattorro_.setDecayTime (seconds);
     sixAPTank_.setDecayTime (seconds);
     quad_.setDecayTime (seconds);
-    fdn_.setDecayTime (seconds); accurateHall_.setDecayTime (seconds);
+    fdn_.setDecayTime (seconds); accurateHall_.setDecayTime (seconds); accurateHall32_.setDecayTime (seconds);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setDecayTime (seconds); });
     spring_.setDecayTime (seconds);
     nonLinear_.setDecayTime (seconds);
@@ -252,7 +256,7 @@ void DuskVerbEngine::pushSizeToTanks (float size)
     dattorro_.setSize (size);
     sixAPTank_.setSize (size);
     quad_.setSize (size);
-    fdn_.setSize (size); accurateHall_.setSize (size);
+    fdn_.setSize (size); accurateHall_.setSize (size); accurateHall32_.setSize (size);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSize (size); });
     spring_.setSize (size);
     nonLinear_.setSize (size);
@@ -267,7 +271,7 @@ void DuskVerbEngine::setBassMultiply (float mult)
     dattorro_.setBassMultiply (mult);
     sixAPTank_.setBassMultiply (mult);
     quad_.setBassMultiply (mult);
-    fdn_.setBassMultiply (mult); accurateHall_.setBassMultiply (mult);
+    fdn_.setBassMultiply (mult); accurateHall_.setBassMultiply (mult); accurateHall32_.setBassMultiply (mult);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setBassMultiply (mult); });
     spring_.setBassMultiply (mult);
     nonLinear_.setBassMultiply (mult);
@@ -282,7 +286,7 @@ void DuskVerbEngine::setMidMultiply (float mult)
     dattorro_.setMidMultiply (mult);
     sixAPTank_.setMidMultiply (mult);
     quad_.setMidMultiply (mult);
-    fdn_.setMidMultiply (mult); accurateHall_.setMidMultiply (mult);
+    fdn_.setMidMultiply (mult); accurateHall_.setMidMultiply (mult); accurateHall32_.setMidMultiply (mult);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setMidMultiply (mult); });
     spring_.setMidMultiply (mult);
     nonLinear_.setMidMultiply (mult);
@@ -297,7 +301,7 @@ void DuskVerbEngine::setTrebleMultiply (float mult)
     dattorro_.setTrebleMultiply (mult);
     sixAPTank_.setTrebleMultiply (mult);
     quad_.setTrebleMultiply (mult);
-    fdn_.setTrebleMultiply (mult); accurateHall_.setTrebleMultiply (mult);
+    fdn_.setTrebleMultiply (mult); accurateHall_.setTrebleMultiply (mult); accurateHall32_.setTrebleMultiply (mult);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setTrebleMultiply (mult); });
     spring_.setTrebleMultiply (mult);
     nonLinear_.setTrebleMultiply (mult);
@@ -314,7 +318,7 @@ void DuskVerbEngine::setAirTrebleMultiply (float mult)
     // reads. Without this, the APVTS damping knob is dead-code on the
     // FDN engine path because fdn_.setTrebleMultiply writes to a member
     // that is never consumed inside the per-line decay calc.
-    fdn_.setAirTrebleMultiply (mult); accurateHall_.setAirTrebleMultiply (mult);
+    fdn_.setAirTrebleMultiply (mult); accurateHall_.setAirTrebleMultiply (mult); accurateHall32_.setAirTrebleMultiply (mult);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setAirTrebleMultiply (mult); });
 }
 
@@ -322,28 +326,28 @@ void DuskVerbEngine::setAirTrebleMultiply (float mult)
 // Forward to BOTH the legacy single tank and the parallel-multiband tanks so
 // the multiband path (when mb_enable is on) receives identical voicing instead
 // of silently running these axes at their defaults.
-void DuskVerbEngine::setSubMultiply     (float mult) { fdn_.setSubMultiply (mult); accurateHall_.setSubMultiply (mult);      multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSubMultiply (mult); }); }
-void DuskVerbEngine::setHiMidMultiply   (float mult) { fdn_.setHiMidMultiply (mult); accurateHall_.setHiMidMultiply (mult);    multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setHiMidMultiply (mult); }); }
+void DuskVerbEngine::setSubMultiply     (float mult) { fdn_.setSubMultiply (mult); accurateHall_.setSubMultiply (mult); accurateHall32_.setSubMultiply (mult);      multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSubMultiply (mult); }); }
+void DuskVerbEngine::setHiMidMultiply   (float mult) { fdn_.setHiMidMultiply (mult); accurateHall_.setHiMidMultiply (mult); accurateHall32_.setHiMidMultiply (mult);    multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setHiMidMultiply (mult); }); }
 // QuadTank 5-band split (hi-mid 4-8k / air >8k). Separate from the FDN path:
 // QuadTank's transparency sentinel is -1, distinct from the FDN convention.
 void DuskVerbEngine::setQuadHiMidMultiply (float mult) { quad_.setHiMidMultiply (mult); }
 void DuskVerbEngine::setQuadAirMultiply   (float mult) { quad_.setAirMultiply (mult); }
-void DuskVerbEngine::setSubCrossoverFreq (float hz)  { fdn_.setSubCrossoverFreq (hz); accurateHall_.setSubCrossoverFreq (hz);   multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSubCrossoverFreq (hz); }); }
-void DuskVerbEngine::setAirCrossoverFreq (float hz)  { fdn_.setAirCrossoverFreq (hz); accurateHall_.setAirCrossoverFreq (hz);   multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setAirCrossoverFreq (hz); }); }
-void DuskVerbEngine::setShaperDepth     (float d)    { fdn_.setShaperDepth (d); accurateHall_.setShaperDepth (d);         multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperDepth (d); }); }
-void DuskVerbEngine::setShaperTimeMs    (float ms)   { fdn_.setShaperTimeMs (ms); accurateHall_.setShaperTimeMs (ms);       multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperTimeMs (ms); }); }
-void DuskVerbEngine::setShaperXoverHz   (float hz)   { fdn_.setShaperXoverHz (hz); accurateHall_.setShaperXoverHz (hz);      multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperXoverHz (hz); }); }
-void DuskVerbEngine::setShaperSens      (float s)    { fdn_.setShaperSens (s); accurateHall_.setShaperSens (s);          multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperSens (s); }); }
-void DuskVerbEngine::setInputSubGainDb  (float db)   { fdn_.setInputSubGainDb (db); accurateHall_.setInputSubGainDb (db);     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputSubGainDb (db); }); }
-void DuskVerbEngine::setInputMidGainDb  (float db)   { fdn_.setInputMidGainDb (db); accurateHall_.setInputMidGainDb (db);     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputMidGainDb (db); }); }
-void DuskVerbEngine::setInputHighGainDb (float db)   { fdn_.setInputHighGainDb (db); accurateHall_.setInputHighGainDb (db);    multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputHighGainDb (db); }); }
+void DuskVerbEngine::setSubCrossoverFreq (float hz)  { fdn_.setSubCrossoverFreq (hz); accurateHall_.setSubCrossoverFreq (hz); accurateHall32_.setSubCrossoverFreq (hz);   multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSubCrossoverFreq (hz); }); }
+void DuskVerbEngine::setAirCrossoverFreq (float hz)  { fdn_.setAirCrossoverFreq (hz); accurateHall_.setAirCrossoverFreq (hz); accurateHall32_.setAirCrossoverFreq (hz);   multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setAirCrossoverFreq (hz); }); }
+void DuskVerbEngine::setShaperDepth     (float d)    { fdn_.setShaperDepth (d); accurateHall_.setShaperDepth (d); accurateHall32_.setShaperDepth (d);         multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperDepth (d); }); }
+void DuskVerbEngine::setShaperTimeMs    (float ms)   { fdn_.setShaperTimeMs (ms); accurateHall_.setShaperTimeMs (ms); accurateHall32_.setShaperTimeMs (ms);       multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperTimeMs (ms); }); }
+void DuskVerbEngine::setShaperXoverHz   (float hz)   { fdn_.setShaperXoverHz (hz); accurateHall_.setShaperXoverHz (hz); accurateHall32_.setShaperXoverHz (hz);      multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperXoverHz (hz); }); }
+void DuskVerbEngine::setShaperSens      (float s)    { fdn_.setShaperSens (s); accurateHall_.setShaperSens (s); accurateHall32_.setShaperSens (s);          multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setShaperSens (s); }); }
+void DuskVerbEngine::setInputSubGainDb  (float db)   { fdn_.setInputSubGainDb (db); accurateHall_.setInputSubGainDb (db); accurateHall32_.setInputSubGainDb (db);     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputSubGainDb (db); }); }
+void DuskVerbEngine::setInputMidGainDb  (float db)   { fdn_.setInputMidGainDb (db); accurateHall_.setInputMidGainDb (db); accurateHall32_.setInputMidGainDb (db);     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputMidGainDb (db); }); }
+void DuskVerbEngine::setInputHighGainDb (float db)   { fdn_.setInputHighGainDb (db); accurateHall_.setInputHighGainDb (db); accurateHall32_.setInputHighGainDb (db);    multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInputHighGainDb (db); }); }
 
 void DuskVerbEngine::setCrossoverFreq (float hz)
 {
     dattorro_.setCrossoverFreq (hz);
     sixAPTank_.setCrossoverFreq (hz);
     quad_.setCrossoverFreq (hz);
-    fdn_.setCrossoverFreq (hz); accurateHall_.setCrossoverFreq (hz);
+    fdn_.setCrossoverFreq (hz); accurateHall_.setCrossoverFreq (hz); accurateHall32_.setCrossoverFreq (hz);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setCrossoverFreq (hz); });
     spring_.setCrossoverFreq (hz);
     nonLinear_.setCrossoverFreq (hz);
@@ -358,7 +362,7 @@ void DuskVerbEngine::setHighCrossoverFreq (float hz)
     dattorro_.setHighCrossoverFreq (hz);
     sixAPTank_.setHighCrossoverFreq (hz);
     quad_.setHighCrossoverFreq (hz);
-    fdn_.setHighCrossoverFreq (hz); accurateHall_.setHighCrossoverFreq (hz);
+    fdn_.setHighCrossoverFreq (hz); accurateHall_.setHighCrossoverFreq (hz); accurateHall32_.setHighCrossoverFreq (hz);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setHighCrossoverFreq (hz); });
     spring_.setHighCrossoverFreq (hz);
     nonLinear_.setHighCrossoverFreq (hz);
@@ -372,7 +376,7 @@ void DuskVerbEngine::setSaturation (float amount)
     dattorro_.setSaturation (amount);
     sixAPTank_.setSaturation (amount);
     quad_.setSaturation (amount);
-    fdn_.setSaturation (amount); accurateHall_.setSaturation (amount);
+    fdn_.setSaturation (amount); accurateHall_.setSaturation (amount); accurateHall32_.setSaturation (amount);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setSaturation (amount); });
     spring_.setSaturation (amount);
     nonLinear_.setSaturation (amount);
@@ -392,7 +396,7 @@ void DuskVerbEngine::setModDepth (float depth)
     dattorro_.setModDepth (depth);
     sixAPTank_.setModDepth (depth);
     quad_.setModDepth (depth);
-    fdn_.setModDepth (depth); accurateHall_.setModDepth (depth);
+    fdn_.setModDepth (depth); accurateHall_.setModDepth (depth); accurateHall32_.setModDepth (depth);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setModDepth (depth); });
     spring_.setModDepth (depth);
     nonLinear_.setModDepth (depth);
@@ -409,7 +413,7 @@ void DuskVerbEngine::setModulationTopology (DspUtils::ModulationTopology t)
     // Phase 2: only FDN + QuadTank have the coherent topology implemented
     // for now. Other engines silently ignore (they use their own bespoke
     // modulators — DPV's structured tank, Shimmer's pitch loop, etc.).
-    fdn_.setModulationTopology (t); accurateHall_.setModulationTopology (t);
+    fdn_.setModulationTopology (t); accurateHall_.setModulationTopology (t); accurateHall32_.setModulationTopology (t);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setModulationTopology (t); });
     quad_.setModulationTopology (t);
 }
@@ -419,7 +423,7 @@ void DuskVerbEngine::setPerLineDecayTilt (float shortLineScale, float longLineSc
     // Phase α: only FDN has the per-line decay-tilt path. QuadTank uses
     // 4 cross-coupled tanks (different topology), Dattorro is a single
     // structured tank — neither has a per-line rank to tilt against.
-    fdn_.setPerLineDecayTilt (shortLineScale, longLineScale); accurateHall_.setPerLineDecayTilt (shortLineScale, longLineScale);
+    fdn_.setPerLineDecayTilt (shortLineScale, longLineScale); accurateHall_.setPerLineDecayTilt (shortLineScale, longLineScale); accurateHall32_.setPerLineDecayTilt (shortLineScale, longLineScale);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setPerLineDecayTilt (shortLineScale, longLineScale); });
 }
 
@@ -427,7 +431,7 @@ void DuskVerbEngine::setAccurateHallOctaveT60 (int band, float seconds)
 {
     // AccurateHall only — the per-octave GEQ is compiled solely into
     // FDNReverbT<true> (accurateHall_). All other engines have no octave T60.
-    accurateHall_.setOctaveT60 (band, seconds);
+    accurateHall_.setOctaveT60 (band, seconds); accurateHall32_.setOctaveT60 (band, seconds);
 }
 
 // ── SparseField (algo 11) early-field generator + tail level ──────────────
@@ -439,13 +443,24 @@ void DuskVerbEngine::setSparseFieldDecayMs  (float ms)   { sparseField_.setDecay
 void DuskVerbEngine::setSparseFieldBurst2Ms (float ms)   { sparseField_.setBurst2Ms (ms); }
 void DuskVerbEngine::setSparseFieldTailGain (float gain) { sparseTailGain_ = std::clamp (gain, 0.0f, 1.0f); }
 
+void DuskVerbEngine::setOutputDiffusion (bool enable, float amount, float lfoScale, float delayScale)
+{
+    outDiffActive_ = enable;
+    if (enable)
+    {
+        outputDiffusion_.setDelayScale (delayScale);   // re-prepares stages
+        outputDiffusion_.setDiffusion (amount);
+        outputDiffusion_.setLfoDepthScale (lfoScale);
+    }
+}
+
 void DuskVerbEngine::setFDNBaseDelays (const int* delays)
 {
     // Phase β: per-preset FDN base-delay set. Only the FDN engine has a
     // 16-line tank; other engines ignore. Pass nullptr → preserve engine
     // default (kDefaultDelays — log-spaced primes 1151..6451 samples).
     if (delays == nullptr) return;
-    fdn_.setBaseDelays (delays); accurateHall_.setBaseDelays (delays);
+    fdn_.setBaseDelays (delays); accurateHall_.setBaseDelays (delays); accurateHall32_.setBaseDelays (delays);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setBaseDelays (delays); });
 }
 
@@ -471,7 +486,7 @@ void DuskVerbEngine::reapplyNeutralEngineConfig()
 void DuskVerbEngine::setFDNInLoopPeaking (float freqHz, float qFactor, float gainDb)
 {
     // Phase ε: only FDN has in-loop per-line peaking infrastructure.
-    fdn_.setInLoopPeaking (freqHz, qFactor, gainDb); accurateHall_.setInLoopPeaking (freqHz, qFactor, gainDb);
+    fdn_.setInLoopPeaking (freqHz, qFactor, gainDb); accurateHall_.setInLoopPeaking (freqHz, qFactor, gainDb); accurateHall32_.setInLoopPeaking (freqHz, qFactor, gainDb);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setInLoopPeaking (freqHz, qFactor, gainDb); });
 }
 
@@ -480,7 +495,7 @@ void DuskVerbEngine::setFDNTimeVaryingHiDamp (float earlyMult, float lateMult,
                                               float refLevel)
 {
     // Phase 3 (VH->0): FDN-only per-line energy-following hi-shelf.
-    fdn_.setTimeVaryingHiDamp (earlyMult, lateMult, crossoverHz, releaseSec, refLevel); accurateHall_.setTimeVaryingHiDamp (earlyMult, lateMult, crossoverHz, releaseSec, refLevel);
+    fdn_.setTimeVaryingHiDamp (earlyMult, lateMult, crossoverHz, releaseSec, refLevel); accurateHall_.setTimeVaryingHiDamp (earlyMult, lateMult, crossoverHz, releaseSec, refLevel); accurateHall32_.setTimeVaryingHiDamp (earlyMult, lateMult, crossoverHz, releaseSec, refLevel);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){
         tk.setTimeVaryingHiDamp (earlyMult, lateMult, crossoverHz, releaseSec, refLevel); });
 }
@@ -503,7 +518,7 @@ void DuskVerbEngine::setFDNDualBassShelf (float fastFc, float slowFc,
 {
     // Phase η: only FDN has the per-line dual-time-constant bass shelf
     // infrastructure.
-    fdn_.setDualBassShelf (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs); accurateHall_.setDualBassShelf (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs);
+    fdn_.setDualBassShelf (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs); accurateHall_.setDualBassShelf (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs); accurateHall32_.setDualBassShelf (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setDualBassShelf (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs); });
 }
 
@@ -512,7 +527,7 @@ void DuskVerbEngine::setModRate (float hz)
     dattorro_.setModRate (hz);
     sixAPTank_.setModRate (hz);
     quad_.setModRate (hz);
-    fdn_.setModRate (hz); accurateHall_.setModRate (hz);
+    fdn_.setModRate (hz); accurateHall_.setModRate (hz); accurateHall32_.setModRate (hz);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setModRate (hz); });
     spring_.setModRate (hz);
     nonLinear_.setModRate (hz);
@@ -527,14 +542,14 @@ void DuskVerbEngine::setModRate (float hz)
 // the other engines have no such stage.
 void DuskVerbEngine::setTailSpinDepth (float depth)
 {
-    fdn_.setTailSpinDepth (depth); accurateHall_.setTailSpinDepth (depth);
+    fdn_.setTailSpinDepth (depth); accurateHall_.setTailSpinDepth (depth); accurateHall32_.setTailSpinDepth (depth);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setTailSpinDepth (depth); });
     reverseRoom_.setTailSpinDepth (depth);
 }
 
 void DuskVerbEngine::setTailSpinRate (float hz)
 {
-    fdn_.setTailSpinRate (hz); accurateHall_.setTailSpinRate (hz);
+    fdn_.setTailSpinRate (hz); accurateHall_.setTailSpinRate (hz); accurateHall32_.setTailSpinRate (hz);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setTailSpinRate (hz); });
     reverseRoom_.setTailSpinRate (hz);
 }
@@ -553,7 +568,7 @@ void DuskVerbEngine::setDiffusion (float amount)
     dattorro_.setTankDiffusion    (amount);
     sixAPTank_.setTankDiffusion (amount);
     quad_.setTankDiffusion        (amount);
-    fdn_.setTankDiffusion         (amount); accurateHall_.setTankDiffusion (amount);
+    fdn_.setTankDiffusion         (amount); accurateHall_.setTankDiffusion (amount); accurateHall32_.setTankDiffusion (amount);
     multibandFdn_.forEachTank ([&](FDNReverb& tk){ tk.setTankDiffusion (amount); });
     spring_.setTankDiffusion      (amount);
     nonLinear_.setTankDiffusion   (amount);
@@ -950,6 +965,12 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
             accurateHall_.process (tankInL_.data(), tankInR_.data(),
                                    tankOutL_.data(), tankOutR_.data(), numSamples);
             break;
+        case EngineType::AccurateHall32:
+            // 32-line dense variant — same octave-GEQ tail, double the feedback
+            // lines + order-32 Hadamard for HF modal density (Bright Hall).
+            accurateHall32_.process (tankInL_.data(), tankInR_.data(),
+                                     tankOutL_.data(), tankOutR_.data(), numSamples);
+            break;
         case EngineType::SparseField:
             // Sparse front-loaded early field (owns 0-~150ms) + reduced
             // AccurateHall octave-GEQ tail (late body only). The tail runs the
@@ -971,6 +992,13 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
             }
             break;
     }
+
+    // ---- 4b) Per-preset post-tank OUTPUT diffusion (Bright Hall) ----
+    // Smears the FDN's sparse HF tail modes into a dense wash (metallic-ring
+    // fix). Post-tank, pre-mix. Skipped entirely when inactive → every other
+    // preset's signal path is unchanged (bit-null verified).
+    if (outDiffActive_)
+        outputDiffusion_.process (tankOutL_.data(), tankOutR_.data(), numSamples);
 
     // ---- 5) Sum + Shell ----
     // DattorroVintage runs its own discrete sparse-tap ER generator and

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -131,6 +131,7 @@ void DuskVerbEngine::clearAllBuffers()
     // into the new preset's tail when an idle engine is reused.
     diffuser_.clear();
     er_.clear();
+    tfLowStateL_ = tfLowStateR_ = tfHighStateL_ = tfHighStateR_ = 0.0f;
 
     std::fill (preDelayBufL_.begin(), preDelayBufL_.end(), 0.0f);
     std::fill (preDelayBufR_.begin(), preDelayBufR_.end(), 0.0f);
@@ -184,6 +185,14 @@ void DuskVerbEngine::copyInputHistoryFrom (const DuskVerbEngine& other)
     }
     er_.copySignalStateFrom (other.er_);
     diffuser_.copyStateFrom (other.diffuser_);
+    // Tank-feed shelf integrator state (post-diffuser, pre-tank). Coeffs/params
+    // are NOT copied — applyEngineConfig already set this engine's tank-feed
+    // config for the new preset; only the one-pole state needs continuity to
+    // avoid a transient pop when swapping into a tankFeedActive_ preset.
+    tfLowStateL_  = other.tfLowStateL_;
+    tfLowStateR_  = other.tfLowStateR_;
+    tfHighStateL_ = other.tfHighStateL_;
+    tfHighStateR_ = other.tfHighStateR_;
 }
 
 void DuskVerbEngine::setAlgorithm (int index)
@@ -497,6 +506,10 @@ void DuskVerbEngine::reapplyNeutralEngineConfig()
     setPerLineDecayTilt (1.0f, 1.0f);
     // FDN base delays → engine default log-spaced primes.
     resetFDNBaseDelays();
+    // Tank-feed EQ → neutral shelves (0 dB → branch skipped → bit-identical).
+    setTankFeedEQ (200.0f, 0.0f, 2500.0f, 0.0f);
+    // Dattorro density-AP jitter → engine default (0.02).
+    setDattorroDensityJitter (0.02f);
 }
 
 void DuskVerbEngine::setFDNInLoopPeaking (float freqHz, float qFactor, float gainDb)
@@ -665,6 +678,25 @@ void DuskVerbEngine::setHiCut (float hz)
 void DuskVerbEngine::setPostTankEQBand (int index, float freqHz, float qFactor, float gainDb)
 {
     postTankEQ_.setBand (index, freqHz, qFactor, gainDb);
+}
+
+void DuskVerbEngine::setDattorroDensityJitter (float fraction)
+{
+    dattorro_.setDensityJitter (fraction);
+}
+
+void DuskVerbEngine::setTankFeedEQ (float lowFc, float lowGainDb, float highFc, float highGainDb)
+{
+    tankFeedLowFc_    = std::clamp (lowFc,  20.0f, 2000.0f);
+    tankFeedHighFc_   = std::clamp (highFc, 500.0f, 16000.0f);
+    tankFeedLowGain_  = std::pow (10.0f, std::clamp (lowGainDb,  -24.0f, 6.0f) / 20.0f);
+    tankFeedHighGain_ = std::pow (10.0f, std::clamp (highGainDb, -24.0f, 6.0f) / 20.0f);
+    const float sr = static_cast<float> (sampleRate_);
+    tankFeedLowCoeff_  = std::exp (-2.0f * 3.14159265f * tankFeedLowFc_  / sr);
+    tankFeedHighCoeff_ = std::exp (-2.0f * 3.14159265f * tankFeedHighFc_ / sr);
+    tankFeedActive_ = std::abs (lowGainDb) > 0.01f || std::abs (highGainDb) > 0.01f;
+    if (! tankFeedActive_)
+        tfLowStateL_ = tfLowStateR_ = tfHighStateL_ = tfHighStateR_ = 0.0f;
 }
 
 void DuskVerbEngine::setERBusShelves (float lowGainDb, float highGainDb)
@@ -909,6 +941,34 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
         && currentEngine_ != EngineType::DattorroVintage
         && currentEngine_ != EngineType::ReverseRoom)
         diffuser_.process (tankInL_.data(), tankInR_.data(), numSamples);
+
+    // ---- 3b) Tank-feed EQ (Progenitor inputdamp) ----
+    // Tilts ONLY the tank feed (the ER branch tapped the signal at step 2).
+    // Feed-forward: loop poles / per-band T60 untouched; the recirculating
+    // field is darker from its first pass. Skipped at 0 dB → bit-identical.
+    if (tankFeedActive_)
+    {
+        const float gL = tankFeedLowGain_  - 1.0f;   // shelf deltas
+        const float gH = tankFeedHighGain_ - 1.0f;
+        const float cL = tankFeedLowCoeff_, cH = tankFeedHighCoeff_;
+        for (int i = 0; i < numSamples; ++i)
+        {
+            float xl = tankInL_[static_cast<size_t> (i)];
+            float xr = tankInR_[static_cast<size_t> (i)];
+            // Low shelf: y = x + (g-1)·LP(x)
+            tfLowStateL_ = (1.0f - cL) * xl + cL * tfLowStateL_;
+            tfLowStateR_ = (1.0f - cL) * xr + cL * tfLowStateR_;
+            xl += gL * tfLowStateL_;
+            xr += gL * tfLowStateR_;
+            // High shelf: y = x + (g-1)·(x - LP(x))
+            tfHighStateL_ = (1.0f - cH) * xl + cH * tfHighStateL_;
+            tfHighStateR_ = (1.0f - cH) * xr + cH * tfHighStateR_;
+            xl += gH * (xl - tfHighStateL_);
+            xr += gH * (xr - tfHighStateR_);
+            tankInL_[static_cast<size_t> (i)] = xl;
+            tankInR_[static_cast<size_t> (i)] = xr;
+        }
+    }
 
     // ---- 4) Selected late tank ----
     switch (currentEngine_)

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -20,6 +20,7 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     sixAPTank_.prepare (sampleRate, maxBlockSize);
     quad_.prepare (sampleRate, maxBlockSize);
     fdn_.prepare (sampleRate, maxBlockSize); accurateHall_.prepare (sampleRate, maxBlockSize);
+    sparseField_.prepare (sampleRate, maxBlockSize);
     multibandFdn_.prepare (sampleRate, maxBlockSize);
     multibandFdn_.setCrossovers (300.0f, 5000.0f);
     spring_.prepare (sampleRate, maxBlockSize);
@@ -48,6 +49,8 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     tankOutR_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
     erOutL_.assign   (static_cast<size_t> (maxBlockSize), 0.0f);
     erOutR_.assign   (static_cast<size_t> (maxBlockSize), 0.0f);
+    sparseOutL_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
+    sparseOutR_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
 
     // Per-sample smoothers — short time constants, advance once per sample.
     constexpr float kPerSampleSmoothMs = 2.0f;
@@ -109,6 +112,7 @@ void DuskVerbEngine::clearAllBuffers()
     quad_     .clearBuffers();
     fdn_      .clearBuffers();
     accurateHall_.clearBuffers();   // FDNReverbT<true> — was missing here (setAlgorithm clears it, but that early-returns when the algo is unchanged → AccurateHall state could leak across same-algo preset swaps).
+    sparseField_.clear();           // algo 11 early-field tap buffers
     multibandFdn_.clearBuffers();
     spring_   .clearBuffers();
     nonLinear_.clearBuffers();
@@ -189,7 +193,7 @@ void DuskVerbEngine::setAlgorithm (int index)
     dattorro_.clearBuffers();
     sixAPTank_.clearBuffers();
     quad_.clearBuffers();
-    fdn_.clearBuffers(); accurateHall_.clearBuffers ();
+    fdn_.clearBuffers(); accurateHall_.clearBuffers (); sparseField_.clear();
     multibandFdn_.clearBuffers();
     spring_.clearBuffers();
     nonLinear_.clearBuffers();
@@ -425,6 +429,15 @@ void DuskVerbEngine::setAccurateHallOctaveT60 (int band, float seconds)
     // FDNReverbT<true> (accurateHall_). All other engines have no octave T60.
     accurateHall_.setOctaveT60 (band, seconds);
 }
+
+// ── SparseField (algo 11) early-field generator + tail level ──────────────
+// buildTaps() runs inside these setters (message thread, preset-apply); the
+// audio-thread process() stays allocation-free.
+void DuskVerbEngine::setSparseFieldSize     (float s)    { sparseField_.setSizeScale (s); }
+void DuskVerbEngine::setSparseFieldOnsetMs  (float ms)   { sparseField_.setOnsetPeakMs (ms); }
+void DuskVerbEngine::setSparseFieldDecayMs  (float ms)   { sparseField_.setDecayMs (ms); }
+void DuskVerbEngine::setSparseFieldBurst2Ms (float ms)   { sparseField_.setBurst2Ms (ms); }
+void DuskVerbEngine::setSparseFieldTailGain (float gain) { sparseTailGain_ = std::clamp (gain, 0.0f, 1.0f); }
 
 void DuskVerbEngine::setFDNBaseDelays (const int* delays)
 {
@@ -937,6 +950,26 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
             accurateHall_.process (tankInL_.data(), tankInR_.data(),
                                    tankOutL_.data(), tankOutR_.data(), numSamples);
             break;
+        case EngineType::SparseField:
+            // Sparse front-loaded early field (owns 0-~150ms) + reduced
+            // AccurateHall octave-GEQ tail (late body only). The tail runs the
+            // preset's full config; sparseTailGain_ pulls its level down so the
+            // sparse field dominates early while the tail supplies decay/body.
+            // The early field and tail are independent, sidestepping the FDN's
+            // inseparable early-wash/late-body. Summed here; SparseField makes
+            // its own early field, so it's excluded from the smooth-ER bus below.
+            accurateHall_.process (tankInL_.data(), tankInR_.data(),
+                                   tankOutL_.data(), tankOutR_.data(), numSamples);
+            sparseField_.process (tankInL_.data(), tankInR_.data(),
+                                  sparseOutL_.data(), sparseOutR_.data(), numSamples);
+            for (int i = 0; i < numSamples; ++i)
+            {
+                tankOutL_[static_cast<size_t> (i)] =
+                    tankOutL_[static_cast<size_t> (i)] * sparseTailGain_ + sparseOutL_[static_cast<size_t> (i)];
+                tankOutR_[static_cast<size_t> (i)] =
+                    tankOutR_[static_cast<size_t> (i)] * sparseTailGain_ + sparseOutR_[static_cast<size_t> (i)];
+            }
+            break;
     }
 
     // ---- 5) Sum + Shell ----
@@ -954,7 +987,8 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
     // reflections (ReverseRoom's rising-onset FIR IS its ER), so adding the
     // shared ER bus on top would double-count the onset. Exclude both.
     const bool useSmoothER = (currentEngine_ != EngineType::DattorroVintage
-                           && currentEngine_ != EngineType::ReverseRoom);
+                           && currentEngine_ != EngineType::ReverseRoom
+                           && currentEngine_ != EngineType::SparseField);
     for (int i = 0; i < numSamples; ++i)
     {
         float erL   = useSmoothER ? erOutL_[static_cast<size_t> (i)] : 0.0f;

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -258,6 +258,7 @@ public:
     void setSparseFieldDecayMs    (float ms);
     void setSparseFieldBurst2Ms   (float ms);
     void setSparseFieldTailGain   (float gain);
+    void setSparseERGain          (float gain);   // algo 13 composite: ER level in the mix
 
     // Per-preset post-tank output diffusion (Bright Hall metallic-ring fix).
     // enable=false → bypassed (bit-null on every other preset). amount maps to
@@ -275,6 +276,14 @@ public:
     // previous preset's custom delays (setFDNBaseDelays(nullptr) only PRESERVES,
     // it does not reset).
     void resetFDNBaseDelays();
+
+    // TiledRoom (algo 13) COMPOSITE voicing — configures the sparse ER front-end
+    // + the ER/tail mix (the 16-line AccurateHall tail is configured via the
+    // preset octave-T60 map + decay/mod). Used by the DUSKVERB_TILEDROOM env
+    // override (tuning sweep) and the per-preset bake. Params:
+    // erSize, onsetMs, erDecayMs, burst2Ms, sparseTailGain, (spare).
+    void setTiledRoomVoicing (float erSize, float onsetMs, float erDecayMs,
+                              float burst2Ms, float sparseTailGain, float spare);
 
     // Reset the name-keyed engine config (PostTankEQ bands, modulation topology,
     // per-line decay tilt, FDN base delays) — the parts NOT carried by APVTS /
@@ -372,6 +381,10 @@ private:
     FDNReverbT<true>   accurateHall_;    // algo 10 (2026-06-09): FDN + per-octave GEQ in the feedback loop (Jot/Schlecht accurate-RT). P2: templated FDNReverbT<true>; GEQ scaffold inert (flat) → still renders identical to FDN. P3 fills the per-octave GEQ.
     SparseEarlyField   sparseField_;     // algo 11 (2026-06-10): velvet-noise front-loaded sparse early field. Summed with a reduced accurateHall_ tail in the SparseField process() case.
     FDNReverbT<true, 32> accurateHall32_; // algo 12 (2026-06-10): 32-line AccurateHall (double lines + order-32 Hadamard) for HF modal density — Bright Hall metallic-ring fix. Gets every accurateHall_ setter forwarded alongside.
+    // algo 13 (TiledRoom) is a COMPOSITE in the process() switch: sparseField_ ER
+    // + accurateHall_ 16-line tail (shared with SparseField). No dedicated member
+    // — the standalone 4-line TiledRoomEngine was a kill-test (flutter+spectral),
+    // superseded by this composite. setTiledRoomVoicing() configures sparseField_.
 
     // Pre-tank input diffuser, applied to every engine. Smears transients
     // before they hit the tank so onsets bloom into the tail rather than
@@ -405,6 +418,10 @@ private:
     // algo 11 SparseField: level of the reduced accurateHall_ tail under the
     // sparse early field (1.0 = full tail). Per-preset via kSparseFieldByName.
     float sparseTailGain_ = 0.45f;
+    // algo 13 composite: ER front-end level in the mix (1.0 = full ER). Lets a
+    // less-front-loaded room (Medium Drum Room, anchor first50 44.8%) back off the
+    // ER so it doesn't overshoot. Default 1.0 = Tiled Room behaviour (bit-exact).
+    float sparseERGain_ = 1.0f;
 
     // Per-sample smoothed shell parameters (consumed inside the per-sample loop).
     // mixSmoother lives on the processor (so the dry signal stays correlated

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -15,6 +15,7 @@
 #include "VintageTankEngine.h"
 #include "ReverseRoomEngine.h"
 #include "SparseEarlyField.h"
+#include "OutputDiffusion.h"
 
 #include <algorithm>
 #include <cmath>
@@ -258,6 +259,12 @@ public:
     void setSparseFieldBurst2Ms   (float ms);
     void setSparseFieldTailGain   (float gain);
 
+    // Per-preset post-tank output diffusion (Bright Hall metallic-ring fix).
+    // enable=false → bypassed (bit-null on every other preset). amount maps to
+    // the allpass coefficient, lfoScale tames the built-in wobble, delayScale
+    // spreads the allpass delays for denser HF smearing.
+    void setOutputDiffusion (bool enable, float amount, float lfoScale, float delayScale);
+
     // Phase β (2026-05-29): per-preset FDN base delays. Lets each preset
     // choose a 16-int delay-line set tuned to match a specific anchor's
     // per-band modal-beat pattern (Hilbert-FFT envelope peak frequency).
@@ -364,12 +371,20 @@ private:
     ReverseRoomEngine  reverseRoom_;     // algo 9 (2026-05-31): causal rising-ER onset + dark FDN tail; replicates Lexicon PCM Room "Reverse 1".
     FDNReverbT<true>   accurateHall_;    // algo 10 (2026-06-09): FDN + per-octave GEQ in the feedback loop (Jot/Schlecht accurate-RT). P2: templated FDNReverbT<true>; GEQ scaffold inert (flat) → still renders identical to FDN. P3 fills the per-octave GEQ.
     SparseEarlyField   sparseField_;     // algo 11 (2026-06-10): velvet-noise front-loaded sparse early field. Summed with a reduced accurateHall_ tail in the SparseField process() case.
+    FDNReverbT<true, 32> accurateHall32_; // algo 12 (2026-06-10): 32-line AccurateHall (double lines + order-32 Hadamard) for HF modal density — Bright Hall metallic-ring fix. Gets every accurateHall_ setter forwarded alongside.
 
     // Pre-tank input diffuser, applied to every engine. Smears transients
     // before they hit the tank so onsets bloom into the tail rather than
     // arriving as discrete clicks.
     DiffusionStage diffuser_;
     EarlyReflections er_;
+
+    // Post-tank OUTPUT diffuser — per-preset (Bright Hall). Smears the FDN's
+    // sparse HF tail modes into a dense wash (kills the metallic ring). OFF by
+    // default: when outDiffActive_ is false the process() call is skipped
+    // entirely → every other preset is bit-null. Set via setOutputDiffusion().
+    OutputDiffusion outputDiffusion_;
+    bool outDiffActive_ = false;
 
     EngineType currentEngine_ = EngineType::Dattorro;
     int currentAlgorithm_ = 0;

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -14,6 +14,7 @@
 #include "SpringEngine.h"
 #include "VintageTankEngine.h"
 #include "ReverseRoomEngine.h"
+#include "SparseEarlyField.h"
 
 #include <algorithm>
 #include <cmath>
@@ -249,6 +250,14 @@ public:
     // that octave inherits the broadband Decay Time.
     void setAccurateHallOctaveT60 (int band, float seconds);
 
+    // SparseField (algo 11) only: the velvet-noise early-field generator dials
+    // + the reduced-tail level. No-op routing on every other engine.
+    void setSparseFieldSize       (float sizeScale);
+    void setSparseFieldOnsetMs    (float ms);
+    void setSparseFieldDecayMs    (float ms);
+    void setSparseFieldBurst2Ms   (float ms);
+    void setSparseFieldTailGain   (float gain);
+
     // Phase β (2026-05-29): per-preset FDN base delays. Lets each preset
     // choose a 16-int delay-line set tuned to match a specific anchor's
     // per-band modal-beat pattern (Hilbert-FFT envelope peak frequency).
@@ -354,6 +363,7 @@ private:
     DspUtils::VintageTankEngine vintageTank_;  // algo 8 (2026-05-29): Griesinger/Lexicon figure-8 modulated AP loop. Built from first principles, replaces the FDN's unitary Hadamard scatter with a recirculating tank that builds modal density over time.
     ReverseRoomEngine  reverseRoom_;     // algo 9 (2026-05-31): causal rising-ER onset + dark FDN tail; replicates Lexicon PCM Room "Reverse 1".
     FDNReverbT<true>   accurateHall_;    // algo 10 (2026-06-09): FDN + per-octave GEQ in the feedback loop (Jot/Schlecht accurate-RT). P2: templated FDNReverbT<true>; GEQ scaffold inert (flat) → still renders identical to FDN. P3 fills the per-octave GEQ.
+    SparseEarlyField   sparseField_;     // algo 11 (2026-06-10): velvet-noise front-loaded sparse early field. Summed with a reduced accurateHall_ tail in the SparseField process() case.
 
     // Pre-tank input diffuser, applied to every engine. Smears transients
     // before they hit the tank so onsets bloom into the tail rather than
@@ -375,6 +385,11 @@ private:
     std::vector<float> tankInL_, tankInR_;
     std::vector<float> tankOutL_, tankOutR_;
     std::vector<float> erOutL_, erOutR_;
+    std::vector<float> sparseOutL_, sparseOutR_;   // algo 11: sparse early-field scratch
+
+    // algo 11 SparseField: level of the reduced accurateHall_ tail under the
+    // sparse early field (1.0 = full tail). Per-preset via kSparseFieldByName.
+    float sparseTailGain_ = 0.45f;
 
     // Per-sample smoothed shell parameters (consumed inside the per-sample loop).
     // mixSmoother lives on the processor (so the dry signal stays correlated

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -564,4 +564,5 @@ private:
 
     void updateLoCutCoeffs (float hz);
     void updateHiCutCoeffs (float hz);
+    void recomputeTankFeedCoeffs();   // tank-feed shelf coeffs from stored Fc at sampleRate_
 };

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -174,6 +174,24 @@ public:
     // call this leave the EQ stage transparent.
     void setPostTankEQBand (int index, float freqHz, float qFactor, float gainDb);
 
+    // Tank-feed EQ (Progenitor-style 'inputdamp', 2026-06-11). First-order
+    // low + high shelves applied to the TANK FEED (post-diffuser, pre-tank),
+    // NOT the wet sum — the parallel ER branch taps the signal earlier and
+    // stays bright. Feed-forward into the loop: the loop poles (per-band T60)
+    // are untouched; only the recirculating field's spectrum is tilted. This
+    // is the decoupled lever for the bright-attack -> dark-tail temporal
+    // signature (anchor cent 2214 -> 1346 Hz over 50 -> 500 ms) that in-loop
+    // damping (pole-coupled) and post-sum trims (time-uniform) both failed
+    // to express. 0 dB gains -> branch skipped -> bit-identical.
+    void setTankFeedEQ (float lowFc, float lowGainDb, float highFc, float highGainDb);
+
+    // Dattorro density-AP wander depth (see DattorroTank::setDensityJitter).
+    // The in-loop time-varying wander FM-scatters tail energy broadband each
+    // pass — the source of the late-window HF plateau + pitch-chorus on dark
+    // rooms. 0.02 (engine default) = bit-identical; forwarded to the Dattorro
+    // tank only.
+    void setDattorroDensityJitter (float fraction);
+
     // ER-bus spectral correction (2026-06-08, energy-arrival campaign). The
     // parallel ER field is a 500 Hz-2 kHz midrange bump (measured: −11.5 dB @
     // 250-500, −9 @ sub, −16 @ 8-16k relative to its 500-1k peak). Boosting it
@@ -390,6 +408,16 @@ private:
     // before they hit the tank so onsets bloom into the tail rather than
     // arriving as discrete clicks.
     DiffusionStage diffuser_;
+
+    // Tank-feed EQ state (Progenitor inputdamp). One-pole LP cores; shelves
+    // realized as y = x + (g-1)*LP(x) (low) and y = x + (g-1)*(x - LP(x))
+    // (high) — exact unity bypass at g=1. Stereo state per shelf.
+    bool  tankFeedActive_   = false;
+    float tankFeedLowFc_    = 200.0f,  tankFeedLowGain_  = 1.0f;   // linear g
+    float tankFeedHighFc_   = 2500.0f, tankFeedHighGain_ = 1.0f;
+    float tankFeedLowCoeff_ = 0.0f,    tankFeedHighCoeff_ = 0.0f;  // LP coeffs
+    float tfLowStateL_ = 0.0f, tfLowStateR_ = 0.0f;
+    float tfHighStateL_ = 0.0f, tfHighStateR_ = 0.0f;
     EarlyReflections er_;
 
     // Post-tank OUTPUT diffuser — per-preset (Bright Hall). Smears the FDN's

--- a/plugins/DuskVerb/src/dsp/FDNReverb.cpp
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.cpp
@@ -82,6 +82,44 @@ void hadamardInPlace8 (float* data)
     }
 }
 
+// In-place fast Walsh-Hadamard transform for N=32 (Sylvester order-32 = the
+// 16x16 butterfly + one more stage; lossless/orthonormal). Drives the dense
+// 32-line AccurateHall32 path. Same structure as hadamardInPlace16 with
+// kLog2N=5 and 1/sqrt(32) normalization folded into the last stage.
+void hadamardInPlace32 (float* data)
+{
+    constexpr int n = 32;
+    constexpr int kLog2N = 5;
+
+    for (int stage = 0; stage < kLog2N - 1; ++stage)
+    {
+        int len = 1 << stage;
+        for (int i = 0; i < n; i += 2 * len)
+        {
+            for (int j = 0; j < len; ++j)
+            {
+                float a = data[i + j];
+                float b = data[i + j + len];
+                data[i + j]       = a + b;
+                data[i + j + len] = a - b;
+            }
+        }
+    }
+
+    constexpr float kNorm = 0.176776695f; // 1/sqrt(32)
+    constexpr int lastLen = 1 << (kLog2N - 1); // 16
+    for (int i = 0; i < n; i += 2 * lastLen)
+    {
+        for (int j = 0; j < lastLen; ++j)
+        {
+            float a = data[i + j];
+            float b = data[i + j + lastLen];
+            data[i + j]            = (a + b) * kNorm;
+            data[i + j + lastLen]  = (a - b) * kNorm;
+        }
+    }
+}
+
 // In-place Householder reflection H = I - 2·v·vᵀ with a per-instance,
 // randomized unit vector v. Replaces the degenerate v = 1/√N form, which had
 // eigenvalue −1 only along the all-ones axis — output[i] = input[i] − 2·mean,
@@ -114,9 +152,15 @@ inline void householderInPlace8 (float* data, const float* v)
 // spaced primes spanning ~2.49 octaves (6451/1151 = 5.605). All primes →
 // mutually coprime → no shared modal alignment. Fits inside kMaxBaseDelay.
 namespace {
-    constexpr int   kDefaultDelays[16] = {
+    // [32]: first 16 = the original log-spaced primes (16-line engines read an
+    // identical first half → bit-null). Lines 16-31 INTERLEAVE 16 more coprime
+    // primes between the originals, doubling the modal density (the 32-line
+    // AccurateHall32 path — Bright Hall metallic-ring fix). All < kMaxBaseDelay.
+    constexpr int   kDefaultDelays[32] = {
         1151, 1289, 1447, 1619, 1823, 2039, 2287, 2579,
-        2887, 3229, 3631, 4073, 4567, 5119, 5749, 6451
+        2887, 3229, 3631, 4073, 4567, 5119, 5749, 6451,
+        1213, 1361, 1531, 1721, 1933, 2153, 2417, 2713,
+        3041, 3413, 3833, 4297, 4817, 5417, 6079, 6469
     };
     constexpr int   kDefaultLeftTaps[8]  = { 0, 3, 5, 7, 8, 10, 12, 15 };
     constexpr int   kDefaultRightTaps[8] = { 1, 2, 4, 6, 9, 11, 13, 14 };
@@ -124,8 +168,8 @@ namespace {
     constexpr float kDefaultRightSigns[8] = { -1, 1, -1, 1, -1, 1, -1, 1 };
 }
 
-template <bool WithOctaveGEQ>
-FDNReverbT<WithOctaveGEQ>::FDNReverbT()
+template <bool WithOctaveGEQ, int N>
+FDNReverbT<WithOctaveGEQ, N>::FDNReverbT()
 {
     std::memcpy (baseDelays_,   kDefaultDelays,    sizeof (baseDelays_));
     std::memcpy (leftTapsIn_,   kDefaultLeftTaps,  sizeof (leftTapsIn_));
@@ -152,8 +196,8 @@ FDNReverbT<WithOctaveGEQ>::FDNReverbT()
     seedHouseholderVectors (seed);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::seedHouseholderVectors (uint32_t seed)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::seedHouseholderVectors (uint32_t seed)
 {
     auto next01 = [&seed]() {
         seed ^= seed << 13; seed ^= seed >> 17; seed ^= seed << 5;
@@ -172,8 +216,8 @@ void FDNReverbT<WithOctaveGEQ>::seedHouseholderVectors (uint32_t seed)
 }
 
 // ---------------------------------------------------------------------------
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::publishPending()
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::publishPending()
 {
     // Pointer swap is the atomic publish. Slot pointer is the only thing the
     // RT thread ever loads — biquad coefficients, perturb matrix, multi-tap
@@ -188,8 +232,8 @@ void FDNReverbT<WithOctaveGEQ>::publishPending()
 }
 
 // ---------------------------------------------------------------------------
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::prepare (double sampleRate, int /*maxBlockSize*/)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::prepare (double sampleRate, int /*maxBlockSize*/)
 {
     sampleRate_ = sampleRate;
 
@@ -393,8 +437,8 @@ void FDNReverbT<WithOctaveGEQ>::prepare (double sampleRate, int /*maxBlockSize*/
 }
 
 // ---------------------------------------------------------------------------
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::process (const float* inputL, const float* inputR,
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::process (const float* inputL, const float* inputR,
                          float* outputL, float* outputR, int numSamples)
 {
     if (! prepared_)
@@ -637,7 +681,14 @@ void FDNReverbT<WithOctaveGEQ>::process (const float* inputL, const float* input
         else
         {
             std::memcpy (feedback, delayOut, sizeof (feedback));
-            hadamardInPlace16 (feedback);
+            // N-select the full Walsh-Hadamard mix. if constexpr keeps the
+            // N==16 path calling the UNCHANGED hadamardInPlace16 (byte-identical
+            // → fleet bit-null); the 32-line AccurateHall32 path uses the
+            // order-32 transform.
+            if constexpr (N == 32)
+                hadamardInPlace32 (feedback);
+            else
+                hadamardInPlace16 (feedback);
         }
 
         // --- 3) Three-band damping + input injection -> write to delay lines ---
@@ -841,8 +892,8 @@ void FDNReverbT<WithOctaveGEQ>::process (const float* inputL, const float* input
 // ===========================================================================
 // Setters — write raw → compute into pending() → publish.
 // ===========================================================================
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setDecayTime (float seconds)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setDecayTime (float seconds)
 {
     decayTime_ = std::clamp (seconds, 0.2f, 600.0f);
     if (! prepared_) return;
@@ -850,8 +901,8 @@ void FDNReverbT<WithOctaveGEQ>::setDecayTime (float seconds)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setBassMultiply (float mult)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setBassMultiply (float mult)
 {
     bassMultiply_ = std::clamp (mult, 0.5f, 2.5f);
     if (! prepared_) return;
@@ -859,8 +910,8 @@ void FDNReverbT<WithOctaveGEQ>::setBassMultiply (float mult)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setMidMultiply (float mult)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setMidMultiply (float mult)
 {
     midMultiply_ = std::clamp (mult, 0.1f, 4.0f);
     if (! prepared_) return;
@@ -868,16 +919,16 @@ void FDNReverbT<WithOctaveGEQ>::setMidMultiply (float mult)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setSaturation (float amount)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setSaturation (float amount)
 {
     pending().saturationAmount = std::clamp (amount, 0.0f, 1.0f);
     if (! prepared_) return;
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setTrebleMultiply (float mult)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setTrebleMultiply (float mult)
 {
     trebleMultiply_ = std::clamp (mult, 0.1f, 1.5f);
     if (! prepared_) return;
@@ -885,8 +936,8 @@ void FDNReverbT<WithOctaveGEQ>::setTrebleMultiply (float mult)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setSubMultiply (float mult)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setSubMultiply (float mult)
 {
     subMultiply_ = std::clamp (mult, 0.1f, 2.5f);
     if (! prepared_) return;
@@ -894,8 +945,8 @@ void FDNReverbT<WithOctaveGEQ>::setSubMultiply (float mult)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setHiMidMultiply (float mult)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setHiMidMultiply (float mult)
 {
     hiMidMultiply_ = std::clamp (mult, 0.1f, 2.5f);
     if (! prepared_) return;
@@ -903,8 +954,8 @@ void FDNReverbT<WithOctaveGEQ>::setHiMidMultiply (float mult)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setSubCrossoverFreq (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setSubCrossoverFreq (float hz)
 {
     subCrossoverFreq_ = std::clamp (hz, 20.0f, 400.0f);
     if (! prepared_) return;
@@ -912,8 +963,8 @@ void FDNReverbT<WithOctaveGEQ>::setSubCrossoverFreq (float hz)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setAirCrossoverFreq (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setAirCrossoverFreq (float hz)
 {
     airCrossoverFreq_ = std::clamp (hz, 2000.0f, 20000.0f);
     if (! prepared_) return;
@@ -925,8 +976,8 @@ void FDNReverbT<WithOctaveGEQ>::setAirCrossoverFreq (float hz)
 // Plain members (like feedbackModDepth_): written on the message thread, read
 // on the audio thread; aligned float load/store is atomic on the target. The
 // block is gated by shaperActive_ so depth 0 (default) never executes → bypass.
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::updateShaperCoeffs()
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::updateShaperCoeffs()
 {
     const float sr = static_cast<float> (sampleRate_);
     const float fc = std::clamp (shaperXoverHz_, 20.0f, 0.49f * sr);
@@ -941,29 +992,29 @@ void FDNReverbT<WithOctaveGEQ>::updateShaperCoeffs()
     shaperRelS_ = onePole (400.0f);            // slow env release (400 ms)
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setShaperDepth (float depth)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setShaperDepth (float depth)
 {
     shaperDepth_  = std::clamp (depth, 0.0f, 1.0f);
     shaperActive_ = shaperDepth_ > 1.0e-6f;
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setShaperTimeMs (float ms)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setShaperTimeMs (float ms)
 {
     shaperTimeMs_ = std::clamp (ms, 20.0f, 300.0f);
     if (prepared_) updateShaperCoeffs();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setShaperXoverHz (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setShaperXoverHz (float hz)
 {
     shaperXoverHz_ = std::clamp (hz, 120.0f, 500.0f);
     if (prepared_) updateShaperCoeffs();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setShaperSens (float sens)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setShaperSens (float sens)
 {
     shaperSens_ = std::clamp (sens, 0.5f, 4.0f);
 }
@@ -972,8 +1023,8 @@ void FDNReverbT<WithOctaveGEQ>::setShaperSens (float sens)
 // Static shelves on the dry input, applied before the delay-line write (scales
 // the input vector B). Outside the feedback loop → ρ(A) untouched → BIBO-safe.
 // Both gains 0 dB → inputMakeupActive_ false → block skipped → bit-exact bypass.
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setInputSubGainDb (float db)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setInputSubGainDb (float db)
 {
     inputSubGainDb_    = std::clamp (db, -6.0f, 6.0f);
     inputMakeupActive_ = std::fabs (inputSubGainDb_)  > 1.0e-4f
@@ -986,8 +1037,8 @@ void FDNReverbT<WithOctaveGEQ>::setInputSubGainDb (float db)
     inputSubR_.designLowShelf (g, 120.0f, sr);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setInputMidGainDb (float db)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setInputMidGainDb (float db)
 {
     inputMidGainDb_    = std::clamp (db, -6.0f, 6.0f);
     inputMakeupActive_ = std::fabs (inputSubGainDb_)  > 1.0e-4f
@@ -1001,8 +1052,8 @@ void FDNReverbT<WithOctaveGEQ>::setInputMidGainDb (float db)
 // pre-gain ⊥ pole locations → restores a band's level (incl. the 500ms+ tail
 // that sets cent_500) WITHOUT changing its in-loop T60. Completes the 3-band
 // pre-emphasis so per-band damping decouples from per-band level. 0 dB → bypass.
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setInputHighGainDb (float db)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setInputHighGainDb (float db)
 {
     inputHighGainDb_   = std::clamp (db, -6.0f, 6.0f);
     inputMakeupActive_ = std::fabs (inputSubGainDb_)  > 1.0e-4f
@@ -1015,8 +1066,8 @@ void FDNReverbT<WithOctaveGEQ>::setInputHighGainDb (float db)
     inputHighR_.designHighShelf (g, 5000.0f, sr);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setCrossoverFreq (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setCrossoverFreq (float hz)
 {
     crossoverFreq_ = std::clamp (hz, 200.0f, 4000.0f);
     if (crossoverFreq_ > highCrossoverFreq_)
@@ -1026,24 +1077,24 @@ void FDNReverbT<WithOctaveGEQ>::setCrossoverFreq (float hz)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setModDepth (float depth)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setModDepth (float depth)
 {
     modDepth_ = std::clamp (depth, 0.0f, 2.0f);
     if (prepared_)
         updateModDepth();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setModRate (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setModRate (float hz)
 {
     modRateHz_ = std::max (hz, 0.01f);
     if (prepared_)
         updateLFORates();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setTailSpinDepth (float depth)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setTailSpinDepth (float depth)
 {
     tailSpinDepth_  = std::clamp (depth, 0.0f, 1.0f);
     const bool active = tailSpinDepth_ > 1.0e-6f;
@@ -1057,8 +1108,8 @@ void FDNReverbT<WithOctaveGEQ>::setTailSpinDepth (float depth)
     tailSpinActive_ = active;
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setTailSpinRate (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setTailSpinRate (float hz)
 {
     tailSpinRateHz_ = std::clamp (hz, 0.1f, 10.0f);
     if (prepared_)
@@ -1068,8 +1119,8 @@ void FDNReverbT<WithOctaveGEQ>::setTailSpinRate (float hz)
 // Per-line phase increment = 2π · (base rate · γ_c) / sampleRate. The γ_c
 // spread gives each delay line its own LFO frequency, so the summed output
 // carries multiple distinct AM components instead of one shared rate.
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::updateTailSpinIncs()
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::updateTailSpinIncs()
 {
     constexpr float kPi2 = 6.283185307179586f;
     const float sr = static_cast<float> (sampleRate_);
@@ -1077,8 +1128,8 @@ void FDNReverbT<WithOctaveGEQ>::updateTailSpinIncs()
         tailSpinInc_[ch] = kPi2 * (tailSpinRateHz_ * tailSpinRateMul_[ch]) / sr;
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setSize (float size)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setSize (float size)
 {
     sizeParam_ = std::clamp (size, 0.0f, 1.0f);
     if (! prepared_) return;
@@ -1088,8 +1139,8 @@ void FDNReverbT<WithOctaveGEQ>::setSize (float size)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setFreeze (bool frozen)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setFreeze (bool frozen)
 {
     const bool wasTransition = (frozen != pending().frozen);
     pending().frozen = frozen;
@@ -1115,8 +1166,8 @@ void FDNReverbT<WithOctaveGEQ>::setFreeze (bool frozen)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setInLoopPeaking (float freqHz, float qFactor, float gainDb)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setInLoopPeaking (float freqHz, float qFactor, float gainDb)
 {
     // Design the same peaking biquad on every line so the modal boost is
     // coherent across the Hadamard mix. Per-line variation would smear
@@ -1139,8 +1190,8 @@ void FDNReverbT<WithOctaveGEQ>::setInLoopPeaking (float freqHz, float qFactor, f
         inLoopPeak_[i].setBand (freqHz, qFactor, gainDb);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setTimeVaryingHiDamp (float earlyMult, float lateMult,
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setTimeVaryingHiDamp (float earlyMult, float lateMult,
                                       float crossoverHz, float releaseSec,
                                       float refLevel)
 {
@@ -1156,8 +1207,8 @@ void FDNReverbT<WithOctaveGEQ>::setTimeVaryingHiDamp (float earlyMult, float lat
     tvHiActive_ = std::fabs (earlyMult - lateMult) > 1.0e-6f;
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setDualBassShelf (float fastFc, float slowFc,
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setDualBassShelf (float fastFc, float slowFc,
                                    float fastGainDb, float slowGainDb,
                                    float transitionMs)
 {
@@ -1175,8 +1226,8 @@ void FDNReverbT<WithOctaveGEQ>::setDualBassShelf (float fastFc, float slowFc,
         dualBassShelf_[i].setShape (fastFc, slowFc, fastGainDb, slowGainDb, transitionMs);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setBaseDelays (const int* delays)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setBaseDelays (const int* delays)
 {
     if (delays == nullptr) return;
     for (int i = 0; i < N; ++i)
@@ -1188,8 +1239,8 @@ void FDNReverbT<WithOctaveGEQ>::setBaseDelays (const int* delays)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::resetBaseDelays()
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::resetBaseDelays()
 {
     // Restore the engine default (log-spaced primes) — used when a session is
     // loaded with no/unknown preset identity so a prior preset's per-preset
@@ -1202,8 +1253,8 @@ void FDNReverbT<WithOctaveGEQ>::resetBaseDelays()
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setOutputTaps (const int* lt, const int* rt,
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setOutputTaps (const int* lt, const int* rt,
                                 const float* ls, const float* rs)
 {
     if (lt == nullptr || rt == nullptr || ls == nullptr || rs == nullptr)
@@ -1225,15 +1276,15 @@ void FDNReverbT<WithOctaveGEQ>::setOutputTaps (const int* lt, const int* rt,
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setLateGainScale (float scale)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setLateGainScale (float scale)
 {
     pending().lateGainScale = std::max (scale, 0.0f);
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setSizeRange (float min, float max)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setSizeRange (float min, float max)
 {
     float newMin = std::max (min, 0.0f);
     float newMax = std::max (max, newMin);
@@ -1251,8 +1302,8 @@ void FDNReverbT<WithOctaveGEQ>::setSizeRange (float min, float max)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setInlineDiffusion (float coeff)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setInlineDiffusion (float coeff)
 {
     LiveParams& p = pending();
     p.inlineDiffCoeff  = std::clamp (coeff, 0.0f, 0.75f);
@@ -1261,22 +1312,22 @@ void FDNReverbT<WithOctaveGEQ>::setInlineDiffusion (float coeff)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setTankDiffusion (float amount)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setTankDiffusion (float amount)
 {
     float a = std::clamp (amount, 0.0f, 1.0f);
     setInlineDiffusion (a * 0.55f);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setUseShortInlineAP (bool use)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setUseShortInlineAP (bool use)
 {
     pending().useShortInlineAP = use;
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setMultiPointOutput (const FDNOutputTap* left, int numL,
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setMultiPointOutput (const FDNOutputTap* left, int numL,
                                      const FDNOutputTap* right, int numR)
 {
     if (left == nullptr || numL <= 0 || right == nullptr || numR <= 0)
@@ -1337,8 +1388,8 @@ void FDNReverbT<WithOctaveGEQ>::setMultiPointOutput (const FDNOutputTap* left, i
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setMultiPointDensity (int tapsPerChannel)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setMultiPointDensity (int tapsPerChannel)
 {
     int totalTaps = tapsPerChannel * N;
     if (totalTaps <= 0 || totalTaps > kMaxMultiTaps)
@@ -1384,8 +1435,8 @@ void FDNReverbT<WithOctaveGEQ>::setMultiPointDensity (int tapsPerChannel)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setHadamardPerturbation (float amount)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setHadamardPerturbation (float amount)
 {
     if (amount <= 0.0f)
     {
@@ -1512,15 +1563,15 @@ void FDNReverbT<WithOctaveGEQ>::setHadamardPerturbation (float amount)
     }
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setUseHouseholder (bool enable)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setUseHouseholder (bool enable)
 {
     pending().useHouseholder = enable;
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setUseWeightedGains (bool enable)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setUseWeightedGains (bool enable)
 {
     useWeightedGains_ = enable;
     if (! prepared_) return;
@@ -1529,8 +1580,8 @@ void FDNReverbT<WithOctaveGEQ>::setUseWeightedGains (bool enable)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setDualSlope (float ratio, int fastCount, float fastGain)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setDualSlope (float ratio, int fastCount, float fastGain)
 {
     dualSlopeRatio_ = std::max (ratio, 0.0f);
     int fastCnt = (fastCount >= 8) ? 8 : 0;
@@ -1545,8 +1596,8 @@ void FDNReverbT<WithOctaveGEQ>::setDualSlope (float ratio, int fastCount, float 
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setStereoCoupling (float amount)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setStereoCoupling (float amount)
 {
     LiveParams& p = pending();
     if (amount < 0.0f)
@@ -1562,8 +1613,8 @@ void FDNReverbT<WithOctaveGEQ>::setStereoCoupling (float amount)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setModDepthFloor (float floor)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setModDepthFloor (float floor)
 {
     modDepthFloor_ = std::clamp (floor, 0.0f, 1.0f);
     if (! prepared_) return;
@@ -1572,8 +1623,8 @@ void FDNReverbT<WithOctaveGEQ>::setModDepthFloor (float floor)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setHighCrossoverFreq (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setHighCrossoverFreq (float hz)
 {
     highCrossoverFreq_ = std::clamp (hz, 1000.0f, 20000.0f);
     if (highCrossoverFreq_ < crossoverFreq_)
@@ -1583,8 +1634,8 @@ void FDNReverbT<WithOctaveGEQ>::setHighCrossoverFreq (float hz)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setAirTrebleMultiply (float mult)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setAirTrebleMultiply (float mult)
 {
     airTrebleMultiply_ = std::clamp (mult, 0.1f, 1.5f);
     if (! prepared_) return;
@@ -1592,8 +1643,8 @@ void FDNReverbT<WithOctaveGEQ>::setAirTrebleMultiply (float mult)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setStructuralHFDamping (float baseFreqHz, float trebleMultiply)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setStructuralHFDamping (float baseFreqHz, float trebleMultiply)
 {
     structHFBaseFreq_ = baseFreqHz;
     LiveParams& p = pending();
@@ -1610,8 +1661,8 @@ void FDNReverbT<WithOctaveGEQ>::setStructuralHFDamping (float baseFreqHz, float 
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setStructuralLFDamping (float hz)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setStructuralLFDamping (float hz)
 {
     LiveParams& p = pending();
     if (hz <= 0.0f)
@@ -1626,14 +1677,14 @@ void FDNReverbT<WithOctaveGEQ>::setStructuralLFDamping (float hz)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setFeedbackModDepth (float depth)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setFeedbackModDepth (float depth)
 {
     feedbackModDepth_ = std::clamp (depth, 0.0f, 1.0f);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setModulationTopology (DspUtils::ModulationTopology t)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setModulationTopology (DspUtils::ModulationTopology t)
 {
     if (t == modulationTopology_)
         return;
@@ -1657,8 +1708,8 @@ void FDNReverbT<WithOctaveGEQ>::setModulationTopology (DspUtils::ModulationTopol
     }
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setCrossoverModDepth (float depth)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setCrossoverModDepth (float depth)
 {
     // The previous behaviour pushed the base coefficient back into the
     // legacy setLowCrossoverCoeff path. With the snapshot now owning the
@@ -1667,8 +1718,8 @@ void FDNReverbT<WithOctaveGEQ>::setCrossoverModDepth (float depth)
     crossoverModDepth_ = std::clamp (depth, 0.0f, 1.0f);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setDecayBoost (float boost)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setDecayBoost (float boost)
 {
     decayBoost_ = std::clamp (boost, 0.3f, 2.0f);
     if (! prepared_) return;
@@ -1676,8 +1727,8 @@ void FDNReverbT<WithOctaveGEQ>::setDecayBoost (float boost)
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setPerLineDecayTilt (float shortLineScale, float longLineScale)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setPerLineDecayTilt (float shortLineScale, float longLineScale)
 {
     // Range bounds: 0.3..3.0× the base decay. Outside this range the
     // per-band ratio gets so extreme that per-line RT60 hits the
@@ -1689,8 +1740,8 @@ void FDNReverbT<WithOctaveGEQ>::setPerLineDecayTilt (float shortLineScale, float
     publishPending();
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::clearBuffers()
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::clearBuffers()
 {
     for (int i = 0; i < N; ++i)
     {
@@ -1730,8 +1781,8 @@ void FDNReverbT<WithOctaveGEQ>::clearBuffers()
 // ===========================================================================
 // Snapshot derivation
 // ===========================================================================
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::computeDelayLengths (LiveParams& p)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::computeDelayLengths (LiveParams& p)
 {
     float sizeScale = sizeRangeMin_ + (sizeRangeMax_ - sizeRangeMin_) * sizeParam_;
     float rateRatio = static_cast<float> (sampleRate_ / kBaseSampleRate);
@@ -1783,8 +1834,8 @@ void FDNReverbT<WithOctaveGEQ>::computeDelayLengths (LiveParams& p)
     }
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::computeDecayCoefficients (LiveParams& p)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::computeDecayCoefficients (LiveParams& p)
 {
     const float sr = static_cast<float> (sampleRate_);
 
@@ -1984,8 +2035,8 @@ void FDNReverbT<WithOctaveGEQ>::computeDecayCoefficients (LiveParams& p)
         p.octaveActive = octaveGEQActive_;
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::updateModDepth()
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::updateModDepth()
 {
     float rateRatio = static_cast<float> (sampleRate_ / kBaseSampleRate);
     modDepthSamples_ = modDepth_ * 4.0f * rateRatio;
@@ -1993,8 +2044,8 @@ void FDNReverbT<WithOctaveGEQ>::updateModDepth()
         lfos_[i].setDepth (modDepthSamples_);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::updateLFORates()
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::updateLFORates()
 {
     // Tightly clustered LFO rate spread (0.95×–1.05×) so 16 delay-line
     // modulators breathe together as a unified slow mass rather than
@@ -2003,9 +2054,13 @@ void FDNReverbT<WithOctaveGEQ>::updateLFORates()
     // Previous spread was 0.80×–1.36× (70 %), which produced audible
     // sideband beating and chorus-in-the-tail across every long-decay
     // FDN preset — the dominant complaint on the hall tails.
-    static constexpr float kRateFactors[N] = {
+    // [32]: first 16 unchanged (16-line path bit-null); lines 16-31 interleave
+    // the same 0.95×–1.05× cluster so all 32 modulators breathe together.
+    static constexpr float kRateFactors[32] = {
         0.950f, 0.957f, 0.964f, 0.971f, 0.978f, 0.985f, 0.992f, 0.998f,
-        1.002f, 1.008f, 1.015f, 1.022f, 1.029f, 1.036f, 1.043f, 1.050f
+        1.002f, 1.008f, 1.015f, 1.022f, 1.029f, 1.036f, 1.043f, 1.050f,
+        0.953f, 0.960f, 0.967f, 0.974f, 0.981f, 0.988f, 0.995f, 1.000f,
+        1.005f, 1.011f, 1.018f, 1.025f, 1.032f, 1.039f, 1.046f, 1.048f
     };
     for (int i = 0; i < N; ++i)
         lfos_[i].setRate (modRateHz_ * kRateFactors[i]);
@@ -2021,8 +2076,8 @@ void FDNReverbT<WithOctaveGEQ>::updateLFORates()
     masterDampingLfoIncr_ = (twoPi * kDampingModRateHz) / static_cast<float> (sampleRate_);
 }
 
-template <bool WithOctaveGEQ>
-void FDNReverbT<WithOctaveGEQ>::setOctaveT60 (int band, float seconds)
+template <bool WithOctaveGEQ, int N>
+void FDNReverbT<WithOctaveGEQ, N>::setOctaveT60 (int band, float seconds)
 {
     if (band < 0 || band >= kNumOctaveBands)
         return;
@@ -2040,5 +2095,6 @@ void FDNReverbT<WithOctaveGEQ>::setOctaveT60 (int band, float seconds)
 
 // Explicit instantiations: <false> = the legacy GEQ-free engine (the whole
 // fleet + Shimmer/NonLinear/ReverseRoom/Multiband); <true> = AccurateHall.
-template class FDNReverbT<false>;
-template class FDNReverbT<true>;
+template class FDNReverbT<false, 16>;   // fdn_ — algos 4/8/9 etc., 16-line (bit-null baseline)
+template class FDNReverbT<true, 16>;    // accurateHall_ — algo 10, 16-line (7 migrated presets)
+template class FDNReverbT<true, 32>;    // accurateHall32_ — algo 12, 32-line (Bright Hall metallic fix)

--- a/plugins/DuskVerb/src/dsp/FDNReverb.cpp
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.cpp
@@ -1933,12 +1933,32 @@ void FDNReverbT<WithOctaveGEQ>::computeDecayCoefficients (LiveParams& p)
             // is a real design output, not a linear blend of two coeffs.
             const float gAirDark   = std::pow (gBase, 1.0f / std::max (airTrebleMultiply_ * 0.60f, 0.01f));
             const float gAirBright = gAir;
+            float tblSub = gSub, tblLoMid = gLoMid, tblMid = gMid, tblHiMid = gHiMid;
+            float tblAirDark = gAirDark, tblAirBright = gAirBright;
+            if constexpr (WithOctaveGEQ)
+            {
+                if (octaveGEQActive_)
+                {
+                    // ModulatedDamping × octave GEQ co-occurrence: the GEQ owns
+                    // ALL static decay (lp.damping is flattened to identity
+                    // above), but the per-sample ModulatedDamping path uses
+                    // THIS table INSTEAD of lp.damping — so the table must be
+                    // flat too, or the FiveBand decay double-applies on top of
+                    // the GEQ (measured ~-50% T60 broadband on Cathedral).
+                    // Keep only the dark/bright air-band breathing RATIO,
+                    // re-centred on unity, so the topology's slow HF
+                    // modulation character survives without static damping.
+                    tblSub = tblLoMid = tblMid = tblHiMid = 1.0f;
+                    tblAirBright = 1.0f;
+                    tblAirDark   = gAirDark / std::max (gAirBright, 1.0e-12f);
+                }
+            }
             for (int s = 0; s < kDampingSteps; ++s)
             {
                 const float t = static_cast<float> (s) / static_cast<float> (kDampingSteps - 1);
-                const float gAirStep = (1.0f - t) * gAirDark + t * gAirBright;
+                const float gAirStep = (1.0f - t) * tblAirDark + t * tblAirBright;
                 const auto coeffs = FiveBandDamping::designCoeffs (
-                    gSub, gLoMid, gMid, gHiMid, gAirStep,
+                    tblSub, tblLoMid, tblMid, tblHiMid, gAirStep,
                     subCrossoverCoeff, lowCrossoverCoeff,
                     highCrossoverCoeff, airCrossoverCoeff, sr);
                 // Defensive stability assert. Each table slot must be a

--- a/plugins/DuskVerb/src/dsp/FDNReverb.cpp
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.cpp
@@ -185,6 +185,13 @@ FDNReverbT<WithOctaveGEQ, N>::FDNReverbT()
     std::memcpy (paramSlots_[0].rightTaps,  kDefaultRightTaps,  sizeof (kDefaultRightTaps));
     std::memcpy (paramSlots_[0].leftSigns,  kDefaultLeftSigns,  sizeof (kDefaultLeftSigns));
     std::memcpy (paramSlots_[0].rightSigns, kDefaultRightSigns, sizeof (kDefaultRightSigns));
+    // outputTapGain: the brace-initializer only sets the first 16 (bit-null for
+    // the 16-line default). For N>16 (AccurateHall32) the tail slots default to
+    // 0, and computeDecayCoefficients does NOT write outputTapGain (only
+    // setDualSlope does) — so a tap indexing >=16 would read a muted 0 until a
+    // dual-slope call happens to run. Fill all N to unity at construction so the
+    // first published snapshot is valid regardless of later setter order.
+    for (int i = 0; i < N; ++i) paramSlots_[0].outputTapGain[i] = 1.0f;
     paramSlots_[1] = paramSlots_[0];
 
     // Per-instance Householder reflector seed. Each FDNReverb gets a distinct

--- a/plugins/DuskVerb/src/dsp/FDNReverb.h
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.h
@@ -26,7 +26,11 @@ struct FDNOutputTap
 // recursive feedback loop can't guarantee bit-null; compile-time elimination
 // can). See the `using FDNReverb = FDNReverbT<false>;` alias below — every
 // existing consumer keeps using the GEQ-free engine unchanged.
-template <bool WithOctaveGEQ = false>
+// N = feedback-line count (16 default; 32 for the dense AccurateHall32 path
+// used by Bright Hall — more HF modal density to kill the metallic ring). N
+// MUST be a power of two (the fast Walsh-Hadamard mix). Templating on N keeps
+// every existing 16-line instantiation byte-identical (separate codegen).
+template <bool WithOctaveGEQ = false, int N = 16>
 class FDNReverbT
 {
 public:
@@ -38,10 +42,10 @@ public:
 
     void setDecayTime (float seconds);
     void setBassMultiply (float mult);
-    void setMidMultiply (float mult);              // NEW: 3-band mid (default 1.0)
+    void setMidMultiply (float mult);              // 3-band mid (default 1.0)
     void setTrebleMultiply (float mult);
     void setCrossoverFreq (float hz);
-    void setSaturation (float amount);             // NEW: 0..1 drive softClip
+    void setSaturation (float amount);             // 0..1 drive softClip
     void setModDepth (float depth);
     void setModRate (float hz);
     void setSize (float size);
@@ -174,7 +178,6 @@ public:
     void clearBuffers();
 
 private:
-    static constexpr int N = 16;
     static constexpr double kBaseSampleRate = 44100.0;
     static constexpr float kTwoPi = 6.283185307179586f;
     static constexpr float kOutputLevel = 1.121f;     // 1/sqrt(8) * 2.0 * 1.585 — consolidated output scaling
@@ -208,7 +211,7 @@ private:
         float modDepthScale     [N] {};
         float inputGainScale    [N] {};
         float outputGainScale   [N] {};
-        float outputTapGain     [N] { 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1 };
+        float outputTapGain     [N] { 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1 };  // first 16 = 1 (16-line bit-null); computeDecayCoefficients overwrites all N
 
         // Tap routing (standard 8-tap path)
         int   leftTaps          [kNumOutputTaps] { 0,3,5,7,8,10,12,15 };
@@ -339,29 +342,40 @@ private:
 
     // 16 prime delay lengths for inline allpasses (at 44.1kHz base rate).
     // All prime and coprime to the main delay lengths to avoid modal alignment.
-    static constexpr int kInlineAPDelays[N] = {
+    // Fixed [32]: lines 0-15 = the original 16-line values (so every 16-line
+    // instantiation reads an identical table → bit-null); lines 16-31 add 16
+    // more coprime primes for the 32-line AccurateHall32 path.
+    static constexpr int kInlineAPDelays[32] = {
         41, 47, 53, 59, 67, 71, 79, 83,
-        89, 97, 101, 107, 109, 113, 127, 131
+        89, 97, 101, 107, 109, 113, 127, 131,
+        137, 139, 149, 353, 359, 367, 373, 379,
+        383, 389, 397, 401, 409, 419, 421, 431
     };
 
     // Second cascade: longer primes for additional density multiplication.
     // Two cascaded allpasses give ~4x echo density per feedback cycle (vs ~2x with one).
-    static constexpr int kInlineAPDelays2[N] = {
+    static constexpr int kInlineAPDelays2[32] = {
         151, 157, 163, 167, 173, 179, 181, 191,
-        193, 197, 199, 211, 223, 227, 229, 233
+        193, 197, 199, 211, 223, 227, 229, 233,
+        433, 439, 443, 449, 457, 461, 463, 467,
+        479, 487, 491, 499, 503, 509, 521, 541
     };
 
     // Third cascade: even longer primes for maximum density multiplication.
     // Three cascaded allpasses give ~8x echo density per feedback cycle.
-    static constexpr int kInlineAPDelays3[N] = {
+    static constexpr int kInlineAPDelays3[32] = {
         251, 257, 263, 269, 271, 277, 281, 283,
-        293, 307, 311, 313, 317, 331, 337, 347
+        293, 307, 311, 313, 317, 331, 337, 347,
+        547, 557, 563, 569, 571, 577, 587, 593,
+        599, 601, 607, 613, 619, 631, 641, 643
     };
 
     // Short inline allpass delays (7-47 samples at 44.1kHz) for Hall.
-    static constexpr int kInlineAPDelaysShort[N] = {
+    static constexpr int kInlineAPDelaysShort[32] = {
         7, 11, 13, 17, 19, 23, 29, 31,
-        37, 41, 43, 47, 7, 11, 13, 17
+        37, 41, 43, 47, 7, 11, 13, 17,
+        53, 59, 61, 67, 71, 73, 79, 83,
+        89, 97, 101, 103, 107, 109, 113, 127
     };
 
     DelayLine delayLines_[N];
@@ -567,4 +581,4 @@ private:
 // the GEQ-free engine — they reference `FDNReverb` and need no edit. AccurateHall
 // declares FDNReverbT<true>. Single source of truth; bit-null isolation is by
 // compile-time GEQ elimination, not duplication.
-using FDNReverb = FDNReverbT<false>;
+using FDNReverb = FDNReverbT<false, 16>;

--- a/plugins/DuskVerb/src/dsp/FDNReverb.h
+++ b/plugins/DuskVerb/src/dsp/FDNReverb.h
@@ -211,7 +211,7 @@ private:
         float modDepthScale     [N] {};
         float inputGainScale    [N] {};
         float outputGainScale   [N] {};
-        float outputTapGain     [N] { 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1 };  // first 16 = 1 (16-line bit-null); computeDecayCoefficients overwrites all N
+        float outputTapGain     [N] { 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1 };  // brace inits first 16 only; the ctor fills all N to 1.0 (computeDecayCoefficients does NOT write this — only setDualSlope does)
 
         // Tap routing (standard 8-tap path)
         int   leftTaps          [kNumOutputTaps] { 0,3,5,7,8,10,12,15 };

--- a/plugins/DuskVerb/src/dsp/OctaveGEQDesign.cpp
+++ b/plugins/DuskVerb/src/dsp/OctaveGEQDesign.cpp
@@ -1,0 +1,117 @@
+// =====================================================================
+// OctaveGEQDesign.cpp — design-time bodies for OctaveBandDamping
+// (AccurateHall per-octave GEQ).
+//
+// These live in their OWN translation unit on purpose: when the iterative
+// composite-exact design was written inline in TwoBandDamping.h, its mere
+// presence in the FDNReverb.cpp TU perturbed the FP codegen of the plain
+// FDNReverbT<false> hot loop (~4e-6 render drift through the feedback —
+// the QuadTankT template lesson, memory duskverb_bitnull_codegen_limit).
+// Out-of-line definitions keep the header (and every including TU) free of
+// the design code; only the call site inside `if constexpr (WithOctaveGEQ)`
+// references these symbols. Message-thread / preset-apply time only —
+// never the audio thread.
+// =====================================================================
+
+#include "TwoBandDamping.h"
+
+double OctaveBandDamping::magnitudeAt (const Coeffs& c, double fHz,
+                                       double sampleRate)
+{
+    const double w  = 2.0 * 3.141592653589793
+                    * std::min (fHz, 0.49 * sampleRate) / sampleRate;
+    const double cr = std::cos (w),  ci = -std::sin (w);        // z^-1
+    const double c2r = cr * cr - ci * ci, c2i = 2.0 * cr * ci;  // z^-2
+    double mag = static_cast<double> (c.broadbandGain);
+    for (int s = 0; s < kNumShelves; ++s)
+    {
+        const double nr = c.b0[s] + c.b1[s] * cr + c.b2[s] * c2r;
+        const double ni =           c.b1[s] * ci + c.b2[s] * c2i;
+        const double dr = 1.0     + c.a1[s] * cr + c.a2[s] * c2r;
+        const double di =           c.a1[s] * ci + c.a2[s] * c2i;
+        mag *= std::sqrt ((nr * nr + ni * ni)
+                        / std::max (dr * dr + di * di, 1.0e-24));
+    }
+    return mag;
+}
+
+OctaveBandDamping::Coeffs OctaveBandDamping::buildCascade (
+    const float* gBand, const float* xoverHz, float sampleRate)
+{
+    Coeffs c;
+    ShelfBiquad bq;
+    for (int k = 0; k < kMidBand; ++k)
+    {
+        const float ratio = gBand[k] / std::max (gBand[k + 1], 1.0e-12f);
+        bq.designLowShelf (ratio, xoverHz[k], sampleRate);
+        c.b0[k] = bq.b0; c.b1[k] = bq.b1; c.b2[k] = bq.b2; c.a1[k] = bq.a1; c.a2[k] = bq.a2;
+    }
+    for (int k = kMidBand; k < kNumShelves; ++k)
+    {
+        const float ratio = gBand[k + 1] / std::max (gBand[k], 1.0e-12f);
+        bq.designHighShelf (ratio, xoverHz[k], sampleRate);
+        c.b0[k] = bq.b0; c.b1[k] = bq.b1; c.b2[k] = bq.b2; c.a1[k] = bq.a1; c.a2[k] = bq.a2;
+    }
+    c.broadbandGain = gBand[kMidBand];
+    return c;
+}
+
+OctaveBandDamping::Coeffs OctaveBandDamping::designCoeffs (
+    const float* gBand, const float* xoverHz, float sampleRate)
+{
+    static constexpr double kCentresHz[kNumBands] = {
+        63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0
+    };
+    double tdB[kNumBands], cdB[kNumBands];
+    for (int k = 0; k < kNumBands; ++k)
+    {
+        const double g = std::clamp (static_cast<double> (gBand[k]), 1.0e-3, 0.9999);
+        tdB[k] = 20.0 * std::log10 (g);
+        cdB[k] = tdB[k];
+    }
+
+    Coeffs best = buildCascade (gBand, xoverHz, sampleRate);
+    double bestErr = 1.0e30;
+    double lambda  = 0.7;
+    int    stall   = 0;
+    for (int iter = 0; iter < 25; ++iter)
+    {
+        float g[kNumBands];
+        for (int k = 0; k < kNumBands; ++k)
+            g[k] = static_cast<float> (std::clamp (
+                       std::pow (10.0, cdB[k] / 20.0), 1.0e-3, 0.9999));
+        const Coeffs c = buildCascade (g, xoverHz, sampleRate);
+
+        double mdB[kNumBands], err = 0.0;
+        for (int k = 0; k < kNumBands; ++k)
+        {
+            mdB[k] = 20.0 * std::log10 (
+                         std::max (magnitudeAt (c, kCentresHz[k], sampleRate), 1.0e-12));
+            err = std::max (err, std::fabs (tdB[k] - mdB[k]));
+        }
+        if (err < bestErr) { best = c; bestErr = err; stall = 0; }
+        else if (++stall >= 3) { lambda *= 0.5; stall = 0; }
+        if (err < 1.0e-3)
+            break;
+        for (int k = 0; k < kNumBands; ++k)
+            cdB[k] += lambda * (tdB[k] - mdB[k]);
+    }
+
+    // Stability guard: corrected commanded gains can crest ABOVE the centre
+    // values BETWEEN centres (and beyond 16 kHz toward Nyquist). Loop
+    // stability needs composite |H| < 1 everywhere, so sweep analytically
+    // and scale the broadband down if anything exceeds the per-band clamp
+    // ceiling. Rarely fires (the always-on AA/DC filters give real margin
+    // at the extremes, conservatively ignored here).
+    double maxMag = std::max (magnitudeAt (best, 0.0, sampleRate),
+                              magnitudeAt (best, 0.5 * sampleRate, sampleRate));
+    const double fLo = 40.0, fHi = 0.49 * sampleRate;
+    for (int i = 0; i < 96; ++i)
+    {
+        const double f = fLo * std::pow (fHi / fLo, i / 95.0);
+        maxMag = std::max (maxMag, magnitudeAt (best, f, sampleRate));
+    }
+    if (maxMag > 0.9999)
+        best.broadbandGain = static_cast<float> (best.broadbandGain * 0.9998 / maxMag);
+    return best;
+}

--- a/plugins/DuskVerb/src/dsp/OctaveGEQDesign.cpp
+++ b/plugins/DuskVerb/src/dsp/OctaveGEQDesign.cpp
@@ -18,8 +18,11 @@
 double OctaveBandDamping::magnitudeAt (const Coeffs& c, double fHz,
                                        double sampleRate)
 {
+    // Clamp at TRUE Nyquist (0.5*sr, z = -1) — the stability sweep probes
+    // there explicitly; clamping lower would silently skip the one frequency
+    // the top shelf's asymptote peaks at.
     const double w  = 2.0 * 3.141592653589793
-                    * std::min (fHz, 0.49 * sampleRate) / sampleRate;
+                    * std::min (fHz, 0.5 * sampleRate) / sampleRate;
     const double cr = std::cos (w),  ci = -std::sin (w);        // z^-1
     const double c2r = cr * cr - ci * ci, c2i = 2.0 * cr * ci;  // z^-2
     double mag = static_cast<double> (c.broadbandGain);

--- a/plugins/DuskVerb/src/dsp/OutputDiffusion.cpp
+++ b/plugins/DuskVerb/src/dsp/OutputDiffusion.cpp
@@ -6,14 +6,23 @@
 
 void OutputDiffusion::prepare (double sampleRate, int /*maxBlockSize*/)
 {
+    sampleRate_ = sampleRate;
+    prepared_   = true;
+    buildStages();
+}
+
+void OutputDiffusion::buildStages()
+{
     static constexpr float kTwoPi = 6.283185307179586f;
-    float ratio = static_cast<float> (sampleRate / DspUtils::kBaseSampleRate);
+    float ratio = static_cast<float> (sampleRate_ / DspUtils::kBaseSampleRate);
 
     float totalAPs = static_cast<float> (kNumStages * 2);
 
     for (int s = 0; s < kNumStages; ++s)
     {
-        float delay = static_cast<float> (kBaseDelays[s]) * ratio;
+        // delayScale_ spreads the base allpass delays so the smearing reaches
+        // the closely-spaced HF modes (longer delay = finer frequency comb).
+        float delay = static_cast<float> (kBaseDelays[s]) * ratio * delayScale_;
         int bufSize = DspUtils::nextPowerOf2 (static_cast<int> (std::ceil (delay)) + 4);
 
         // Light LFO modulation: depth 0.3-0.5 samples @44.1kHz, rate 0.2-0.5 Hz
@@ -22,14 +31,16 @@ void OutputDiffusion::prepare (double sampleRate, int /*maxBlockSize*/)
         float phaseL = kTwoPi * static_cast<float> (s) / totalAPs;
         float rateL  = 0.2f + 0.3f * static_cast<float> (s) / (totalAPs - 1.0f);
         float depthL = (0.3f + 0.2f * static_cast<float> (s) / (totalAPs - 1.0f)) * ratio;
-        leftAP_[s].prepare (bufSize, delay, rateL, depthL, phaseL, sampleRate);
+        leftAP_[s].prepare (bufSize, delay, rateL, depthL, phaseL, sampleRate_);
 
         int ri = s + kNumStages;
         float phaseR = kTwoPi * static_cast<float> (ri) / totalAPs;
         float rateR  = 0.2f + 0.3f * static_cast<float> (ri) / (totalAPs - 1.0f);
         float depthR = (0.3f + 0.2f * static_cast<float> (ri) / (totalAPs - 1.0f)) * ratio;
-        rightAP_[s].prepare (bufSize, delay, rateR, depthR, phaseR, sampleRate);
+        rightAP_[s].prepare (bufSize, delay, rateR, depthR, phaseR, sampleRate_);
     }
+    // Re-apply the LFO-depth scale (prepare reset baseLfoDepth_ on each stage).
+    setLfoDepthScale (lfoScale_);
 }
 
 void OutputDiffusion::process (float* left, float* right, int numSamples)
@@ -52,8 +63,10 @@ void OutputDiffusion::process (float* left, float* right, int numSamples)
 
 void OutputDiffusion::setDiffusion (float amount)
 {
-    // Maps 0.0-1.0 to coefficient 0.0-0.3
-    // 4 stages at g=0.3 gives smoother frequency response than 2 stages at g=0.5,
-    // with reduced density for cleaner tail character
-    diffusionCoeff_ = std::clamp (amount, 0.0f, 1.0f) * 0.3f;
+    // Maps 0.0-1.0 to coefficient 0.0-0.62. The deeper 8-stage cascade needs
+    // a stronger per-stage coefficient to fully decorrelate the FDN's sparse
+    // HF modes into a dense wash (the old 4-stage ×0.3 cap topped out at
+    // kurtosis ~18 vs the anchor's 12). 0.62 stays well inside allpass
+    // stability and below the point where the cascade rings on its own.
+    diffusionCoeff_ = std::clamp (amount, 0.0f, 1.0f) * 0.62f;
 }

--- a/plugins/DuskVerb/src/dsp/OutputDiffusion.h
+++ b/plugins/DuskVerb/src/dsp/OutputDiffusion.h
@@ -1,33 +1,64 @@
 #pragma once
 
 #include "DiffusionStage.h" // reuses ModulatedAllpass
+#include <algorithm>
 
 // Post-FDN output diffusion: 4 cascaded allpass filters per channel.
 // Lower coefficient than input diffusion to add density without smearing stereo image.
+//
+// Activated per-preset (Bright Hall, 2026-06-10) to smear the FDN's sparse
+// high-frequency tail modes into a denser, smoother wash — the 16-line FDN
+// leaves isolated HF resonances above 4 kHz (tail spectral kurtosis ~19 vs a
+// dense reference ~12) that read as a metallic ring. delayScale spreads the
+// allpass delays so the smearing reaches the closely-spaced HF modes.
 class OutputDiffusion
 {
 public:
     void prepare (double sampleRate, int maxBlockSize);
     void process (float* left, float* right, int numSamples);
     void setDiffusion (float amount);
+    void clear()
+    {
+        for (int s = 0; s < kNumStages; ++s) { leftAP_[s].clear(); rightAP_[s].clear(); }
+    }
     // 0 disables the built-in LFO wobble on every output allpass (the
     // cumulative effect across 4 stages × 2 channels can cause pitch
     // smearing for presets that stack this on top of a modulated tank).
     void setLfoDepthScale (float scale)
     {
+        lfoScale_ = scale;
         for (int s = 0; s < kNumStages; ++s)
         {
             leftAP_[s].setLfoDepthScale (scale);
             rightAP_[s].setLfoDepthScale (scale);
         }
     }
+    // Scale the base allpass delays (× scale). Longer delays decorrelate the
+    // closely-spaced HF modes more (denser smearing). Re-prepares the stages
+    // (message-thread / preset-apply only — allocates).
+    void setDelayScale (float scale)
+    {
+        delayScale_ = std::max (0.25f, scale);
+        if (prepared_)
+            buildStages();
+    }
 
 private:
-    static constexpr int kNumStages = 4;
-    static constexpr int kBaseDelays[kNumStages] = { 523, 163, 349, 241 };
+    void buildStages();
+
+    // 8 stages (was 4): turning the FDN's sparse HF modes into a dense
+    // Gaussian wash needs a deep dispersion cascade — 4 weak allpasses only
+    // dropped tail kurtosis 19.3->18.0. Mutually-prime delays for maximal
+    // dispersion density.
+    static constexpr int kNumStages = 8;
+    static constexpr int kBaseDelays[kNumStages] = { 523, 163, 349, 241, 431, 283, 617, 191 };
 
     ModulatedAllpass leftAP_[kNumStages];
     ModulatedAllpass rightAP_[kNumStages];
 
-    float diffusionCoeff_ = 0.4f;
+    float  diffusionCoeff_ = 0.4f;
+    float  delayScale_     = 1.0f;
+    float  lfoScale_       = 1.0f;
+    double sampleRate_     = 44100.0;
+    bool   prepared_       = false;
 };

--- a/plugins/DuskVerb/src/dsp/QuadTank.h
+++ b/plugins/DuskVerb/src/dsp/QuadTank.h
@@ -34,11 +34,11 @@ public:
 
     void setDecayTime (float seconds);
     void setBassMultiply (float mult);
-    void setMidMultiply (float mult);              // NEW: 3-band mid (default 1.0)
+    void setMidMultiply (float mult);              // 3-band mid (default 1.0)
     void setTrebleMultiply (float mult);
     void setCrossoverFreq (float hz);
     void setHighCrossoverFreq (float hz);
-    void setSaturation (float amount);             // NEW: 0..1 drive softClip
+    void setSaturation (float amount);             // 0..1 drive softClip
     void setModDepth (float depth);
     void setModRate (float hz);
     void setSize (float size);

--- a/plugins/DuskVerb/src/dsp/SparseEarlyField.h
+++ b/plugins/DuskVerb/src/dsp/SparseEarlyField.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include "DspUtils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+// SparseEarlyField — front-loaded, sparse, broadband, WIDE early-reflection
+// field extending to ~200 ms. The early-dominant topology that the standard
+// parallel EarlyReflections (24 taps, 8-80 ms, inverse-distance, LP-rolled,
+// anti-phase R) cannot be: VVV front-loads 56% of energy in the first 50 ms and
+// stays SPARSE/discrete out to ~200 ms (two-burst kurtosis trajectory), where
+// every DuskVerb tank/FDN back-loads into a Gaussian wash by 60 ms.
+//
+// Velvet-noise-style sparse signed taps (one per "grain" cell, pseudo-random
+// sub-cell position + sign), with:
+//   - density + gain FRONT-LOADED (decreasing with time) -> energy_t50/first50,
+//   - a TWO-BURST density envelope (dense 0-40 ms, second cluster ~95-140 ms)
+//     -> the diffusion_flux kurtosis shape,
+//   - a gently-RISING onset gain ramp (peak ~onsetPeakMs) -> attack_time/onset_slope,
+//   - INDEPENDENT L/R tap times+signs (decorrelated, not anti-phase) -> wide,
+//     uniform stereo image (stereo_corr ~ 0),
+//   - broadband taps (no per-tap LP) -> spectrally full like VVV.
+//
+// Deterministic (seeded) tap geometry => reproducible renders. Allocation-free
+// process; taps rebuilt off-thread on param change.
+class SparseEarlyField
+{
+public:
+    void prepare (double sampleRate, int /*maxBlockSize*/)
+    {
+        sampleRate_ = sampleRate;
+        const int bufLen = DspUtils::nextPowerOf2 (
+            static_cast<int> (std::ceil (kMaxTimeMs * 0.001 * sampleRate)) + 8);
+        bufferL_.assign (static_cast<size_t> (bufLen), 0.0f);
+        bufferR_.assign (static_cast<size_t> (bufLen), 0.0f);
+        mask_ = bufLen - 1;
+        writePos_ = 0;
+        prepared_ = true;
+        buildTaps();
+    }
+
+    void setSizeScale (float s)   { sizeScale_  = std::max (0.05f, s); if (prepared_) buildTaps(); }
+    void setOnsetPeakMs (float m) { onsetPeakMs_ = std::max (0.0f, m); if (prepared_) buildTaps(); }
+    void setDecayMs (float m)     { decayMs_    = std::max (10.0f, m); if (prepared_) buildTaps(); }
+    void setBurst2Ms (float m)    { burst2Ms_   = std::max (0.0f, m); if (prepared_) buildTaps(); }
+
+    void process (const float* inL, const float* inR,
+                  float* outL, float* outR, int numSamples)
+    {
+        if (! prepared_) { std::fill (outL, outL+numSamples, 0.0f); std::fill (outR, outR+numSamples, 0.0f); return; }
+        for (int i = 0; i < numSamples; ++i)
+        {
+            const float x = 0.5f * (inL[i] + inR[i]);
+            bufferL_[static_cast<size_t> (writePos_)] = x;   // mono feed; L/R differ only by tap geometry
+            bufferR_[static_cast<size_t> (writePos_)] = x;
+
+            float l = 0.0f, r = 0.0f;
+            for (int t = 0; t < numTapsL_; ++t)
+                l += tapGainL_[t] * bufferL_[static_cast<size_t> ((writePos_ - tapDelayL_[t]) & mask_)];
+            for (int t = 0; t < numTapsR_; ++t)
+                r += tapGainR_[t] * bufferR_[static_cast<size_t> ((writePos_ - tapDelayR_[t]) & mask_)];
+
+            outL[i] = l * kOutputScale;
+            outR[i] = r * kOutputScale;
+            writePos_ = (writePos_ + 1) & mask_;
+        }
+    }
+
+    void clear()
+    {
+        std::fill (bufferL_.begin(), bufferL_.end(), 0.0f);
+        std::fill (bufferR_.begin(), bufferR_.end(), 0.0f);
+        writePos_ = 0;
+    }
+
+private:
+    static constexpr int   kMaxTaps     = 160;
+    static constexpr float kMaxTimeMs   = 220.0f;
+    static constexpr float kOutputScale = 1.0f;
+    // ~32 grain cells span 0..200ms; density envelope decides how many fire.
+    static constexpr int   kCells       = 200;   // 1 ms cells
+
+    // 32-bit xorshift — deterministic, no Math.random (reproducible renders).
+    struct Rng { uint32_t s; float next() { s^=s<<13; s^=s>>17; s^=s<<5; return (s & 0xFFFFFF) / float(0x1000000); } };
+
+    void buildTaps()
+    {
+        const float sr = static_cast<float> (sampleRate_);
+        numTapsL_ = numTapsR_ = 0;
+        buildChannel (0xC0FFEEu, tapDelayL_, tapGainL_, numTapsL_, sr);
+        buildChannel (0x1234567u, tapDelayR_, tapGainR_, numTapsR_, sr);
+        normalize (tapGainL_, numTapsL_);
+        normalize (tapGainR_, numTapsR_);
+    }
+
+    // Density(t): front-loaded base (high near 0, decaying) + a second bump
+    // around burst2Ms_. Probability a 1 ms cell emits a tap.
+    float density (float tMs) const
+    {
+        const float b1 = std::exp (-tMs / 18.0f);                       // burst 1: dense 0-40ms
+        const float b2 = (burst2Ms_ > 0.0f)
+            ? 0.55f * std::exp (-((tMs - burst2Ms_) * (tMs - burst2Ms_)) / (2.0f * 22.0f * 22.0f))
+            : 0.0f;                                                      // burst 2: cluster ~burst2Ms_
+        return std::clamp (b1 + b2 + 0.06f, 0.0f, 1.0f);                 // 0.06 floor → sparse tail to 200ms
+    }
+
+    // Tap GAIN envelope: gently rising to onsetPeakMs_ then exponential decay.
+    float gainEnv (float tMs) const
+    {
+        const float rise = (onsetPeakMs_ > 0.0f)
+            ? std::min (1.0f, tMs / onsetPeakMs_)                        // linear ramp to peak
+            : 1.0f;
+        const float dec  = std::exp (-tMs / decayMs_);
+        return rise * dec;
+    }
+
+    void buildChannel (uint32_t seed, int* delays, float* gains, int& n, float sr)
+    {
+        Rng rng { seed };
+        for (int c = 0; c < kCells && n < kMaxTaps; ++c)
+        {
+            const float baseMs = static_cast<float> (c) * sizeScale_;
+            if (baseMs > kMaxTimeMs) break;
+            if (rng.next() < density (baseMs))
+            {
+                const float subMs = rng.next() * sizeScale_;            // jitter within cell (L/R independent)
+                const float tMs   = baseMs + subMs;
+                const int   d      = static_cast<int> (tMs * 0.001f * sr);
+                if (d <= 0 || d > mask_) continue;
+                const float sign  = (rng.next() < 0.5f) ? -1.0f : 1.0f;
+                delays[n] = d;
+                gains[n]  = sign * gainEnv (tMs);
+                ++n;
+            }
+        }
+    }
+
+    void normalize (float* gains, int n)
+    {
+        float e = 0.0f;
+        for (int i = 0; i < n; ++i) e += gains[i] * gains[i];
+        if (e <= 0.0f) return;
+        const float g = 1.0f / std::sqrt (e);                            // unit-energy field
+        for (int i = 0; i < n; ++i) gains[i] *= g;
+    }
+
+    double sampleRate_ = 44100.0;
+    bool   prepared_   = false;
+    std::vector<float> bufferL_, bufferR_;
+    int    writePos_ = 0, mask_ = 0;
+
+    int   tapDelayL_[kMaxTaps] {}, tapDelayR_[kMaxTaps] {};
+    float tapGainL_ [kMaxTaps] {}, tapGainR_ [kMaxTaps] {};
+    int   numTapsL_ = 0, numTapsR_ = 0;
+
+    float sizeScale_  = 1.0f;     // ms per cell (scales the whole field in time)
+    float onsetPeakMs_ = 14.0f;   // rising-onset peak
+    float decayMs_    = 55.0f;    // overall gain decay constant
+    float burst2Ms_   = 115.0f;   // second density cluster centre (0 = off)
+};

--- a/plugins/DuskVerb/src/dsp/TwoBandDamping.h
+++ b/plugins/DuskVerb/src/dsp/TwoBandDamping.h
@@ -412,31 +412,36 @@ public:
     void prepare (float sampleRate) { sampleRate_ = sampleRate; reset(); }
     void reset() { for (auto& s : shelf_) s.reset(); }
 
+    // Composite |H| of the float-quantized cascade at one frequency, in
+    // double precision. Evaluating the FLOAT coefficients (not an idealized
+    // double design) is essential: the realized in-loop filter IS the float
+    // cascade, so coefficient quantization error gets absorbed by the
+    // correction loop in designCoeffs. Message-thread / design-time only.
+    //
+    // NOTE: the design-time bodies (magnitudeAt / designCoeffs /
+    // buildCascade) live in OctaveGEQDesign.cpp, NOT inline here — inline
+    // bodies in this header measurably perturbed the FP codegen of the plain
+    // FDNReverbT<false> hot loop in the same TU (~4e-6 render drift; see
+    // memory duskverb_bitnull_codegen_limit). Keep them out-of-line.
+    static double magnitudeAt (const Coeffs& c, double fHz, double sampleRate);
+
     // gBand[0..8] = absolute per-round-trip loop gain at each octave centre.
     // xoverHz[0..7] = inter-octave crossover frequencies (geometric means of
     // adjacent centres = the full_check T60-gate band edges).
+    //
+    // Composite-exact design: the adjacent-ratio shelf cascade alone does NOT
+    // realize gBand[k] at the octave centres — 2nd-order RBJ transition
+    // slopes leak across the 1-octave spacing, and at long T60 (g → 0.99+) a
+    // ~0.1 dB composite error is a huge T60 error (this leakage is what made
+    // the external render-based octave-T60 calibrator diverge on steep/long
+    // profiles: Bright Hall >190 s, Cathedral >40 s). So iterate the
+    // COMMANDED gains in log domain (damped fixed point, λ=0.7, keep-best,
+    // λ-halving on stall) until the measured composite hits the targets at
+    // all nine ISO centres, then guard loop stability with an analytic
+    // between-centre sweep. Design-time only (message thread, ≤25 redesigns,
+    // allocation-free); the audio-thread process() is unchanged.
     static Coeffs designCoeffs (const float* gBand, const float* xoverHz,
-                                float sampleRate)
-    {
-        Coeffs c;
-        ShelfBiquad bq;
-        // Low side: octaves 0..3 below the 1 kHz mid.
-        for (int k = 0; k < kMidBand; ++k)
-        {
-            const float ratio = gBand[k] / std::max (gBand[k + 1], 1.0e-12f);
-            bq.designLowShelf (ratio, xoverHz[k], sampleRate);
-            c.b0[k] = bq.b0; c.b1[k] = bq.b1; c.b2[k] = bq.b2; c.a1[k] = bq.a1; c.a2[k] = bq.a2;
-        }
-        // High side: octaves 5..8 above the mid.
-        for (int k = kMidBand; k < kNumShelves; ++k)
-        {
-            const float ratio = gBand[k + 1] / std::max (gBand[k], 1.0e-12f);
-            bq.designHighShelf (ratio, xoverHz[k], sampleRate);
-            c.b0[k] = bq.b0; c.b1[k] = bq.b1; c.b2[k] = bq.b2; c.a1[k] = bq.a1; c.a2[k] = bq.a2;
-        }
-        c.broadbandGain = gBand[kMidBand];
-        return c;
-    }
+                                float sampleRate);
 
     // Eight DF1 shelving biquads in series, then broadband gain.
     float process (float input, const Coeffs& c)
@@ -453,6 +458,14 @@ public:
     }
 
 private:
+    // The raw adjacent-ratio cascade (pre-correction): low shelves encode
+    // gBand[k]/gBand[k+1] below the mid, high shelves gBand[k+1]/gBand[k]
+    // above it, broadband = gBand[4]. Exact only for brick-wall shelves;
+    // designCoeffs iterates commanded gains against magnitudeAt to make the
+    // realized composite exact at the centres.
+    static Coeffs buildCascade (const float* gBand, const float* xoverHz,
+                                float sampleRate);
+
     float       sampleRate_ = 44100.0f;
     ShelfBiquad shelf_[kNumShelves];   // z1/z2 state only
 };

--- a/plugins/DuskVerb/tools/perceptual_diff.py
+++ b/plugins/DuskVerb/tools/perceptual_diff.py
@@ -735,20 +735,20 @@ def main():
     lex_crest = spectral_crest_db(lex_nb[int(0.1 * sr):], sr)
     dv_crest = spectral_crest_db(dv_nb[int(0.1 * sr):], sr)
 
-    # NEW: D50 (50 ms clarity), stereo correlation, time-domain crest
+    # D50 (50 ms clarity), stereo correlation, time-domain crest
     lex_d50 = d50(lex_ir_t, sr)
     dv_d50 = d50(dv_ir_t, sr)
     lex_stereo = stereo_correlation(lex_nb_path)
     dv_stereo  = stereo_correlation(dv_nb_path)
     lex_tdc = time_domain_crest(lex_nb, sr)
     dv_tdc  = time_domain_crest(dv_nb, sr)
-    # NEW: K-weighted LUFS (perceived loudness on music-like content)
+    # K-weighted LUFS (perceived loudness on music-like content)
     lex_lufs = k_weighted_lufs(lex_nb, sr)
     dv_lufs  = k_weighted_lufs(dv_nb, sr)
-    # NEW: momentary LUFS max (peak loudness over any 400 ms window)
+    # momentary LUFS max (peak loudness over any 400 ms window)
     lex_mlufs = momentary_lufs_max(lex_nb, sr)
     dv_mlufs  = momentary_lufs_max(dv_nb,  sr)
-    # NEW: boxiness (200-500 Hz peak vs flanks)
+    # boxiness (200-500 Hz peak vs flanks)
     lex_box = box_ratio_db(lex_nb, sr)
     dv_box  = box_ratio_db(dv_nb, sr)
 

--- a/plugins/DuskVerb/tools/tuner/NEW_ENGINE_SCOPING.md
+++ b/plugins/DuskVerb/tools/tuner/NEW_ENGINE_SCOPING.md
@@ -95,3 +95,131 @@ measure it.
    no-convolution positioning)? → picks A vs (C+B).
 2. Scope: full ground-up (A, multi-week) vs the cheaper T60-focused FDN+GEQ evolution (C) first?
 3. Target: match VVV specifically, or a general VVV-class hall? (affects how hard P3 is pushed.)
+
+---
+
+# 2026-06-11 — GATE-DRIVEN REVERSE-ENGINEERING SCOPE (room category)
+
+## Reframe (per user): don't R&D blind — reverse-engineer to KNOWN target values
+We have the anchor's exact measured gate values. The engine is not an open search; it is a
+spec: build each stage to PRODUCE the known number, verify against it, move on. The full_check
+harness already prints DV-vs-anchor per gate, so every stage has a closed-loop target.
+
+## What already ships (reuse, don't rebuild)
+- T60 9-vs-5 wall → **AccurateHall** (algo 10/12): FDN + per-octave in-loop GEQ. Reuse the GEQ.
+- Early-field/front-load wall → **composite ER** (algo 13): `SparseEarlyField` + tail. Reuse it.
+- Remaining blocker = the **smooth dense late field**: `diffusion_flux`, `osc P2P`,
+  `tail pitch-chorus` — the Hadamard FDN's fixed beating. This is the ONLY novel piece to build.
+
+## The reverse-engineering target table (Medium Drum Room anchor = vvv-fat-snare-room)
+Every value below is MEASURED from the anchor (the full_check `Lex=`/`VVV=` column). The new
+engine must reproduce each; the right column is the stage + design that produces it by construction.
+
+| Gate (anchor target) | Engine stage → design that hits it |
+|---|---|
+| `diffusion_flux` (anchor's kurtosis-vs-time shape; gate ≤1.5 L1) | **late-field density trajectory** — velvet tap-density envelope (A) OR allpass-mesh depth (B), tuned to the anchor's two-burst shape. THE novel core. |
+| `osc P2P` +20.5 dB | late-field **modal smoothness** — independent dense taps (velvet, corr≈0) or deep allpass → low envelope ripple. Set density high enough to hit ~20.5. |
+| `tail pitch-chorus` 3.67 Hz | **no intrinsic delay modulation** (velvet taps are static positions; allpass mesh unmodulated) + a slow explicit chorus tuned to 3.67. |
+| per-octave `T60` (≈0.73-1.03 s, the MDR calibrated map) | **per-band decay** — parallel band branches with independent density/gain envelopes = arbitrary per-band T60 (reuse the octave-GEQ target table). |
+| `decay low_mid` 0.262 s, `decay mid` 0.345 s, `edt` 0.068/0.097/0.100 | per-band envelope SHAPE (edt≠T60): convex early-decay knee per band. |
+| `ss` per band (low-mid −31.98, air −50.88, sub/low) | per-band **steady-state level** = per-band tap-gain (independent of decay, since density sets energy and envelope sets decay). |
+| `energy_first50` 44.8%, `t50` 60 ms, `attack` 21.9 ms, `onset` 1.148 | **composite ER front-end** (already built) — tune its density/gain to these. |
+| `cent_50` 2214 Hz, `cent_500` 1346 Hz | per-band tap-gain spectral tilt (early vs late windows). |
+| `stereo_corr` +0.151, `width` | **independent L/R** tap sequences scaled to the target corr (not 0, not anti-phase). |
+| `boom` (−73…−76), `bloom 8-12k` −61.5, `env_shape` | late-low-band gain + HF-band envelope; falls out of the per-band level/decay handles. |
+
+## De-risked plan — the hard target FIRST (go/no-go in days)
+- **P0 — SMOOTHNESS KILL-TEST.** Prototype ONLY the bare late field (velvet or allpass-mesh),
+  mono, single-band, isolated. Measure `diffusion_flux`, `osc P2P`, `tail pitch-chorus` vs the
+  anchor. **GO only if it reaches (or clearly trends to) the anchor's values** — diffusion ≤~1.5,
+  osc P2P ≈20.5, pitch-chorus tunable to 3.67. If a velvet/allpass tail can't beat the FDN's
+  fixed beating here, the engine is falsified cheaply — STOP. This is the entire gamble.
+- **P1** per-band decay branches → hit the per-octave T60 + decay/edt targets.
+- **P2** weld the built composite ER → hit the early-field targets.
+- **P3** independent L/R + slow chorus → hit stereo_corr + pitch-chorus.
+- **P4** per-band level tilt → hit ss + cent + boom + bloom; migrate the room category
+  (MDR/Ambience/79VC/Cathedral), each beats its FDN n_fail, ear-confirmed, fleet bit-null.
+
+## Effort / risk / reward
+- **P0 = days, decides everything.** P1-P4 = multi-week if P0 passes.
+- **Risk concentrated in P0** (smooth dense tail to gate level is the research bit). Reverse-
+  engineering helps: we tune to a KNOWN number, not search blind. Medium confidence velvet/allpass
+  beats Hadamard on the 3 smoothness gates; the per-band stages (P1-P4) are well-understood once
+  P0 lands.
+- **Reward:** cracks the whole room/hall category, not just MDR. New `EngineType` slot; existing
+  fleet bit-null by construction.
+- **Decision still open:** velvet (A) needs the "is procedurally-generated noise algorithmic?"
+  call; if no, the allpass-scattering mesh (B) is the unambiguously-algorithmic fallback for P0.
+
+## Recommendation
+Greenlight **P0 only** (the smoothness kill-test, days). It reverse-engineers the one uncertain
+piece against its known anchor value and tells us — cheaply — whether the multi-week engine is
+worth building. Everything else (ER, GEQ damping, per-band, slot integration) is already proven.
+
+---
+
+## RESOLUTION (2026-06-11, post-falsification)
+
+**P0 velvet kill-test: RUN TWICE, FALSIFIED TWICE** in the real full_check harness
+(diffusion_flux ~16 vs FDN 14 — worse). Root cause of the bad GO above: the prototype
+metrics did not match full_check's diffusion_flux_curve (window/onset mismatch read
+anchor peak kurt 32 vs the true 93), and the DuskVerb shell (Hi-Cut shelf chain)
+smears discrete velvet spikes to Gaussian kurt ~3 before measurement. The scoping
+table above is RETAINED for its gate→stage mapping but its GO is void.
+
+**What actually happened instead:** the cent_500/ss/decay walls this doc targeted
+turned out to be (a) the FDN-vs-dark-room mismatch — solved by migrating MDR to the
+Dattorro allpass tank (algo 0), and (b) a HARNESS BUG — the gain-match step
+requantized float renders to 16-bit PCM, faking cent_500 +141% (true value passed).
+See scoreboard_2026-06-11.md and memory duskverb-harness-pcm16-requantization.
+MDR honest n_fail 21 (Dattorro r3) + early-field r4 sweep in progress. The remaining
+early-field cluster (attack/onset/first50/osc-P2P/diffusion_flux) = discrete-
+reflection texture — IF a future engine attacks it, the shell-smear constraint above
+still applies to any spike-based design (measure THROUGH the shell, in full_check,
+from day one).
+
+---
+
+## MDR SPARSE-ER COMPOSITE WELD — pipe laid 2026-06-11 (execute next session)
+
+**Why (data-grounded, not theory):** fleet scan proved diffusion_flux + pitch-chorus
+are NOT universal walls — Ambience clears diffusion_flux at 1.51 and 4/5 presets pass
+pitch-chorus, all through the same shell. MDR's diffusion_flux=16 is a LOCAL mismatch:
+its anchor is a spiky discrete-reflection room (kurt peak ~93) vs DV's smooth Dattorro
+wash. The fix is a discrete early field matched to that profile — exactly what Tiled
+Room's sparse-ER front does (cut ITS diffusion_flux to 6.28). Bonus: the same discrete
+early structure attacks the early-field cluster (attack/onset/first50) — same root.
+
+**Design = mirror the Tiled Room composite (DuskVerbEngine.cpp:1039), Dattorro tail
+instead of AccurateHall:**
+
+  new EngineType::RoomComposite = 14   (slot 14 is free post multi-stage revert)
+  dispatch:
+    dattorro_.process   (tankIn -> tankOut, n);       // mature dense tail (no flutter)
+    sparseField_.process(tankIn -> sparseOut, n);      // discrete spiky ER front
+    for i: tankOut[i] = tankOut[i]*sparseTailGain_ + sparseOut[i]*sparseERGain_;
+
+**Exact code points (all additive, fleet bit-null by new-slot construction):**
+- AlgorithmConfig.h: enum RoomComposite=14; kEngines += { "Drum Room", RoomComposite };
+  getNumAlgorithms 14->15; bounds index>=15.
+- render.cpp:98 kNumAlgorithms 14->15 (+ comment).
+- DuskVerbEngine.cpp: dispatch case (above) + add RoomComposite to the useSmoothER
+  EXCLUSION (~line 1089, like TiledRoom — it makes its own early field) + clearAllBuffers
+  already clears sparseField_/dattorro_. prepare already prepares both.
+- PluginEditor.h getEngineAccent: add a case (else -Wswitch).
+- reuse: sparseTailGain_/sparseERGain_, setSparseField{Size,OnsetMs,DecayMs,Burst2Ms},
+  setSparseERGain/TailGain — all already wired for TiledRoom.
+
+**Migration + tuning (the real work — needs the anti-beating sweep result for the tail
+voicing first):**
+- FactoryPresets MDR row algo 0->14; carry the baked Dattorro tail voicing (the
+  anti-beating sweep winner) as the tail; add a kRoomCompositeByName voicing map
+  (sparseField size/onset/decay/burst2 + er/tail gains) tuned to MDR's anchor.
+- TUNE sparseField tap density/onset to MDR's kurt-93 early profile (drive diffusion_flux
+  16->toward gate) + er/tail balance for attack/onset/first50. Joint sweep, honest harness.
+
+**Honest risk (why this is scoped, not blind-built tonight):** an ER+FDN composite on MDR
+was falsified at 24 EARLIER THIS SESSION — but (a) that was under the contaminated PCM16
+harness (cent_500 was fake), (b) FDN tail not Dattorro (Dattorro already killed the ring +
+got honest 20), (c) it didn't target diffusion_flux/kurtosis specifically. Re-justified,
+but bring eyes: bake ONLY if it beats the anti-beating baseline (never-worse), ear-confirm.

--- a/plugins/DuskVerb/tools/tuner/baseDelay_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/baseDelay_sweep.py
@@ -31,7 +31,7 @@ RENDER = REPO / "build" / "tests" / "duskverb_render" / "duskverb_render"
 VST3 = Path.home() / ".vst3" / "DuskVerb.vst3"
 
 K_MIN = 700           # ~16ms @ 48kHz lower bound
-K_MAX = 6700          # FDNReverb::kMaxBaseDelay
+K_MAX = 6700          # MUST match FDNReverb::kMaxBaseDelay (engine clamps above this)
 N_LINES = 16
 
 # Per-band Hilbert targets in Hz. Bands match full_check.py band edges.

--- a/plugins/DuskVerb/tools/tuner/calibrate_octave_t60.py
+++ b/plugins/DuskVerb/tools/tuner/calibrate_octave_t60.py
@@ -127,7 +127,17 @@ def main():
                     continue
                 pct = (d - a) / a * 100
                 ok = abs(pct) <= 5; npass += ok
-                new[k] = round(targets[name][k] * (a / d), 4)
+                # Divergence guard: with the composite-exact GEQ the fixed
+                # point converges fast wherever the band is reachable. A
+                # target inflating past 8x the anchor means an in-loop loss
+                # CEILING (e.g. the always-on 17 kHz anti-alias one-pole caps
+                # 16k T60 at ~3-4 s) — cap and flag instead of running away.
+                proposed = targets[name][k] * (a / d)
+                if proposed > 8.0 * a:
+                    new[k] = round(8.0 * a, 4)
+                    cells.append(f"{['63','125','250','500','1k','2k','4k','8k','16k'][k]}:{pct:+.0f}%CEIL")
+                    continue
+                new[k] = round(proposed, 4)
                 cells.append(f"{['63','125','250','500','1k','2k','4k','8k','16k'][k]}:{pct:+.0f}%")
             print(f"  {name:22s} {npass}/9  " + " ".join(cells))
             targets[name] = new

--- a/plugins/DuskVerb/tools/tuner/calibrate_octave_t60.py
+++ b/plugins/DuskVerb/tools/tuner/calibrate_octave_t60.py
@@ -44,6 +44,7 @@ ANCHORS = {
     "79 Vocal Chamber":     f"{ANCH}/vvv-79vc/vvv-79vc_noiseburst.wav",
     "Ambience":             f"{ANCH}/vvv-ambience/vvv-ambience_noiseburst.wav",
     "Bright Hall":          f"{ANCH}/vvv-bright-hall/vvv-bright-hall_noiseburst.wav",
+    "Medium Drum Room":     f"{ANCH}/vvv-fat-snare-room/vvv-fat-snare-room_noiseburst.wav",
 }
 
 

--- a/plugins/DuskVerb/tools/tuner/calibrate_octave_t60.py
+++ b/plugins/DuskVerb/tools/tuner/calibrate_octave_t60.py
@@ -98,12 +98,15 @@ def render(name):
 
 
 def measure(dv, anchor):
-    out = []
-    for lo, hi in BANDS:
-        d = _t60_band_schroeder(dv, lo, hi)
-        a = _t60_band_schroeder(anchor, lo, hi)
-        out.append((d, a))
-    return out
+    # Parallel band measurement: 18 independent sosfiltfilt+Schroeder fits.
+    # Threads (not processes) — scipy releases the GIL in the filter kernels
+    # and shared arrays avoid the copy blow-up that OOM'd past process pools
+    # (memory: duskverb_tuner_workers). ~4x on the measure step.
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=6) as ex:
+        dvs = [ex.submit(_t60_band_schroeder, dv, lo, hi) for lo, hi in BANDS]
+        anc = [ex.submit(_t60_band_schroeder, anchor, lo, hi) for lo, hi in BANDS]
+        return [(d.result(), a.result()) for d, a in zip(dvs, anc)]
 
 
 def main():

--- a/plugins/DuskVerb/tools/tuner/dense32_kurtosis_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/dense32_kurtosis_sweep.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Optimize the AccurateHall32 (Algorithm 12) 32-delay mode-spread so the FDN's
+HF tail modes interleave into a uniform dense wash instead of the sparse metallic
+clusters the naive doubled set produces.
+
+Search: 32 prime-snapped delay variables, each bounded to a tight window around a
+geometric (log-spaced) anchor. The anchor set's mean is rescaled to match the
+shipping 16-line baseline mean, so the average loop delay (and therefore the
+calibrated T60) stays put while Optuna micro-shifts individual spacings to
+interleave harmonic poles. Realized mean is penalized so prime-snap/dedupe drift
+can't move T60. Distinct primes (coprime) suppress flutter echoes.
+
+Objective:
+  PRIMARY  minimize aggregate 2-14 kHz tail spectral kurtosis toward target 12.0
+  PENALTY  heavy penalty on any sub-band (2-4k, 4-6k, 6-9k, 9-14k) kurtosis > 6.0
+  GUARD    small penalty on |mean(delays) - baseline_mean| to hold T60
+
+Renders Bright Hall on Algorithm 12 via the DUSKVERB_FDN_DELAYS env override
+(32-CSV) — no rebuild per trial.
+
+Run from repo root:  python3 plugins/DuskVerb/tools/tuner/dense32_kurtosis_sweep.py --trials 100
+"""
+import argparse, os, sys, glob, shutil, subprocess
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import soundfile as sf, numpy as np, optuna
+from scipy.signal import butter, sosfiltfilt
+
+REPO = Path(__file__).resolve().parents[4]
+REND = REPO / "build/tests/duskverb_render/duskverb_render"
+ANCH = Path.home() / "projects/dusk-audio-tools/tuner_runs/anchors/vvv-bright-hall"
+WET  = ["--program", "Bright Hall", "--param", "Algorithm=12",
+        "--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0"]
+SUB  = [(2000, 4000), (4000, 6000), (6000, 9000), (9000, 14000)]
+TARGET_AGG = 12.0          # anchor aggregate 2-14k kurtosis
+SUB_CAP    = 6.0           # any sub-band above this is heavily penalized
+
+# Engine canonical 16-line baseline = FDNReverb.cpp kDefaultDelays first 16.
+# This is "the working 16-line baseline" the ticket anchors the mean to.
+BASE16 = [1151, 1289, 1447, 1619, 1823, 2039, 2287, 2579,
+          2887, 3229, 3631, 4073, 4567, 5119, 5749, 6451]
+# kDefaultDelays second 16 (interleaved primes) — the current naive AccurateHall32
+# default. NAIVE32 = the real compiled default, the honest baseline column.
+NEW16 = [1213, 1361, 1531, 1721, 1933, 2153, 2417, 2713,
+         3041, 3413, 3833, 4297, 4817, 5417, 6079, 6469]
+NAIVE32 = sorted(BASE16 + NEW16)
+BASE_MEAN = float(np.mean(BASE16))
+
+
+KMAX = 6700                # FDNReverb kMaxBaseDelay — clamp ceiling, must not collide
+
+def primes_upto(n):
+    s = np.ones(n + 1, dtype=bool); s[:2] = False
+    for i in range(2, int(n ** 0.5) + 1):
+        if s[i]: s[i * i::i] = False
+    return np.flatnonzero(s)
+PRIMES = primes_upto(7000)
+PRIMES = PRIMES[PRIMES <= KMAX]    # never exceed the clamp ceiling (avoids dup-at-6700)
+
+
+def nearest_prime(x):
+    i = int(np.searchsorted(PRIMES, x))
+    cands = PRIMES[max(0, i - 1):i + 2]
+    return int(cands[np.argmin(np.abs(cands - x))])
+
+
+# 32 geometric anchors over 1130..6300, rescaled so their mean == BASE_MEAN.
+# Top kept below KMAX with window headroom so no prime snaps to the clamp ceiling.
+_lo, _hi, _N = 1130.0, 6300.0, 32
+_anchors = _lo * (_hi / _lo) ** (np.arange(_N) / (_N - 1))
+_anchors *= BASE_MEAN / _anchors.mean()
+ANCHORS = _anchors
+# per-index window = 0.42 * local spacing (clamped) — keeps the search prime-tight.
+_gap = np.gradient(ANCHORS)
+WIN = np.clip(0.42 * _gap, 28, 240).astype(int)
+
+
+def tail_kurt(p, lo, hi):
+    x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    pk = int(np.argmax(np.abs(m))); seg = m[pk + int(0.3 * sr):pk + int(1.5 * sr)]
+    if len(seg) < sr // 4: return None
+    sos = butter(4, [lo, min(hi, sr * 0.49)], 'band', fs=sr, output='sos')
+    y = sosfiltfilt(sos, seg)
+    sp = np.abs(np.fft.rfft(y * np.hanning(len(y)))) + 1e-12
+    fr = np.fft.rfftfreq(len(y), 1 / sr); b = (fr >= lo) & (fr <= hi); spb = sp[b]
+    return float(((spb - spb.mean()) ** 4).mean() / (spb.var() ** 2 + 1e-30))
+
+
+def _nearest_unused(target, used):
+    """Nearest prime index to target whose prime is unused, spiralling outward."""
+    c = int(np.clip(np.searchsorted(PRIMES, target), 0, len(PRIMES) - 1))
+    for step in range(len(PRIMES)):
+        for j in (c - step, c + step):            # 0, then ±1, ±2, ... (both dirs)
+            if 0 <= j < len(PRIMES) and int(PRIMES[j]) not in used:
+                return int(PRIMES[j])
+    raise RuntimeError("prime pool exhausted")
+
+
+def build_delays(offsets):
+    """offsets[i] in [-WIN[i], WIN[i]] -> snapped, distinct, sorted 32 primes.
+    Collisions fall back to the nearest unused prime in EITHER direction, so one
+    near the KMAX ceiling steps downward instead of overshooting the clamp."""
+    used = set(); out = []
+    for i, off in enumerate(offsets):
+        p = _nearest_unused(ANCHORS[i] + off, used)
+        used.add(p); out.append(p)
+    return sorted(out)
+
+
+def render_kurts(delays, tag):
+    d = f"/tmp/d32_{tag}"; shutil.rmtree(d, ignore_errors=True); os.makedirs(d)
+    env = dict(os.environ, DUSKVERB_FDN_DELAYS=",".join(str(x) for x in delays))
+    r = subprocess.run([str(REND), *WET, "--output-dir", d], capture_output=True, env=env)
+    nb = glob.glob(f"{d}/*_noiseburst.wav")
+    if r.returncode != 0 or not nb: return None, None
+    agg = tail_kurt(nb[0], 2000, 14000)
+    sub = {b: tail_kurt(nb[0], *b) for b in SUB}
+    return agg, sub
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=100)
+    ap.add_argument("--workers", type=int, default=6)
+    a = ap.parse_args()
+
+    anb = str(ANCH / "vvv-bright-hall_noiseburst.wav")
+    a_agg = tail_kurt(anb, 2000, 14000)
+    a_sub = {b: tail_kurt(anb, *b) for b in SUB}
+    print(f"anchor      agg2-14k={a_agg:.1f}  "
+          f"sub={ {f'{l//1000}-{h//1000}k': round(a_sub[(l,h)],1) for l,h in SUB} }")
+    n_agg, n_sub = render_kurts(NAIVE32, "naive")
+    print(f"naive-32    agg2-14k={n_agg:.1f}  "
+          f"sub={ {f'{l//1000}-{h//1000}k': round(n_sub[(l,h)],1) for l,h in SUB} }")
+    print(f"target agg={TARGET_AGG}  sub-cap={SUB_CAP}  base_mean={BASE_MEAN:.0f}\n")
+
+    def obj(trial):
+        offs = [trial.suggest_int(f"o{i}", -int(WIN[i]), int(WIN[i])) for i in range(_N)]
+        delays = build_delays(offs)
+        agg, sub = render_kurts(delays, str(trial.number))
+        if agg is None: return 1e3
+        loss = abs(agg - TARGET_AGG)                       # PRIMARY
+        for b in SUB:                                      # PENALTY: heavy over-cap
+            loss += 2.0 * max(0.0, sub[b] - SUB_CAP)
+        loss += 0.012 * abs(float(np.mean(delays)) - BASE_MEAN)   # GUARD: hold T60
+        trial.set_user_attr("delays", delays)
+        trial.set_user_attr("agg", agg)
+        trial.set_user_attr("sub", [round(sub[b], 1) for b in SUB])
+        return loss
+
+    study = optuna.create_study(direction="minimize",
+                                sampler=optuna.samplers.TPESampler(seed=42))
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study.optimize(obj, n_trials=a.trials, n_jobs=a.workers)
+
+    bt = study.best_trial
+    best = bt.user_attrs["delays"]
+    print(f"\nBEST  loss={study.best_value:.2f}  agg2-14k={bt.user_attrs['agg']:.1f}  "
+          f"sub={bt.user_attrs['sub']}  mean={np.mean(best):.0f}")
+
+    # Final scoreboard: naive-32 vs optimized vs anchor.
+    b_agg, b_sub = render_kurts(best, "best")
+    print(f"\n{'band':8s} {'naive32':>9s} {'optim':>9s} {'anchor':>9s}")
+    rows = [("2-14k", (2000, 14000))] + [(f"{l//1000}-{h//1000}k", (l, h)) for l, h in SUB]
+    for lab, (lo, hi) in rows:
+        nk = tail_kurt(glob.glob('/tmp/d32_naive/*_noiseburst.wav')[0], lo, hi)
+        ok = tail_kurt(glob.glob('/tmp/d32_best/*_noiseburst.wav')[0], lo, hi)
+        ak = tail_kurt(anb, lo, hi)
+        print(f"{lab:8s} {nk:9.1f} {ok:9.1f} {ak:9.1f}")
+
+    print("\n// AccurateHall32 mode-spread (32 prime delays, mean-anchored to 16-line baseline)")
+    print("static constexpr int kBrightHall32Delays[32] = {")
+    for r in range(0, 32, 8):
+        print("    " + ", ".join(f"{v:4d}" for v in best[r:r + 8]) + ",")
+    print("};")
+
+if __name__ == "__main__":
+    main()

--- a/plugins/DuskVerb/tools/tuner/joint_dense32_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/joint_dense32_sweep.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Joint re-sweep of the AccurateHall32 (algo 12) Bright Hall 32-delay set.
+
+The kurtosis-only dense32 sweep cut the metallic ring (tail 2-14k kurtosis
+19.3 -> 14.3) but, by ignoring every gate, destroyed the 16-line mod-beat
+ripple alignment and shifted modal energy -> full_check n_fail 9 -> 20. This
+sweep optimizes the SAME 32 delays against full_check n_fail directly (the real
+gate suite: ripple, bloom, ss-level, decay, boom, stereo/width), holding the
+metal win as a soft ceiling so the recovered config stays dense.
+
+  PRIMARY  minimize full_check n_fail (gain-matched, sustained-correct)
+  HOLD     keep tail 2-14k kurtosis <= 16.0 (penalty above) — preserve the metal win
+  GUARD    keep mean(delays) ~ 3121 (the 16-line baseline mean -> T60)
+
+Warm-started from the kurtosis-optimal 32 set (its offsets=0 is enqueued as the
+first trial), tight +/-90-sample prime windows so it recovers the gates without
+collapsing the spectral spread. Renders BH on its native algo (12) via the
+DUSKVERB_FDN_DELAYS env override — no rebuild per trial.
+
+Run from repo root:
+  python3 plugins/DuskVerb/tools/tuner/joint_dense32_sweep.py --trials 90
+"""
+import argparse, os, sys, glob, json, shutil, subprocess
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import soundfile as sf, numpy as np, optuna
+from dense32_kurtosis_sweep import tail_kurt, PRIMES, _nearest_unused, BASE_MEAN
+
+REPO = Path(__file__).resolve().parents[4]
+REND = str(REPO / "build/tests/duskverb_render/duskverb_render")
+FC   = str(Path(__file__).resolve().parent / "full_check.py")
+ANCH = Path.home() / "projects/dusk-audio-tools/tuner_runs/anchors/vvv-bright-hall"
+APREF = "vvv-bright-hall"
+WET  = ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0",
+        "--sustained-pink-seconds", "4.0"]
+STIM = ["impulse", "noiseburst", "snare", "sine1k", "sustained"]
+
+# Warm-start center = the kurtosis-optimal 32 delays (baked into BH on 2026-06-10).
+CENTER = [1171, 1237, 1301, 1381, 1471, 1511, 1607, 1699,
+          1811, 1931, 2069, 2129, 2267, 2371, 2539, 2647,
+          2789, 3037, 3089, 3307, 3571, 3767, 3967, 4153,
+          4391, 4657, 4937, 5227, 5471, 5779, 6131, 6577]
+_N = len(CENTER)
+WIN = 90                       # +/- sample window around each center, prime-snapped
+KURT_CEIL = 16.0               # hold the metal win (kurtosis-optimal set is 14.3)
+BASELINE_NFAIL = 9             # BH algo-10 AccurateHall — the never-worse bar
+
+
+def build_delays(offsets):
+    used = set(); out = []
+    for i, off in enumerate(offsets):
+        p = _nearest_unused(CENTER[i] + off, used)
+        used.add(p); out.append(p)
+    return sorted(out)
+
+
+def rms(p):
+    x, _ = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    return float(np.sqrt(np.mean(m * m)))
+
+
+def eval_delays(delays, tag):
+    """Render BH (algo 12) with these delays, gain-match, full_check -> (n_fail, kurt).
+    Fully exception-contained: ANY failure (bad render, unreadable WAV, dir race)
+    returns (None, None) so one bad trial can't kill the whole study.optimize."""
+    dv = f"/tmp/j32_{tag}"; lex = f"/tmp/j32_{tag}_lex"
+    try:
+        shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+        os.makedirs(dv, exist_ok=True); os.makedirs(lex, exist_ok=True)
+        env = dict(os.environ, DUSKVERB_FDN_DELAYS=",".join(str(x) for x in delays))
+        r = subprocess.run([REND, "--program", "Bright Hall", "--output-dir", dv, *WET],
+                           cwd=str(REPO), capture_output=True, text=True, env=env)
+        nb = glob.glob(f"{dv}/*_noiseburst.wav")
+        if r.returncode != 0 or not nb:
+            return None, None
+        for s in STIM:
+            src = ANCH / f"{APREF}_{s}.wav"
+            if src.exists(): shutil.copy(src, f"{lex}/anchor_{s}.wav")
+        a = rms(f"{lex}/anchor_noiseburst.wav"); d = rms(nb[0])
+        if d < 1e-12: return None, None
+        g = a / d
+        for f in glob.glob(f"{dv}/*.wav"):
+            x, sr = sf.read(f); sf.write(f, x * g, sr)
+        r = subprocess.run([sys.executable, FC, dv, lex, "--name", "Bright Hall", "--json"],
+                           capture_output=True, text=True)
+        nfail = None
+        for line in r.stdout.splitlines():
+            if line.startswith("JSON_RESULT:"):
+                nfail = json.loads(line.split("JSON_RESULT: ")[1])["n_fail"]; break
+        kurt = tail_kurt(nb[0], 2000, 14000)
+        return nfail, kurt
+    except Exception:                              # noqa: BLE001 — report-and-continue
+        return None, None
+    finally:
+        # Free the per-trial renders immediately — 90 trials x (dv+lex) sustained
+        # WAVs otherwise fill the tmpfs (ENOSPC mid-sweep). Keep nothing.
+        shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=90)
+    ap.add_argument("--workers", type=int, default=5)
+    a = ap.parse_args()
+
+    nf0, k0 = eval_delays(CENTER, "warm")
+    print(f"warm-start (kurtosis-optimal set): n_fail={nf0}  kurt2-14k={k0:.1f}  "
+          f"(baseline algo-10 = {BASELINE_NFAIL})\n")
+
+    def obj(trial):
+        offs = [trial.suggest_int(f"o{i}", -WIN, WIN) for i in range(_N)]
+        delays = build_delays(offs)
+        nf, kurt = eval_delays(delays, str(trial.number))
+        if nf is None: return 1e3
+        loss = float(nf)
+        loss += 0.5 * max(0.0, kurt - KURT_CEIL)             # hold the metal win
+        loss += 0.01 * abs(float(np.mean(delays)) - BASE_MEAN)  # hold T60
+        trial.set_user_attr("delays", delays)
+        trial.set_user_attr("nfail", nf)
+        trial.set_user_attr("kurt", round(kurt, 1))
+        return loss
+
+    # SQLite storage: in-memory studies vanish on crash (an ENOSPC mid-run lost a
+    # whole pass once). Persist so best survives interruption and is queryable live.
+    study = optuna.create_study(direction="minimize", study_name="j32",
+                                storage="sqlite:////tmp/j32_study.db",
+                                load_if_exists=True,
+                                sampler=optuna.samplers.TPESampler(seed=42))
+    # NB: do NOT enqueue_trial(CENTER) — enqueue + n_jobs>1 + SQLite storage
+    # double-tells the seeded trial ("Cannot tell a COMPLETE trial" crash). The
+    # warm-start is already measured+printed above; TPE explores the CENTER
+    # neighbourhood anyway since every offset window is centred on 0.
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study.optimize(obj, n_trials=a.trials, n_jobs=a.workers)
+
+    bt = study.best_trial
+    best = bt.user_attrs["delays"]
+    print(f"\nBEST  loss={study.best_value:.2f}  n_fail={bt.user_attrs['nfail']}  "
+          f"kurt2-14k={bt.user_attrs['kurt']}  mean={np.mean(best):.0f}")
+    print(f"  vs baseline algo-10 n_fail {BASELINE_NFAIL} | warm-start n_fail {nf0} kurt {k0:.1f}")
+    print("\nstatic constexpr int kBrightHall32Delays[32] = {")
+    for r in range(0, 32, 8):
+        print("    " + ", ".join(f"{v:4d}" for v in best[r:r + 8]) + ",")
+    print("};")
+
+if __name__ == "__main__":
+    main()

--- a/plugins/DuskVerb/tools/tuner/mdr_earlyfield_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/mdr_earlyfield_sweep.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Optuna COLD-START sweep: Dattorro (algo 0) voicing on Medium Drum Room.
+
+MDR is baked algo 0; this drives the voicing entirely via --param (NO rebuild
+per trial). Objective = full_check n_fail + continuous tiebreak (summed gate
+exceedance, mapped into [0,1) so n_fail always dominates → Optuna gets a
+gradient through n_fail plateaus). Sustained-correct, gain-matched to the
+anchor noiseburst RMS. Self-cleaning per-trial dirs (tmpfs OOM lesson).
+SQLite-persisted (resumable). No enqueue_trial (race bug). n_jobs=6.
+"""
+import os, sys, glob, json, shutil, subprocess, re
+from pathlib import Path
+import optuna, soundfile as sf, numpy as np
+
+# Repo root = .../plugins/DuskVerb/tools/tuner/<this> -> parents[4]. Override
+# with REPO_PATH for non-standard checkouts.
+REPO = os.environ.get("REPO_PATH", str(Path(__file__).resolve().parents[4]))
+REND = f"{REPO}/build/tests/duskverb_render/duskverb_render"
+ANCH = os.path.expanduser("~/projects/dusk-audio-tools/tuner_runs/anchors")
+FC   = f"{REPO}/plugins/DuskVerb/tools/tuner/full_check.py"
+WET  = ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0",
+        "--sustained-pink-seconds", "4.0"]
+STIM = ["impulse", "noiseburst", "snare", "sine1k", "sustained"]
+NAME = "Medium Drum Room"
+ADIR, APREF = f"{ANCH}/vvv-fat-snare-room", "vvv-fat-snare-room"
+WORK = "/tmp/dattorro_sweep"
+os.makedirs(WORK, exist_ok=True)
+
+# (display_name, lo, hi). Ranges seeded from this session's probes: Decay 0.65
+# gave T60-500 0.35s vs anchor 0.93s -> need ~2x; anchor T60 0.66(16k)..0.99(125)
+# so Treble<1 (HF shorter), Bass~1. Size ~0.4 (anchor 38.8%).
+PARAMS = [  # round 4: EARLY-FIELD axis on the frozen r3 tank. Target cluster:
+            # attack +17ms slow, onset -76%, first50 +19pp, snare-RMS +2.7,
+            # osc P2P -5.4, width-low/stereo. Tank micro-dims for rebalance only.
+    ("Early Ref Level",  0.10, 0.55),
+    ("Early Ref Boost",  1.0,  4.5),
+    ("Early Ref Rise",   4.0,  26.0),
+    ("Early Ref Size",   0.40, 0.95),
+    ("ER Bus Low Gain",  -8.0, 4.0),
+    ("ER Bus High Gain", -4.0, 8.0),
+    ("Tank Level",       0.45, 1.00),
+    ("Pre-Delay",        4.0,  14.0),
+    ("Width",            0.85, 1.10),
+    ("Decay Time",       0.90, 1.05),
+    ("Treble Multiply",  0.60, 0.78),
+]
+_UNUSED_ENV_PARAMS = [
+    ("tf_low_db",  -8.0, 0.0),    # tank-feed low shelf @ 250 Hz (boom/ss-sub)
+    ("tf_high_db", -12.0, 0.0),   # tank-feed high shelf (late HF / ss air)
+    ("tf_high_fc", 1200.0, 4000.0),
+    ("densjit",    0.0, 0.02),    # density-AP wander (pitch-chorus vs ring)
+]
+
+
+def rms(p):
+    x, _ = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    return float(np.sqrt(np.mean(m * m)))
+
+
+def exceedance(fails):
+    """Sum |Δ|/gate over fail lines (generic parse). Tiebreak only."""
+    tot = 0.0
+    for f in fails:
+        dm = re.search(r"Δ=\s*([+-]?[\d.]+)", f)
+        gm = re.search(r"gate=[±≤]?\s*([\d.]+)", f)
+        if dm and gm:
+            g = float(gm.group(1))
+            if g > 0:
+                tot += abs(float(dm.group(1))) / g
+    return tot
+
+
+def objective(trial):
+    tid = trial.number
+    pflags = []
+    for nm, lo, hi in PARAMS:
+        v = trial.suggest_float(nm, lo, hi)
+        pflags += ["--param", f"{nm}={v}"]
+    renv = dict(os.environ)   # feed-EQ/densjit ride the baked maps
+    dv, lex = f"{WORK}/t{tid}", f"{WORK}/t{tid}_lex"
+    shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+    os.makedirs(dv); os.makedirs(lex)
+    try:
+        r = subprocess.run([REND, "--program", NAME, "--output-dir", dv, *WET, *pflags],
+                           cwd=REPO, capture_output=True, text=True, timeout=150, env=renv)
+        nb = glob.glob(f"{dv}/*_noiseburst.wav")
+        if r.returncode != 0 or not nb:
+            return 999.0
+        for s in STIM:
+            src = f"{ADIR}/{APREF}_{s}.wav"
+            if os.path.exists(src):
+                shutil.copy(src, f"{lex}/anchor_{s}.wav")
+        g = rms(f"{lex}/anchor_noiseburst.wav") / max(rms(nb[0]), 1e-12)
+        for f in glob.glob(f"{dv}/*.wav"):
+            x, sr = sf.read(f); sf.write(f, x * g, sr, subtype='FLOAT')
+        r = subprocess.run([sys.executable, FC, dv, lex, "--name", NAME, "--json"],
+                           capture_output=True, text=True, timeout=150)
+        res = None
+        for line in r.stdout.splitlines():
+            if line.startswith("JSON_RESULT:"):
+                res = json.loads(line.split("JSON_RESULT: ")[1])
+        if res is None:
+            return 999.0
+        nf = res["n_fail"]
+        ex = exceedance(res["fails"])
+        trial.set_user_attr("n_fail", nf)
+        return nf + ex / (ex + 50.0)
+    except Exception:
+        return 999.0
+    finally:
+        shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    n_trials = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+    n_jobs   = int(sys.argv[2]) if len(sys.argv) > 2 else 6
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study = optuna.create_study(direction="minimize", study_name="mdr_r4_er",
+                                storage=f"sqlite:///{WORK}/study_r4.db", load_if_exists=True)
+    done = len([t for t in study.trials if t.state.is_finished()])
+    print(f"resuming: {done} trials done; running {n_trials} more, {n_jobs} workers")
+    study.optimize(objective, n_trials=n_trials, n_jobs=n_jobs)
+    bt = study.best_trial
+    print("BEST n_fail:", bt.user_attrs.get("n_fail"), "objective:", round(study.best_value, 4))
+    print("BEST params:", json.dumps(study.best_params, indent=2))

--- a/plugins/DuskVerb/tools/tuner/mdr_progenitor_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/mdr_progenitor_sweep.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Optuna COLD-START sweep: Dattorro (algo 0) voicing on Medium Drum Room.
+
+MDR is baked algo 0; this drives the voicing entirely via --param (NO rebuild
+per trial). Objective = full_check n_fail + continuous tiebreak (summed gate
+exceedance, mapped into [0,1) so n_fail always dominates → Optuna gets a
+gradient through n_fail plateaus). Sustained-correct, gain-matched to the
+anchor noiseburst RMS. Self-cleaning per-trial dirs (tmpfs OOM lesson).
+SQLite-persisted (resumable). No enqueue_trial (race bug). n_jobs=6.
+"""
+import os, sys, glob, json, shutil, subprocess, re
+from pathlib import Path
+import optuna, soundfile as sf, numpy as np
+
+# Repo root = .../plugins/DuskVerb/tools/tuner/<this> -> parents[4]. Override
+# with REPO_PATH for non-standard checkouts.
+REPO = os.environ.get("REPO_PATH", str(Path(__file__).resolve().parents[4]))
+REND = f"{REPO}/build/tests/duskverb_render/duskverb_render"
+ANCH = os.path.expanduser("~/projects/dusk-audio-tools/tuner_runs/anchors")
+FC   = f"{REPO}/plugins/DuskVerb/tools/tuner/full_check.py"
+WET  = ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0",
+        "--sustained-pink-seconds", "4.0"]
+STIM = ["impulse", "noiseburst", "snare", "sine1k", "sustained"]
+NAME = "Medium Drum Room"
+ADIR, APREF = f"{ANCH}/vvv-fat-snare-room", "vvv-fat-snare-room"
+WORK = "/tmp/dattorro_sweep"
+os.makedirs(WORK, exist_ok=True)
+
+# (display_name, lo, hi). Ranges seeded from this session's probes: Decay 0.65
+# gave T60-500 0.35s vs anchor 0.93s -> need ~2x; anchor T60 0.66(16k)..0.99(125)
+# so Treble<1 (HF shorter), Bass~1. Size ~0.4 (anchor 38.8%).
+PARAMS = [  # round 3: HONEST harness (float-preserving gain-match). T60 all long
+            # -> decay down; ER overshoot -> boost/rise down; honest spectral fit.
+    ("Decay Time",       0.85, 1.30),
+    ("Size",             0.30, 0.45),
+    ("Treble Multiply",  0.40, 0.75),
+    ("Mid Multiply",     0.60, 0.90),
+    ("Bass Multiply",    0.60, 0.95),
+    ("Diffusion",        0.55, 0.85),
+    ("Hi Cut",         3500.0, 6500.0),
+    ("Hi Cut Shelf",    -9.0, -3.0),
+    ("Early Ref Boost",  1.0,  2.2),
+    ("Early Ref Rise",   8.0,  30.0),
+    ("Early Ref Level",  0.15, 0.40),
+    ("Mod Depth",        0.00, 0.25),
+]
+# env-driven engine levers (direct-call path)
+ENV_PARAMS = [
+    ("tf_low_db",  -8.0, 0.0),    # tank-feed low shelf @ 250 Hz (boom/ss-sub)
+    ("tf_high_db", -12.0, 0.0),   # tank-feed high shelf (late HF / ss air)
+    ("tf_high_fc", 1200.0, 4000.0),
+    ("densjit",    0.0, 0.02),    # density-AP wander (pitch-chorus vs ring)
+]
+
+
+def rms(p):
+    x, _ = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    return float(np.sqrt(np.mean(m * m)))
+
+
+def exceedance(fails):
+    """Sum |Δ|/gate over fail lines (generic parse). Tiebreak only."""
+    tot = 0.0
+    for f in fails:
+        dm = re.search(r"Δ=\s*([+-]?[\d.]+)", f)
+        gm = re.search(r"gate=[±≤]?\s*([\d.]+)", f)
+        if dm and gm:
+            g = float(gm.group(1))
+            if g > 0:
+                tot += abs(float(dm.group(1))) / g
+    return tot
+
+
+def objective(trial):
+    tid = trial.number
+    pflags = []
+    for nm, lo, hi in PARAMS:
+        v = trial.suggest_float(nm, lo, hi)
+        pflags += ["--param", f"{nm}={v}"]
+    ev = {nm: trial.suggest_float(nm, lo, hi) for nm, lo, hi in ENV_PARAMS}
+    renv = dict(os.environ)
+    renv["DUSKVERB_TANKFEED"] = f"250,{ev['tf_low_db']},{ev['tf_high_fc']},{ev['tf_high_db']}"
+    renv["DUSKVERB_DENSJIT"]  = f"{ev['densjit']}"
+    dv, lex = f"{WORK}/t{tid}", f"{WORK}/t{tid}_lex"
+    shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+    os.makedirs(dv); os.makedirs(lex)
+    try:
+        r = subprocess.run([REND, "--program", NAME, "--output-dir", dv, *WET, *pflags],
+                           cwd=REPO, capture_output=True, text=True, timeout=150, env=renv)
+        nb = glob.glob(f"{dv}/*_noiseburst.wav")
+        if r.returncode != 0 or not nb:
+            return 999.0
+        for s in STIM:
+            src = f"{ADIR}/{APREF}_{s}.wav"
+            if os.path.exists(src):
+                shutil.copy(src, f"{lex}/anchor_{s}.wav")
+        g = rms(f"{lex}/anchor_noiseburst.wav") / max(rms(nb[0]), 1e-12)
+        for f in glob.glob(f"{dv}/*.wav"):
+            x, sr = sf.read(f); sf.write(f, x * g, sr, subtype='FLOAT')
+        r = subprocess.run([sys.executable, FC, dv, lex, "--name", NAME, "--json"],
+                           capture_output=True, text=True, timeout=150)
+        res = None
+        for line in r.stdout.splitlines():
+            if line.startswith("JSON_RESULT:"):
+                res = json.loads(line.split("JSON_RESULT: ")[1])
+        if res is None:
+            return 999.0
+        nf = res["n_fail"]
+        ex = exceedance(res["fails"])
+        trial.set_user_attr("n_fail", nf)
+        return nf + ex / (ex + 50.0)
+    except Exception:
+        return 999.0
+    finally:
+        shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    n_trials = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+    n_jobs   = int(sys.argv[2]) if len(sys.argv) > 2 else 6
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study = optuna.create_study(direction="minimize", study_name="mdr_r3_honest",
+                                storage=f"sqlite:///{WORK}/study_r3.db", load_if_exists=True)
+    done = len([t for t in study.trials if t.state.is_finished()])
+    print(f"resuming: {done} trials done; running {n_trials} more, {n_jobs} workers")
+    study.optimize(objective, n_trials=n_trials, n_jobs=n_jobs)
+    bt = study.best_trial
+    print("BEST n_fail:", bt.user_attrs.get("n_fail"), "objective:", round(study.best_value, 4))
+    print("BEST params:", json.dumps(study.best_params, indent=2))

--- a/plugins/DuskVerb/tools/tuner/outdiff_kurtosis_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/outdiff_kurtosis_sweep.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Optimize the Bright Hall post-tank OutputDiffusion params to smear the FDN's
+sparse HF tail modes toward the anchor's dense wash. Objective = overall 2-14k
+tail spectral kurtosis + the 4-6k / 6-9k / 9-14k sub-band kurtosis, driven
+toward the anchor baselines. Renders via the DUSKVERB_OUTDIFF env override
+(amount,lfoScale,delayScale) — no rebuild per trial. Holds a light guard on the
+broadband HF level so the smear doesn't dull the (bright) preset.
+
+Run from repo root:  python3 outdiff_kurtosis_sweep.py --trials 160
+"""
+import argparse, os, sys, glob, shutil, subprocess
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import soundfile as sf, numpy as np, optuna
+from scipy.signal import butter, sosfiltfilt
+
+REPO = Path(__file__).resolve().parents[4]
+REND = REPO / "build/tests/duskverb_render/duskverb_render"
+ANCH = Path.home() / "projects/dusk-audio-tools/tuner_runs/anchors/vvv-bright-hall"
+WET  = ["--param","Dry/Wet=1.0","--param","Bus Mode=1","--param","Freeze=0"]
+SUB  = [(2000,4000),(4000,6000),(6000,9000),(9000,14000)]   # last 3 are the spike bands
+
+def tail_kurt(p, lo, hi):
+    x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    pk = int(np.argmax(np.abs(m))); seg = m[pk+int(0.3*sr):pk+int(1.5*sr)]
+    if len(seg) < sr//4: return None
+    sos = butter(4, [lo, min(hi, sr*0.49)], 'band', fs=sr, output='sos')
+    y = sosfiltfilt(sos, seg)
+    sp = np.abs(np.fft.rfft(y*np.hanning(len(y)))) + 1e-12
+    fr = np.fft.rfftfreq(len(y), 1/sr); b = (fr>=lo)&(fr<=hi); spb = sp[b]
+    return float(((spb-spb.mean())**4).mean() / (spb.var()**2 + 1e-30))
+
+def hf_level(p, lo=4000, hi=12000):
+    x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    sp = np.abs(np.fft.rfft(m)); fr = np.fft.rfftfreq(len(m), 1/sr)
+    return 10*np.log10(np.mean(sp[(fr>=lo)&(fr<hi)]**2) + 1e-30)
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--trials", type=int, default=160)
+    ap.add_argument("--workers", type=int, default=6); a = ap.parse_args()
+    anb = str(ANCH / "vvv-bright-hall_noiseburst.wav")
+    a_overall = tail_kurt(anb, 2000, 14000)
+    a_sub = {b: tail_kurt(anb, *b) for b in SUB}
+    a_hf = hf_level(anb)
+    print(f"anchor: overall kurt={a_overall:.1f}  sub={ {f'{l//1000}-{h//1000}k':round(a_sub[(l,h)],1) for l,h in SUB} }")
+
+    def obj(trial):
+        amt = trial.suggest_float("amount", 0.3, 1.0)
+        lfo = trial.suggest_float("lfoScale", 0.0, 1.0)
+        dsc = trial.suggest_float("delayScale", 0.5, 4.0)
+        d = f"/tmp/odk_{trial.number}"; shutil.rmtree(d, ignore_errors=True); os.makedirs(d)
+        env = dict(os.environ, DUSKVERB_OUTDIFF=f"{amt},{lfo},{dsc}")
+        r = subprocess.run([str(REND),"--program","Bright Hall","--output-dir",d,*WET],
+                           capture_output=True, env=env)
+        nb = glob.glob(f"{d}/*_noiseburst.wav")
+        if r.returncode != 0 or not nb: return 1e3
+        ov = tail_kurt(nb[0], 2000, 14000)
+        if ov is None: return 1e3
+        pen = abs(ov - a_overall)                          # overall toward anchor
+        for b in SUB[1:]:                                  # 4-6/6-9/9-14k toward ~5
+            s = tail_kurt(nb[0], *b)
+            if s is None: return 1e3
+            pen += 0.6*max(0.0, s - max(a_sub[b], 5.0))
+        pen += 0.5*max(0.0, a_hf - hf_level(nb[0]) - 1.0)  # don't dull >1 dB below anchor HF
+        return pen
+
+    study = optuna.create_study(direction="minimize", sampler=optuna.samplers.TPESampler(seed=42))
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study.optimize(obj, n_trials=a.trials, n_jobs=a.workers)
+    bp = study.best_params
+    print(f"\nBEST  amount={bp['amount']:.3f} lfoScale={bp['lfoScale']:.3f} delayScale={bp['delayScale']:.3f}  pen={study.best_value:.2f}")
+    # final scoreboard
+    d = "/tmp/odk_best"; shutil.rmtree(d, ignore_errors=True); os.makedirs(d)
+    env = dict(os.environ, DUSKVERB_OUTDIFF=f"{bp['amount']},{bp['lfoScale']},{bp['delayScale']}")
+    subprocess.run([str(REND),"--program","Bright Hall","--output-dir",d,*WET], capture_output=True, env=env)
+    nb = glob.glob(f"{d}/*_noiseburst.wav")[0]
+    print(f"\n{'band':10s} {'baseline':>9s} {'diffused':>9s} {'anchor':>8s}")
+    base_dir = "/tmp/pcheck_bright_hall"
+    bnb = glob.glob(f"{base_dir}/*_noiseburst.wav")
+    bnb = bnb[0] if bnb else None
+    for lab,(lo,hi) in [("2-14k",(2000,14000)),("4-6k",(4000,6000)),("6-9k",(6000,9000)),("9-14k",(9000,14000))]:
+        bk = tail_kurt(bnb, lo, hi) if bnb else float('nan')
+        dk = tail_kurt(nb, lo, hi); ak = tail_kurt(anb, lo, hi)
+        print(f"{lab:10s} {bk:9.1f} {dk:9.1f} {ak:8.1f}")
+    print(f"\nbaked line: {{ \"Bright Hall\", {{ {bp['amount']:.3f}f, {bp['lfoScale']:.3f}f, {bp['delayScale']:.3f}f }} }},")
+
+if __name__ == "__main__":
+    main()

--- a/plugins/DuskVerb/tools/tuner/outdiff_kurtosis_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/outdiff_kurtosis_sweep.py
@@ -72,8 +72,12 @@ def main():
     # final scoreboard
     d = "/tmp/odk_best"; shutil.rmtree(d, ignore_errors=True); os.makedirs(d)
     env = dict(os.environ, DUSKVERB_OUTDIFF=f"{bp['amount']},{bp['lfoScale']},{bp['delayScale']}")
-    subprocess.run([str(REND),"--program","Bright Hall","--output-dir",d,*WET], capture_output=True, env=env)
-    nb = glob.glob(f"{d}/*_noiseburst.wav")[0]
+    proc = subprocess.run([str(REND),"--program","Bright Hall","--output-dir",d,*WET], capture_output=True, env=env)
+    hits = glob.glob(f"{d}/*_noiseburst.wav")
+    if proc.returncode != 0 or not hits:
+        print(f"\n[final render failed rc={proc.returncode}; best params above]")
+        return
+    nb = hits[0]
     print(f"\n{'band':10s} {'baseline':>9s} {'diffused':>9s} {'anchor':>8s}")
     base_dir = "/tmp/pcheck_bright_hall"
     bnb = glob.glob(f"{base_dir}/*_noiseburst.wav")

--- a/plugins/DuskVerb/tools/tuner/parallel_check.py
+++ b/plugins/DuskVerb/tools/tuner/parallel_check.py
@@ -45,6 +45,15 @@ def rms(p):
 
 
 def check_one(name):
+    # Contain ALL worker exceptions: one bad render/read must not kill the
+    # whole sweep (ThreadPoolExecutor.map re-raises at iteration otherwise).
+    try:
+        return _check_one(name)
+    except Exception as e:  # noqa: BLE001 — report-and-continue tool
+        return name, None, f"exception: {e}"
+
+
+def _check_one(name):
     adir, apref = PRESETS[name]
     slug = name.lower().replace(" ", "_")
     dv, lex = f"/tmp/pcheck_{slug}", f"/tmp/pcheck_{slug}_lex"

--- a/plugins/DuskVerb/tools/tuner/parallel_check.py
+++ b/plugins/DuskVerb/tools/tuner/parallel_check.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Parallel gain-matched full_check across presets (6 workers).
+
+Each preset renders into its OWN --output-dir (no shared-glob collisions),
+gain-matches to its anchor noiseburst RMS, runs full_check, and reports
+n_fail. Renders + checks run concurrently in a 6-worker pool (12-core box;
+leaves headroom for the OS — memory: duskverb_tuner_workers OOM ceiling).
+
+Usage: parallel_check.py [preset ...]      (default: all anchored presets)
+       parallel_check.py --fails NAME      (print the failing-gate list too)
+"""
+import os, sys, glob, json, shutil, subprocess
+from concurrent.futures import ThreadPoolExecutor
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import soundfile as sf, numpy as np
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+REND = os.path.join(REPO, "build/tests/duskverb_render/duskverb_render")
+VVV  = os.path.join(REPO, "tests/duskverb_render/output/vvv")
+ANCH = os.path.expanduser("~/projects/dusk-audio-tools/tuner_runs/anchors")
+FC   = os.path.join(os.path.dirname(__file__), "full_check.py")
+WET  = ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0"]
+STIM = ["impulse", "noiseburst", "snare", "sine1k"]
+
+# preset -> (anchor_dir, anchor_prefix)
+PRESETS = {
+    "Vocal Plate":          (VVV,                       "vvv_vocal_plate"),
+    "Drum Plate":           (VVV,                       "vvv_Drum_Plate"),
+    "Vocal Hall":           (VVV,                       "vvv_Vocal_Hall"),
+    "Cathedral Large Hall": (f"{ANCH}/vvv-cathedral",   "vvv-cathedral"),
+    "Blade Runner 224":     (f"{ANCH}/vvv-blade-runner","vvv-blade-runner"),
+    "Tiled Room":           (f"{ANCH}/vvv-tiled-room",  "vvv-tiled-room"),
+    "79 Vocal Chamber":     (f"{ANCH}/vvv-79vc",        "vvv-79vc"),
+    "Ambience":             (f"{ANCH}/vvv-ambience",    "vvv-ambience"),
+    "Bright Hall":          (f"{ANCH}/vvv-bright-hall", "vvv-bright-hall"),
+}
+
+
+def rms(p):
+    x, _ = sf.read(p)
+    m = x.mean(axis=1) if x.ndim > 1 else x
+    return float(np.sqrt(np.mean(m * m)))
+
+
+def check_one(name):
+    adir, apref = PRESETS[name]
+    slug = name.lower().replace(" ", "_")
+    dv, lex = f"/tmp/pcheck_{slug}", f"/tmp/pcheck_{slug}_lex"
+    shutil.rmtree(dv, ignore_errors=True)
+    os.makedirs(dv); os.makedirs(lex, exist_ok=True)
+    r = subprocess.run([REND, "--program", name, "--output-dir", dv, *WET],
+                       cwd=REPO, capture_output=True, text=True)
+    if r.returncode != 0:
+        return name, None, f"render rc={r.returncode}: {r.stderr[-300:]}"
+    nb = glob.glob(f"{dv}/*_noiseburst.wav")
+    if not nb:
+        return name, None, "no noiseburst rendered"
+    for s in STIM:
+        src = f"{adir}/{apref}_{s}.wav"
+        if os.path.exists(src):
+            shutil.copy(src, f"{lex}/anchor_{s}.wav")
+    a = rms(f"{lex}/anchor_noiseburst.wav")
+    d = rms(nb[0])
+    if d < 1e-12:
+        return name, None, "silent render"
+    g = a / d
+    for f in glob.glob(f"{dv}/*.wav"):
+        x, sr = sf.read(f); sf.write(f, x * g, sr)
+    r = subprocess.run([sys.executable, FC, dv, lex, "--name", name, "--json"],
+                       capture_output=True, text=True)
+    for line in r.stdout.splitlines():
+        if line.startswith("JSON_RESULT:"):
+            res = json.loads(line.split("JSON_RESULT: ")[1])
+            return name, res, None
+    return name, None, f"no JSON_RESULT (rc={r.returncode})"
+
+
+def main():
+    args = [a for a in sys.argv[1:] if a != "--fails"]
+    show_fails = "--fails" in sys.argv
+    names = args if args else list(PRESETS)
+    bad = [n for n in names if n not in PRESETS]
+    if bad:
+        sys.exit(f"unknown preset(s): {bad}; known: {list(PRESETS)}")
+    with ThreadPoolExecutor(max_workers=6) as ex:
+        for name, res, err in ex.map(check_one, names):
+            if err:
+                print(f"{name:22s} ERROR  {err}")
+            else:
+                print(f"{name:22s} n_fail={res['n_fail']}")
+                if show_fails:
+                    for f in res["fails"]:
+                        print("   ", f)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/DuskVerb/tools/tuner/parallel_check.py
+++ b/plugins/DuskVerb/tools/tuner/parallel_check.py
@@ -20,8 +20,13 @@ REND = os.path.join(REPO, "build/tests/duskverb_render/duskverb_render")
 VVV  = os.path.join(REPO, "tests/duskverb_render/output/vvv")
 ANCH = os.path.expanduser("~/projects/dusk-audio-tools/tuner_runs/anchors")
 FC   = os.path.join(os.path.dirname(__file__), "full_check.py")
-WET  = ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0"]
-STIM = ["impulse", "noiseburst", "snare", "sine1k"]
+# --sustained-pink-seconds: the tail-mod-ripple + mod-freq gates measure on
+# the SUSTAINED render (full_check falls back to noiseburst otherwise, which
+# its own authors flag as an unreliable noise-vs-noise comparison). Render it
+# so presets whose anchors have a sustained capture get the intended gate.
+WET  = ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0",
+        "--sustained-pink-seconds", "4.0"]
+STIM = ["impulse", "noiseburst", "snare", "sine1k", "sustained"]
 
 # preset -> (anchor_dir, anchor_prefix)
 PRESETS = {

--- a/plugins/DuskVerb/tools/tuner/parallel_check.py
+++ b/plugins/DuskVerb/tools/tuner/parallel_check.py
@@ -62,8 +62,8 @@ def _check_one(name):
     adir, apref = PRESETS[name]
     slug = name.lower().replace(" ", "_")
     dv, lex = f"/tmp/pcheck_{slug}", f"/tmp/pcheck_{slug}_lex"
-    shutil.rmtree(dv, ignore_errors=True)
-    os.makedirs(dv); os.makedirs(lex, exist_ok=True)
+    shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+    os.makedirs(dv); os.makedirs(lex)
     r = subprocess.run([REND, "--program", name, "--output-dir", dv, *WET],
                        cwd=REPO, capture_output=True, text=True)
     if r.returncode != 0:

--- a/plugins/DuskVerb/tools/tuner/parallel_check.py
+++ b/plugins/DuskVerb/tools/tuner/parallel_check.py
@@ -81,7 +81,11 @@ def _check_one(name):
         return name, None, "silent render"
     g = a / d
     for f in glob.glob(f"{dv}/*.wav"):
-        x, sr = sf.read(f); sf.write(f, x * g, sr)
+        # subtype='FLOAT': the default WAV subtype is PCM_16, which silently
+        # REQUANTIZES the float render — the added -96 dBFS dither floor
+        # dominates quiet late windows (cent_500 read 3253 Hz vs the true
+        # 1374 on MDR) and penalized every preset's late-window gates.
+        x, sr = sf.read(f); sf.write(f, x * g, sr, subtype="FLOAT")
     r = subprocess.run([sys.executable, FC, dv, lex, "--name", name, "--json"],
                        capture_output=True, text=True)
     for line in r.stdout.splitlines():

--- a/plugins/DuskVerb/tools/tuner/parallel_check.py
+++ b/plugins/DuskVerb/tools/tuner/parallel_check.py
@@ -34,6 +34,7 @@ PRESETS = {
     "79 Vocal Chamber":     (f"{ANCH}/vvv-79vc",        "vvv-79vc"),
     "Ambience":             (f"{ANCH}/vvv-ambience",    "vvv-ambience"),
     "Bright Hall":          (f"{ANCH}/vvv-bright-hall", "vvv-bright-hall"),
+    "Medium Drum Room":     (f"{ANCH}/vvv-fat-snare-room", "vvv-fat-snare-room"),
 }
 
 

--- a/plugins/DuskVerb/tools/tuner/ripple_delay_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/ripple_delay_sweep.py
@@ -90,7 +90,7 @@ def main():
         g=anchor_nb_rms/ (np.sqrt(np.mean((sf.read(glob.glob(f"{d}/*_noiseburst.wav")[0])[0]).mean(axis=1)**2))+1e-12)
         from scipy.signal import butter as _bt, sosfiltfilt as _sf
         i0=int(2.5*sr); i1=min(len(m), int(4.0*sr)); seg=m[i0:i1]*g
-        for (lo,hi),e0 in ss_ref.items():
+        for (lo,hi),e0 in (ss_ref.items() if use_sus else []):
             sos=_bt(4,[lo,min(hi,sr*0.49)],'band',fs=sr,output='sos')
             e=20*np.log10(np.sqrt(np.mean(_sf(sos,seg)**2))+1e-12)
             pen += 0.5*max(0.0, abs(e-e0)-1.6)

--- a/plugins/DuskVerb/tools/tuner/ripple_delay_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/ripple_delay_sweep.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Base-delay sweep to minimize per-band tail-envelope ripple std vs a VVV
+anchor (the gate the VH/BH delay sets already satisfy). Optuna over 16 FDN
+base delays in [700, 6700], applied via the DUSKVERB_FDN_DELAYS env override
+(no rebuild per trial). Objective = sum over the preset's FAILING ripple bands
+of max(0, dv_std - anchor_std), measured gate-exact (sustained 0.5-3s, or the
+noiseburst fallback when the anchor has no sustained render), gain-matched. A
+light guard penalizes broadband tail-length drift so the octave-T60 recal that
+follows stays small. Prints best delays as a C++ initializer.
+
+Usage: ripple_delay_sweep.py "Ambience" --trials 200 --bands high
+"""
+import argparse, os, sys, glob, shutil, subprocess
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import soundfile as sf, numpy as np, optuna
+from full_check import _tail_env_ripple_db, _t60_band_schroeder
+
+REPO = Path(__file__).resolve().parents[4]
+REND = REPO / "build/tests/duskverb_render/duskverb_render"
+ANCH = Path.home() / "projects/dusk-audio-tools/tuner_runs/anchors"
+VVV  = REPO / "tests/duskverb_render/output/vvv"
+PR = {"Drum Plate": (VVV, "vvv_Drum_Plate"),
+      "Ambience": (ANCH/"vvv-ambience", "vvv-ambience"),
+      "Medium Drum Room": (ANCH/"vvv-fat-snare-room", "vvv-fat-snare-room")}
+BANDS = {"bass": (40,250), "lowmid": (250,1000), "mid": (1000,4000), "high": (4000,12000)}
+
+def rms(p):
+    x,_=sf.read(p); m=x.mean(axis=1) if x.ndim>1 else x; return float(np.sqrt(np.mean(m*m)))
+
+def main():
+    ap=argparse.ArgumentParser(); ap.add_argument("preset"); ap.add_argument("--trials",type=int,default=200)
+    ap.add_argument("--bands",nargs="+",required=True); ap.add_argument("--workers",type=int,default=6)
+    a=ap.parse_args()
+    adir,apref=PR[a.preset]; slug=a.preset.lower().replace(" ","_")
+    asus=adir/f"{apref}_sustained.wav"; anb=adir/f"{apref}_noiseburst.wav"
+    use_sus=asus.exists(); aref=str(asus if use_sus else anb)
+    anchor_std={b:_tail_env_ripple_db(aref,0.5,3.0,*BANDS[b]) for b in a.bands}
+    anchor_std_all={b:_tail_env_ripple_db(aref,0.5,3.0,*BANDS[b]) for b in BANDS}
+    anchor_nb_rms=rms(str(anb))
+    # anchor per-octave T60 (9 ISO bands) measured on the anchor noiseburst —
+    # the sweep must hold these (±5% gate) so NO post-sweep octave recal is
+    # needed (recal would shift decay and re-open the ripple it just fixed).
+    OCT=[(44,88),(88,177),(177,355),(355,710),(710,1420),(1420,2840),(2840,5680),(5680,11360),(11360,18000)]
+    anchor_t60=[_t60_band_schroeder(str(anb),lo,hi) for lo,hi in OCT]
+    # ss-energy reference = the ANCHOR's steady-state per-band energy (the
+    # actual ss-gate target). The swept delays must fix ripple WITHOUT moving
+    # DV's gain-matched ss bands away from the anchor. Anchor needs no gain
+    # term (DV is matched TO it).
+    import numpy as np
+    from scipy.signal import butter as _bt0, sosfiltfilt as _sf0
+    _xr,_sr=sf.read(aref); _mr=_xr.mean(axis=1) if _xr.ndim>1 else _xr
+    _seg=_mr[int(2.5*_sr):min(len(_mr),int(4.0*_sr))]
+    SSB=[(50,100),(100,250),(250,500),(500,2000),(2000,5000),(5000,10000),(10000,20000)]
+    ss_ref={}
+    for lo,hi in SSB:
+        sos=_bt0(4,[lo,min(hi,_sr*0.49)],'band',fs=_sr,output='sos')
+        ss_ref[(lo,hi)]=20*np.log10(np.sqrt(np.mean(_sf0(sos,_seg)**2))+1e-12)
+    def obj(trial):
+        ds=sorted(trial.suggest_int(f"d{i}",700,6700) for i in range(16))
+        d=f"/tmp/rds_{slug}_t{trial.number}"; shutil.rmtree(d,ignore_errors=True); os.makedirs(d)
+        env=dict(os.environ, DUSKVERB_FDN_DELAYS=",".join(map(str,ds)))
+        r=subprocess.run([str(REND),"--program",a.preset,"--output-dir",d,"--param","Dry/Wet=1.0",
+                          "--param","Bus Mode=1","--param","Freeze=0","--sustained-pink-seconds","4.0"],
+                         capture_output=True,env=env)
+        cand=glob.glob(f"{d}/*sustained*.wav") if use_sus else glob.glob(f"{d}/*_noiseburst.wav")
+        if r.returncode!=0 or not cand: return 1e3
+        dv=cand[0]; pen=0.0
+        # (1) ripple: keep EVERY band's std within +1.0 dB of the anchor (margin
+        #     under the +1.5 gate). No reward for over-smoothing — that is what
+        #     redistributed band energy and opened ss/boom gates.
+        for b in ["bass","lowmid","mid","high"]:
+            s=_tail_env_ripple_db(dv,0.5,3.0,*BANDS[b])
+            if s is None: return 1e3
+            ar=anchor_std_all[b]
+            if ar is not None: pen += 3.0*max(0.0, (s-ar)-1.0)
+        # (2) preserve steady-state per-band energy vs the default-delay render
+        #     (so the ripple fix does not move the ss/boom gates). Band RMS over
+        #     the sustained steady window, gain-matched to anchor.
+        # (3) octave-T60 match on the trial noiseburst (hold anchor decay so no recal)
+        nbf=glob.glob(f"{d}/*_noiseburst.wav")
+        if nbf:
+            for (lo,hi),at in zip(OCT,anchor_t60):
+                if at is None or at<=0.05: continue
+                mt=_t60_band_schroeder(nbf[0],lo,hi)
+                if mt is None: pen+=2.0; continue
+                pen += 2.0*max(0.0, abs(mt-at)/at - 0.05)
+        import numpy as _np
+        x,sr=sf.read(dv); m=x.mean(axis=1) if x.ndim>1 else x
+        g=anchor_nb_rms/ (np.sqrt(np.mean((sf.read(glob.glob(f"{d}/*_noiseburst.wav")[0])[0]).mean(axis=1)**2))+1e-12)
+        from scipy.signal import butter as _bt, sosfiltfilt as _sf
+        i0=int(2.5*sr); i1=min(len(m), int(4.0*sr)); seg=m[i0:i1]*g
+        for (lo,hi),e0 in ss_ref.items():
+            sos=_bt(4,[lo,min(hi,sr*0.49)],'band',fs=sr,output='sos')
+            e=20*np.log10(np.sqrt(np.mean(_sf(sos,seg)**2))+1e-12)
+            pen += 0.5*max(0.0, abs(e-e0)-1.6)
+        return pen
+    study=optuna.create_study(direction="minimize",sampler=optuna.samplers.TPESampler(seed=42))
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study.optimize(obj,n_trials=a.trials,n_jobs=a.workers)
+    ds=sorted(study.best_params[f"d{i}"] for i in range(16))
+    print(f"\n{a.preset} best ripple penalty={study.best_value:.3f}")
+    print("  { "+", ".join(map(str,ds))+" }")
+    # final gate-exact readout at best
+    d=f"/tmp/rds_{slug}_best"; shutil.rmtree(d,ignore_errors=True); os.makedirs(d)
+    env=dict(os.environ, DUSKVERB_FDN_DELAYS=",".join(map(str,ds)))
+    subprocess.run([str(REND),"--program",a.preset,"--output-dir",d,"--param","Dry/Wet=1.0","--param","Bus Mode=1","--param","Freeze=0","--sustained-pink-seconds","4.0"],capture_output=True,env=env)
+    dv=(glob.glob(f"{d}/*sustained*.wav") if use_sus else glob.glob(f"{d}/*_noiseburst.wav"))[0]
+    for b in ["bass","lowmid","mid","high"]:
+        s=_tail_env_ripple_db(dv,0.5,3.0,*BANDS[b]); ar=_tail_env_ripple_db(aref,0.5,3.0,*BANDS[b])
+        dl=s-ar; print(f"    {b:7s} Δ={dl:+.2f} {'PASS' if dl<=1.5 else 'FAIL'}")
+
+if __name__=="__main__": main()

--- a/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-10.md
+++ b/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-10.md
@@ -6,7 +6,7 @@ Composite-exact octave GEQ era (commit 9d00545): every old leaky-cascade
 
 | Preset | Engine | n_fail | prev | Δ | Notes |
 |---|---|---:|---:|---:|---|
-| Bright Hall | AccurateHall | 9 | 18 | -9 | migrated off VintageTank 2026-06-10 |
+| Bright Hall | AccurateHall32 | 13 | 16 | -3 | 32-line dense FDN (algo 12) 2026-06-11; tail kurtosis ~18->14.9 (the metal). NB prior "9" was STALE (pre-sustained-fix); algo-10 sustained-correct baseline = 16 |
 | 79 Vocal Chamber | QuadTank | 10 | 10 | 0 | AccurateHall trial REJECTED (23 — late-heavy field wrong for tight chamber) |
 | Blade Runner 224 | AccurateHall | 11 | 15 | -4 | recal + 250 Hz decouple (350 Hz pteq) |
 | Vocal Plate | AccurateHall | 13 | 14 | -1 | 5 kHz post-tank tilt; 1 kHz pteq is POISON on VP |

--- a/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-10.md
+++ b/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-10.md
@@ -1,0 +1,35 @@
+# DuskVerb anchored-preset scoreboard — 2026-06-10
+
+Gain-matched full_check (parallel_check.py), 100%-wet renders, current harness.
+Composite-exact octave GEQ era (commit 9d00545): every old leaky-cascade
+"T60-ceiling / kept-on-FDN" verdict re-evaluated this round.
+
+| Preset | Engine | n_fail | prev | Δ | Notes |
+|---|---|---:|---:|---:|---|
+| Bright Hall | AccurateHall | 9 | 18 | -9 | migrated off VintageTank 2026-06-10 |
+| 79 Vocal Chamber | QuadTank | 10 | 10 | 0 | AccurateHall trial REJECTED (23 — late-heavy field wrong for tight chamber) |
+| Blade Runner 224 | AccurateHall | 11 | 15 | -4 | recal + 250 Hz decouple (350 Hz pteq) |
+| Vocal Plate | AccurateHall | 13 | 14 | -1 | 5 kHz post-tank tilt; 1 kHz pteq is POISON on VP |
+| Cathedral Large Hall | AccurateHall | 13 | 26 | -13 | migrated off FDN 2026-06-09 |
+| Drum Plate | AccurateHall | 16 | 31 | -15 | migrated off FDN 2026-06-10; pteq 1k+8/150+3.5 |
+| Vocal Hall | AccurateHall | 16 | 20 | -4 | tank 0.42→0.50 + pteq 70 Hz softened |
+| Tiled Room | AccurateHall | 17 | 18 | -1 | migrated; residual = energy-arrival wall (anchor first50 69%) |
+| Medium Drum Room | AccurateHall | 17 | new | — | NEW preset, VVV "Fat Snare Room" anchor (re-captured via --nparam) |
+| Ambience | AccurateHall | 20 | 21 | -1 | Width 1.42→1.05 |
+
+## Structural walls (unchanged, fleet-wide)
+- diffusion_flux: all presets (dense-FDN vs sparse-modal) — early-field engine ticket.
+- attack/onset/t50/first50: early-field wall; worst on front-loaded rooms
+  (Tiled anchor first50=69%, Ambience 54%). MDR partially closed via
+  er_boost 7 + er_rise 33 ms (the bimodal-attack landing trick).
+- boom/body late-window curvature (VH/DP): anchor holds early level, DV decays
+  exponentially; EDT shaper stays disabled (documented IMD).
+- width-vs-corr 1:1 trade (global Width vs per-band targets).
+- env_p2p / env_shape / tail pitch-chorus: modulation-topology character.
+
+## Method notes this round
+- Optuna remains cold-start-only and its proxy loss DIVERGES from full_check
+  (MDR capped sweep "won" at 23 internal, scored 27 on full_check; hand row 24).
+- pteq tuning: ONE band at a time; gain-match renormalization turns multi-band
+  edits into whack-a-mole (every preset this round confirmed it).
+- In-loop peaking (fbInLoopDb) must be 0 on AccurateHall presets.

--- a/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-11.md
+++ b/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-11.md
@@ -1,0 +1,49 @@
+# DuskVerb anchored-preset scoreboard — 2026-06-11
+
+Gain-matched full_check via `parallel_check.py` (6-worker), 100%-wet renders,
+**sustained-correct harness** (`--sustained-pink-seconds 4.0`, so the ripple /
+mod-freq / ss-energy / per-band edt+decay families actually run on the sustained
+render instead of falling back to the noiseburst floor).
+
+> ⚠️ These numbers are HIGHER than `scoreboard_2026-06-10.md`. That board predates
+> the sustained-gate fix — its sustained family was silently skipped, so every
+> n_fail there was optimistic (it's what made Bright Hall read "9" when the honest
+> number was 16). This board is the truth. The increases below are measurement
+> honesty, NOT regressions — the only real engine change since is Bright Hall
+> (32-line migration, a genuine 16→13 improvement + the metallic-tail fix).
+
+| Rank | Preset | Engine | n_fail | prev board (stale) | Notes |
+|---:|---|---|---:|---:|---|
+| 1 | Tiled Room | Hall | 26 | 17 | early-field wall (anchor first50 ≈ 69%) dominates |
+| 2 | Medium Drum Room | Hall | 25 | 17 | early-field + boom; front-loaded room |
+| 3 | Ambience | Hall | 23 | 20 | early-field (first50 ≈ 54%) + width |
+| 4 | Blade Runner 224 | Hall | 20 | 11 | recal'd; long-tail hall |
+| 5 | Cathedral Large Hall | Hall | 19 | 13 | large hall, late-field + ss |
+| 6 | 79 Vocal Chamber | Room | 18 | 10 | QuadTank gain==decay==level coupling wall |
+| 7 | Vocal Hall | Hall | 16 | 16 | early-field + boom/body |
+| 7 | Drum Plate | Hall | 16 | 16 | de-honked; boom/env_shape |
+| 9 | Vocal Plate | Hall | 13 | 13 | 1 kHz pteq is poison; clean floor |
+| 9 | Bright Hall | Concert Hall | 13 | 16 | **32-line dense FDN: 16→13 + tail kurtosis ~18→14.9 (metal)** |
+
+Engine names are the standardized 2026-06-11 labels (Hall = AccurateHall algo 10;
+Concert Hall = AccurateHall32 algo 12; Room = QuadTank algo 3).
+
+## Structural walls (fleet-wide, dominate the leaders)
+- **Early-field wall** (attack/onset/energy_t50/first50 + diffusion_flux): worst
+  on the front-loaded rooms — Tiled (first50 ≈ 69%), Ambience (54%), MDR. No
+  FDN/tank preset tuning closes it; needs the early-field engine (SparseField was
+  the prototype, falsified under sustained-correct gates — see memory).
+- **FDN gain==decay==level coupling** (Vocal Plate, 79 Vocal Chamber, Cathedral):
+  feedback gain sets decay AND level per band; per-band level trims drag T60.
+- **boom / body late-window curvature** (VH/DP/MDR): anchor holds early level,
+  DV decays exponentially; EDT shaper stays disabled (documented IMD).
+- **Modal residuals** (Bright Hall): 1 kHz steady overshoot + 12.9 kHz needle are
+  delay-placement artifacts of the 32-line set — not closable by the inert
+  Mid/Treble Multiply (octave GEQ flattens 3-band damping) or broadband Hi Cut.
+
+## Method notes (carried forward)
+- Re-measure the baseline on the CURRENT harness before any never-worse call —
+  the stale-board "9" nearly triggered a wrong Bright Hall revert.
+- Optuna cold-start only; manual off per-gate deltas for already-tuned presets.
+- The 32-line AccurateHall32 is a built/bit-null engine slot; only Bright Hall
+  ships on it. FDN / Vintage Hall / Sparse engines are unused but selectable.

--- a/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-11.md
+++ b/plugins/DuskVerb/tools/tuner/scoreboard_2026-06-11.md
@@ -5,6 +5,13 @@ Gain-matched full_check via `parallel_check.py` (6-worker), 100%-wet renders,
 mod-freq / ss-energy / per-band edt+decay families actually run on the sustained
 render instead of falling back to the noiseburst floor).
 
+> ⚠️ 2026-06-11 (late): HARNESS REQUANTIZATION BUG fixed — the gain-match step
+> (`sf.write` without subtype) silently converted float renders to 16-bit PCM,
+> injecting a dither floor that dominated every quiet late window (MDR cent_500
+> read +141% vs a TRUE +2%; osc P2P artificially passed). Anchors were only
+> copied → stayed clean → DV alone was penalized. All boards before this note
+> scored against that floor. parallel_check.py now writes subtype='FLOAT'.
+
 > ⚠️ These numbers are HIGHER than `scoreboard_2026-06-10.md`. That board predates
 > the sustained-gate fix — its sustained family was silently skipped, so every
 > n_fail there was optimistic (it's what made Bright Hall read "9" when the honest
@@ -14,19 +21,34 @@ render instead of falling back to the noiseburst floor).
 
 | Rank | Preset | Engine | n_fail | prev board (stale) | Notes |
 |---:|---|---|---:|---:|---|
-| 1 | Tiled Room | Hall | 26 | 17 | early-field wall (anchor first50 ≈ 69%) dominates |
-| 2 | Medium Drum Room | Hall | 25 | 17 | early-field + boom; front-loaded room |
-| 3 | Ambience | Hall | 23 | 20 | early-field (first50 ≈ 54%) + width |
-| 4 | Blade Runner 224 | Hall | 20 | 11 | recal'd; long-tail hall |
-| 5 | Cathedral Large Hall | Hall | 19 | 13 | large hall, late-field + ss |
-| 6 | 79 Vocal Chamber | Room | 18 | 10 | QuadTank gain==decay==level coupling wall |
-| 7 | Vocal Hall | Hall | 16 | 16 | early-field + boom/body |
-| 7 | Drum Plate | Hall | 16 | 16 | de-honked; boom/env_shape |
+| 4 | Ambience | Hall | 16 | 20 | **tunable-cluster sweep 23→16**: bass-damp+bandtrim (boom/640), partial front-load (er_boost 3.1+tank 0.63 CLOSED attack/onset/t50/first50), edt. Residual: boom-1-2s long tail (octave-T60), sharp 640 notch, anti-phase stereo |
+| 3 | Blade Runner 224 | Hall | 17 | 11 | **tunable-cluster sweep 20→17**: ER ON (was OFF → fixed 107ms attack) + decay 13.6→11.1 (tail_t60) + damping/diffusion/spectral. Residual edt+254% is octave-T60-locked (GEQ recal = next pass) |
+| 5 | Medium Drum Room | Plate | 18 | 17 | **fake 25 → honest 18**: Dattorro re-engine (ring) + r3/r4 tank+early-field + anti-beating sweep (pitch-chorus 8.2x→3.65x via modal geometry). Residual = diffusion_flux (spiky-anchor mismatch, → sparse-ER composite, scoped) + first50 front-load + ss-band splits |
+| 7 | Cathedral Large Hall | Hall | 15 | 13 | **early-field+spectral sweep 19→15**: Pre-Delay 20.88→2.48ms + strong-fast ER (boost 4.96/rise 1.53) cracked the 147→2.3ms attack; bandtrim ss-mids cut. Residual edt+498% octave-T60-locked (GEQ recal next) |
+| 5 | 79 Vocal Chamber | Room | 18 | 10 | QuadTank gain==decay==level coupling wall |
+| 6 | Vocal Hall | Hall | 16 | 16 | early-field + boom/body |
+| 6 | Drum Plate | Hall | 16 | 16 | de-honked; boom/env_shape |
+| 6 | Tiled Room | Tiled Room | 16 | 17 | **composite ER+dark-tail engine (algo 13): 26→16** |
 | 9 | Vocal Plate | Hall | 13 | 13 | 1 kHz pteq is poison; clean floor |
 | 9 | Bright Hall | Concert Hall | 13 | 16 | **32-line dense FDN: 16→13 + tail kurtosis ~18→14.9 (metal)** |
 
 Engine names are the standardized 2026-06-11 labels (Hall = AccurateHall algo 10;
-Concert Hall = AccurateHall32 algo 12; Room = QuadTank algo 3).
+Concert Hall = AccurateHall32 algo 12; Room = QuadTank algo 3; Plate = Dattorro
+algo 0; Tiled Room = composite algo 13).
+
+### MDR 2026-06-11 campaign (25 → 20, then the floor)
+Falsified IN ORDER, each measured in the real harness: 3-band MultibandFDN (29),
+AccurateHall32 32-line (32 — the 12.9k ring is input-HF recirculation, line count
+can't fix a dark room), Dattorro re-engine (**20, BAKED** — allpass tank damps HF
+out of the loop: ring + cent_50 + decay-band + osc P2P all closed), multi-stage
+secondary in-loop damping (22/23 — any in-loop filter moves the system poles:
+level==decay, optimizer drove it transparent, engine reverted), post-loop level
+shaping via BandTrim/pteq env hooks (LIVE + T60-orthogonal as predicted, but
+inert on cent_500: a −9 dB notch AT 3253 Hz moved it 16 Hz — cent_500 is the
+balance point of a broad static-spectrum tail, not a mode). Remaining 20 =
+time-varying spectral decay the anchor has and a static-spectrum tank can't
+express (anchor cent 2214→1346 over 50→500 ms; DV 2809→3253) + intrinsic
+pitch-chorus/diffusion_flux. Preset-tuning floor reached on every axis.
 
 ## Structural walls (fleet-wide, dominate the leaders)
 - **Early-field wall** (attack/onset/energy_t50/first50 + diffusion_flux): worst

--- a/plugins/DuskVerb/tools/tuner/tiledroom_voicing_sweep.py
+++ b/plugins/DuskVerb/tools/tuner/tiledroom_voicing_sweep.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Voice the TiledRoomEngine (algo 13) on the VVV Tiled Room anchor.
+
+Sweeps the 6 engine voicing params via the DUSKVERB_TILEDROOM env override
+(erGain, tailGain, feedback, lpHz, onsetMs, erDecayMs) — no rebuild per trial.
+Objective = full_check n_fail (gain-matched, sustained-correct). Robust harness
+(exception-contained eval, self-cleaning per-trial dirs, SQLite-persisted study,
+no enqueue) — same lessons as joint_dense32_sweep.py.
+
+Run:  python3 -u plugins/DuskVerb/tools/tuner/tiledroom_voicing_sweep.py --trials 120
+"""
+import argparse, os, sys, glob, json, shutil, subprocess
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import soundfile as sf, numpy as np, optuna
+
+REPO = Path(__file__).resolve().parents[4]
+REND = str(REPO / "build/tests/duskverb_render/duskverb_render")
+FC   = str(Path(__file__).resolve().parent / "full_check.py")
+# Defaults voice Tiled Room; --preset/--anchor/--apref/--baseline retarget any
+# algo-13 composite preset (e.g. Medium Drum Room). All composite presets share
+# the DUSKVERB_TILEDROOM env hook + the kCompositeERByName config path.
+PRESET = "Tiled Room"
+ANCH = Path.home() / "projects/dusk-audio-tools/tuner_runs/anchors/vvv-tiled-room"
+APREF = "vvv-tiled-room"
+WET  = ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1", "--param", "Freeze=0",
+        "--sustained-pink-seconds", "4.0"]
+STIM = ["impulse", "noiseburst", "snare", "sine1k", "sustained"]
+BASELINE = 26   # FDN algo-10 baseline (sustained-correct); set per-preset via --baseline
+
+
+def rms(p):
+    x, _ = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    return float(np.sqrt(np.mean(m * m)))
+
+
+def eval_voicing(cfg, tag, bt=None):
+    dv = f"/tmp/trv_{tag}"; lex = f"/tmp/trv_{tag}_lex"
+    try:
+        shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+        os.makedirs(dv, exist_ok=True); os.makedirs(lex, exist_ok=True)
+        env = dict(os.environ, DUSKVERB_TILEDROOM=",".join(f"{v:.4f}" for v in cfg))
+        if bt is not None:   # UltraRoom decouple: post-loop per-band level trim (dB)
+            env["DUSKVERB_BANDTRIM"] = ",".join(f"{v:.3f}" for v in bt)
+        r = subprocess.run([REND, "--program", PRESET, "--output-dir", dv, *WET],
+                           cwd=str(REPO), capture_output=True, text=True, env=env)
+        nb = glob.glob(f"{dv}/*_noiseburst.wav")
+        if r.returncode != 0 or not nb:
+            return None
+        for s in STIM:
+            src = ANCH / f"{APREF}_{s}.wav"
+            if src.exists(): shutil.copy(src, f"{lex}/anchor_{s}.wav")
+        a = rms(f"{lex}/anchor_noiseburst.wav"); d = rms(nb[0])
+        if d < 1e-12: return None
+        g = a / d
+        for f in glob.glob(f"{dv}/*.wav"):
+            x, sr = sf.read(f); sf.write(f, x * g, sr)
+        r = subprocess.run([sys.executable, FC, dv, lex, "--name", PRESET, "--json"],
+                           capture_output=True, text=True)
+        nf = None
+        for line in r.stdout.splitlines():
+            if line.startswith("JSON_RESULT:"):
+                nf = json.loads(line.split("JSON_RESULT: ")[1])["n_fail"]; break
+        if nf is None: return None
+        # energy_first50: % of impulse-response energy in the first 50 ms post-peak
+        imp = glob.glob(f"{dv}/*_impulse.wav")
+        first50 = None
+        if imp:
+            x, sr = sf.read(imp[0]); m = x.mean(axis=1) if x.ndim > 1 else x
+            pk = int(np.argmax(np.abs(m))); seg = m[pk:] ** 2
+            tot = float(seg.sum())
+            if tot > 1e-20:
+                first50 = 100.0 * float(seg[:int(0.05 * sr)].sum()) / tot
+        return (nf, first50)
+    except Exception:
+        return None
+    finally:
+        shutil.rmtree(dv, ignore_errors=True); shutil.rmtree(lex, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=120)
+    ap.add_argument("--workers", type=int, default=4)
+    ap.add_argument("--preset", default="Tiled Room")
+    ap.add_argument("--anchor", default=None, help="anchor dir (default vvv-tiled-room)")
+    ap.add_argument("--apref", default=None, help="anchor file prefix")
+    ap.add_argument("--baseline", type=int, default=26)
+    ap.add_argument("--study", default="trv", help="sqlite study name (use distinct per preset)")
+    ap.add_argument("--first50-target", type=float, default=None,
+                    help="anchor energy_first50 to this %% (penalize deviation); None = pure n_fail")
+    ap.add_argument("--bandtrim", action="store_true",
+                    help="also sweep the 4 post-loop band-level trims (UltraRoom decouple)")
+    a = ap.parse_args()
+    global PRESET, ANCH, APREF, BASELINE
+    PRESET = a.preset; BASELINE = a.baseline
+    if a.anchor: ANCH = Path(a.anchor)
+    if a.apref:  APREF = a.apref
+
+    def obj(trial):
+        # COMPOSITE params: erSize,onsetMs,erDecayMs,burst2Ms,sparseTailGain,erGain.
+        # erGain backs off the ER level so a less-front-loaded room (MDR, first50
+        # 44.8%) doesn't overshoot. Objective = n_fail + a continuous penalty that
+        # anchors energy_first50 to --first50-target (None = pure n_fail).
+        cfg = [
+            trial.suggest_float("erSize",         0.30, 0.70),
+            trial.suggest_float("onsetMs",        0.8, 2.5),
+            trial.suggest_float("erDecayMs",      16.0, 32.0),
+            trial.suggest_float("burst2Ms",       0.0, 45.0),
+            trial.suggest_float("sparseTailGain", 0.40, 0.92),
+            trial.suggest_float("erGain",         0.25, 1.00),
+        ]
+        bt = None
+        if a.bandtrim:   # UltraRoom decouple: post-loop per-band ss-level trims (dB)
+            bt = [trial.suggest_float("bt_sub",   -6.0, 6.0),
+                  trial.suggest_float("bt_lowmid", -6.0, 6.0),
+                  trial.suggest_float("bt_midhi",  -6.0, 6.0),
+                  trial.suggest_float("bt_air",    -6.0, 6.0)]
+        res = eval_voicing(cfg, str(trial.number), bt)
+        if res is None: return 1e3
+        nf, first50 = res
+        trial.set_user_attr("cfg", [round(v, 4) for v in cfg])
+        trial.set_user_attr("bt", [round(v, 3) for v in bt] if bt else None)
+        trial.set_user_attr("nfail", nf)
+        trial.set_user_attr("first50", round(first50, 1) if first50 is not None else None)
+        loss = float(nf)
+        if a.first50_target is not None and first50 is not None:
+            loss += 0.12 * abs(first50 - a.first50_target)   # anchor first50 to the target
+        return loss
+
+    study = optuna.create_study(direction="minimize", study_name=a.study,
+                                storage=f"sqlite:////tmp/{a.study}_study.db", load_if_exists=True,
+                                sampler=optuna.samplers.TPESampler(seed=42))
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study.optimize(obj, n_trials=a.trials, n_jobs=a.workers)
+
+    # Report the lowest-n_fail trial (not just lowest-loss) for the scoreboard.
+    cs = [t for t in study.trials if t.value is not None and t.value < 1e2]
+    bestnf = min(cs, key=lambda t: (t.user_attrs.get("nfail", 99), t.value))
+    print(f"\nBEST n_fail={bestnf.user_attrs['nfail']} first50={bestnf.user_attrs.get('first50')} "
+          f"({PRESET}, baseline {BASELINE})")
+    print("ER cfg (erSize,onsetMs,erDecayMs,burst2Ms,sparseTailGain,erGain):")
+    print("  " + ",".join(str(v) for v in bestnf.user_attrs["cfg"]))
+    if bestnf.user_attrs.get("bt"):
+        print("bandtrim (sub,lowMid,midHi,air dB): " + ",".join(str(v) for v in bestnf.user_attrs["bt"]))
+
+if __name__ == "__main__":
+    main()

--- a/plugins/chord-analyzer/Source/ChordRecorder.cpp
+++ b/plugins/chord-analyzer/Source/ChordRecorder.cpp
@@ -27,8 +27,8 @@ void ChordRecorder::stopRecording(double currentTimeSec)
 {
     if (!recording) return;
 
-    // End any active chord at the actual stop moment. Previously this
-    // used getRecordingDuration() which reads the last completed event's
+    // End any active chord at the actual stop moment. Don't use
+    // getRecordingDuration() here: it reads the last completed event's
     // endpoint — for the still-active chord that's effectively its own
     // start time, giving duration = 0 and dropping it via the < 0.05s
     // guard in endCurrentChord(). Convert the absolute plugin time the

--- a/plugins/convolution-reverb/ConvolutionEngine.h
+++ b/plugins/convolution-reverb/ConvolutionEngine.h
@@ -388,7 +388,6 @@ private:
     bool reversed = false;
     bool useZeroLatency = true;
 
-    // New features
     float irOffset = 0.0f;                    // IR start offset (0-0.5)
     Quality quality = Quality::Medium;        // Sample rate quality
     StereoMode stereoMode = StereoMode::TrueStereo;  // Stereo processing mode

--- a/plugins/convolution-reverb/PluginEditor.cpp
+++ b/plugins/convolution-reverb/PluginEditor.cpp
@@ -269,7 +269,6 @@ ConvolutionReverbEditor::ConvolutionReverbEditor(ConvolutionReverbProcessor& p)
     zeroLatencyAttachment = std::make_unique<juce::AudioProcessorValueTreeState::ButtonAttachment>(
         params, "zero_latency", *zeroLatencyButton);
 
-    // New parameter attachments
     irOffsetAttachment = std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(
         params, "ir_offset", *irOffsetSlider);
     qualityAttachment = std::make_unique<juce::AudioProcessorValueTreeState::ComboBoxAttachment>(

--- a/plugins/convolution-reverb/PluginEditor.h
+++ b/plugins/convolution-reverb/PluginEditor.h
@@ -126,7 +126,7 @@ private:
     // Latency toggle
     std::unique_ptr<juce::ToggleButton> zeroLatencyButton;
 
-    // New controls - IR Offset
+    // IR Offset controls
     std::unique_ptr<juce::Slider> irOffsetSlider;
     std::unique_ptr<juce::Label> irOffsetLabel;
     std::unique_ptr<juce::Label> irOffsetValueLabel;
@@ -200,7 +200,6 @@ private:
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> eqHighGainAttachment;
     std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment> zeroLatencyAttachment;
 
-    // New parameter attachments
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> irOffsetAttachment;
     std::unique_ptr<juce::AudioProcessorValueTreeState::ComboBoxAttachment> qualityAttachment;
     std::unique_ptr<juce::AudioProcessorValueTreeState::ButtonAttachment> volumeCompAttachment;

--- a/plugins/convolution-reverb/PluginProcessor.cpp
+++ b/plugins/convolution-reverb/PluginProcessor.cpp
@@ -38,7 +38,6 @@ ConvolutionReverbProcessor::ConvolutionReverbProcessor()
     eqHighGainParam = parameters.getRawParameterValue("eq_high_gain");
     zeroLatencyParam = parameters.getRawParameterValue("zero_latency");
 
-    // New parameters
     irOffsetParam = parameters.getRawParameterValue("ir_offset");
     qualityParam = parameters.getRawParameterValue("quality");
     volumeCompParam = parameters.getRawParameterValue("volume_comp");

--- a/plugins/convolution-reverb/PluginProcessor.h
+++ b/plugins/convolution-reverb/PluginProcessor.h
@@ -146,7 +146,6 @@ private:
     std::atomic<float>* eqHighGainParam = nullptr;
     std::atomic<float>* zeroLatencyParam = nullptr;
 
-    // New parameters
     std::atomic<float>* irOffsetParam = nullptr;        // IR start offset (0-1)
     std::atomic<float>* qualityParam = nullptr;         // Quality/sample rate (0=Lo-Fi, 1=Low, 2=Medium, 3=High)
     std::atomic<float>* volumeCompParam = nullptr;      // Volume compensation on/off

--- a/plugins/groovemind/Source/DrummerEngine.cpp
+++ b/plugins/groovemind/Source/DrummerEngine.cpp
@@ -153,9 +153,8 @@ bool DrummerEngine::loadStyleClassifier(const juce::File& modelFile)
 //==============================================================================
 void DrummerEngine::selectPatternWithML()
 {
-    // This method now delegates to selectNewPattern which handles both ML and non-ML paths
-    // Keeping as a separate entry point for explicit ML selection if needed
-    if (!styleClassifier.loaded())
+    // Implements ML-based pattern selection with query-based fallback.
+    // Duplicates selectNewPattern() logic as a separate entry point for explicit ML selection.    if (!styleClassifier.loaded())
     {
         // Use query-based fallback directly to avoid recursion
         auto query = buildQuery();

--- a/plugins/groovemind/Source/DrummerEngine.cpp
+++ b/plugins/groovemind/Source/DrummerEngine.cpp
@@ -154,7 +154,8 @@ bool DrummerEngine::loadStyleClassifier(const juce::File& modelFile)
 void DrummerEngine::selectPatternWithML()
 {
     // Implements ML-based pattern selection with query-based fallback.
-    // Duplicates selectNewPattern() logic as a separate entry point for explicit ML selection.    if (!styleClassifier.loaded())
+    // Duplicates selectNewPattern() logic as a separate entry point for explicit ML selection.
+    if (!styleClassifier.loaded())
     {
         // Use query-based fallback directly to avoid recursion
         auto query = buildQuery();

--- a/plugins/multi-comp/AnalogLookAndFeel.cpp
+++ b/plugins/multi-comp/AnalogLookAndFeel.cpp
@@ -833,7 +833,7 @@ void GRHistoryGraph::updateHistory(const UniversalCompressor& processor)
 {
     // Note: Both updateHistory and paint run on the message thread (timer callback
     // and paint are both message-thread operations in JUCE), so no synchronization
-    // is needed within this component. The processor's grHistory array now uses
+    // is needed within this component. The processor's grHistory array uses
     // atomic<float> elements for thread-safe reads from the audio thread.
 
     // Copy from processor's atomic array to local array

--- a/plugins/multi-q/MultiQ.cpp
+++ b/plugins/multi-q/MultiQ.cpp
@@ -705,9 +705,8 @@ void MultiQ::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*
         eqTypeCrossfade.setCurrentAndTargetValue(0.0f);
         eqTypeCrossfade.setTargetValue(1.0f);
 
-        // Note: previously this block enforced minimum 2x OS for British/Tube when OS=Off.
-        // Now Off is removed — minimum is always 2x — so no EQ-type-driven sample-rate
-        // adjustment is needed here.
+        // Oversampling (hqEnabled) can be Off, 2x, or 4x and is chosen by the user,
+        // not by EQ type, so no EQ-type-driven sample-rate adjustment is needed here.
 
         previousEQType = eqType;
 

--- a/plugins/tape-echo/Source/DSP/TapeEcho.h
+++ b/plugins/tape-echo/Source/DSP/TapeEcho.h
@@ -135,7 +135,7 @@ public:
 
         updateDelayTimes();
 
-        prepared.store(true, std::memory_order_release);  // Now ready for processing
+        prepared.store(true, std::memory_order_release);
     }
 
     bool isPrepared() const { return prepared.load(std::memory_order_acquire); }

--- a/plugins/tape-echo/Source/PluginProcessor.cpp
+++ b/plugins/tape-echo/Source/PluginProcessor.cpp
@@ -176,7 +176,7 @@ void TapeEchoProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
 
     currentSampleRate = sampleRate;
 
-    // Initialize oversampling (2x) - but don't use it for now to debug
+    // Initialize oversampling (2x) - not currently used for processing
     oversampling = std::make_unique<juce::dsp::Oversampling<float>>(
         2, 1, juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR, true);
     oversampling->initProcessing(static_cast<size_t>(samplesPerBlock));
@@ -204,7 +204,6 @@ void TapeEchoProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
     originalLatencySamples_ = static_cast<int>(oversampling->getLatencyInSamples());
     setLatencySamples(originalLatencySamples_);
 
-    // Now ready to process
     readyToProcess.store(true, std::memory_order_release);
 }
 

--- a/rebuild_all.sh
+++ b/rebuild_all.sh
@@ -287,7 +287,7 @@ echo
 
 # Final status
 if [ ${#FAILED_PLUGINS[@]} -eq 0 ]; then
-    print_success "All plugins built and installed successfully! 🎉"
+    print_success "All plugins built and installed successfully!"
 
     # Show cache stats if using ccache
     if [ "$USE_FAST" = true ] && command_exists ccache; then

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -891,6 +891,7 @@ int main (int argc, char** argv)
     // (last write wins). Applied AFTER the preset so they override anything
     // the preset set. Works against any plugin — DuskVerb, Valhalla, Lex, etc.
     std::vector<std::pair<juce::String, juce::String>> paramOverrides;
+    std::vector<std::pair<juce::String, juce::String>> nparamOverrides;
     for (int i = 1; i < argc; ++i)
     {
         juce::String a = argv[i];
@@ -937,6 +938,21 @@ int main (int argc, char** argv)
                                              spec.substring (eq + 1).trim());
             else
                 std::cerr << "  ! ignoring malformed --param '" << spec << "' (expected NAME=VALUE)" << std::endl;
+        }
+        else if (a == "--nparam" && i + 1 < argc)
+        {
+            // Format: NAME=NORMVALUE — sets the parameter's NORMALISED value
+            // directly, bypassing getValueForText. Needed when replaying a
+            // plugin's own saved state (e.g. a Valhalla .vstpreset XML, whose
+            // attributes are normalised 0..1 floats): the text parser would
+            // misread "0.2299" as 0.23 seconds/percent/etc.
+            const juce::String spec = argv[++i];
+            const int eq = spec.indexOfChar ('=');
+            if (eq > 0 && eq < spec.length() - 1)
+                nparamOverrides.emplace_back (spec.substring (0, eq).trim(),
+                                              spec.substring (eq + 1).trim());
+            else
+                std::cerr << "  ! ignoring malformed --nparam '" << spec << "' (expected NAME=NORMVALUE)" << std::endl;
         }
         else if (! a.startsWith ("--"))
         {
@@ -1179,7 +1195,7 @@ int main (int argc, char** argv)
     // normalised" for small 0..1 floats when getValueForText returns 0.
     auto applyParamOverrides = [&]()
     {
-        if (paramOverrides.empty())
+        if (paramOverrides.empty() && nparamOverrides.empty())
             return;
         for (const auto& [name, valueStr] : paramOverrides)
         {
@@ -1209,6 +1225,19 @@ int main (int argc, char** argv)
             p->setValueNotifyingHost (normalised);
             std::cout << "  --param " << name << " set='" << valueStr
                       << "' norm=" << normalised
+                      << " read_back='" << p->getText (p->getValue(), 50) << "'" << std::endl;
+        }
+        for (const auto& [name, valueStr] : nparamOverrides)
+        {
+            auto* p = findParam (*plugin, name);
+            if (p == nullptr)
+            {
+                std::cerr << "  ! --nparam: parameter '" << name << "' not found" << std::endl;
+                continue;
+            }
+            const float normalised = juce::jlimit (0.0f, 1.0f, valueStr.getFloatValue());
+            p->setValueNotifyingHost (normalised);
+            std::cout << "  --nparam " << name << " norm=" << normalised
                       << " read_back='" << p->getText (p->getValue(), 50) << "'" << std::endl;
         }
     };

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -95,8 +95,8 @@ namespace
     // and cannot link the plugin enum, so bump this by hand when an engine is
     // added). Was a stale 9 after ReverseRoom became the 10th engine — that
     // off-by-one divisor misrouted --param "Algorithm" (e.g. FDN 4 → wrong engine).
-    static constexpr int   kNumAlgorithms    = 13;   // 0..12: + 12 AccurateHall32 (Dense)
-    static constexpr float kAlgorithmDivisor = static_cast<float> (kNumAlgorithms - 1);  // 11.0f
+    static constexpr int   kNumAlgorithms    = 14;   // 0..13: + 13 TiledRoom
+    static constexpr float kAlgorithmDivisor = static_cast<float> (kNumAlgorithms - 1);  // 13.0f
 
     // Keys are the human-readable parameter NAMES (matching what the AU host
     // surfaces). The original string IDs from the plugin source are hashed to

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -95,8 +95,8 @@ namespace
     // and cannot link the plugin enum, so bump this by hand when an engine is
     // added). Was a stale 9 after ReverseRoom became the 10th engine — that
     // off-by-one divisor misrouted --param "Algorithm" (e.g. FDN 4 → wrong engine).
-    static constexpr int   kNumAlgorithms    = 11;   // 0..10: + 10 AccurateHall (FDN-GEQ)
-    static constexpr float kAlgorithmDivisor = static_cast<float> (kNumAlgorithms - 1);  // 10.0f
+    static constexpr int   kNumAlgorithms    = 12;   // 0..11: + 11 SparseField (Early)
+    static constexpr float kAlgorithmDivisor = static_cast<float> (kNumAlgorithms - 1);  // 11.0f
 
     // Keys are the human-readable parameter NAMES (matching what the AU host
     // surfaces). The original string IDs from the plugin source are hashed to

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -1235,6 +1235,13 @@ int main (int argc, char** argv)
                 std::cerr << "  ! --nparam: parameter '" << name << "' not found" << std::endl;
                 continue;
             }
+            if (! valueStr.containsOnly ("0123456789.+-eE")
+                || valueStr.trim().isEmpty())
+            {
+                std::cerr << "  ! --nparam " << name << ": value '" << valueStr
+                          << "' is not a number, skipped" << std::endl;
+                continue;
+            }
             const float normalised = juce::jlimit (0.0f, 1.0f, valueStr.getFloatValue());
             p->setValueNotifyingHost (normalised);
             std::cout << "  --nparam " << name << " norm=" << normalised

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -95,7 +95,7 @@ namespace
     // and cannot link the plugin enum, so bump this by hand when an engine is
     // added). Was a stale 9 after ReverseRoom became the 10th engine — that
     // off-by-one divisor misrouted --param "Algorithm" (e.g. FDN 4 → wrong engine).
-    static constexpr int   kNumAlgorithms    = 12;   // 0..11: + 11 SparseField (Early)
+    static constexpr int   kNumAlgorithms    = 13;   // 0..12: + 12 AccurateHall32 (Dense)
     static constexpr float kAlgorithmDivisor = static_cast<float> (kNumAlgorithms - 1);  // 11.0f
 
     // Keys are the human-readable parameter NAMES (matching what the AU host


### PR DESCRIPTION
## DuskVerb: room/hall fleet calibration, added new engines and tuning

Continues #87 past the #102 merge. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three new reverb algorithms (expanded spatial textures), sparse early-field / tiled-room composite voicing, and per-preset output-diffusion and tank-feed EQ controls.
  * New density-jitter control for Dattorro-style tanks.
  * Preset dropdown now uses a dark-styled menu.

* **Enhancements**
  * Extensive factory-preset retuning and expanded 32-line reverb configuration for richer tails and voicing.

* **Bug Fixes**
  * Fixed discrete-parameter restore edge cases and reduced preset/engine switching artifacts.

* **Documentation**
  * README and tuning docs updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->