### PR TITLE
Duskverb width tuning

### DIFF
--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -566,7 +566,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Vintage Vocal Plate",  "Plates",
           1,  0.5f,   false, 10.0f, 0,  // 2026-06-15 DPV(1). AccurateHall(10) migration TESTED+reverted: FDN slow-bloom suited the 91ms attack + killed boing, but washy early field regressed it (33 vs 21). busMode false.
           0.90000f, 0.80357f, 0.29369f, 1.64421f, 1.30000f, 1.38104f,  522.55f,  // 2026-06-24 Decay knob 0.50->0.90 + octave decayRef 0.40->0.724 (= the octave curve's natural scale-1.0 broadband): now the DISPLAYED Decay Time ~= the REALIZED RT60 (~0.90s, toward Lex 0.93) instead of the old misleading 0.5s knob / 0.876s actual. (Prior: 0.50 knob re-tune vs corrected anchor.)
-          0.24230f, 0.00f, 0.30f, 42.811f, 15000.0f, 1.00000f, false, 11.03f,  // 2026-06-14 Phase-3 match-EQ (s=0.75): gainTrim +11.03 (20->19). Width 1.0.
+          0.24230f, 0.00f, 0.30f, 25.000f, 15000.0f, 1.00000f, false, 11.03f,  // 2026-06-29 Lo Cut 42.8->25 (EAR "<80Hz different"): restores deep-sub 20-40Hz to MATCH anchor (was -6.4dB under at 42.8, -10.4 at the wrong 55; at 25 it's +0.1). HPF cutoff so it adds <55Hz weight WITHOUT the 40-300Hz boom. Also lifts the ss-deep-sub-20-50 gate (-6 under).  // 2026-06-14 Phase-3 match-EQ (s=0.75): gainTrim +11.03. Width 1.0.
           /* mono */ 20.0f, /* mid */ 1.42055f, /* highX */ 7049.45f, /* sat */ 0.12959f,
           /* hiCutShelfGainDb */ -6.0f,   // 2026-06-16 EAR: -12->-6 brighten (Lexicon brighter than ours)
           /* gate */ true,
@@ -574,9 +574,9 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
           /* sixAPBloomStagger    */ { 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f },
           /* sixAPEarlyMix        */ 0.5f,  /* sixAPOutputTrim    */ 1.3f,
           /* bassChoke            */ 20.0f,
-          /* dpvHfShelfGainDb     */ 8.50f,       // 2026-06-24 EAR "Lex brighter": shelf 3.25->8.5 lifts the
+          /* dpvHfShelfGainDb     */ 8.50f,       // 2026-06-29 HF cut to 5.5 REVERTED: closed ss-hi/air but net-0 (gain-match whack-a-mole) AND darkened cent_50 -19%->-29% = re-muffle (the user's complaint). HF bloom vs cent is the documented Dattorro density coupling wall.  // 2026-06-24 EAR "Lex brighter": shelf 3.25->8.5 lifts the
           /* dpvHfShelfFreqHz     */ 4049.0f,     // EARLY field to ~Lex cent_50 5191; struct-damp 6605->4000
-          /* dpvStructHfDampHz    */ 4000.0f,     // keeps the LATE tail dark (cent_500 ~Lex 1688). Bright-early/dark-late; residual bloom 4-8k/8-12k is the Dattorro HF-density coupling the real Lex avoids (EAR-CHECK).
+          /* dpvStructHfDampHz    */ 5500.0f,     // 2026-06-29 4000->5500 (EAR "Lex crispier/fuller top"): less per-pass HF damping -> HF tail sustains longer (T60-16k 0.25->? toward Lex 0.55) = crispy sparkle + fills the tail. DV decay was HF-tilted (low long, top dies fast); Lex is EVEN across freq.
           /* dpvBoxCutGainDb      */ -1.52f,      // 2026-06-19: confirmed via bake-sweep the DPV EQ is LIVE but
           /* dpvBoxCutFreqHz      */ 704.0f,      // every lever is coupled to a structural wall — HF shelf brightens
           /* dpvBassShelfGainDb   */ 0.82f,       // cent_50 but blooms the tank HF (29->33); box/bass cut fixes sub/mid
@@ -1287,7 +1287,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Black Hole",           "Shimmer",
           7,  0.50f, false,   0.0f, 0,
           10.8728f, 0.56922f, 0.50890f, 0.10000f, 1.16880f, 0.53601f,  372.24f,  // 2026-06-16 EAR: modRate->0.1 = feedback 0 to match Valhalla BlackHole (screenshot feedback 0.000). DV sine 2k was +40dB hot vs anchor = over-shimmer. NOTE: DV pitch is feedback-loop-only → fb0 may kill shimmer (topology check).
-          0.85741f, 0.05f, 0.70f, 24.591f, 18926.8f, 1.26041f, false, 7.64f,  // 2026-06-14 Phase-3 match-EQ (s=0.75): gainTrim re-matched (+7.64) after the output match-EQ cut (28->25).
+          0.85741f, 0.05f, 0.70f, 24.591f, 18926.8f, 1.10000f, false, 7.64f,  // 2026-06-29 Width 1.26->1.10: DV's broadband stereo ran too WIDE (stereo_corr -0.01 vs Valhalla +0.12); 1.10 closes it (25->24). (snare confirmed DV wider than Valhalla, not narrower.)  // 2026-06-14 Phase-3 match-EQ (s=0.75): gainTrim re-matched (+7.64) after the output match-EQ cut (28->25).
           /* mono */ 60.0f, /* mid */ 0.75073f, /* highX */ 3390.34f, /* sat */ 0.38197f },
         // ── Deep Blue Day ────────────────────────────────────────────────
         // Reference: external reference Shimmer "DeepBlueDay" preset (named after the
@@ -1310,7 +1310,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Deep Blue Day",        "Shimmer",
           7,  0.50f, false,  25.0f, 0,  // mix pinned 50% — all Valhalla Shimmer factory presets ship 50% wet (verified from plugin UI 2026-06-15)
           18.000f, 0.59833f, 0.50f, 0.60500f, 0.999f, 1.000f, 668.755f,  // 2026-06-19 EAR "a bit more low end than VS over the long tail": Bass 1.5->1.0 — over the 15s tail Bass 1.5 made the LOW band (150-400) plateau (-25->-28dB t6->t13) while VS DECAYS (-24->-32); the down voice now supplies the warm low so Bass no longer needs 1.5 to fake it, and 1.0 restores VS's low-band decay (low@13s -32 = VS).  // (superseded) modRate 1.30->0.605 = feedback ~11.5%->~5% — tames DV's over-hot high octave to match VVV + frees headroom (less regen → the down voice runs hotter without clipping).  // "low missing in tail / darker": Bass 0.659->1.5 — Bass<1 made the LOW band decay FASTER than the tail (low died early -> tail lacked warm low -> sounded bright/thin). 1.5 sustains the low (low T60 12.5->13.3s ~VVV). NB tail HF is already DARKER than VVV; the "bright" was the missing low, not hot highs.  // decay 9.34->18 — THE fix. DV's tail was ~HALF VVV's length (per-band T60 7-10s vs VVV 13-16s); the sustained-spectrum match hid it (level, not ring-time). 18 ~doubles the tail toward VVV's 13-16s ambient wash. Feedback kept at 1.30 (~11.5%, user's clean setting) — the decay does the fullness, not metallic regeneration.  // 2026-06-16 EAR: modRate 0.605->1.30 = feedback ~0.048->0.115 (user: "closer to 11-12%")
-          0.80742f, 0.20f, 0.50f, 26.925f, 19144.104f, 1.69030f, false, 0.37f,
+          0.80742f, 0.20f, 0.50f, 26.925f, 19144.104f, 1.69030f, false, -4.50f,  // 2026-06-29 gainTrim 0.37->-4.50: the new −2 oct SUB voice (kShimmerSubByName 3.8) added deep-low energy that pushed the wet-stem peak 0.37->-0.3dB; trim back to ~-5dB so it matches Valhalla Shimmer's own stem level (-5.6dB peak) and stays mix-safe (50% mix + hot dry can't clip). Rel-fundamental shape (the screenshot match) is gain-invariant.
           /* mono */ 20.0f, /* mid */ 1.200f, /* highX */ 2157.808f, /* sat */ 0.23195f, /* hiCutShelfGainDb */ -12.109f },  // 2026-06-19 EAR "a bit fuller": mid 0.606->1.2 — DV's mid body (500-2k) ran ~0.5dB thinner + 0.7dB quieter than the anchor; mid_mult lifts the mid GEQ (shimmer feedback is in the pitch loop = sparkle not body; mid_mult is the body lever).  // 29->27->23: Shimmer 2nd pitch voice (+24, fills 12-24k) + Hi Cut 4521->11000 so its HF reaches output (matches Valhalla broadband octave; the dark 4521 was choking the new top band)
     };
     return presets;

--- a/plugins/DuskVerb/src/FactoryPresets.h
+++ b/plugins/DuskVerb/src/FactoryPresets.h
@@ -513,7 +513,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Vocal Plate",          "Plates",
           10, 0.35f, false, 29.16f, 0,   // algo 10 = AccurateHall (2026-06-09): per-octave GEQ T60. T60 6/9->9/9, gain-matched full_check 25->14 vs FDN. Octave targets in kAccurateHallT60ByName.
           0.689f, 0.15f, 0.37f, 1.51f, 1.281f, 1.028f, 392.516f,  // 2026-06-24 Decay knob 0.849->0.689 = realized broadband RT60 (honest knob; AccurateHall decayRef auto-tracks the knob so scale stays 1.0 -> octave T60 table + sound UNCHANGED).  // T60 decay tune 2026-06-08 (gain-matched): Decay 1.02->0.90 + Treble 0.85->0.60 closes T60 6/9 (63/250/500/2k/4k/8k match VVV, tail_t60 within 3%). Hi-Mid PINNED 0.85 via kFiveBandByName so the air band isn't double-damped. Residual 125/1k/16k = single-octave anomalies (9-octave-vs-5-band wall).
-          0.58f, 0.25f, 0.76f, 30.0f, 17597.191f, 1.02f, false, 1.88f,  // 2026-06-14 Phase-3 match-EQ: gainTrim re-matched (+1.88) after the output match-EQ cut (26->20). Lo Cut 30 keeps the lows.
+          0.58f, 0.25f, 0.76f, 30.0f, 17597.191f, 0.98f, false, 1.88f,  // 2026-06-28 Width 1.02->0.98: closes stereo_corr (DV -0.16 vs anchor -0.04, too wide) -> 19->18.  // 2026-06-14 Phase-3 match-EQ: gainTrim re-matched (+1.88) after the output match-EQ cut (26->20). Lo Cut 30 keeps the lows.
           /* mono */ 20.0f, /* mid */ 1.33f, /* highX */ 2196.609f, /* sat */ 0.03f, /* hiCutShelfGainDb */ -5.774f },
         // ═══════════ PLATES ═══════════
         // ── Vintage Vocal Plate ──────────────────────────────────────────────
@@ -881,7 +881,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Cathedral Large Hall", "Halls",
           14, 0.45f, false, 20.0f, 0,   // 2026-06-24 predelay 2.484->20.0 ms = VVV Cathedral PREDELAY (20.00 ms, from the GUI). DV brought the reverb in ~18ms early, fusing it with the transient -> no distinct "second tap"; the 20ms gap is the slap the ear hears.  // 2026-06-13: migrated FDN(10) -> DenseHall(14); dense diffused tail kills the metallic ring (tail kurtosis 14.6 -> 7.2)
           4.434f, 0.93880f, 0.38010f, 1.18680f, 0.750f, 1.557f,  265.871f,  // 2026-06-24 Decay knob 4.2->4.434 = realized broadband RT60 (honest; DenseHall decayRef auto-tracks knob -> scale 1.0 -> octave T60 table + sound UNCHANGED).  // 2026-06-17 EAR: decay 3.10->4.2 = anchor low T60 (4.02s) for low sustain.  // 2026-06-16 re-tune vs corrected anchor: Treble 1.416->0.75 (T60 2k/4k into gate), 24->22  // 2026-06-14 gain-matched 8-lever sweep (44->29): decay 3.10, Treble 1.416, Bass 1.557, LowXover 266.  // decay 3.44->4.07: restore length after honest-decay fold-in (RT60 3.38->~4.0)  // Treble 1.28->0.50: darken to anchor brightness (centroid 1987->1545, anchor 1551).
-          0.74244f, 0.05000f, 0.44666f,  40.730f, 16050.768f, 1.00257f, false, 6.01f,  // 2026-06-16 erLevel 0.36->0.05: Cathedral anchor is BACK-loaded (first50 13.6%), wants minimal discrete ER.2026-06-14 Phase-3 match-EQ: gainTrim re-matched (+6.01) after the output match-EQ cut (29->22). HiCut 16051.
+          0.74244f, 0.05000f, 0.44666f,  40.730f, 16050.768f, 1.05000f, false, 6.01f,  // 2026-06-28 Width 1.00257->1.05: closes width-mid .3-5k (DV +0.15 vs anchor +0.03, too narrow) -> 20->19 (width-low stays: global Width saturates on the low band).  // 2026-06-16 erLevel 0.36->0.05: Cathedral anchor is BACK-loaded (first50 13.6%), wants minimal discrete ER.2026-06-14 Phase-3 match-EQ: gainTrim re-matched (+6.01) after the output match-EQ cut (29->22). HiCut 16051.
           /* mono */ 20.0f, /* mid */ 1.026f, /* highX */ 3071.094f, /* sat */ 0.00126f,  // 2026-06-14 sweep: Mid 1.026, HighXover 3071.  // edt+498% residual is octave-T60-locked (GEQ recal = next pass)
           /* hiCutShelfGainDb */ -6.206f },   // 2026-06-14 sweep (was -9.0).
         // ── Blade Runner 224 ─────────────────────────────────────────────────
@@ -1139,7 +1139,7 @@ inline const std::vector<FactoryPreset>& getFactoryPresets()
         { "Ambience",             "Rooms",
           10, 0.40f, false,  8.00f, 0,   // 2026-06-12 anti-wash: predelay 2.91->8 ms for early-reflection separation (algo 10 AccurateHall)
           1.373f, 0.26283f, 0.17870f, 0.17487f, 0.64252f, 0.62992f,  327.98f,  // 2026-06-24 Decay knob 1.51574->1.373 = realized broadband RT60 (honest; AccurateHall decayRef auto-tracks knob -> scale 1.0 -> octave T60 table + sound UNCHANGED).
-          0.49320f, 0.86847f, 0.56f, 30.214f, 15746.05f, 1.07315f, false, 2.95f,  // tunable-cluster sweep 2026-06-11: 23 -> 16 (bass-damp+bandtrim boom/640, partial front-load, edt). gainTrim +3.28 = 100%-wet noiseburst RMS match.
+          0.49320f, 0.86847f, 0.56f, 30.214f, 15746.05f, 1.00000f, false, 2.95f,  // 2026-06-28 Width 1.07315->1.00: closes width-low <300 (DV -0.26 vs anchor -0.13, over-decorrelated) -> 17->16.  // tunable-cluster sweep 2026-06-11: 23 -> 16 (bass-damp+bandtrim boom/640, partial front-load, edt). gainTrim +3.28 = 100%-wet noiseburst RMS match.
           /* mono */ 20.0f, /* mid */ 0.70170f, /* highX */ 5834.41f, /* sat */ 0.16156f, /* hiCutShelfGainDb */ -5.41295f },
         // ── 1981 Gated Snare ─────────────────────────────────────────────────
         // Engine: NonLinear v6 (algo 5) — TRUE STATIC FIR. The envelope

--- a/plugins/DuskVerb/src/PluginEditor.cpp
+++ b/plugins/DuskVerb/src/PluginEditor.cpp
@@ -542,6 +542,7 @@ DuskVerbEditor::DuskVerbEditor (DuskVerbProcessor& p)
     // category (Plates, Halls, Ambient, etc.) becomes a nested submenu so
     // the top-level menu fits in a small popup instead of one giant scroll.
     presetBox_.menuBuilder = [this] { return buildPresetMenu(); };
+    presetBox_.maxMenuColumns = 2;   // two columns; buildPresetMenu() inserts the column break
     addAndMakeVisible (presetBox_);
     refreshPresetList();
 
@@ -1145,7 +1146,17 @@ void DuskVerbEditor::resized()
     layoutKnobsInGroup ({ r3MacroX, row3Y, r3MacroW, row3H }, topPad,
                         { { &tone_, knobMed }, { &character_, knobMed }, { &duck_, knobMed } }, sf, row3BottomMargin);
 
-    titleClickArea_ = { 0, 0, getWidth(), scaler_.scaled (52) };
+    // Patreon/supporters overlay opens only on the "DUSKVERB" wordmark itself,
+    // not the whole top row. Mirror the title draw in paint() (centred, 32*sf
+    // bold, 0.95 h-scale) to get the wordmark's actual bounds.
+    {
+        const auto sf = scaler_.getScaleFactor();
+        juce::Font titleFont (juce::FontOptions (32.0f * sf, juce::Font::bold));
+        titleFont.setHorizontalScale (0.95f);
+        const int textW = juce::GlyphArrangement::getStringWidthInt (titleFont, "DUSKVERB");
+        const int textX = (getWidth() - textW) / 2;
+        titleClickArea_ = { textX, scaler_.scaled (4), textW, scaler_.scaled (40) };
+    }
 
     if (supportersOverlay_)
         supportersOverlay_->setBounds (getLocalBounds());
@@ -1208,12 +1219,24 @@ juce::PopupMenu DuskVerbEditor::buildPresetMenu()
     // meant a pick "sometimes didn't take". A single scrollable column with
     // non-clickable section headers groups by category just as clearly and is
     // robust in-window (one mouse-down, no sideways submenu to miss/clip).
+    // Two columns: split at the category boundary nearest the halfway point so a
+    // header never detaches from its items (the bug that forced single-column).
+    // The explicit addColumnBreak() controls WHERE JUCE wraps, instead of letting
+    // it auto-split mid-category. maxMenuColumns=2 is set on presetBox_ to match.
+    const size_t splitTarget = presets.size() / 2;
+    bool columnBroken = false;
     juce::String currentCategory;
     for (size_t i = 0; i < presets.size(); ++i)
     {
         const juce::String cat = presets[i].category;
         if (cat != currentCategory)
         {
+            // Break to the second column at the first new category past halfway.
+            if (! columnBroken && i >= splitTarget)
+            {
+                menu.addColumnBreak();
+                columnBroken = true;
+            }
             menu.addSectionHeader (cat);
             currentCategory = cat;
         }

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -49,7 +49,14 @@ struct TuningEnv
     const char* maindet;
     const char* buildup;
     const char* shimmerdown;
+    const char* shimmersub;
+    const char* shimmerhpf;
+    const char* shimmerstereo;
+    const char* shimmerair;
     const char* frontload;
+    const char* dpvrefl;
+    const char* densefield;
+    const char* ddensefield;
     const char* airshelf;
     const char* lowshelf;
     const char* differ;
@@ -80,7 +87,14 @@ struct TuningEnv
           maindet   (std::getenv ("DUSKVERB_MAINDET")),
           buildup   (std::getenv ("DUSKVERB_BUILDUP")),
           shimmerdown (std::getenv ("DUSKVERB_SHIMMERDOWN")),
+          shimmersub (std::getenv ("DUSKVERB_SHIMMERSUB")),
+          shimmerhpf (std::getenv ("DUSKVERB_SHIMMERHPF")),
+          shimmerstereo (std::getenv ("DUSKVERB_SHIMMERSTEREO")),
+          shimmerair (std::getenv ("DUSKVERB_SHIMMERAIR")),
           frontload (std::getenv ("DUSKVERB_FRONTLOAD")),
+          dpvrefl   (std::getenv ("DUSKVERB_DPVREFL")),
+          densefield (std::getenv ("DUSKVERB_DENSEFIELD")),
+          ddensefield (std::getenv ("DUSKVERB_DDENSEFIELD")),
           airshelf  (std::getenv ("DUSKVERB_AIRSHELF")),
           lowshelf  (std::getenv ("DUSKVERB_LOWSHELF")),
           differ    (std::getenv ("DUSKVERB_DIFFER")) {}
@@ -2245,7 +2259,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Vintage Gold Plate",   { 5000.0f,   7.5f } },   // cent_50 -30.5->-5.4, cent_500 -19.5->+5.9
             { "Deep Blue Day",        { 3000.0f,   6.0f } },   // cent_50 -14.4->+7.0, cent_500 -29.1->-9.5
             { "Ambience",             { 3000.0f,  -5.0f } },   // bright-late: cent_500 +45.3->+5.1, cent_50 +12.5->-11.7
-            { "Black Hole",           { 3000.0f,  12.0f } },   // cent_50 -19.7->+13.9 (closes early); cent_500 -16.9 residual = structural FDN HF-decay wall (skipped per ear call)
+            { "Black Hole",           { 3000.0f,   2.5f } },   // 2026-06-29 gain 12->2.5 (EAR "DV brighter" + snare/noiseburst): +12 over-cranked the 4-12k presence ~9 dB hot vs Valhalla (snare HF tilt -6 vs -15) — harsh-bright. 2.5 matches the 4-12k presence (tilt ~-15 = Valhalla) -> n_fail 34->25. DV stays darker by CENTROID (no >12k air) — that's the 12 kHz pitch-shifter AA ceiling, structural. (Prev +12 chased cent_50 on the early window but over-brightened the band the ear hears.)
             // NOT here (cent_500 is a LATE-tail per-band-DECAY / low-mid-LEVEL problem the
             // air-shelf can't fix; fixed at the proper in-loop lever instead):
             //   Vocal Plate     -> AccurateHall low-mid LEVEL cut (pteqByName) — 63/250Hz +10dB hot
@@ -2395,7 +2409,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Blade Runner 224",     { 0.88f, 1.00f, 1.00f } },  // narrow low → width-low passes (29→28)
             { "Medium Drum Room",     { 1.12f, 1.12f, 1.00f } },  // WIDEN lo/mid → stereo_corr+width lo/mid (26→24)
             { "Reverse Taps",         { 0.50f, 0.88f, 0.88f } },  // strong narrow low + lo mid/hi (46→44)
-            { "Vintage Vocal Plate",  { 0.85f, 1.00f, 1.00f } },  // narrow low → width-low passes (36→35)
+            { "Vintage Vocal Plate",  { 0.85f, 1.00f, 1.00f } },  // narrow low → width-low passes (36→35). (2026-06-29: the 1.50 widen was front-load compensation; reverted with the front-load.)
             { "Vintage Gold Plate",   { 0.80f, 0.90f, 1.00f } },  // 2026-06-23 workflow: narrow low+mid → stereo_corr + width-low pass (14→12)
             { "Tiled Room",           { 0.88f, 1.00f, 1.00f } },  // 2026-06-23 workflow: narrow low → width-low pass, stereo_corr held (14→13)
             // No clean per-band fix (stereo fails trade / decouple): Drum Plate
@@ -2775,7 +2789,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // main lines (close-spaced coprime modes → kills the comb resonance); det[4]
         // = per-line incommensurate detune {Ldel1,Ldel2,Rdel1,Rdel2}. Defaults
         // (false / identity) = byte-identical for every non-room Dattorro preset.
-        struct DensityConfig { float density = 0.0f, modred = 1.0f, indiff = 0.0f, softonset = 0.0f, bloom = 0.0f;
+        struct DensityConfig { float density = 0.0f, modred = 1.0f, indiff = 0.0f, softonset = 0.0f, bloom = 0.0f, bloomExp = 1.0f;
                                bool roomfill = false; float det[4] = { 1.0f, 1.0f, 1.0f, 1.0f }; };
         static constexpr std::array<std::pair<std::string_view, DensityConfig>, 3> kDattorroDensityByName = {{
             // BEGIN_DATTDENS_MAP (offline density/modred/indiff sweep, key on exact row name)
@@ -2786,7 +2800,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             { "Drum Plate", { 1.0f /*density*/, 1.0f /*modred*/, 1.0f /*indiff*/ } },
             // Vintage Vocal Plate: input diffusion densifies the early field
             // (24->22 vs the corrected anchor); octave GEQ left off (3-band path).
-            { "Vintage Vocal Plate", { 0.0f /*density*/, 1.0f /*modred*/, 1.0f /*indiff*/ } },
+            { "Vintage Vocal Plate", { 0.0f /*density*/, 1.0f /*modred*/, 1.0f /*indiff*/, 0.0f /*softonset*/, 90.0f /*bloom*/, 2.0f /*bloomExp*/ } },  // 2026-06-29 density REVERTED to 0: the 12-AP cascade SHORTENED the HF tail (T60-16k 0.41->0.25 = dull top); the structHfDamp 9000 fix now supplies fullness (tailFlat 0.24 > anchor 0.20) AND the crispy HF sustain (16k 0.59 vs anchor 0.55) the EAR wants. + bloom-attack 90ms/exp 2.0: slow-build swell back-loads the onset WITHOUT pre-echo -> energy_t50/first50/transient_def/impulse-RMS. attack_time caps ~70ms; sine1k = 1k modal wall.
             // Vintage Gold Plate: density 1.0 engages the full 12-AP in-loop
             // cascade — more modes = shallower spectral comb (ripple 6.2->~2).
             // Pairs with the octave GEQ (re-calibrated for the longer loop).
@@ -2803,10 +2817,10 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             // or accept the boing. See memory duskverb_boing_sparse_modal.
             // END_DATTDENS_MAP
         }};
-        float density = 0.0f, modred = 1.0f, indiff = 0.0f, softonset = 0.0f, bloom = 0.0f;
+        float density = 0.0f, modred = 1.0f, indiff = 0.0f, softonset = 0.0f, bloom = 0.0f, bloomExp = 1.0f;
         bool  roomfill = false; float det[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
         if (const auto* p = findPresetConfig (kDattorroDensityByName, std::string_view (name)))
-        { density = p->density; modred = p->modred; indiff = p->indiff; softonset = p->softonset; bloom = p->bloom;
+        { density = p->density; modred = p->modred; indiff = p->indiff; softonset = p->softonset; bloom = p->bloom; bloomExp = p->bloomExp;
           roomfill = p->roomfill; for (int b = 0; b < 4; ++b) det[b] = p->det[b]; }
         if (const char* e = tuningEnv().dens;   e != nullptr && e[0] != '\0') density   = juce::String (e).getFloatValue();
         if (const char* e = tuningEnv().modred; e != nullptr && e[0] != '\0') modred    = juce::String (e).getFloatValue();
@@ -2825,6 +2839,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         engine.setDattorroBloomAttackMs (bloom);
         engine.setDattorroDensityRoomFill (roomfill);
         engine.setDattorroMainLineDetune (det[0], det[1], det[2], det[3]);
+        engine.setDattorroBloomExp (bloomExp);
         if (const char* e = tuningEnv().bloomexp; e != nullptr && e[0] != '\0') engine.setDattorroBloomExp (juce::String (e).getFloatValue());
     }
 
@@ -2873,7 +2888,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             // the anchor's BROADBAND decay (0.93s) exceeds its own max per-band (0.80s),
             // so per-band-match and audible-broadband-match are mutually exclusive here;
             // the user hears broadband → ear over the per-band gates.
-            { "Vintage Vocal Plate", { { 0.650f, 0.640f, 0.620f, 0.666f, 0.744f, 0.658f, 0.595f, 0.700f, 1.210f }, 0.703f } },  // 2026-06-24 decayRef tuned so the Decay knob (0.90) reads ~= the realized RT60 (~0.90s): decayRef 0.724 gave realized 0.874 @ knob 0.90 (3% low); 0.703 lifts scale 1.24->1.28 -> realized ~0.90 = honest knob.
+            { "Vintage Vocal Plate", { { 0.650f, 0.640f, 0.620f, 0.666f, 0.744f, 0.658f, 0.595f, 0.700f, 1.210f }, 0.700f } },  // 2026-06-29 decayRef 0.82->0.70 (EAR "Lex rings out longer / DV shorter"): LENGTHENS the tail to match the anchor's PERCEIVED ringout (mid-tail @1.2s -91->-81 ≈ anchor -79). UNDOES Surgery A's gate-driven shortening: the T60-25dB gate measures the anchor's EARLY slope (0.61s) but the Lex is NON-EXPONENTIAL (rings out far past that), so matching the gate made DV sound too short. Ear > gate here; raises n_fail (T60 "too long") but matches the audible tail.
         }};
         float t60[9] = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         float ref = 0.0f;
@@ -2906,7 +2921,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             // via the noiseburst gain-match (sub-bass pops hot) — left uncut.
             // 2026-06-20 EAR "brighter": eased the 4k/8k/16k cuts (-5/-4/-2 -> -2/-1/0)
             // so the (now longer + thus darker) tail keeps its top → cent_50 stays bright.
-            { "Vintage Vocal Plate", { { 0.0f, 0.0f, -2.0f, -3.0f, -6.0f, -3.0f, -2.0f, -1.0f, 0.0f } } },
+            { "Vintage Vocal Plate", { { 0.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, 0.0f } } },  // 2026-06-29 EAR "muffled/midrange different": the old -6dB@1k + -3@500/2k scoop GOUGED the upper-mid presence (snare tail 630-2500Hz was -5 to -7dB under anchor). Flatten to a gentle -1 uniform trim -> tail upper-mid match 5.3->3.3 L1, n_fail 36->35. Residual jaggedness (peaks 125/400, dip 1k) is DPV modal structure vs Lexicon, not EQ-fixable. Sweep: tonal_sweep.py / tonal_refine.py.
             // (Drum Plate REMOVED 2026-06-15: the tonal cuts were treating a
             // SYMPTOM — the +6dB@125 tilt is the boing mode's energy. It gamed the
             // sustained gates (19->8 fiction), broke the impulse/hit loudness
@@ -2939,6 +2954,12 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // pattern as kWidthBandsByName / kDenseHallOctaveT60ByName.
         static constexpr std::array<std::pair<std::string_view, FrontLoadConfig>, 0> kDpvFrontLoadByName = {
             // BEGIN_DPVFRONTLOAD_MAP
+            // 2026-06-29 REVERTED: enabling the front-load ER for VVP closed the energy-arrival
+            // gates (35->15) but fired ER taps 56/98ms BEFORE the delayed main (143ms) = audible
+            // PRE-ECHO double-tap (user ear-caught). It gamed the gates with an artifact the anchor
+            // does not have (anchor = main 83ms + POST-main second tap 143ms). The network can only
+            // pre-echo on this engine config; a proper post-main second tap needs a discrete delay
+            // tap the DPV lacks (engine work). Left off = byte-null.
             // END_DPVFRONTLOAD_MAP
         };
         float erGain = 0.0f, predelayMs = 60.0f, tapMs = 80.0f, lpHz = 7000.0f;
@@ -2955,6 +2976,86 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
             if (toks.size() > 3) lpHz       = toks[3].getFloatValue();
         }
         engine.setDpvFrontLoad (erGain, predelayMs, tapMs, lpHz);
+
+        // Post-main second reflection tap (the anchor's ~143 ms "duh-DUH"). A
+        // darkened delayed copy summed POST-tank (arrives AFTER the main onset —
+        // no pre-echo, unlike the front-load ER). Per-preset {ms, gain, lpHz};
+        // gain 0 (unlisted) = off = byte-identical. Env DUSKVERB_DPVREFL="ms,gain,lpHz".
+        struct PostMainTapConfig { float ms, gain, lpHz; };
+        static constexpr std::array<std::pair<std::string_view, PostMainTapConfig>, 0> kDpvPostMainTapByName = {
+            // BEGIN_DPVPOSTMAIN_MAP
+            // END_DPVPOSTMAIN_MAP
+        };
+        float pmMs = 143.0f, pmGain = 0.0f, pmLpHz = 6000.0f;
+        for (const auto& e : kDpvPostMainTapByName)
+            if (e.first == nameView)
+            { pmMs = e.second.ms; pmGain = e.second.gain; pmLpHz = e.second.lpHz; break; }
+        if (const char* e = tuningEnv().dpvrefl; e != nullptr && e[0] != '\0')
+        {
+            juce::StringArray toks; toks.addTokens (juce::String (e), ",", "");
+            if (toks.size() > 0) pmMs   = toks[0].getFloatValue();
+            if (toks.size() > 1) pmGain = toks[1].getFloatValue();
+            if (toks.size() > 2) pmLpHz = toks[2].getFloatValue();
+        }
+        engine.setDpvPostMainTap (pmMs, pmGain, pmLpHz);
+
+        // Dense early-field: a compact Schroeder reverb summed POST-tank to fill
+        // the loud post-onset 0.1-0.5s "shelf" the sparse Dattorro tank lacks (the
+        // ear's "fuller"). Per-preset {gain, predelayMs, t60Ms}; gain 0 = off.
+        // Env DUSKVERB_DENSEFIELD="gain,predelayMs,t60Ms".
+        struct DenseFieldConfig { float gain, predelayMs, t60Ms; };
+        static constexpr std::array<std::pair<std::string_view, DenseFieldConfig>, 1> kDpvDenseFieldByName = {{
+            // BEGIN_DPVDENSEFIELD_MAP
+            // 2026-06-29 (EAR "Lex fuller"): a compact Schroeder reverb (4 combs + 2
+            // allpasses, predelayed 80 ms so it's POST-onset, T60 500 ms) summed post-
+            // tank fills the loud 0.1-0.5 s "shelf" the sparse Dattorro tank lacks.
+            // Closes the new decay_tail_l1 gate (the metric that matches the ear) with
+            // no pre-echo / no flux spike / no clip. The shape floor the tuning couldn't.
+            { "Vintage Vocal Plate", { 0.22f /*gain*/, 65.0f /*predelayMs*/, 650.0f /*t60Ms*/ } },  // 2026-06-29 fuller pass: longer T60 (650) SPREADS the early energy (fills @0.3s -30->-28 toward anchor -24) instead of a louder peak (gain 0.24 made a 140ms bump). Single clean onset, decay_tail passes, no flux.
+            // END_DPVDENSEFIELD_MAP
+        }};
+        float dfGain = 0.0f, dfPre = 70.0f, dfT60 = 500.0f;
+        for (const auto& e : kDpvDenseFieldByName)
+            if (e.first == nameView)
+            { dfGain = e.second.gain; dfPre = e.second.predelayMs; dfT60 = e.second.t60Ms; break; }
+        if (const char* e = tuningEnv().densefield; e != nullptr && e[0] != '\0')
+        {
+            juce::StringArray toks; toks.addTokens (juce::String (e), ",", "");
+            if (toks.size() > 0) dfGain = toks[0].getFloatValue();
+            if (toks.size() > 1) dfPre  = toks[1].getFloatValue();
+            if (toks.size() > 2) dfT60  = toks[2].getFloatValue();
+        }
+        engine.setDpvDenseField (dfGain, dfPre, dfT60);
+
+        // Dattorro (algo 0) dense early-field — the SAME compact Schroeder field,
+        // summed post-tank in DuskVerbEngine (DattorroTank.cpp untouched → every
+        // algo-0 preset bit-null when off). Fills the thin tail of the short rooms
+        // (Medium Drum Room: decay sub/low/mid -23..-30% vs the fat-snare anchor).
+        // Per-preset {gain, predelayMs, t60Ms}; gain 0 (unlisted) = off.
+        // Env DUSKVERB_DDENSEFIELD="gain,predelayMs,t60Ms" for rebuild-free sweeps.
+        static constexpr std::array<std::pair<std::string_view, DenseFieldConfig>, 1> kDattorroDenseFieldByName = {{
+            // BEGIN_DATTORRODENSEFIELD_MAP
+            // 2026-06-29: the same dense-field win as VVP, ported to the algo-0 rooms.
+            // Medium Drum Room's tail was thin (decay sub/low/mid -23..-30%, T60-500
+            // -24% vs the fat-snare anchor); a compact Schroeder field (predelay 42 ms
+            // = POST-onset, long T60 730 ms SPREADS energy into the 0.1-0.5 s window)
+            // fills it: 25 -> 19. Residual 19 = boing (333 Hz sparse mode), T60-63
+            // bass coupling, discrete-ER structure, cent/sine1k voicing -- structural.
+            { "Medium Drum Room", { 0.27f /*gain*/, 42.0f /*predelayMs*/, 730.0f /*t60Ms*/ } },
+            // END_DATTORRODENSEFIELD_MAP
+        }};
+        float ddGain = 0.0f, ddPre = 70.0f, ddT60 = 500.0f;
+        for (const auto& e : kDattorroDenseFieldByName)
+            if (e.first == nameView)
+            { ddGain = e.second.gain; ddPre = e.second.predelayMs; ddT60 = e.second.t60Ms; break; }
+        if (const char* e = tuningEnv().ddensefield; e != nullptr && e[0] != '\0')
+        {
+            juce::StringArray toks; toks.addTokens (juce::String (e), ",", "");
+            if (toks.size() > 0) ddGain = toks[0].getFloatValue();
+            if (toks.size() > 1) ddPre  = toks[1].getFloatValue();
+            if (toks.size() > 2) ddT60  = toks[2].getFloatValue();
+        }
+        engine.setDattorroDenseField (ddGain, ddPre, ddT60);
     }
 
     // Sweep override: DUSKVERB_FDN_DELAYS env var wins over the map. CSV of
@@ -3096,7 +3197,7 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         // static-init guard lock + heap-allocate on first preset swap. Same RT-safe
         // pattern as kWidthBandsByName / kDenseHallOctaveT60ByName.
         static constexpr std::array<std::pair<std::string_view, float>, 1> kShimmerDownByName = {{
-            { "Deep Blue Day", 1.50f },   // 2026-06-19: warm-low octave-DOWN voice IN THE FEEDBACK LOOP (alongside the up shimmer → builds with IDENTICAL timing, no late "kick-in"; softClip ceil 1.5 + 60Hz HPF + final tanh → wet stem bit-bounded). Matches VALHALLA SHIMMER DeepBlueDay (program 3), NOT VVV. downMix 4.0 made the WET low so hot that at 50% mix + a hot dry track the SUM clipped in the DAW (+ the loud low masked the high octave) — backed off to 1.5: 250Hz 45 (VS 60), 500Hz 37 (VS 64). Warm but mix-safe; wet-stem peak -4.9dB even on a sustained chord.
+            { "Deep Blue Day", 0.35f },   // 2026-06-29: −1 oct voice DROPPED 1.5→0.35 — the new −2 oct SUB voice (below) does the low work far more efficiently (reaches 250 Hz in one step vs the −1 oct cascade dying out). 0.35 just tops up the 500 Hz rung. See kShimmerSubByName/kShimmerHpfByName for the validated 1 kHz-sine match to Valhalla Shimmer program 3.
         }};
         float downMix = 0.0f;
         const std::string_view nameView (name);
@@ -3105,6 +3206,75 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         if (const char* env = tuningEnv().shimmerdown; env != nullptr && env[0] != '\0')
             downMix = juce::String (env).getFloatValue();
         engine.setShimmerDownOctaveMix (downMix);
+
+        // Sub voice (−2 oct → 250 Hz) + feedback-HPF corner: the −1 oct cascade dies out
+        // before the deep lows; the sub voice reaches 250 Hz in one step and a lower HPF
+        // corner lets the 60-250 Hz wash survive the loop. Matches Valhalla Shimmer
+        // DeepBlueDay (program 3: 250 Hz −9 dB, 60-200 wash −15..−22 rel. fundamental).
+        // 0 / default 60 = bit-null (Black Hole + non-shimmer untouched).
+        // Env DUSKVERB_SHIMMERSUB="mix", DUSKVERB_SHIMMERHPF="hz" for rebuild-free sweeps.
+        static constexpr std::array<std::pair<std::string_view, float>, 1> kShimmerSubByName = {{
+            // 2026-06-29: −2 oct (×0.25 → 250 Hz) voice. Tuned vs Valhalla Shimmer program 3
+            // on a sustained 1 kHz sine (rel. fundamental @ output level): lifts 31-60 Hz
+            // −55→−30 (Val −22), 60-125 −54→−20 (Val −18), 250 Hz −28→−3 (Val −9). The deep
+            // low warmth DV lacked. Residual: 250-500 runs ~+6 dB hot (the +12 st up voice
+            // re-pitches the sub's 250 → 500) — structural, not tunable from here.
+            { "Deep Blue Day", 3.20f },
+        }};
+        static constexpr std::array<std::pair<std::string_view, float>, 1> kShimmerHpfByName = {{
+            { "Deep Blue Day", 24.0f },  // feedback HPF 60→24 so the regenerated 31-125 Hz wash survives the loop (24 still clears the ~12 Hz grain rumble). Flattens DV's over-steep low cascade toward Valhalla's.
+        }};
+        float subMix = 0.0f, hpfHz = 60.0f;
+        for (const auto& e : kShimmerSubByName) if (e.first == nameView) { subMix = e.second; break; }
+        for (const auto& e : kShimmerHpfByName) if (e.first == nameView) { hpfHz  = e.second; break; }
+        if (const char* env = tuningEnv().shimmersub; env != nullptr && env[0] != '\0')
+            subMix = juce::String (env).getFloatValue();
+        if (const char* env = tuningEnv().shimmerhpf; env != nullptr && env[0] != '\0')
+            hpfHz  = juce::String (env).getFloatValue();
+        engine.setShimmerSubOctaveMix  (subMix);
+        engine.setShimmerFeedbackHpfHz (hpfHz);
+
+        // Wet stereo chorus/ensemble — Valhalla Shimmer Black Hole swings the image at
+        // ~0.83 Hz (measured L-R mod rms 6.8 dB vs DV's static 2.2). A slow anti-phase
+        // modulated-delay pair gives that moving field. {rateHz, depth}; depth 0 = off.
+        // Env DUSKVERB_SHIMMERSTEREO="rateHz,depth".
+        static constexpr std::array<std::pair<std::string_view, std::pair<float,float>>, 1> kShimmerStereoByName = {{
+            // 2026-06-29: rate 0.42 Hz (the comb passes its notch TWICE per LFO cycle, so
+            // the L-R movement lands at 2×0.42 = 0.83 Hz = Valhalla's measured rate), depth
+            // 0.8. Result vs Valhalla Shimmer Black Hole: L-R mod rate 0.83 Hz (exact),
+            // correlation +0.62 (Val +0.60), movement rms 4.2 dB (Val 6.8 — full magnitude
+            // destabilises the rate, 4.2 is the musical max; up from DV's static 2.2).
+            { "Black Hole", { 0.42f, 0.00f } },   // 2026-06-29 DORMANT: the sine-tuned chorus matched the 0.83 Hz movement but worsened the broadband stereo_corr gate (-0.22 vs anchor +0.12 = over-wide) — the real BH "stereo" gap is mono HIGHS (width hi +0.02 vs +0.95), addressed via width/brightness below. Infra kept for a future gentler pass.
+        }};
+        float smRate = 0.83f, smDepth = 0.0f;
+        for (const auto& e : kShimmerStereoByName) if (e.first == nameView) { smRate = e.second.first; smDepth = e.second.second; break; }
+        if (const char* env = tuningEnv().shimmerstereo; env != nullptr && env[0] != '\0')
+        {
+            juce::StringArray toks; toks.addTokens (juce::String (env), ",", "");
+            if (toks.size() > 0) smRate  = toks[0].getFloatValue();
+            if (toks.size() > 1) smDepth = toks[1].getFloatValue();
+        }
+        engine.setShimmerStereoMod (smRate, smDepth);
+
+        // HF-air voice — the genuine >12 kHz air Valhalla Shimmer has (centroid ~9.9k/6.6k vs
+        // DV ~6k/5k). A post-loop +12 st shifter on the wet 6-12 kHz makes 12-24 k air,
+        // bypassing the reverb HF-damp + 14 k feedback LPF that cap it. mix 0 = off = bit-null.
+        // Env DUSKVERB_SHIMMERAIR="mix".
+        static constexpr std::array<std::pair<std::string_view, float>, 2> kShimmerAirByName = {{
+            // 2026-06-30: post-loop +12 st air voice = the genuine >12 kHz air the engine
+            // couldn't make (the reverb HF-damps + the 14 k feedback LPF cut the in-loop air).
+            // Raises the snare centroid toward Valhalla WITHOUT harshening 4-12k (unlike the
+            // air shelf): BH 6006→7029 (Val 9920), DBD 4936→5749 (Val 6620), tilt stays matched.
+            // Capped at the max that doesn't regress the noiseburst ss_air gate (DV's residual
+            // 12.9 k AA spike already runs the noiseburst air-heavy) — closes ~half the gap clean.
+            { "Black Hole",    1.5f },
+            { "Deep Blue Day", 2.0f },
+        }};
+        float airMix = 0.0f;
+        for (const auto& e : kShimmerAirByName) if (e.first == nameView) { airMix = e.second; break; }
+        if (const char* env = tuningEnv().shimmerair; env != nullptr && env[0] != '\0')
+            airMix = juce::String (env).getFloatValue();
+        engine.setShimmerHFAir (airMix);
     }
 
     if (! fdnDelaysFromEnv)   // an env DUSKVERB_FDN_DELAYS override owns the delays — don't clobber it

--- a/plugins/DuskVerb/src/PluginProcessor.cpp
+++ b/plugins/DuskVerb/src/PluginProcessor.cpp
@@ -53,6 +53,11 @@ struct TuningEnv
     const char* shimmerhpf;
     const char* shimmerstereo;
     const char* shimmerair;
+    const char* shimmerdense;
+    const char* shimmerspin;
+    const char* shimmerupv;
+    const char* shimmeroct;
+    const char* shimmernoise;
     const char* frontload;
     const char* dpvrefl;
     const char* densefield;
@@ -91,6 +96,11 @@ struct TuningEnv
           shimmerhpf (std::getenv ("DUSKVERB_SHIMMERHPF")),
           shimmerstereo (std::getenv ("DUSKVERB_SHIMMERSTEREO")),
           shimmerair (std::getenv ("DUSKVERB_SHIMMERAIR")),
+          shimmerdense (std::getenv ("DUSKVERB_SHIMMERDENSE")),
+          shimmerspin (std::getenv ("DUSKVERB_SHIMMERSPIN")),
+          shimmerupv (std::getenv ("DUSKVERB_SHIMMERUPV")),
+          shimmeroct (std::getenv ("DUSKVERB_SHIMMEROCT")),
+          shimmernoise (std::getenv ("DUSKVERB_SHIMMERNOISE")),
           frontload (std::getenv ("DUSKVERB_FRONTLOAD")),
           dpvrefl   (std::getenv ("DUSKVERB_DPVREFL")),
           densefield (std::getenv ("DUSKVERB_DENSEFIELD")),
@@ -3275,6 +3285,75 @@ void FactoryPreset::applyEngineConfig (DuskVerbEngine& engine) const
         if (const char* env = tuningEnv().shimmerair; env != nullptr && env[0] != '\0')
             airMix = juce::String (env).getFloatValue();
         engine.setShimmerHFAir (airMix);
+
+        // Dense-diffusion tank swap (fixes the metallic HF tail; kurt ~26 -> ~7).
+        // Per-preset bake below; default false = legacy sparse FDN (bit-identical).
+        // Env DUSKVERB_SHIMMERDENSE=1 forces it on for A/B.
+        static constexpr std::array<std::pair<std::string_view, bool>, 2> kShimmerDenseByName = {{
+            { "Black Hole",    false },   // flipped to true once re-voiced (Phase 3/4)
+            { "Deep Blue Day", false },
+        }};
+        bool useDense = false;
+        for (const auto& e : kShimmerDenseByName) if (e.first == nameView) { useDense = e.second; break; }
+        if (const char* env = tuningEnv().shimmerdense; env != nullptr && env[0] != '\0')
+            useDense = juce::String (env).getIntValue() != 0;
+        engine.setShimmerUseDenseReverb (useDense);
+
+        // Tail spin-comb: smears the FDN's metallic HF while keeping its cascade/width/HF
+        // (Deep Blue Day's fix — its character fights the full DenseHall swap). Per-preset
+        // bake below; env DUSKVERB_SHIMMERSPIN=1 for A/B. Only meaningful on the FDN path.
+        static constexpr std::array<std::pair<std::string_view, bool>, 2> kShimmerTailSpinByName = {{
+            { "Black Hole",    false },   // BH uses DenseHall, not the spin-comb
+            { "Deep Blue Day", false },   // flipped to true once re-voiced
+        }};
+        bool useSpin = false;
+        for (const auto& e : kShimmerTailSpinByName) if (e.first == nameView) { useSpin = e.second; break; }
+        if (const char* env = tuningEnv().shimmerspin; env != nullptr && env[0] != '\0')
+            useSpin = juce::String (env).getIntValue() != 0;
+        engine.setShimmerUseTailSpin (useSpin);
+
+        // Per-preset up-voice scale — fills the mid tail (250 Hz-1 kHz) on transients. Deep Blue
+        // Day boosts to match Valhalla's fuller snare-body regeneration. 1.0/1.0 = bit-identical.
+        static constexpr std::array<std::pair<std::string_view, std::pair<float, float>>, 2> kShimmerUpVoiceByName = {{
+            { "Black Hole",    { 1.0f, 1.0f } },
+            { "Deep Blue Day", { 1.0f, 1.0f } },   // tuned by the sweep below
+        }};
+        float upv1 = 1.0f, upv2 = 1.0f;
+        for (const auto& e : kShimmerUpVoiceByName) if (e.first == nameView) { upv1 = e.second.first; upv2 = e.second.second; break; }
+        if (const char* env = tuningEnv().shimmerupv; env != nullptr && env[0] != '\0')
+        {
+            juce::StringArray parts; parts.addTokens (juce::String (env), ",", "");
+            if (parts.size() >= 2) { upv1 = parts[0].getFloatValue(); upv2 = parts[1].getFloatValue(); }
+        }
+        engine.setShimmerUpVoiceScale (upv1, upv2);
+
+        // Dry-fed even octave cascade (500/250/125/62 Hz) — Deep Blue Day uses it INSTEAD of the
+        // old feedback down/sub voices (which were subharmonic-masked + the sub ratio was clamped
+        // to −12). All-zero = off/bit-null. Env DUSKVERB_SHIMMEROCT="g500,g250,g125,g62".
+        static const std::array<std::pair<std::string_view, std::array<float, 4>>, 2> kShimmerOctaveByName = {{
+            { "Black Hole",    { 0.0f, 0.0f, 0.0f, 0.0f } },
+            { "Deep Blue Day", { 0.0f, 0.0f, 0.0f, 0.0f } },   // tuned by the sweep below
+        }};
+        float octGains[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        for (const auto& e : kShimmerOctaveByName) if (e.first == nameView) { for (int i = 0; i < 4; ++i) octGains[i] = e.second[i]; break; }
+        if (const char* env = tuningEnv().shimmeroct; env != nullptr && env[0] != '\0')
+        {
+            juce::StringArray parts; parts.addTokens (juce::String (env), ",", "");
+            for (int i = 0; i < 4 && i < parts.size(); ++i) octGains[i] = parts[i].getFloatValue();
+        }
+        engine.setShimmerOctaveCascade (octGains);
+
+        // Tail noise floor — the dense noise-like fade Valhalla has; masks the sparse-mode ring.
+        // gain 0 = off/bit-null. Env DUSKVERB_SHIMMERNOISE.
+        static constexpr std::array<std::pair<std::string_view, float>, 2> kShimmerTailNoiseByName = {{
+            { "Black Hole",    0.0f },
+            { "Deep Blue Day", 0.0f },   // tuned by the sweep below
+        }};
+        float noiseGain = 0.0f;
+        for (const auto& e : kShimmerTailNoiseByName) if (e.first == nameView) { noiseGain = e.second; break; }
+        if (const char* env = tuningEnv().shimmernoise; env != nullptr && env[0] != '\0')
+            noiseGain = juce::String (env).getFloatValue();
+        engine.setShimmerTailNoise (noiseGain);
     }
 
     if (! fdnDelaysFromEnv)   // an env DUSKVERB_FDN_DELAYS override owns the delays — don't clobber it

--- a/plugins/DuskVerb/src/dsp/DattorroPlateVintage.cpp
+++ b/plugins/DuskVerb/src/dsp/DattorroPlateVintage.cpp
@@ -47,9 +47,39 @@ void DattorroPlateVintage::prepare (double sampleRate, int maxBlockSize)
     erLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (frontLpHz_, 0.45f * sampleRate_) / sampleRate_);
     erLpZL_ = erLpZR_ = 0.0f;
 
+    // Post-main second-reflection tap ring (~300 ms headroom for a ~143 ms tap).
+    const int postMax = std::max (16, static_cast<int> (0.30f * sampleRate_));
+    postMainL_.prepare (postMax); postMainR_.prepare (postMax);
+    postMainDelayL_ = std::min (std::max (1, static_cast<int> (postMainMs_ * 0.001f * sampleRate_)), postMainL_.mask);
+    postMainDelayR_ = std::min (std::max (1, static_cast<int> ((postMainMs_ + 9.0f) * 0.001f * sampleRate_)), postMainR_.mask);
+    postMainLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (postMainLpHz_, 0.45f * sampleRate_) / sampleRate_);
+    postMainLpZL_ = postMainLpZR_ = 0.0f;
+
+    // Dense early-field combs/allpasses + predelay (generous headroom).
+    const float rr = sampleRate_ / 44100.0f;
+    for (int c = 0; c < 4; ++c)
+    {
+        dfComb_[c].prepare (static_cast<int> (kDfCombMs[c] * 0.001f * sampleRate_) + 8);
+        dfCombLen_[c] = std::max (1, static_cast<int> (kDfCombMs[c] * 0.001f * sampleRate_));
+    }
+    dfAp1_.prepare (static_cast<int> (kDfAp1Ms * 0.001f * sampleRate_) + 8);
+    dfAp2_.prepare (static_cast<int> (kDfAp2Ms * 0.001f * sampleRate_) + 8);
+    dfAp1Len_ = std::max (1, static_cast<int> (kDfAp1Ms * 0.001f * sampleRate_));
+    dfAp2Len_ = std::max (1, static_cast<int> (kDfAp2Ms * 0.001f * sampleRate_));
+    dfPre_.prepare (static_cast<int> (0.30f * sampleRate_));   // up to 300 ms predelay
+    dfApR_.prepare (static_cast<int> (kDfDecorrMs * 0.001f * sampleRate_) + 8);
+    dfApRLen_ = std::max (1, static_cast<int> (kDfDecorrMs * 0.001f * sampleRate_));
+    dfLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (kDfLpHz, 0.45f * sampleRate_) / sampleRate_);
+    dfLpZ_ = 0.0f;
+    (void) rr;
+
     tank_.setStructuralHFDamping (structHfDampHz_);
 
     prepared_ = true;
+
+    // After prepared_ — setDenseField()'s recompute path is guarded on it, so
+    // dfPreSamp_/dfCombG_ would stay uninitialised if called earlier.
+    setDenseField (dfGain_, dfPredelayMs_, dfT60Ms_);   // (re)compute feedback + predelay
 }
 
 void DattorroPlateVintage::clearBuffers()
@@ -62,6 +92,11 @@ void DattorroPlateVintage::clearBuffers()
     erDelayL_.clear(); erDelayR_.clear();
     tankPreL_.clear(); tankPreR_.clear();
     erLpZL_ = erLpZR_ = 0.0f;
+    postMainL_.clear(); postMainR_.clear();
+    postMainLpZL_ = postMainLpZR_ = 0.0f;
+    for (int c = 0; c < 4; ++c) dfComb_[c].clear();
+    dfAp1_.clear(); dfAp2_.clear(); dfPre_.clear(); dfApR_.clear();
+    dfLpZ_ = 0.0f;
 }
 
 void DattorroPlateVintage::process (const float* inputL, const float* inputR,
@@ -126,6 +161,12 @@ void DattorroPlateVintage::process (const float* inputL, const float* inputR,
             earlyL_[static_cast<size_t> (n)] = frontErGain_ * erLpZL_;
             earlyR_[static_cast<size_t> (n)] = frontErGain_ * erLpZR_;
             // Pre-delay the tank input so its dense field fills in after the build.
+            // CAUTION: this OVERWRITES preTankL_/R_ with the PREDELAYED input. The post-main
+            // tap + dense field (post-tank loop) also read preTankL_/R_, so front-load is
+            // MUTUALLY EXCLUSIVE with them on a single preset — re-enabling front-load
+            // alongside the dense field would feed the tap/field the predelayed copy (wrong
+            // tap timing). Today no preset combines them (kDpvFrontLoadByName + kDpvPostMainTapByName
+            // are both empty); if that changes, capture the original pre-tank into a separate buffer.
             tankPreL_.write (il); tankPreR_.write (ir);
             preTankL_[static_cast<size_t> (n)] = tankPreL_.readAgo (frontPredelaySamp_);
             preTankR_[static_cast<size_t> (n)] = tankPreR_.readAgo (frontPredelaySamp_);
@@ -146,6 +187,56 @@ void DattorroPlateVintage::process (const float* inputL, const float* inputR,
         {
             l += earlyL_[static_cast<size_t> (n)];
             r += earlyR_[static_cast<size_t> (n)];
+        }
+        // Post-main second reflection tap: a darkened, delayed copy of the
+        // pre-tank signal summed POST-tank so it arrives AFTER the main onset —
+        // the anchor's ~143 ms second arrival, WITHOUT pre-echo. preTankL_ holds
+        // the pre-tank filtered signal (front is off for VVP). gain 0 = bit-null.
+        if (postMainActive_)
+        {
+            const float dl = postMainL_.readAgo (postMainDelayL_);
+            const float dr = postMainR_.readAgo (postMainDelayR_);
+            // Write silence while frozen so the tap admits no new input and its
+            // held content drains out with the frozen tank (mirrors the dense
+            // field's dfFrozen_ 0-feed above).
+            postMainL_.write (dfFrozen_ ? 0.0f : preTankL_[static_cast<size_t> (n)]);
+            postMainR_.write (dfFrozen_ ? 0.0f : preTankR_[static_cast<size_t> (n)]);
+            postMainLpZL_ += postMainLpCoeff_ * (dl - postMainLpZL_);
+            postMainLpZR_ += postMainLpCoeff_ * (dr - postMainLpZR_);
+            l += postMainGain_ * postMainLpZL_;
+            r += postMainGain_ * postMainLpZR_;
+        }
+        // Dense early-field: predelayed mono input → 4 parallel combs (dense
+        // diffuse buildup, medium decay) → 2 series allpasses → summed to output.
+        // Fills the post-onset 0.1-0.5 s shelf the sparse tank can't (no pre-echo:
+        // the predelay starts it after the main onset).
+        if (dfActive_)
+        {
+            // Fed 0 when frozen so the dense field decays out with the held tank
+            // (mirrors the algo-0 path in DuskVerbEngine).
+            const float xin = dfFrozen_ ? 0.0f
+                : 0.5f * (preTankL_[static_cast<size_t> (n)] + preTankR_[static_cast<size_t> (n)]);
+            // Read the predelayed tap BEFORE advancing the ring so dfPreSamp_ maps
+            // to an exact dfPreSamp_-sample delay (write-then-read was one sample
+            // early and aliased a stale slot at zero delay). Fast path for 0.
+            const float xp = (dfPreSamp_ == 0) ? xin : dfPre_.readAgo (dfPreSamp_);
+            dfPre_.write (xin);
+            float s = 0.0f;
+            for (int c = 0; c < 4; ++c)
+            {
+                const float d = dfComb_[c].readAgo (dfCombLen_[c]);
+                dfComb_[c].write (xp + dfCombG_[c] * d);
+                s += d;
+            }
+            s *= 0.25f;
+            const float a1 = dfAp1_.readAgo (dfAp1Len_); const float y1 = -kDfApG * s  + a1; dfAp1_.write (s  + kDfApG * y1);
+            const float a2 = dfAp2_.readAgo (dfAp2Len_); const float y2 = -kDfApG * y1 + a2; dfAp2_.write (y1 + kDfApG * y2);
+            // Darken (early reflections are duller) then decorrelate R for stereo.
+            dfLpZ_ += dfLpCoeff_ * (y2 - dfLpZ_);
+            const float yL = dfLpZ_;
+            const float ar = dfApR_.readAgo (dfApRLen_); const float yR = -kDfDecorrG * yL + ar; dfApR_.write (yL + kDfDecorrG * yR);
+            l += dfGain_ * yL;
+            r += dfGain_ * yR;
         }
         outputL[n] = l;
         outputR[n] = r;
@@ -172,7 +263,7 @@ void DattorroPlateVintage::setOctaveDecayRef    (float v) { tank_.setOctaveDecay
 void DattorroPlateVintage::setTonalCorrDb     (int b, float v) { tank_.setTonalCorrDb (b, v); }
 void DattorroPlateVintage::setBloomAttackMs     (float v) { tank_.setBloomAttackMs     (v); }
 void DattorroPlateVintage::setBloomExp          (float v) { tank_.setBloomExp          (v); }
-void DattorroPlateVintage::setFreeze            (bool  v) { tank_.setFreeze            (v); }
+void DattorroPlateVintage::setFreeze            (bool  v) { dfFrozen_ = v; tank_.setFreeze (v); }
 
 void DattorroPlateVintage::setFrontLoad (float erGain, float predelayMs, float tapMs, float lpHz)
 {
@@ -188,6 +279,39 @@ void DattorroPlateVintage::setFrontLoad (float erGain, float predelayMs, float t
         // representable instead. (2026-06-23 review fix; latent — current callers stay small.)
         frontPredelaySamp_ = std::min (frontPredelaySamp_, tankPreL_.mask);
         erLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (frontLpHz_, 0.45f * sampleRate_) / sampleRate_);
+    }
+}
+
+void DattorroPlateVintage::setPostMainTap (float ms, float gain, float lpHz)
+{
+    postMainMs_     = std::max (1.0f, ms);
+    postMainGain_   = std::clamp (gain, 0.0f, 4.0f);
+    postMainLpHz_   = std::clamp (lpHz, 1000.0f, 20000.0f);
+    postMainActive_ = postMainGain_ > 1.0e-6f;
+    if (prepared_)
+    {
+        postMainDelayL_ = std::min (std::max (1, static_cast<int> (postMainMs_ * 0.001f * sampleRate_)), postMainL_.mask);
+        postMainDelayR_ = std::min (std::max (1, static_cast<int> ((postMainMs_ + 9.0f) * 0.001f * sampleRate_)), postMainR_.mask);
+        postMainLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (postMainLpHz_, 0.45f * sampleRate_) / sampleRate_);
+    }
+}
+
+void DattorroPlateVintage::setDenseField (float gain, float predelayMs, float t60Ms)
+{
+    dfGain_       = std::clamp (gain, 0.0f, 4.0f);
+    dfPredelayMs_ = std::max (0.0f, predelayMs);
+    dfT60Ms_      = std::clamp (t60Ms, 50.0f, 2000.0f);
+    dfActive_     = dfGain_ > 1.0e-6f;
+    if (prepared_)
+    {
+        dfPreSamp_ = std::min (std::max (0, static_cast<int> (dfPredelayMs_ * 0.001f * sampleRate_)), dfPre_.mask);
+        const float t60s = dfT60Ms_ * 0.001f;
+        for (int c = 0; c < 4; ++c)
+        {
+            // Schroeder comb feedback for the target T60: g = 10^(-3·Lsec/T60).
+            const float Lsec = dfCombLen_[c] / sampleRate_;
+            dfCombG_[c] = std::clamp (std::pow (10.0f, -3.0f * Lsec / t60s), 0.0f, 0.97f);
+        }
     }
 }
 

--- a/plugins/DuskVerb/src/dsp/DattorroPlateVintage.h
+++ b/plugins/DuskVerb/src/dsp/DattorroPlateVintage.h
@@ -109,6 +109,24 @@ public:
     // pre-network engine byte-for-byte.
     void setFrontLoad (float erGain, float predelayMs, float tapMs, float lpHz);
 
+    // Post-main discrete second reflection tap — the anchor's "duh-DUH"
+    // (Lexicon Vintage Plate: main onset ~83 ms + a near-equal SECOND arrival
+    // ~143 ms). A darkened, stereo-decorrelated, delayed copy of the pre-tank
+    // signal summed POST-tank, arriving AFTER the main onset (the opposite of
+    // the front-load ER, which pre-echoes). Mirrors DenseHall's reflBuf tap.
+    // ms = tap time (input-relative), gain = level (>1 allowed), lpHz = darken.
+    // gain 0 = off = byte-identical.
+    void setPostMainTap (float ms, float gain, float lpHz);
+
+    // Dense early-field — a compact Schroeder reverb (4 parallel combs + 2 series
+    // allpasses) fed from the pre-tank input via a predelay, summed POST-tank.
+    // Fills the loud post-onset 0.1-0.5 s "shelf" a real plate has but the sparse
+    // Dattorro tank lacks (its early field disperses too fast → thin/peaked). The
+    // predelay keeps it AFTER the main onset (no pre-echo); the combs build dense
+    // diffuse energy (not discrete taps → no diffusion_flux spike) then decay at
+    // t60Ms. gain 0 = off = byte-identical.
+    void setDenseField (float gain, float predelayMs, float t60Ms);
+
 private:
     DattorroTank tank_;
 
@@ -242,6 +260,36 @@ private:
     static constexpr int   kErTaps = 3;
     static constexpr float kErTapFrac[kErTaps] = { 0.30f, 0.60f, 0.92f };
     static constexpr float kErTapGain[kErTaps] = { 0.50f, 0.72f, 1.00f };
+
+    // ── Post-main second reflection tap (see setPostMainTap) ──
+    // Delayed darkened copy of the pre-tank signal, summed POST-tank so it lands
+    // AFTER the main onset (no pre-echo). Power-of-2 ring + 1-pole LP + R offset
+    // for L/R decorrelation. gain 0 → inactive → bit-null (skipped entirely).
+    RingDelay postMainL_, postMainR_;
+    int   postMainDelayL_ = 0, postMainDelayR_ = 0;
+    float postMainGain_   = 0.0f;                 // 0 = off (bit-null)
+    float postMainLpZL_   = 0.0f, postMainLpZR_ = 0.0f, postMainLpCoeff_ = 1.0f;
+    float postMainMs_     = 143.0f;               // tap time (input-relative)
+    float postMainLpHz_   = 6000.0f;              // darken (real reflections are duller)
+    bool  postMainActive_ = false;
+
+    // ── Dense early-field (see setDenseField) ── 4 combs + 2 allpasses, mono.
+    RingDelay dfComb_[4], dfAp1_, dfAp2_, dfPre_;
+    int   dfCombLen_[4] = { 0, 0, 0, 0 }, dfAp1Len_ = 0, dfAp2Len_ = 0, dfPreSamp_ = 0;
+    float dfCombG_[4]   = { 0.0f, 0.0f, 0.0f, 0.0f };
+    float dfGain_       = 0.0f;                    // 0 = off (bit-null)
+    float dfT60Ms_      = 500.0f, dfPredelayMs_ = 70.0f;
+    bool  dfActive_     = false;
+    bool  dfFrozen_     = false;                   // when set, dense field is zero-fed (decays with the tank)
+    float dfLpZ_        = 0.0f, dfLpCoeff_ = 1.0f; // darken (early reflections are duller)
+    RingDelay dfApR_;   int dfApRLen_ = 0;         // R-channel decorrelation allpass (stereo)
+    static constexpr float kDfApG   = 0.7f;
+    static constexpr float kDfLpHz  = 12000.0f;    // dense-field band-limit (near-bypass; LP hurt the shelf fill)
+    static constexpr float kDfDecorrMs = 3.7f;     // R decorrelation delay (mild)
+    static constexpr float kDfDecorrG  = 0.14f;    // mild decorrelation (anchor early field is near-mono)
+    // Comb/allpass base delays (ms @ 44.1k) — prime-ish, dense buildup.
+    static constexpr float kDfCombMs[4] = { 23.3f, 29.7f, 37.1f, 43.3f };
+    static constexpr float kDfAp1Ms = 5.5f, kDfAp2Ms = 1.7f;
     // Per-preset EQ state — cached so individual setter calls re-design
     // the affected filter without losing the other axis's setting. Defaults
     // match the original Vintage Vocal Plate calibration.

--- a/plugins/DuskVerb/src/dsp/DenseEarlyField.h
+++ b/plugins/DuskVerb/src/dsp/DenseEarlyField.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <vector>
+#include <cmath>
+#include <algorithm>
+
+// Dense early-field — a compact Schroeder reverb (4 parallel combs + 2 series
+// allpasses, mono) fed from a predelayed dry-mono input, darkened and mildly
+// R-decorrelated, intended to be summed POST-tank. It fills the loud post-onset
+// 0.1-0.5 s "shelf" a real plate / room has but a sparse Dattorro tank disperses
+// too fast (a thin, peaked tail). The predelay keeps the field AFTER the main
+// onset (no pre-echo). gain 0 → inactive → contributes exactly 0 (bit-null sum).
+//
+// The algorithm mirrors DattorroPlateVintage's inline dense field (which stays
+// inline there to preserve its byte-exact VVP render). This header lets the
+// DuskVerbEngine reuse the same field for the algo-0 Dattorro rooms without
+// touching DattorroTank.cpp — so every algo-0 preset stays bit-null when the
+// field is off. See [[duskverb_dpv_dense_early_field]].
+class DenseEarlyField
+{
+public:
+    void prepare (double sampleRate)
+    {
+        sampleRate_ = static_cast<float> (sampleRate);
+        for (int c = 0; c < 4; ++c)
+        {
+            comb_[c].prepare (static_cast<int> (kCombMs[c] * 0.001f * sampleRate_) + 8);
+            combLen_[c] = std::max (1, static_cast<int> (kCombMs[c] * 0.001f * sampleRate_));
+        }
+        ap1_.prepare (static_cast<int> (kAp1Ms * 0.001f * sampleRate_) + 8);
+        ap2_.prepare (static_cast<int> (kAp2Ms * 0.001f * sampleRate_) + 8);
+        ap1Len_ = std::max (1, static_cast<int> (kAp1Ms * 0.001f * sampleRate_));
+        ap2Len_ = std::max (1, static_cast<int> (kAp2Ms * 0.001f * sampleRate_));
+        pre_.prepare (static_cast<int> (0.30f * sampleRate_));   // up to 300 ms predelay
+        apR_.prepare (static_cast<int> (kDecorrMs * 0.001f * sampleRate_) + 8);
+        apRLen_ = std::max (1, static_cast<int> (kDecorrMs * 0.001f * sampleRate_));
+        lpCoeff_ = 1.0f - std::exp (-6.283185307f
+                       * std::min (kLpHz, 0.45f * sampleRate_) / sampleRate_);
+        prepared_ = true;
+        setParams (gain_, predelayMs_, t60Ms_);   // (re)compute feedback + predelay
+    }
+
+    void clear()
+    {
+        for (int c = 0; c < 4; ++c) comb_[c].clear();
+        ap1_.clear(); ap2_.clear(); pre_.clear(); apR_.clear();
+        lpZ_ = 0.0f;
+    }
+
+    void setParams (float gain, float predelayMs, float t60Ms)
+    {
+        gain_       = std::clamp (gain, 0.0f, 4.0f);
+        predelayMs_ = std::max (0.0f, predelayMs);
+        t60Ms_      = std::clamp (t60Ms, 50.0f, 2000.0f);
+        active_     = gain_ > 1.0e-6f;
+        if (prepared_)
+        {
+            preSamp_ = std::min (std::max (0, static_cast<int> (predelayMs_ * 0.001f * sampleRate_)), pre_.mask);
+            const float t60s = t60Ms_ * 0.001f;
+            for (int c = 0; c < 4; ++c)
+            {
+                // Schroeder comb feedback for the target T60: g = 10^(-3·Lsec/T60).
+                const float Lsec = combLen_[c] / sampleRate_;
+                combG_[c] = std::clamp (std::pow (10.0f, -3.0f * Lsec / t60s), 0.0f, 0.97f);
+            }
+        }
+    }
+
+    bool active() const { return active_; }
+
+    // Process one mono input sample; ADDS the gain-scaled stereo dense-field
+    // contribution into addL/addR. Caller guards on active() and supplies the
+    // dry-mono input (0 when frozen, so the field decays out with the tank).
+    inline void processSample (float monoIn, float& addL, float& addR)
+    {
+        // Read the predelayed tap BEFORE advancing the ring so preSamp_ maps to an
+        // exact preSamp_-sample delay (write-then-read was one sample early and read a
+        // stale slot at zero delay). Fast path when preSamp_ is 0 (no predelay).
+        const float xp = (preSamp_ == 0) ? monoIn : pre_.readAgo (preSamp_);
+        pre_.write (monoIn);
+        float s = 0.0f;
+        for (int c = 0; c < 4; ++c)
+        {
+            const float d = comb_[c].readAgo (combLen_[c]);
+            comb_[c].write (xp + combG_[c] * d);
+            s += d;
+        }
+        s *= 0.25f;
+        const float a1 = ap1_.readAgo (ap1Len_); const float y1 = -kApG * s  + a1; ap1_.write (s  + kApG * y1);
+        const float a2 = ap2_.readAgo (ap2Len_); const float y2 = -kApG * y1 + a2; ap2_.write (y1 + kApG * y2);
+        // Darken (early reflections are duller) then decorrelate R for stereo.
+        lpZ_ += lpCoeff_ * (y2 - lpZ_);
+        const float yL = lpZ_;
+        const float ar = apR_.readAgo (apRLen_); const float yR = -kDecorrG * yL + ar; apR_.write (yL + kDecorrG * yR);
+        addL += gain_ * yL;
+        addR += gain_ * yR;
+    }
+
+private:
+    // Power-of-2 ring delay (single-write, integer taps) — mirrors the type used
+    // by DattorroPlateVintage's dense field so the math is bit-for-bit the same.
+    struct RingDelay
+    {
+        std::vector<float> buf; int mask = 0, w = 0;
+        void prepare (int maxSamples)
+        {
+            int n = 1; while (n < std::max (2, maxSamples + 1)) n <<= 1;
+            buf.assign (static_cast<size_t> (n), 0.0f); mask = n - 1; w = 0;
+        }
+        void clear() { std::fill (buf.begin(), buf.end(), 0.0f); w = 0; }
+        inline void  write (float x)        { buf[static_cast<size_t> (w)] = x; w = (w + 1) & mask; }
+        inline float readAgo (int d) const  { return buf[static_cast<size_t> ((w - d) & mask)]; }
+    };
+
+    float sampleRate_ = 48000.0f;
+    bool  prepared_   = false;
+
+    RingDelay comb_[4], ap1_, ap2_, pre_, apR_;
+    int   combLen_[4] = { 0, 0, 0, 0 }, ap1Len_ = 0, ap2Len_ = 0, apRLen_ = 0, preSamp_ = 0;
+    float combG_[4]   = { 0.0f, 0.0f, 0.0f, 0.0f };
+    float gain_       = 0.0f;                       // 0 = off (bit-null)
+    float t60Ms_      = 500.0f, predelayMs_ = 70.0f;
+    bool  active_     = false;
+    float lpZ_        = 0.0f, lpCoeff_ = 1.0f;       // 1-pole darken state
+
+    static constexpr float kApG     = 0.7f;
+    static constexpr float kLpHz    = 12000.0f;     // band-limit (near-bypass; LP hurts the shelf fill)
+    static constexpr float kDecorrMs = 3.7f;        // R decorrelation delay (mild)
+    static constexpr float kDecorrG  = 0.14f;       // mild decorrelation (early field near-mono)
+    static constexpr float kCombMs[4] = { 23.3f, 29.7f, 37.1f, 43.3f };  // prime-ish, dense buildup
+    static constexpr float kAp1Ms = 5.5f, kAp2Ms = 1.7f;
+};

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -791,6 +791,11 @@ void DuskVerbEngine::setShimmerSubOctaveMix  (float mix) { shimmer_.setSubOctave
 void DuskVerbEngine::setShimmerFeedbackHpfHz (float hz)  { shimmer_.setFeedbackHpfHz (hz); }
 void DuskVerbEngine::setShimmerStereoMod     (float hz, float d) { shimmer_.setStereoMod (hz, d); }
 void DuskVerbEngine::setShimmerHFAir         (float mix) { shimmer_.setHFAir (mix); }
+void DuskVerbEngine::setShimmerUseDenseReverb (bool on)  { shimmer_.setUseDenseReverb (on); }
+void DuskVerbEngine::setShimmerUseTailSpin    (bool on)  { shimmer_.setUseTailSpin (on); }
+void DuskVerbEngine::setShimmerUpVoiceScale   (float v1, float v2) { shimmer_.setUpVoiceScale (v1, v2); }
+void DuskVerbEngine::setShimmerOctaveCascade  (const float gains[4]) { shimmer_.setOctaveCascade (gains); }
+void DuskVerbEngine::setShimmerTailNoise      (float gain) { shimmer_.setTailNoise (gain); }
 
 // Tail Spin/Wander (post-loop output AM) exists only on the FDN-based engines.
 // Forward to the FDN tank and to ReverseRoom (which owns an FDN for its tail);

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -24,6 +24,7 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
 
     // All engines stay prepared so setAlgorithm() never has to allocate.
     dattorro_.prepare (sampleRate, maxBlockSize);
+    dattorroDenseField_.prepare (sampleRate);
     sixAPTank_.prepare (sampleRate, maxBlockSize);
     quad_.prepare (sampleRate, maxBlockSize);
     fdn_.prepare (sampleRate, maxBlockSize); accurateHall_.prepare (sampleRate, maxBlockSize);
@@ -156,6 +157,7 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
 void DuskVerbEngine::clearAllBuffers()
 {
     dattorro_ .clearBuffers();
+    dattorroDenseField_.clear();
     sixAPTank_.clearBuffers();
     quad_     .clearBuffers();
     fdn_      .clearBuffers();
@@ -269,6 +271,7 @@ void DuskVerbEngine::setAlgorithm (int index)
     currentEngine_ = getAlgorithmConfig (index).engine;
 
     dattorro_.clearBuffers();
+    dattorroDenseField_.clear();
     sixAPTank_.clearBuffers();
     quad_.clearBuffers();
     fdn_.clearBuffers(); accurateHall_.clearBuffers (); sparseField_.clear(); diffuseER_.clear(); outputDiffusion_.clear(); denseHall_.clear(); buildupDiffuser_.clear();
@@ -784,6 +787,10 @@ void DuskVerbEngine::setModRate (float hz)
 
 // Shimmer octave-DOWN voice level (the warm low). Shimmer engine only; 0 = bit-null.
 void DuskVerbEngine::setShimmerDownOctaveMix (float mix) { shimmer_.setDownOctaveMix (mix); }
+void DuskVerbEngine::setShimmerSubOctaveMix  (float mix) { shimmer_.setSubOctaveMix  (mix); }
+void DuskVerbEngine::setShimmerFeedbackHpfHz (float hz)  { shimmer_.setFeedbackHpfHz (hz); }
+void DuskVerbEngine::setShimmerStereoMod     (float hz, float d) { shimmer_.setStereoMod (hz, d); }
+void DuskVerbEngine::setShimmerHFAir         (float mix) { shimmer_.setHFAir (mix); }
 
 // Tail Spin/Wander (post-loop output AM) exists only on the FDN-based engines.
 // Forward to the FDN tank and to ReverseRoom (which owns an FDN for its tail);
@@ -1113,6 +1120,21 @@ void DuskVerbEngine::setDpvFrontLoad (float erGain, float predelayMs, float tapM
     dattorroVintage_.setFrontLoad (erGain, predelayMs, tapMs, lpHz);
 }
 
+void DuskVerbEngine::setDpvPostMainTap (float ms, float gain, float lpHz)
+{
+    dattorroVintage_.setPostMainTap (ms, gain, lpHz);
+}
+
+void DuskVerbEngine::setDpvDenseField (float gain, float predelayMs, float t60Ms)
+{
+    dattorroVintage_.setDenseField (gain, predelayMs, t60Ms);
+}
+
+void DuskVerbEngine::setDattorroDenseField (float gain, float predelayMs, float t60Ms)
+{
+    dattorroDenseField_.setParams (gain, predelayMs, t60Ms);
+}
+
 void DuskVerbEngine::updateLoCutCoeffs (float hz)
 {
     // RBJ 2nd-order Butterworth high-pass.
@@ -1375,6 +1397,25 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
         case EngineType::Dattorro:
             dattorro_.process (tankInL_.data(), tankInR_.data(),
                                tankOutL_.data(), tankOutR_.data(), numSamples);
+            // Dense early-field: predelayed dry-mono → compact Schroeder reverb,
+            // summed POST-tank to fill the thin post-onset shelf of the short rooms.
+            // Off (gain 0) → skipped entirely → tankOut byte-identical (bit-null).
+            // Fed 0 when frozen so the field decays out with the held tank.
+            if (dattorroDenseField_.active())
+            {
+                for (int i = 0; i < numSamples; ++i)
+                {
+                    // Drive from the CLEAN dry-mono snapshot (captured before the
+                    // diffuser + tank-feed EQ mutate tankIn), not the processed
+                    // tank input, so the dense field is a defined discrete feed.
+                    const float xin = frozen_ ? 0.0f
+                        : reflDryMono_[static_cast<size_t> (i)];
+                    float dl = 0.0f, dr = 0.0f;
+                    dattorroDenseField_.processSample (xin, dl, dr);
+                    tankOutL_[static_cast<size_t> (i)] += dl;
+                    tankOutR_[static_cast<size_t> (i)] += dr;
+                }
+            }
             break;
         case EngineType::SixAPTank:
             sixAPTank_.process (tankInL_.data(), tankInR_.data(),

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -3,6 +3,7 @@
 #include "AlgorithmConfig.h"
 #include "DattorroTank.h"
 #include "DattorroPlateVintage.h"
+#include "DenseEarlyField.h"
 #include "DiffusionStage.h"
 #include "EarlyReflections.h"
 #include "FDNReverb.h"
@@ -131,6 +132,10 @@ public:
     void setModDepth      (float depth);
     void setModRate       (float hz);
     void setShimmerDownOctaveMix (float mix);   // Shimmer warm-low voice (octave down); 0 = bit-null
+    void setShimmerSubOctaveMix  (float mix);   // Shimmer deep-low voice (2 octaves down → 250 Hz); 0 = bit-null
+    void setShimmerFeedbackHpfHz (float hz);    // Shimmer feedback-loop HPF corner (low-cascade survival); default 60
+    void setShimmerStereoMod     (float rateHz, float depth); // Shimmer wet stereo chorus/ensemble; depth 0 = bit-null
+    void setShimmerHFAir         (float mix);   // Shimmer post-loop +12st air voice (genuine >12k air); mix 0 = bit-null
     void setTailSpinDepth (float depth);   // post-loop output AM; FDN/ReverseRoom only
     void setTailSpinRate  (float hz);
     void setDiffusion     (float amount);
@@ -424,6 +429,16 @@ public:
     // DattorroPlateVintage front-load early-reflection network (algo 1 only).
     // erGain 0 = bypassed (byte-identical). See DattorroPlateVintage::setFrontLoad.
     void setDpvFrontLoad         (float erGain, float predelayMs, float tapMs, float lpHz);
+    // DPV post-main second reflection tap (the anchor's ~143 ms "duh-DUH").
+    // gain 0 = off = byte-identical. Forwards to DattorroPlateVintage::setPostMainTap.
+    void setDpvPostMainTap       (float ms, float gain, float lpHz);
+    // DPV dense early-field (fills the post-onset 0.1-0.5s "shelf"). gain 0 = off.
+    void setDpvDenseField        (float gain, float predelayMs, float t60Ms);
+    // Dattorro (algo 0) dense early-field — the SAME compact Schroeder field as the
+    // DPV one, but summed post-tank in this engine (DattorroTank.cpp stays untouched →
+    // all algo-0 presets bit-null when off). Fills the thin tail of the short rooms
+    // (Medium Drum Room: decay sub/low/mid -23..-30% vs anchor). gain 0 = off.
+    void setDattorroDenseField   (float gain, float predelayMs, float t60Ms);
 
     // Reset all delay buffers, biquad state, pre-delay, and mono-maker LP state
     // to silence. Used by the processor to bring an idle engine to a clean
@@ -457,6 +472,7 @@ private:
     NonLinearEngine    nonLinear_;
     ShimmerEngine      shimmer_;
     DattorroPlateVintage dattorroVintage_;  // re-pointed 2026-05-13: algo 7 slot now hosts DattorroPlateVintage (vintage-hardware post-EQ on Dattorro tank). Variable name retained so call sites stay stable.
+    DenseEarlyField    dattorroDenseField_; // algo 0 dense early-field, summed post-tank (off by default → bit-null). See setDattorroDenseField.
     ReverseRoomEngine  reverseRoom_;     // algo 9 (2026-05-31): causal rising-ER onset + dark FDN tail; replicates Lexicon PCM Room "Reverse 1".
     FDNReverbT<true>   accurateHall_;    // algo 10 (2026-06-09): FDN + per-octave GEQ. Also the fallback for the removed VintageTank(8)/AccurateHall32(12) engines on old saved sessions.
     SparseEarlyField   sparseField_;     // algo 11 (2026-06-10): velvet-noise front-loaded sparse early field. Summed with a reduced accurateHall_ tail in the SparseField process() case.

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -136,6 +136,11 @@ public:
     void setShimmerFeedbackHpfHz (float hz);    // Shimmer feedback-loop HPF corner (low-cascade survival); default 60
     void setShimmerStereoMod     (float rateHz, float depth); // Shimmer wet stereo chorus/ensemble; depth 0 = bit-null
     void setShimmerHFAir         (float mix);   // Shimmer post-loop +12st air voice (genuine >12k air); mix 0 = bit-null
+    void setShimmerUseDenseReverb (bool on);    // Shimmer tank: DenseHall (smooth HF) vs legacy sparse FDN (metallic); false = bit-identical
+    void setShimmerUseTailSpin    (bool on);    // Shimmer FDN output spin-comb (smears metallic, keeps FDN cascade/width/HF); false = untouched
+    void setShimmerUpVoiceScale   (float v1, float v2);  // Shimmer +12/+24 up-voice scale (mid-tail fill); 1.0/1.0 = bit-identical
+    void setShimmerOctaveCascade  (const float gains[4]); // Shimmer dry-fed even down-cascade (500/250/125/62); all 0 = bit-null
+    void setShimmerTailNoise      (float gain);  // Shimmer envelope-tracked tail noise floor (dense noise-like fade); 0 = bit-null
     void setTailSpinDepth (float depth);   // post-loop output AM; FDN/ReverseRoom only
     void setTailSpinRate  (float hz);
     void setDiffusion     (float amount);

--- a/plugins/DuskVerb/src/dsp/ShimmerEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/ShimmerEngine.cpp
@@ -206,10 +206,22 @@ void ShimmerEngine::prepare (double sampleRate, int maxBlockSize)
     pitchSubR_.setModulation (5.9f, 0.018f, 0x5B0117Bu);
     pitchSubL_.setPitchRatio (kVoiceSubRatio);     // −2 oct (×0.25 → 250 Hz)
     pitchSubR_.setPitchRatio (kVoiceSubRatio);
+    // Dry-fed octave cascade: 4 mono −12 st stages, each modulated at its own rate/seed so the
+    // octave reads as a smooth band (not a discrete mode). Feed-forward from the dry input.
+    for (int i = 0; i < kNumOctaves; ++i)
+    {
+        octGenL_[i].prepare (sampleRate);
+        octGenL_[i].setPitchRatio (0.5f);          // −1 oct per stage (cascade: 500/250/125/62)
+        octGenL_[i].setModulation (4.3f + 0.6f * static_cast<float> (i), 0.020f,
+                                   0x0C7A5E01u + static_cast<std::uint32_t> (i));
+    }
     stereoMod_.prepare (sampleRate);
     air_.prepare (sampleRate);
     air_.setMix (airMix_);
     stereoMod_.setParams (stereoModRate_, stereoModDepth_, sampleRate);
+    tailSpin_.prepare (sampleRate);
+    tailNoise_.prepare (sampleRate);
+    tailNoise_.setGain (noiseGain_);
 
     // Hall reverb baseline: long, lush, slightly dark (period-correct
     // for the late-1970s digital hall hardware character that the original Eno/Lanois rig used).
@@ -223,6 +235,18 @@ void ShimmerEngine::prepare (double sampleRate, int maxBlockSize)
     reverb_.setHighCrossoverFreq (3500.0f);
     reverb_.setSaturation        (0.0f);
     reverb_.setTankDiffusion     (0.85f);
+
+    // Dense-diffusion tank, same voicing baseline as the FDN above. DenseHall
+    // has no tank-diffusion or saturation knob (diffusion is structural, and
+    // the shimmer's softClip saturation lives in the feedback loop, not here).
+    denseReverb_.prepare (sampleRate, maxBlockSize);
+    denseReverb_.setDecayTime         (4.0f);
+    denseReverb_.setSize              (0.75f);
+    denseReverb_.setBassMultiply      (1.10f);
+    denseReverb_.setMidMultiply       (1.00f);
+    denseReverb_.setTrebleMultiply    (0.85f);
+    denseReverb_.setCrossoverFreq     (550.0f);
+    denseReverb_.setHighCrossoverFreq (3500.0f);
 
     reverbInL_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
     reverbInR_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
@@ -261,9 +285,13 @@ void ShimmerEngine::clearBuffers()
     pitchDownR_.clear();
     pitchSubL_.clear();
     pitchSubR_.clear();
+    for (int i = 0; i < kNumOctaves; ++i) octGenL_[i].clear();
+    tailNoise_.clear();
     stereoMod_.clear();
     air_.clear();
+    tailSpin_.clear();
     reverb_.clearBuffers();
+    denseReverb_.clear();
     std::fill (reverbInL_.begin(), reverbInL_.end(), 0.0f);
     std::fill (reverbInR_.begin(), reverbInR_.end(), 0.0f);
     std::fill (wetL_.begin(),      wetL_.end(),      0.0f);
@@ -281,18 +309,19 @@ void ShimmerEngine::clearBuffers()
 
 void ShimmerEngine::setDecayTime (float seconds)
 {
-    // Pass through to the FDN reverb. The FDN has its own internal range
-    // clamping. Long decays (3-6 s) are typical for shimmer cascade.
+    // Pass through to BOTH tanks. Each has its own internal range clamping.
+    // Long decays (3-6 s) are typical for shimmer cascade.
     reverb_.setDecayTime (seconds);
+    denseReverb_.setDecayTime (seconds);
 }
 
-void ShimmerEngine::setSize         (float size) { reverb_.setSize (size); }
-void ShimmerEngine::setBassMultiply (float mult) { reverb_.setBassMultiply (mult); }
-void ShimmerEngine::setMidMultiply  (float mult) { reverb_.setMidMultiply  (mult); }
-void ShimmerEngine::setTrebleMultiply (float mult) { reverb_.setTrebleMultiply (mult); }
-void ShimmerEngine::setCrossoverFreq  (float hz)   { reverb_.setCrossoverFreq  (hz); }
-void ShimmerEngine::setHighCrossoverFreq (float hz){ reverb_.setHighCrossoverFreq (hz); }
-void ShimmerEngine::setTankDiffusion (float amount){ reverb_.setTankDiffusion (amount); }
+void ShimmerEngine::setSize         (float size) { reverb_.setSize (size); denseReverb_.setSize (size); }
+void ShimmerEngine::setBassMultiply (float mult) { reverb_.setBassMultiply (mult); denseReverb_.setBassMultiply (mult); }
+void ShimmerEngine::setMidMultiply  (float mult) { reverb_.setMidMultiply  (mult); denseReverb_.setMidMultiply  (mult); }
+void ShimmerEngine::setTrebleMultiply (float mult) { reverb_.setTrebleMultiply (mult); denseReverb_.setTrebleMultiply (mult); }
+void ShimmerEngine::setCrossoverFreq  (float hz)   { reverb_.setCrossoverFreq  (hz); denseReverb_.setCrossoverFreq (hz); }
+void ShimmerEngine::setHighCrossoverFreq (float hz){ reverb_.setHighCrossoverFreq (hz); denseReverb_.setHighCrossoverFreq (hz); }
+void ShimmerEngine::setTankDiffusion (float amount){ reverb_.setTankDiffusion (amount); }  // FDN only; DenseHall diffusion is structural
 void ShimmerEngine::setDownOctaveMix (float mix)   { downMix_ = std::clamp (mix, 0.0f, 4.0f); }
 void ShimmerEngine::setSubOctaveMix  (float mix)   { subMix_  = std::clamp (mix, 0.0f, 4.0f); }
 void ShimmerEngine::setHFAir (float mix) { airMix_ = mix; air_.setMix (mix); }
@@ -338,6 +367,26 @@ void ShimmerEngine::setFreeze (bool frozen)
 {
     frozen_ = frozen;
     reverb_.setFreeze (frozen);
+    denseReverb_.setFreeze (frozen);
+}
+
+void ShimmerEngine::setUseDenseReverb (bool on) { useDenseReverb_ = on; }
+void ShimmerEngine::setUseTailSpin    (bool on) { useTailSpin_ = on; }
+void ShimmerEngine::setTailNoise      (float gain) { noiseGain_ = gain; tailNoise_.setGain (gain); }
+void ShimmerEngine::setUpVoiceScale (float v1, float v2)
+{
+    voice1Scale_ = std::clamp (v1, 0.0f, 4.0f);
+    voice2Scale_ = std::clamp (v2, 0.0f, 4.0f);
+}
+void ShimmerEngine::setOctaveCascade (const float gains[4])
+{
+    bool any = false;
+    for (int i = 0; i < kNumOctaves; ++i)
+    {
+        octGain_[i] = std::clamp (gains[i], 0.0f, 8.0f);
+        any = any || (octGain_[i] > 1.0e-6f);
+    }
+    octActive_ = any;
 }
 
 void ShimmerEngine::updatePitchRatio()
@@ -396,10 +445,14 @@ void ShimmerEngine::process (const float* inL, const float* inR,
         // feedback-extended reverb.
         const float fbSrcL = fbDelayLineL_[static_cast<size_t> (readPos)];
         const float fbSrcR = fbDelayLineR_[static_cast<size_t> (readPos)];
-        float pitchedFbL = kVoice1Mix * pitchL_.process (fbSrcL)
-                         + kVoice2Mix * pitch2L_.process (fbSrcL);
-        float pitchedFbR = kVoice1Mix * pitchR_.process (fbSrcR)
-                         + kVoice2Mix * pitch2R_.process (fbSrcR);
+        // Per-preset scale on the upward voices (voice1 +12 st fills 250-500, voice2 +24 st fills
+        // 500-1k). Deep Blue Day boosts these to regenerate the mid tail harder on transients
+        // (the snare body ×2/×4 → the 250 Hz-1 kHz body Valhalla has). Default 1.0 → ×1.0f bypass
+        // → bit-identical to legacy for Black Hole + every other preset.
+        float pitchedFbL = kVoice1Mix * voice1Scale_ * pitchL_.process (fbSrcL)
+                         + kVoice2Mix * voice2Scale_ * pitch2L_.process (fbSrcL);
+        float pitchedFbR = kVoice1Mix * voice1Scale_ * pitchR_.process (fbSrcR)
+                         + kVoice2Mix * voice2Scale_ * pitch2R_.process (fbSrcR);
         // Octave-DOWN voice IN THE FEEDBACK: pitch the feedback down −1 oct + add back.
         // The loop regenerates the descending ladder (500→250→125 Hz) GRADUALLY over
         // its 50 ms passes → loud deep low that builds SMOOTHLY (no abrupt "kick-in"
@@ -440,16 +493,36 @@ void ShimmerEngine::process (const float* inL, const float* inR,
         const float fbR = DspUtils::softClip (bandedR * fb * kFeedbackLoopAttn,
                                               kFeedbackSoftClipKnee, kFeedbackSoftClipCeil);
 
-        // Mix node: dry input + pitched feedback → reverb input.
-        reverbInL_[static_cast<size_t> (n)] = driveL + fbL;
-        reverbInR_[static_cast<size_t> (n)] = driveR + fbR;
+        // Dry-fed octave cascade (mono, feed-forward): each −12 st stage pitches the previous
+        // stage's output down another octave, summed at its own gain → an independent, EVEN
+        // 500/250/125/62 Hz descent (Valhalla's structure) that does NOT depend on the feedback
+        // loop. Fed from the raw dry (inL/inR), so a transient generates the full cascade in one
+        // pass instead of starving the feedback voices. octActive_ false → skipped → bit-null.
+        float octMono = 0.0f;
+        if (octActive_)
+        {
+            float src = 0.5f * (inL[n] + inR[n]);
+            for (int i = 0; i < kNumOctaves; ++i)
+            {
+                src = octGenL_[i].process (src);        // cascade: 1k→500→250→125→62
+                octMono += octGain_[i] * src;
+            }
+        }
+
+        // Mix node: dry input + pitched feedback + dry-fed octaves → reverb input.
+        reverbInL_[static_cast<size_t> (n)] = driveL + fbL + octMono;
+        reverbInR_[static_cast<size_t> (n)] = driveR + fbR + octMono;
 
         if (++readPos >= fbDelaySamples_) readPos = 0;
     }
 
     // ── Pass 2: reverb on the (dry + pitched-fb) mix → wet. ──
-    reverb_.process (reverbInL_.data(), reverbInR_.data(),
-                     wetL_.data(),      wetR_.data(),      numSamples);
+    if (useDenseReverb_)
+        denseReverb_.process (reverbInL_.data(), reverbInR_.data(),
+                              wetL_.data(),      wetR_.data(),      numSamples);
+    else
+        reverb_.process (reverbInL_.data(), reverbInR_.data(),
+                         wetL_.data(),      wetR_.data(),      numSamples);
 
     // ── Pass 3: emit wet (with output trim) AND write wet into the
     // feedback delay line for next-cycle pitch + recirculation. Engine
@@ -469,12 +542,19 @@ void ShimmerEngine::process (const float* inL, const float* inR,
 
         float oL = wL, oR = wR;
 
+        // Tail spin-comb on the OUTPUT ONLY (post-feedback-write → the recirculating
+        // cascade stays un-spun). Smears the FDN's metallic HF; off → oL/oR untouched.
+        if (useTailSpin_) tailSpin_.process (oL, oR);
+
         // Stereo modulation on the OUTPUT ONLY (post-feedback-write so the loop is
         // unaffected). depth 0 → struct inactive → oL/oR unchanged → bit-null.
         // Post-loop HF-air voice (genuine >12 kHz air; bypasses the reverb HF-damp + loop LPF).
         // Taps the raw wet (wL/wR), pitches its 6-12 kHz up to 12-24 k. mix 0 → bit-null.
         if (air_.active) air_.process (wL, wR, oL, oR);
         if (stereoMod_.active) stereoMod_.process (oL, oR);
+        // Tail noise floor — envelope-tracked to the wet, fades with the decay (Valhalla's
+        // dense noise-like fade; masks the sparse-mode ring). gain 0 → skipped → bit-null.
+        if (tailNoise_.active()) tailNoise_.process (wL, wR, oL, oR);
         outL[n] = std::tanh (oL * kWetOutputGain);
         outR[n] = std::tanh (oR * kWetOutputGain);
     }

--- a/plugins/DuskVerb/src/dsp/ShimmerEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/ShimmerEngine.cpp
@@ -501,7 +501,13 @@ void ShimmerEngine::process (const float* inL, const float* inR,
         float octMono = 0.0f;
         if (octActive_)
         {
-            float src = 0.5f * (inL[n] + inR[n]);
+            // Feed SILENCE while frozen: the octave cascade reads the LIVE dry input (unlike the
+            // pitch voices, which read the frozen feedback), so tracking live input during a freeze
+            // would leak that freeze-time material into the octaves on un-freeze. Silence drains
+            // the grain buffers so the held tank stays clean and the cascade resumes from the live
+            // input on release. (When frozen the reverb discards its input anyway; this keeps the
+            // generator state aligned with the freeze so there's no unfreeze transient.)
+            float src = frozen_ ? 0.0f : 0.5f * (inL[n] + inR[n]);
             for (int i = 0; i < kNumOctaves; ++i)
             {
                 src = octGenL_[i].process (src);        // cascade: 1k→500→250→125→62

--- a/plugins/DuskVerb/src/dsp/ShimmerEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/ShimmerEngine.cpp
@@ -200,6 +200,16 @@ void ShimmerEngine::prepare (double sampleRate, int maxBlockSize)
     pitchDownR_.setModulation (6.1f, 0.018f, 0xD0117Bu);
     pitchDownL_.setPitchRatio (kVoiceDownRatio);   // −1 oct (×0.5 → 500 Hz)
     pitchDownR_.setPitchRatio (kVoiceDownRatio);
+    pitchSubL_.prepare (sampleRate);
+    pitchSubR_.prepare (sampleRate);
+    pitchSubL_.setModulation (4.7f, 0.018f, 0x5B0117Au);
+    pitchSubR_.setModulation (5.9f, 0.018f, 0x5B0117Bu);
+    pitchSubL_.setPitchRatio (kVoiceSubRatio);     // −2 oct (×0.25 → 250 Hz)
+    pitchSubR_.setPitchRatio (kVoiceSubRatio);
+    stereoMod_.prepare (sampleRate);
+    air_.prepare (sampleRate);
+    air_.setMix (airMix_);
+    stereoMod_.setParams (stereoModRate_, stereoModDepth_, sampleRate);
 
     // Hall reverb baseline: long, lush, slightly dark (period-correct
     // for the late-1970s digital hall hardware character that the original Eno/Lanois rig used).
@@ -230,8 +240,8 @@ void ShimmerEngine::prepare (double sampleRate, int maxBlockSize)
     fbDelayLineR_.assign (static_cast<size_t> (fbDelaySamples_), 0.0f);
 
     const float sr = static_cast<float> (sampleRate);
-    fbHpfL_.setHPCutoff (kFeedbackHpfHz, sr);
-    fbHpfR_.setHPCutoff (kFeedbackHpfHz, sr);
+    fbHpfL_.setHPCutoff (feedbackHpfHz_, sr);
+    fbHpfR_.setHPCutoff (feedbackHpfHz_, sr);
     fbLpfL_.setLPCutoff (kFeedbackLpfHz, sr);
     fbLpfR_.setLPCutoff (kFeedbackLpfHz, sr);
     fbHpfL_.clear(); fbHpfR_.clear();
@@ -249,6 +259,10 @@ void ShimmerEngine::clearBuffers()
     pitch2R_.clear();
     pitchDownL_.clear();
     pitchDownR_.clear();
+    pitchSubL_.clear();
+    pitchSubR_.clear();
+    stereoMod_.clear();
+    air_.clear();
     reverb_.clearBuffers();
     std::fill (reverbInL_.begin(), reverbInL_.end(), 0.0f);
     std::fill (reverbInR_.begin(), reverbInR_.end(), 0.0f);
@@ -280,6 +294,21 @@ void ShimmerEngine::setCrossoverFreq  (float hz)   { reverb_.setCrossoverFreq  (
 void ShimmerEngine::setHighCrossoverFreq (float hz){ reverb_.setHighCrossoverFreq (hz); }
 void ShimmerEngine::setTankDiffusion (float amount){ reverb_.setTankDiffusion (amount); }
 void ShimmerEngine::setDownOctaveMix (float mix)   { downMix_ = std::clamp (mix, 0.0f, 4.0f); }
+void ShimmerEngine::setSubOctaveMix  (float mix)   { subMix_  = std::clamp (mix, 0.0f, 4.0f); }
+void ShimmerEngine::setHFAir (float mix) { airMix_ = mix; air_.setMix (mix); }
+void ShimmerEngine::setStereoMod (float rateHz, float depth)
+{
+    stereoModRate_  = rateHz;
+    stereoModDepth_ = depth;
+    stereoMod_.setParams (rateHz, depth, sampleRate_);
+}
+void ShimmerEngine::setFeedbackHpfHz (float hz)
+{
+    feedbackHpfHz_ = std::clamp (hz, 15.0f, 200.0f);
+    const float sr = static_cast<float> (sampleRate_);
+    fbHpfL_.setHPCutoff (feedbackHpfHz_, sr);
+    fbHpfR_.setHPCutoff (feedbackHpfHz_, sr);
+}
 
 void ShimmerEngine::setSaturation (float amount)
 {
@@ -376,13 +405,25 @@ void ShimmerEngine::process (const float* inL, const float* inR,
         // its 50 ms passes → loud deep low that builds SMOOTHLY (no abrupt "kick-in"
         // like a self-feeding output ladder). softClip bounds the per-grain peaks; the
         // 60 Hz HPF below caps the sub; a MODERATE downMix_ keeps the loop gain < 1 so
-        // it stays bounded (the clip was over-cranking to 3.5). 0 → skipped → bit-null.
+        // it stays bounded (the clip was over-cranking to 3.5). 0 → branch skipped (byte-
+        // identical on non-shimmer presets; this loop is the recursive-feedback TU, see the .h).
         if (downMix_ > 0.0f)
         {
             pitchedFbL += downMix_ * DspUtils::softClip (pitchDownL_.process (fbSrcL),
                                                          kFeedbackSoftClipKnee, kFeedbackSoftClipCeil);
             pitchedFbR += downMix_ * DspUtils::softClip (pitchDownR_.process (fbSrcR),
                                                          kFeedbackSoftClipKnee, kFeedbackSoftClipCeil);
+        }
+        // Octave-DOWN-2 (sub) voice: reaches 250 Hz in ONE step where the −1 oct cascade
+        // dies out, then the loop regenerates 125→62 Hz from it → the deep low wash Valhalla
+        // Shimmer has. Same softClip + loop band-pass keep it bounded. 0 → branch skipped
+        // (byte-identical on non-shimmer presets; recursive-feedback TU, see the .h note).
+        if (subMix_ > 0.0f)
+        {
+            pitchedFbL += subMix_ * DspUtils::softClip (pitchSubL_.process (fbSrcL),
+                                                        kFeedbackSoftClipKnee, kFeedbackSoftClipCeil);
+            pitchedFbR += subMix_ * DspUtils::softClip (pitchSubR_.process (fbSrcR),
+                                                        kFeedbackSoftClipKnee, kFeedbackSoftClipCeil);
         }
 
         // Band-pass the pitch-shifted feedback: HPF removes grain-rate
@@ -426,7 +467,15 @@ void ShimmerEngine::process (const float* inL, const float* inR,
         fbDelayLineR_[static_cast<size_t> (fbDelayWritePos_)] = wR;
         if (++fbDelayWritePos_ >= fbDelaySamples_) fbDelayWritePos_ = 0;
 
-        outL[n] = std::tanh (wL * kWetOutputGain);
-        outR[n] = std::tanh (wR * kWetOutputGain);
+        float oL = wL, oR = wR;
+
+        // Stereo modulation on the OUTPUT ONLY (post-feedback-write so the loop is
+        // unaffected). depth 0 → struct inactive → oL/oR unchanged → bit-null.
+        // Post-loop HF-air voice (genuine >12 kHz air; bypasses the reverb HF-damp + loop LPF).
+        // Taps the raw wet (wL/wR), pitches its 6-12 kHz up to 12-24 k. mix 0 → bit-null.
+        if (air_.active) air_.process (wL, wR, oL, oR);
+        if (stereoMod_.active) stereoMod_.process (oL, oR);
+        outL[n] = std::tanh (oL * kWetOutputGain);
+        outR[n] = std::tanh (oR * kWetOutputGain);
     }
 }

--- a/plugins/DuskVerb/src/dsp/ShimmerEngine.h
+++ b/plugins/DuskVerb/src/dsp/ShimmerEngine.h
@@ -73,6 +73,10 @@ public:
     void setModRate           (float hz);      // hijacked: FEEDBACK (0.1..10 → 0..0.95)
     void setTankDiffusion     (float amount);
     void setDownOctaveMix     (float mix);     // octave-DOWN voice level (0 = off/bit-null) — the warm low Valhalla Shimmer has, DV's up-only voices lacked
+    void setSubOctaveMix      (float mix);     // octave-DOWN-2 voice (×0.25 → 250 Hz from 1 kHz); 0 = off/bit-null — reaches the deep lows in ONE step where the −1 oct cascade dies out
+    void setFeedbackHpfHz     (float hz);      // feedback-loop HPF corner; lower = the low cascade survives (default 60; ~35 keeps killing the 12 Hz grain rumble)
+    void setStereoMod         (float rateHz, float depth);  // wet-output stereo chorus/ensemble (anti-phase modulated delay); depth 0 = bypassed/bit-null. Matches Valhalla Black Hole's moving stereo field.
+    void setHFAir             (float mix);   // post-loop +12 st air voice (genuine >12 kHz air); mix 0 = bit-null
     void setFreeze            (bool frozen);
 
 private:
@@ -167,11 +171,28 @@ private:
     // output-side self-feeding ladder had a per-rung grain latency → audibly late). A
     // softClip bounds the per-grain peaks; the 60 Hz feedback HPF caps the runaway sub;
     // a MODERATE downMix_ keeps the loop gain < 1 so it stays bounded (the clip was
-    // over-cranking the mix). downMix_ 0 → voice skipped → bit-null (Black Hole + every
-    // non-shimmer preset untouched).
+    // over-cranking the mix). downMix_ 0 → branch skipped (contributes nothing). NON-shimmer
+    // presets are byte-identical (they never instantiate this engine); the shimmer presets
+    // that DO run this loop with downMix_ 0 are functionally unchanged but NOT byte-guaranteed
+    // (this is the recursive-feedback TU — a guarded branch can still perturb FP ~1e-4 via
+    // codegen, see duskverb_bitnull_codegen_limit) — they're validated by ear/anchor, not byte-null.
     GranularPitchShifter pitchDownL_, pitchDownR_;    // −1 oct (×0.5 → 500 Hz)
     static constexpr float kVoiceDownRatio  = 0.5f;   // −12 st
     float downMix_ = 0.0f;                            // per-preset; 0 = off (bit-null)
+
+    // SUB voice (2026-06-29) — pitches the feedback DOWN TWO octaves (×0.25). The −1 oct
+    // voice must cascade 1k→500→250→125 over successive loop passes, losing level each step
+    // (softClip + loop attn), so the deep lows never arrive — measured against Valhalla
+    // Shimmer DeepBlueDay the DV deficit GROWS with depth (500 Hz −7 dB, 250 −19, 125 −21,
+    // 60 −35). This voice reaches 250 Hz in ONE step (and the loop regenerates 125→62 from
+    // it), filling the low wash Valhalla has. Same loop = identical build timing. subMix_ 0
+    // → branch skipped. Byte-identical on NON-shimmer presets (they don't run this engine);
+    // the shimmer presets that run this loop with subMix_ 0 are functionally unchanged but
+    // NOT byte-guaranteed (recursive-feedback TU codegen ~1e-4, see duskverb_bitnull_codegen_limit)
+    // — validated by ear/anchor, not byte-null.
+    GranularPitchShifter pitchSubL_, pitchSubR_;      // −2 oct (×0.25 → 250 Hz)
+    static constexpr float kVoiceSubRatio   = 0.25f;  // −24 st
+    float subMix_ = 0.0f;                             // per-preset; 0 = off (bit-null)
 
     // Hall reverb — reuses the existing FDNReverb (same engine that
     // powers the "Realistic Space" / FDN algorithm). Configured in
@@ -257,12 +278,105 @@ private:
         void clear() { prevIn = prevOut = 0.0f; }
     };
     OnePole fbHpfL_, fbHpfR_, fbLpfL_, fbLpfR_;
+
+    // Stereo modulation (chorus/ensemble) on the WET output — a slow LFO sweeps
+    // per-channel modulated delays in ANTI-PHASE, so the L/R combs move oppositely:
+    // on a steady tone the image swings side-to-side (Valhalla Shimmer Black Hole
+    // measured 0.83 Hz, ±25 dB L-R), on broadband it's a moving, animated field.
+    // depth 0 → bypassed → bit-null. Applied post-feedback-write so the loop stays clean.
+    struct StereoMod
+    {
+        std::vector<float> bufL, bufR; int mask = 0, w = 0;
+        float phase = 0.0f, inc = 0.0f, depthSamp = 0.0f, baseSamp = 0.0f, blend = 0.0f, panDepth = 0.0f;
+        bool active = false;
+        void prepare (double sr)
+        {
+            int n = 1; while (n < static_cast<int> (0.06 * sr)) n <<= 1;
+            bufL.assign (static_cast<size_t> (n), 0.0f); bufR.assign (static_cast<size_t> (n), 0.0f);
+            mask = n - 1; w = 0; phase = 0.0f;
+        }
+        void clear() { std::fill (bufL.begin(), bufL.end(), 0.0f); std::fill (bufR.begin(), bufR.end(), 0.0f); w = 0; phase = 0.0f; }
+        void setParams (float rateHz, float depth01, double sr)
+        {
+            inc       = 6.283185307f * rateHz / static_cast<float> (sr);
+            baseSamp  = 0.012f * static_cast<float> (sr);            // ~12 ms centre delay
+            const float d = std::clamp (depth01, 0.0f, 1.0f);
+            depthSamp = d * 0.008f * static_cast<float> (sr);  // up to ±8 ms sweep (chorus → correlation/character)
+            blend     = d;                                     // 0 = dry only, 1 = full chorus comb
+            panDepth  = d * 0.9f;                              // anti-phase amplitude swing (auto-pan → the slow L-R level mod); 0.9 → ±~25 dB at full depth
+            active    = d > 1.0e-4f;
+        }
+        inline float readInterp (const std::vector<float>& b, float d) const
+        {
+            const float rp = static_cast<float> (w) - d;
+            int i0 = static_cast<int> (std::floor (rp));
+            const float fr = rp - static_cast<float> (i0);
+            const int a = i0 & mask, c = (i0 + 1) & mask;
+            return b[static_cast<size_t> (a)] + fr * (b[static_cast<size_t> (c)] - b[static_cast<size_t> (a)]);
+        }
+        inline void process (float& l, float& r)
+        {
+            bufL[static_cast<size_t> (w)] = l; bufR[static_cast<size_t> (w)] = r;
+            const float lfo = std::sin (phase);
+            phase += inc; if (phase > 6.283185307f) phase -= 6.283185307f;
+            const float yL = readInterp (bufL, baseSamp + depthSamp * lfo);   // L sweeps one way…
+            const float yR = readInterp (bufR, baseSamp - depthSamp * lfo);   // …R the opposite (anti-phase)
+            const float cL = (1.0f - 0.5f * blend) * l + 0.5f * blend * yL;   // chorus comb (→ correlation/character)
+            const float cR = (1.0f - 0.5f * blend) * r + 0.5f * blend * yR;
+            const float pan = panDepth * lfo;                                 // anti-phase amplitude (→ the slow L-R level swing)
+            l = cL * (1.0f + pan);
+            r = cR * (1.0f - pan);
+            w = (w + 1) & mask;
+        }
+    };
+    StereoMod stereoMod_;
+    float stereoModRate_ = 0.83f, stereoModDepth_ = 0.0f;   // depth 0 = bypassed (bit-null)
+
+    // HF-air voice — the genuine >12 kHz "air" Valhalla Shimmer has (centroid ~9.9k BH /
+    // 6.6k DBD vs DV ~6k/5k). DV's reverb HF-damps + AA-caps the top, and the +12 loop
+    // voice's air is cut by the 14 kHz feedback LPF before it recirculates. This taps the
+    // wet 6-12 kHz POST-loop, pitches it up +12 st (the granular shifter outputs up to 24 kHz
+    // at base rate — its AA caps the INPUT at 12 k, not the output), keeps only >11 kHz, and
+    // sums it in. Post-loop → bypasses the reverb HF-damp + loop LPF, no cascade regression.
+    // L/R-independent → decorrelates the highs (width_hi). mix 0 → skipped → bit-null.
+    struct HFAirVoice
+    {
+        GranularPitchShifter shifterL, shifterR;   // +12 st (ratio 2): 6-12k → 12-24k air
+        OnePole tapHpL, tapHpR;                    // ~6 kHz HP: feed only the wet HF to the shifter
+        OnePole airHpL, airHpR;                    // ~11 kHz HP: keep only the pitched-up air
+        float mix = 0.0f; bool active = false;
+        void prepare (double sr)
+        {
+            shifterL.prepare (sr); shifterR.prepare (sr);
+            shifterL.setPitchRatio (2.0f); shifterR.setPitchRatio (2.0f);
+            shifterL.setModulation (5.1f, 0.012f, 0xA11A1Au); shifterR.setModulation (6.3f, 0.012f, 0xA11A1Bu);
+            const float s = static_cast<float> (sr);
+            tapHpL.setHPCutoff (6000.0f, s); tapHpR.setHPCutoff (6000.0f, s);
+            airHpL.setHPCutoff (11000.0f, s); airHpR.setHPCutoff (11000.0f, s);
+            clear();
+        }
+        void clear()
+        {
+            shifterL.clear(); shifterR.clear();
+            tapHpL.clear(); tapHpR.clear(); airHpL.clear(); airHpR.clear();
+        }
+        void setMix (float m) { mix = std::clamp (m, 0.0f, 4.0f); active = mix > 1.0e-6f; }
+        inline void process (float wL, float wR, float& addL, float& addR)
+        {
+            addL += mix * airHpL.processHP (shifterL.process (tapHpL.processHP (wL)));
+            addR += mix * airHpR.processHP (shifterR.process (tapHpR.processHP (wR)));
+        }
+    };
+    HFAirVoice air_;
+    float airMix_ = 0.0f;   // mix 0 = off (bit-null)
+
     // HPF at 60 Hz — tuned to kill the granular-pitch-shifter's grain-rate
     // fundamental (≈12 Hz at 4096-sample grains / 48 kHz) and its first
     // few odd harmonics (~36, 60 Hz), while preserving natural-reverb
     // low-frequency content above 60 Hz. Earlier iteration at 120 Hz was
     // over-aggressive and removed musical bass that external reference clearly retains.
     static constexpr float kFeedbackHpfHz = 60.0f;
+    float feedbackHpfHz_ = kFeedbackHpfHz;   // runtime-tunable corner (setFeedbackHpfHz); default = the constant → bit-null for presets that don't override
     // LPF at 14 kHz — a gentle ceiling on the feedback path. Each cascade cycle
     // pitches up by N semitones (×2 at +12), so without any cap the migrated
     // content piles up against the AA-filter wall as a metallic 1-3 kHz peak.

--- a/plugins/DuskVerb/src/dsp/ShimmerEngine.h
+++ b/plugins/DuskVerb/src/dsp/ShimmerEngine.h
@@ -2,6 +2,7 @@
 
 #include "DspUtils.h"
 #include "FDNReverb.h"
+#include "DenseHallReverb.h"
 
 #include <array>
 #include <cmath>
@@ -77,6 +78,11 @@ public:
     void setFeedbackHpfHz     (float hz);      // feedback-loop HPF corner; lower = the low cascade survives (default 60; ~35 keeps killing the 12 Hz grain rumble)
     void setStereoMod         (float rateHz, float depth);  // wet-output stereo chorus/ensemble (anti-phase modulated delay); depth 0 = bypassed/bit-null. Matches Valhalla Black Hole's moving stereo field.
     void setHFAir             (float mix);   // post-loop +12 st air voice (genuine >12 kHz air); mix 0 = bit-null
+    void setUseDenseReverb    (bool on);     // route the tank through DenseHallReverb (dense diffusion → smooth, non-metallic HF tail) instead of the sparse 16-line FDN. false = legacy FDN (bit-identical).
+    void setUseTailSpin       (bool on);     // 2-stage modulated-allpass spin-comb on the FDN wet output — smears the metallic HF while keeping the FDN's cascade/width/HF (for Deep Blue Day). false = untouched.
+    void setTailNoise         (float gain);  // envelope-tracked band-limited noise floor on the output — the dense noise-like fade Valhalla has; masks the sparse-mode ring. 0 = off/bit-null.
+    void setUpVoiceScale      (float v1, float v2);  // per-preset scale on the +12/+24 up-voices — fills the mid tail (250 Hz-1 kHz) harder on transients (Deep Blue Day). 1.0/1.0 = bit-identical.
+    void setOctaveCascade     (const float gains[4]);  // dry-fed feed-forward octave cascade levels (500/250/125/62 Hz) — matches Valhalla's even down-cascade. all 0 = off/bit-null.
     void setFreeze            (bool frozen);
 
 private:
@@ -161,6 +167,8 @@ private:
     static constexpr float kVoice2OctaveMul = 2.0f;   // +12 st above voice 1
     static constexpr float kVoice1Mix       = 0.78f;
     static constexpr float kVoice2Mix       = 0.60f;   // 2026-06-16: 0.34->0.60 — boost the +24 air voice to fill 12-24k toward the anchor's broadband octave (cent_500/spec_L1@12.9k).
+    float voice1Scale_ = 1.0f;   // per-preset multiplier on kVoice1Mix (mid-tail fill); 1.0 = legacy
+    float voice2Scale_ = 1.0f;   // per-preset multiplier on kVoice2Mix; 1.0 = legacy
 
     // DOWN voice (2026-06-19) — pitches the feedback DOWN one octave (×0.5) IN THE
     // FEEDBACK LOOP, alongside the up voices. The loop regenerates a descending ladder
@@ -194,6 +202,19 @@ private:
     static constexpr float kVoiceSubRatio   = 0.25f;  // −24 st
     float subMix_ = 0.0f;                             // per-preset; 0 = off (bit-null)
 
+    // DRY-FED OCTAVE CASCADE (2026-07-01) — a mono, FEED-FORWARD chain of −12 st pitch stages
+    // fed from the DRY input (not the feedback), each octave summed into the reverb input at its
+    // OWN gain. This is what Valhalla Shimmer does: independent per-octave generation → a gentle
+    // EVEN 500/250/125/62 descent. DV's old feedback down/sub voices could not (they read the
+    // recirculated wet, so a transient starves them, and the "sub" ratio 0.25 was silently
+    // clamped to 0.5 by setPitchRatio — never actually −24 st). Feed-forward → each stage's level
+    // is set purely by its gain, decoupled from feedback. All gains 0 → octActive_ false →
+    // skipped → bit-null. kNumOctaves stages: octGen_[0]=500, [1]=250, [2]=125, [3]=62 Hz.
+    static constexpr int kNumOctaves = 4;
+    GranularPitchShifter octGenL_[kNumOctaves];       // mono chain (index 0 = highest octave)
+    float octGain_[kNumOctaves] = { 0.0f, 0.0f, 0.0f, 0.0f };  // per-octave levels (per-preset)
+    bool  octActive_ = false;                         // any gain > 0
+
     // Hall reverb — reuses the existing FDNReverb (same engine that
     // powers the "Realistic Space" / FDN algorithm). Configured in
     // prepare() for a "long lush hall" baseline; per-preset setters
@@ -212,6 +233,14 @@ private:
     // (Lagrange/allpass interpolation) or a parallel non-recirculating pitched
     // voice — an engine fork, to be done with ear-validation in the loop.
     FDNReverb reverb_;
+
+    // Dense-diffusion alternative tank (10 input allpasses + 3 nested loop
+    // allpasses/line + 2 output spin-combs). Same class the hall presets use
+    // to reach kurtosis ~7; here it replaces the sparse FDN's metallic HF ring
+    // (kurt ~26) when useDenseReverb_ is set. Separate instance from the halls'
+    // denseHall_ → non-shimmer presets are unaffected. Off = legacy FDN path.
+    DenseHallReverb denseReverb_;
+    bool useDenseReverb_ = false;
 
     // Per-block scratch buffers for the pitch-shifter → reverb stage.
     // pitch shifter writes into these; reverb reads them and writes
@@ -330,6 +359,85 @@ private:
         }
     };
     StereoMod stereoMod_;
+
+    // Tail spin-comb — a 2-stage cascade of MODULATED Schroeder allpasses on the
+    // WET output (allpass = magnitude-flat → no comb notches, only the slow spin
+    // modulation smears the spectrum). L/R run in opposite mod phase. It smears the
+    // sparse FDN's metallic HF modes (kurt ~31 → ~9, matching Valhalla) WITHOUT the
+    // density of a full reverb swap, so the FDN tank's deep-low cascade / width /
+    // HF-sustain are preserved. Applied to the OUTPUT only, post-feedback-write, so
+    // the recirculating cascade stays un-spun. Used on Deep Blue Day (keeps its FDN);
+    // Black Hole uses DenseHall instead. off (useTailSpin_ = false) → oL/oR untouched.
+    struct TailSpin
+    {
+        struct AP { std::vector<float> buf; int mask = 0, w = 0, len = 0; float exc = 0;
+            void alloc (int n, int e) { len = std::max (1, n); exc = (float) e;
+                int sz = 1; while (sz < len + e + 8) sz <<= 1; buf.assign ((size_t) sz, 0.0f); mask = sz - 1; w = 0; }
+            void clear() { std::fill (buf.begin(), buf.end(), 0.0f); w = 0; }
+            inline float process (float x, float mod) {
+                const float rp = (float) w - (float) len - exc * mod;
+                const int i0 = (int) std::floor (rp); const float fr = rp - (float) i0;
+                const float d = DspUtils::cubicHermite (buf.data(), mask, i0, fr);   // HF-lossless
+                const float in = x + kSG * d; buf[(size_t) w] = in + DspUtils::kDenormalPrevention; w = (w + 1) & mask;
+                return d - kSG * in; }
+            static constexpr float kSG = 0.7f; };
+        AP l0, l1, r0, r1; float ph0 = 0.0f, ph1 = 1.7f, inc0 = 0.0f, inc1 = 0.0f;
+        void prepare (double sr) {
+            const float s = (float) sr;
+            l0.alloc ((int) (0.0070f * s), (int) (0.0015f * s)); r0.alloc ((int) (0.0070f * s), (int) (0.0015f * s));
+            l1.alloc ((int) (0.0080f * s), (int) (0.0015f * s)); r1.alloc ((int) (0.0080f * s), (int) (0.0015f * s));
+            inc0 = 6.283185307f * 1.30f / s; inc1 = 6.283185307f * 1.53f / s; ph0 = 0.0f; ph1 = 1.7f; }
+        void clear() { l0.clear(); l1.clear(); r0.clear(); r1.clear(); ph0 = 0.0f; ph1 = 1.7f; }
+        inline void process (float& L, float& R) {
+            const float m0 = std::sin (ph0), m1 = std::sin (ph1);
+            ph0 += inc0; if (ph0 > 6.283185307f) ph0 -= 6.283185307f;
+            ph1 += inc1; if (ph1 > 6.283185307f) ph1 -= 6.283185307f;
+            L = l1.process (l0.process (L,  m0),  m1);
+            R = r1.process (r0.process (R, -m0), -m1); }   // opposite mod → L/R decorrelation
+    };
+    TailSpin tailSpin_;
+    bool useTailSpin_ = false;
+
+    // Tail noise floor — the dense, noise-like decay Valhalla's shimmer has and DV's sparse FDN
+    // lacks (measured: Valhalla's fade stays denser + ~2 dB higher; DV collapses to a single
+    // sparse mode). A low-level band-limited noise, ENVELOPE-TRACKED to the wet tail so it fades
+    // WITH the decay ("white noise heard as the audio fades out"). It fills the spectral gaps
+    // between DV's sparse modes → masks the discrete low-mode ring (203 Hz boing) so it blends
+    // into a wash instead of standing out as a pitch. gain 0 → inactive → bit-null.
+    struct TailNoise
+    {
+        static constexpr std::uint32_t kSeedL = 0x9E3779B9u;
+        static constexpr std::uint32_t kSeedR = 0x85EBCA6Bu;
+        std::uint32_t rngL = kSeedL, rngR = kSeedR;
+        float envL = 0.0f, envR = 0.0f, atk = 0.0f, rel = 0.0f;
+        OnePole hpL, hpR, lpL, lpR;               // band-limit the noise to the tail's dark color
+        float gain_ = 0.0f; bool active_ = false;
+        void prepare (double sr) {
+            const float s = static_cast<float> (sr);
+            atk = std::exp (-1.0f / (0.005f * s));    // ~5 ms attack
+            rel = std::exp (-1.0f / (0.100f * s));    // ~100 ms release (tracks the decay smoothly)
+            hpL.setHPCutoff (250.0f, s); hpR.setHPCutoff (250.0f, s);
+            lpL.setLPCutoff (7000.0f, s); lpR.setLPCutoff (7000.0f, s);
+        }
+        void clear() { rngL = kSeedL; rngR = kSeedR; envL = envR = 0.0f; hpL.clear(); hpR.clear(); lpL.clear(); lpR.clear(); }
+        void setGain (float g) { gain_ = std::max (0.0f, g); active_ = gain_ > 1.0e-6f; }
+        bool active() const { return active_; }
+        inline float noise (std::uint32_t& s) {
+            s ^= s << 13; s ^= s >> 17; s ^= s << 5;
+            return static_cast<float> (s) * (1.0f / 2147483648.0f) - 1.0f;   // ~[-1,1)
+        }
+        inline void process (float wetL, float wetR, float& oL, float& oR) {
+            const float aL = std::abs (wetL), aR = std::abs (wetR);
+            envL = (aL > envL) ? aL + atk * (envL - aL) : aL + rel * (envL - aL);   // fast up, slow down
+            envR = (aR > envR) ? aR + atk * (envR - aR) : aR + rel * (envR - aR);
+            const float nL = lpL.processLP (hpL.processHP (noise (rngL)));
+            const float nR = lpR.processLP (hpR.processHP (noise (rngR)));
+            oL += gain_ * envL * nL;
+            oR += gain_ * envR * nR;
+        }
+    };
+    TailNoise tailNoise_;
+    float noiseGain_ = 0.0f;   // per-preset; 0 = off (bit-null)
     float stereoModRate_ = 0.83f, stereoModDepth_ = 0.0f;   // depth 0 = bypassed (bit-null)
 
     // HF-air voice — the genuine >12 kHz "air" Valhalla Shimmer has (centroid ~9.9k BH /

--- a/plugins/DuskVerb/tools/tuner/SCOPE_modal_density.md
+++ b/plugins/DuskVerb/tools/tuner/SCOPE_modal_density.md
@@ -1,0 +1,124 @@
+# SCOPE — Modal-density fix (sine1k honk + boing + diffusion_flux)
+
+2026-06-28. Origin: fleet audit on merged main. `sine1k_full_rms` (14/18),
+`tail_resonance`/boing (8), `diffusion_flux` (6) are ONE defect — modal sparsity.
+A reverb mode parks near a probe frequency (Cathedral 499×2≈1k, Small Drum 963 Hz),
+so a sustained tone resonates and the tail rings. Broadband bands MATCH the anchor
+(mid-1k, T60-1k pass), so it is invisible to level/decay gates and largely masked
+on real material. See memory `duskverb_sine1k_honk_is_modal_sparsity`.
+
+## Not one fix — three buckets (different physics)
+
+| bucket | presets | modal fails | tank-density verdict |
+|---|---|---|---|
+| Long halls | Cathedral, Large Chamber, Blade Runner, Vocal Hall (DenseHall 8-line) + Ambience (AccurateHall 16) | ~8 | tractable — long tail sustains density |
+| Short rooms | Small Drum, Medium Drum, Live Room (Dattorro) | ~5 | PROVEN DEAD END (reverted 2026-06-17) |
+| Plates | Drum Plate, Vintage Gold (Dattorro) | ~2 | already density 1.0; near floor, skip |
+
+The short-room density-fill (#87: `setDensityRoomFill` + 12-AP cascade +
+`setMainLineDetune`) was built, tuned, then REVERTED — post-mortem in
+PluginProcessor.cpp kDattorroDensityByName (~line 2794): density-fill kills the
+boing (Small 10→0 dB) but the 12 hall APs stretch the loop to ~200 ms → short-room
+T60 collapses/runs-away non-monotonically. "Rooms need ENGINE MIGRATION (FDN
+16-line / velvet, dense modes w/o a runaway loop) or accept the boing."
+
+## Engine state (important — the dense engines were retired)
+- **AccurateHall32** (32-line FDN, algo 12): REMOVED 2026-06-13 — case falls back to
+  16-line AccurateHall (DuskVerbEngine.cpp:1445). Re-enabling = re-instantiate
+  `FDNReverbT<true,32>` + wire the case.
+- **VelvetTail** (`VelvetTail.h`, loopless velvet-noise FIR tail): exists but has NO
+  routing case in DuskVerbEngine. Unwired. The source-prescribed short-room target
+  needs wiring first.
+- Densest LIVE engine = 16-line AccurateHall (algo 10) / its SparseField(11) +
+  TiledRoom(13) composites (16-line dense tail + front-loaded sparse ER).
+
+## De-risk renders (force preset onto 16-line FDN, gain-matched full_check)
+T60 off (dormant octave table) — read the MODAL gates only.
+
+| probe | sine1k | boing | flux | read |
+|---|---|---|---|---|
+| Cathedral DenseHall(8) baseline | **+9.53 ✗** | pass | pass | parked 1k mode |
+| Cathedral → AccurateHall(16) | **−2.32** (≈pass) | pass | pass | **mode GONE** — density direction validated |
+| Small Drum Dattorro baseline | +8.65 ✗ | **+9.8 ✗ @963** | pass | sparse room mode |
+| Small Drum → AccurateHall(16) | +4.73 ✗ (halved) | **pass** | 1.65 ✗ | boing gone, but FDN wash → n_fail 25→31 |
+
+16-line FDN dissolves the hall modal triad cleanly; on a short room it kills the
+boing but trades it for FDN back-load wash + T60 trouble (the documented loop
+problem).
+
+## Workstream A — HALLS (SUPERSEDED / REVERTED — do NOT follow)
+> **Outdated.** The Cathedral pilot below disproved this plan: migrating halls to the
+> FDN-based SparseField composite (algo 11) only RELOCATES the sparsity (honk → HF
+> metal) and was reverted. The authoritative guidance is **"PILOT RESULTS"** and
+> **"CORRECTED recommendation — densify DenseHall's LOW-MID"** at the end of this doc.
+> The text below is kept only for the historical rationale.
+
+Migrate the 4 DenseHall halls to the **SparseField composite (algo 11)** = 16-line
+dense AccurateHall tail (kills modes, de-risk-proven) + front-loaded sparse ER
+(keeps the front-load that DenseHall+BuildupDiffuser currently provides). Plain
+algo 10 would lose the front-load (energy_t50/onset would regress), so use 11.
+
+Steps per preset (Cathedral, Large Chamber, Blade Runner, Vocal Hall):
+1. Switch FactoryPresets algo 14 → 11; set the SparseField ER tap list + tail/ER
+   gain from the existing DenseHall ER config.
+2. Add an octave-T60 entry to `kAccurateHallT60ByName` and run
+   `calibrate_octave_t60.py` (LIVE tooling — Vocal Plate/Ambience/Tiled already use it).
+3. Re-check width/level/front-load; sweep residuals.
+
+- Yield: ~7 modal fails + the AccurateHall octave-GEQ decouples T60 (may close
+  several T60/decay fails the DenseHall 3-band path can't).
+- Cost: ~½–1 day per preset (re-tune), 4 presets. Reuses live engine + tooling.
+- Risk: SparseField ER must reproduce each hall's early field; cent/bright-early
+  profile differs. Bit-null N/A (this is a deliberate engine change per preset).
+
+## Workstream B — SHORT ROOMS (defer; low confidence)
+Source-prescribed loopless engine (VelvetTail) is unwired; 16-line FDN only
+half-fixes and adds wash. Options, both expensive:
+- B1: wire VelvetTail into DuskVerbEngine (new routing case + config) and re-tune
+  Small/Medium Drum + Live Room from scratch (multi-day each; new engine = new gate
+  profile — Reverse Taps on velvet sits at 26).
+- B2: accept the room boing (it is partly masked on real broadband material).
+
+Recommend B2 for now; revisit B1 only after A lands and if the rooms still rank.
+
+## Honest ceiling
+Realistic recovery ≈ 7–12 fails, NOT all 28. New engines carry new gate profiles;
+short rooms may net little. (NOTE: the original "biggest win = 4 hall migrations to
+SparseField(11)" estimate is SUPERSEDED — the pilot below showed it trades honk for
+HF metal and was reverted; see the CORRECTED recommendation.)
+
+## PILOT RESULTS (2026-06-28, Cathedral) — Workstream A revised
+
+Ran the full Cathedral algo 14→11 migration + octave recal end-to-end. Outcome
+**disproves the "migrate halls to FDN" recommendation above:**
+
+| stage | n_fail | note |
+|---|---|---|
+| DenseHall baseline (ship) | 19 | mid honk +9.5, boing, smooth top |
+| algo 11 raw (seeded octave) | 17 | **modal triad GONE** (no sine1k/boing/flux) |
+| + octave recal (9/9) | 14 | T60/decay/cent_500 fixed |
+| + OutputDiffusion 0.4 (env) | 13 | ss air closed |
+
+Density DOES kill the low-mid honk/boing (−6, the audible mid defect). BUT a NEW
+fail appears: **HF-tail texture +10** (metallic 2-12k tail). OutputDiffusion (+0.3)
+and modulation (Mod 0.8) are INERT on it. Forcing 32 lines (`FDNReverbT<true,32>`)
+only reaches +7.1 — still fails (gate +2). Even 32 lines ≠ VVV smoothness (12.5).
+
+**Conclusion: FDN line-count RELOCATES sparsity, doesn't eliminate it.** 8-line
+DenseHall = sparse low-mid (honk). 16/32-line FDN = dense low-mid but sparse HF
+(metal — FDN lacks DenseHall's in-loop allpass diffusion, which already gives
+kurtosis 7.2). The engines have inverse profiles. Migrating halls to FDN trades
+honk for metal — net gate win, net sonic wash. **AccurateHall32 re-enable NOT worth
+it** (doesn't reach smoothness). Pilot reverted.
+
+## CORRECTED recommendation — densify DenseHall's LOW-MID
+Keep DenseHall (its HF diffusion is the asset). Add low-mid mode density:
+- **A1′ — extend DenseHall 8→16 lines**: Hadamard 8×8→16×16 in DenseHallReverb.h +
+  rebuild the line-length array (closer-spaced ratios) + per-preset octave re-tune.
+  Real DSP surgery. Keeps the HF diffusion → no metal.
+- **A2′ — longer in-loop density allpasses**: add ~30-100ms in-loop APs (Dattorro-#87
+  style) to densify low-mid modes. The LONG hall tails sustain the loop length (unlike
+  the short rooms that floored — `duskverb_boing_sparse_modal`). Cheaper than A1′; test
+  on Cathedral first (sine1k/boing the read).
+
+Either is a focused DenseHall engine task. A2′ is the cheaper spike — try it first.

--- a/plugins/DuskVerb/tools/tuner/SCOPE_modal_density.md
+++ b/plugins/DuskVerb/tools/tuner/SCOPE_modal_density.md
@@ -53,23 +53,23 @@ problem).
 > **"CORRECTED recommendation — densify DenseHall's LOW-MID"** at the end of this doc.
 > The text below is kept only for the historical rationale.
 
-Migrate the 4 DenseHall halls to the **SparseField composite (algo 11)** = 16-line
+_The retired plan (kept only for rationale — it was NOT carried out):_ it would have
+migrated the 4 DenseHall halls to the **SparseField composite (algo 11)** = 16-line
 dense AccurateHall tail (kills modes, de-risk-proven) + front-loaded sparse ER
-(keeps the front-load that DenseHall+BuildupDiffuser currently provides). Plain
-algo 10 would lose the front-load (energy_t50/onset would regress), so use 11.
+(to keep the front-load DenseHall+BuildupDiffuser provides). Plain algo 10 would have
+lost the front-load (energy_t50/onset regressing), so it specified 11.
 
-Steps per preset (Cathedral, Large Chamber, Blade Runner, Vocal Hall):
+The per-preset steps would have been (Cathedral, Large Chamber, Blade Runner, Vocal Hall):
 1. Switch FactoryPresets algo 14 → 11; set the SparseField ER tap list + tail/ER
    gain from the existing DenseHall ER config.
 2. Add an octave-T60 entry to `kAccurateHallT60ByName` and run
    `calibrate_octave_t60.py` (LIVE tooling — Vocal Plate/Ambience/Tiled already use it).
 3. Re-check width/level/front-load; sweep residuals.
 
-- Yield: ~7 modal fails + the AccurateHall octave-GEQ decouples T60 (may close
-  several T60/decay fails the DenseHall 3-band path can't).
-- Cost: ~½–1 day per preset (re-tune), 4 presets. Reuses live engine + tooling.
-- Risk: SparseField ER must reproduce each hall's early field; cent/bright-early
-  profile differs. Bit-null N/A (this is a deliberate engine change per preset).
+Projected at the time: ~7 modal fails closed + the AccurateHall octave-GEQ decoupling
+T60; ~½–1 day per preset × 4; risk that SparseField ER couldn't reproduce each hall's
+early field (cent/bright-early profile differs). **This was disproven by the pilot and
+reverted — see "PILOT RESULTS" and "CORRECTED recommendation" below.**
 
 ## Workstream B — SHORT ROOMS (defer; low confidence)
 Source-prescribed loopless engine (VelvetTail) is unwired; 16-line FDN only

--- a/plugins/DuskVerb/tools/tuner/fleet_audit.py
+++ b/plugins/DuskVerb/tools/tuner/fleet_audit.py
@@ -153,8 +153,11 @@ def render_and_check(name, no_render=False):
         os.makedirs(dv)
         cmd = [REND, "--vst3", VST3, "--program", name, "--output-dir", dv,
                "--sustained-pink-seconds", "4.0"]
-        if not shim:
-            cmd += ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1"]
+        # Force full-wet for every preset. Shimmer presets ADD a sustained-sine
+        # render for the down-octave cascade gate (in addition to full-wet).
+        cmd += ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1"]
+        if shim:
+            cmd += ["--long-sine-seconds", "15"]   # sustained sine for the down-octave cascade gate
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=420)
         nb = glob.glob(f"{dv}/*_noiseburst.wav")
         if r.returncode != 0 or not nb:
@@ -172,7 +175,7 @@ def render_and_check(name, no_render=False):
     # ALWAYS (re)populate the anchor dir so full_check, run right after, never
     # sees an empty/stale lex on the --no-render reuse path.
     shutil.rmtree(lex, ignore_errors=True); os.makedirs(lex)
-    for s in STIM:
+    for s in STIM + (["sinelong"] if shim else []):
         src = f"{adir}/{apref}_{s}.wav"
         if os.path.exists(src):
             shutil.copy(src, f"{lex}/anchor_{s}.wav")

--- a/plugins/DuskVerb/tools/tuner/fleet_audit.py
+++ b/plugins/DuskVerb/tools/tuner/fleet_audit.py
@@ -153,11 +153,16 @@ def render_and_check(name, no_render=False):
         os.makedirs(dv)
         cmd = [REND, "--vst3", VST3, "--program", name, "--output-dir", dv,
                "--sustained-pink-seconds", "4.0"]
-        # Force full-wet for every preset. Shimmer presets ADD a sustained-sine
-        # render for the down-octave cascade gate (in addition to full-wet).
-        cmd += ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1"]
         if shim:
-            cmd += ["--long-sine-seconds", "15"]   # sustained sine for the down-octave cascade gate
+            # Shimmer presets are rendered at their NATIVE 50% wet — the Valhalla Shimmer
+            # anchors were captured at 50% (BH/DBD mix 0.50), so forcing full-wet compared a
+            # dry-less DV tail against a mix that carries the dry transient, faking the whole
+            # front-load/energy-arrival gate cluster (attack, energy_t50/first50, transient).
+            # Add the sustained sine for the down-octave cascade gate.
+            cmd += ["--long-sine-seconds", "15"]
+        else:
+            # Non-shimmer presets match 100%-wet Valhalla anchors → force full-wet.
+            cmd += ["--param", "Dry/Wet=1.0", "--param", "Bus Mode=1"]
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=420)
         nb = glob.glob(f"{dv}/*_noiseburst.wav")
         if r.returncode != 0 or not nb:

--- a/plugins/DuskVerb/tools/tuner/full_check.py
+++ b/plugins/DuskVerb/tools/tuner/full_check.py
@@ -175,6 +175,16 @@ GATES = {
     # Catches "DV drops, Lex holds flat" contour mismatch that scalar
     # decay metrics miss. <2 dB is excellent; 5 dB is audibly different.
     'env_shape_l1_dB':      3.0,
+    # TAIL DECAY-ENVELOPE match (2026-06-29, EAR "Lex fuller / rings out longer").
+    # The per-octave T60 gate fits the -5to-25 dB EARLY slope on the NOISEBURST
+    # and extrapolates assuming EXPONENTIAL decay — but the Lex Vintage Plate is
+    # NON-EXPONENTIAL (a loud 0.3-0.5 s "shelf" + a long quiet ringout) on the
+    # SNARE. Matching the early slope makes DV's exponential tail die too soon
+    # (sounds short/thin) while the noiseburst T60 reads DV as "too long". This
+    # gate compares the SNARE tail's dB-below-peak (the perceived ringout, level-
+    # independent) at 0.3/0.5/0.8/1.2 s vs the anchor — the decay SHAPE the ear
+    # actually hears. Mean |Δ| over the audible points; perceptual decay JND ~3 dB.
+    'decay_tail_l1_dB':     3.0,
     # Late-window low-band integrated RMS — catches "boomy" tail (DV bass
     # rings 0.5-2 s past where Lex's structural damping has attenuated it).
     # spec_L1 averaging is steady-state-spectrum-only and can pass while
@@ -221,6 +231,7 @@ GATES = {
     # high) — heard as "DV brighter / more honky" on vocal material.
     # Asymmetric tolerance because hot is the audible defect.
     'sine1k_full_rms_dB':   2.0,
+    'down_octave_cascade_dB': 4.0,   # SHIMMER only: per-band rel-fundamental JND on the SUSTAINED-sine down-octave cascade (the regenerative low warmth the 2s sine1k can't show)
     # PER-STIMULUS RMS DELTA — broadband level on each stimulus. Single
     # Gain Trim knob can't match all stimuli simultaneously when the
     # spectrum diverges, so this is informational + advisory. Gate as
@@ -273,7 +284,7 @@ ENGINE_CEILINGS = {
 # the h3 odd-harmonic clip signature), so the THD gate is meaningless here and is
 # skipped. Name-based, not category: "Black Hole" is category "Ambient" but still
 # Shimmer. The other distortion checks still apply.
-SHIMMER_PRESETS = {'Black Hole', 'Cascading Heaven', 'Deep Blue Day'}
+SHIMMER_PRESETS = {'Black Hole', 'Deep Blue Day'}   # the 2 shimmer (algo 7) presets; Cascading Heaven/Mobius were deleted in the 2026-06 roster cleanup
 
 
 def _is_ceiling(gate_id: str, category: str) -> bool:
@@ -426,6 +437,29 @@ def _full_rms_db (p):
     import soundfile as sf
     x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
     return float(20.0 * np.log10(max(np.sqrt(np.mean(m ** 2)), 1.0e-12)))
+
+
+_CASCADE_BANDS = [(31, 60), (60, 125), (125, 250), (235, 265), (470, 530)]
+
+def _rel_fundamental_bands (p, t0=10.0, t1=14.0):
+    """Per-band RMS normalized to the 1 kHz fundamental (dB), from a steady window of a
+    SUSTAINED sine render. Gain-independent (rel to the fundamental), so it survives the
+    noiseburst gain-match. Returns None if the render is too short (e.g. the old 2 s file)."""
+    import soundfile as sf
+    x, sr = sf.read(p); m = x.mean(axis=1) if x.ndim > 1 else x
+    i0, i1 = int(t0 * sr), min(int(t1 * sr), len(m))
+    if i1 - i0 < int(sr * 1.0):
+        return None
+    seg = m[i0:i1]
+    X = np.abs(np.fft.rfft(seg * np.hanning(len(seg))))
+    f = np.fft.rfftfreq(len(seg), 1.0 / sr)
+    def band_rms (lo, hi):
+        msk = (f >= lo) & (f < hi)
+        return float(np.sqrt(np.mean(X[msk] ** 2))) if msk.any() else 0.0
+    fund = band_rms(960.0, 1040.0)
+    if fund < 1.0e-9:
+        return None
+    return {(lo, hi): 20.0 * np.log10(band_rms(lo, hi) / fund + 1.0e-12) for (lo, hi) in _CASCADE_BANDS}
 
 
 def _sine1k_thd_pct (p, f0=1000.0):
@@ -1418,7 +1452,7 @@ def audit(dv_dir, lex_dir, name='preset', category='', sustained_pink_seconds=4.
     snare_lx = find_stim(lex_dir, 'snare')
     if snare_dv and snare_lx:
         from metrics_external import envelope_shape_l1 as _env_l1
-        x_dv, sr_dv = sf.read(snare_dv); x_lx, _ = sf.read(snare_lx)
+        x_dv, sr_dv = sf.read(snare_dv); x_lx, sr_lx = sf.read(snare_lx)
         m_dv = x_dv.mean(axis=1) if x_dv.ndim>1 else x_dv
         m_lx = x_lx.mean(axis=1) if x_lx.ndim>1 else x_lx
         env_l1 = _env_l1(m_dv, m_lx, sr_dv, post_peak_ms=500.0)
@@ -1428,6 +1462,34 @@ def audit(dv_dir, lex_dir, name='preset', category='', sustained_pink_seconds=4.
         print(line)
         if not passing and env_l1 == env_l1:
             fails.append(line.strip())
+
+    # ─── Tail decay-envelope match (perceptual ringout + fullness) ───
+    # The early-slope T60 gate (noiseburst, -5to-25 dB, exponential extrapolation)
+    # misses the Lex's non-exponential SNARE tail (loud 0.3-0.5 s shelf + long
+    # quiet ringout) the ear hears as "fuller / rings out longer". Compare the
+    # snare tail's dB-below-peak (decay SHAPE, level-independent) at perceptual
+    # times vs the anchor. See GATES['decay_tail_l1_dB'].
+    if snare_dv and snare_lx:
+        def _tail_env_db (m, sr):
+            pk = float (np.max (np.abs (m))) + 1.0e-12
+            out = {}
+            for tt in (0.3, 0.5, 0.8, 1.2):
+                a = int (tt * sr); seg = m[a : a + int (0.05 * sr)]
+                out[tt] = (20.0 * np.log10 (np.sqrt (np.mean (seg ** 2)) / pk + 1.0e-12)
+                           if len (seg) > 16 else None)
+            return out
+        ed_dv = _tail_env_db (m_dv, sr_dv); ed_lx = _tail_env_db (m_lx, sr_lx)
+        # Compare only where the anchor tail is still audible (>= -95 dB below peak).
+        diffs = [abs (ed_dv[tt] - ed_lx[tt]) for tt in ed_dv
+                 if ed_dv[tt] is not None and ed_lx[tt] is not None and ed_lx[tt] >= -95.0]
+        if diffs:
+            tail_l1 = float (np.mean (diffs))
+            print("\n── TAIL DECAY-ENVELOPE (snare, perceptual ringout/fullness 0.3-1.2 s) ──")
+            passing = tail_l1 <= GATES['decay_tail_l1_dB']
+            line = (f"  {'decay_tail_L1 (dB)':30s}  {tail_l1:6.2f}  "
+                    f"gate=±{GATES['decay_tail_l1_dB']}  {'✓' if passing else '✗'}")
+            print(line)
+            if not passing: fails.append(line.strip())
 
     # ─── Oscillation (detrended envelope ripple) ───
     if dv and lx:
@@ -1558,6 +1620,32 @@ def audit(dv_dir, lex_dir, name='preset', category='', sustained_pink_seconds=4.
     if dv_dir and lex_dir and name in SHIMMER_PRESETS:
         print("\n── SINE 1 kHz THD ── SKIPPED (Shimmer engine: octave pitch-shift "
               "reads as harmonics by design)")
+        # Down-octave cascade gate (SHIMMER only) — the regenerative low warmth a 1 kHz
+        # tone develops over SECONDS. Measured on the SUSTAINED *_sinelong.wav (the 2 s
+        # sine1k is too short for the cascade to build). Rel-fundamental, so gain-safe.
+        print("\n── DOWN-OCTAVE CASCADE (sustained 1 kHz, rel. fundamental) ──")
+        dv_sl = find_stim(dv_dir, 'sinelong'); lx_sl = find_stim(lex_dir, 'sinelong')
+        if not (dv_sl and lx_sl):
+            print("  cascade                      SKIPPED (no *_sinelong.wav — render with --long-sine-seconds 15)")
+        else:
+            dvb = _rel_fundamental_bands(dv_sl); lxb = _rel_fundamental_bands(lx_sl)
+            if dvb is None or lxb is None:
+                print("  cascade                      SKIPPED (sinelong too short)")
+            else:
+                # Only count bands where the ANCHOR has perceptually relevant content
+                # (>= -45 dB rel fundamental). Presets without a down voice (Black Hole)
+                # have a near-silent cascade in BOTH → no qualifying band → gate skipped.
+                for b in _CASCADE_BANDS:
+                    print(f"    {b[0]:>4}-{b[1]:<4} Hz   DV={dvb[b]:+6.1f}  VVV={lxb[b]:+6.1f}  Δ={dvb[b]-lxb[b]:+5.1f}")
+                diffs = [abs(dvb[b] - lxb[b]) for b in _CASCADE_BANDS if lxb[b] >= -45.0]
+                if not diffs:
+                    print("  down-octave cascade          SKIPPED (anchor has no down-octave content)")
+                else:
+                    l1 = float(np.mean(diffs)); g = GATES['down_octave_cascade_dB']
+                    passing = l1 <= g
+                    line = (f"  down-octave cascade L1 (dB)   {l1:5.2f}  gate=±{g}  {'✓' if passing else '✗'}")
+                    print(line)
+                    if not passing: fails.append(line.strip())
     elif dv_dir and lex_dir:
         print("\n── SINE 1 kHz THD (nonlinearity detector, DV-excess over anchor) ──")
         thd_gate = GATES['sine1k_thd_excess_pct']

--- a/plugins/shared/DuskComboBox.h
+++ b/plugins/shared/DuskComboBox.h
@@ -42,6 +42,12 @@ public:
         ids. */
     std::function<juce::PopupMenu()> menuBuilder;
 
+    /** Max columns for the popup. Default 1 = single scrolling column (keeps
+        category headers glued to their items). Set >1 only when the menuBuilder
+        inserts explicit addColumnBreak()s at category boundaries, so the split
+        can't detach a header from its items. */
+    int maxMenuColumns = 1;
+
     void showPopup() override
     {
         juce::PopupMenu menu = menuBuilder ? menuBuilder() : buildFlatMenu();
@@ -61,8 +67,10 @@ public:
                            // which detaches a category header from its items (the
                            // "Chambers" header landed bottom-left while its presets
                            // wrapped to the top-right column). One column + scroll
-                           // arrows keeps every header glued to its items.
-                           .withMaximumNumColumns (1);
+                           // arrows keeps every header glued to its items — UNLESS the
+                           // menuBuilder sets maxMenuColumns >1 AND inserts explicit
+                           // addColumnBreak()s at category boundaries (preset menu does).
+                           .withMaximumNumColumns (maxMenuColumns);
 
         // Render in-window. Parent to the top-level editor so the menu lives in
         // the existing plugin surface (no native popup window). If we are not

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -888,6 +888,7 @@ int main (int argc, char** argv)
     // true steady-state per-band decay (the way musical content drives a
     // reverb, not a 100 ms burst). 0 = disabled.
     double sustainedPinkSeconds = 0.0;
+    double longSineSeconds = 0.0;   // opt-in long sustained 1 kHz sine (shimmer cascade); 0 = off
     // Per-parameter overrides via --param NAME=VALUE. Stored in declaration
     // order so multiple --param flags compose the way the user wrote them
     // (last write wins). Applied AFTER the preset so they override anything
@@ -929,6 +930,8 @@ int main (int argc, char** argv)
             prerunSeconds = juce::String (argv[++i]).getDoubleValue();
         else if (a == "--sustained-pink-seconds" && i + 1 < argc)
             sustainedPinkSeconds = juce::String (argv[++i]).getDoubleValue();
+        else if (a == "--long-sine-seconds" && i + 1 < argc)
+            longSineSeconds = juce::String (argv[++i]).getDoubleValue();
         else if (a == "--param" && i + 1 < argc)
         {
             // Format: NAME=VALUE  (NAME may contain spaces; matches the
@@ -1744,6 +1747,24 @@ int main (int argc, char** argv)
         fillSineTone (input, kSampleRate, 1000.0, -12.0);
         auto output = renderThroughPlugin (*plugin, input);
         auto outFile = outDir.getChildFile (slug + "_sine1k.wav");
+        if (writeWav (outFile, output, kSampleRate))
+            std::cout << "Wrote " << outFile.getFullPathName() << std::endl;
+    }
+
+    // ---- Render 4b (optional): LONG sustained 1 kHz sine ----
+    // The 2 s sine1k above is too short for a REGENERATIVE shimmer cascade to build
+    // (the down/sub octave ladder needs ~5-10 s to populate 500/250/125/62 Hz). This
+    // opt-in long render at -18 dBFS lets the cascade settle so the rel-fundamental
+    // down-octave gate measures the real low-octave content. Off (==0) → not written
+    // → every existing render byte-identical (bit-null). 15 s matches the anchor protocol.
+    if (longSineSeconds > 0.0)
+    {
+        plugin->reset();
+        const int sineSamples = static_cast<int> (kSampleRate * longSineSeconds);
+        juce::AudioBuffer<float> input (2, sineSamples);
+        fillSineTone (input, kSampleRate, 1000.0, -18.0);
+        auto output = renderThroughPlugin (*plugin, input);
+        auto outFile = outDir.getChildFile (slug + "_sinelong.wav");
         if (writeWav (outFile, output, kSampleRate))
             std::cout << "Wrote " << outFile.getFullPathName() << std::endl;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-column preset menu and improved preset popup layout in the plugin editor.
  * Expanded DuskVerb’s sound design options with new dense early-reflection stages and enhanced shimmer behavior (including dense routing and extended tail/output shaping).
  * Updated several factory presets with revised tuning for selected halls, plates, ambience, and shimmer-style sounds.
  * Added support for longer sustained sine renders during analysis.
* **Bug Fixes**
  * Refined the title wordmark click-hitbox for more accurate interaction.
  * Improved preset switching behavior to reduce unintended carryover between sound modes.
* **Documentation**
  * Added/updated tuner notes and analysis gates related to modal-density evaluation and shimmer-specific down-octave checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->