### PR TITLE
105 multi q plugin keeps resetting to default preset when using british or tube mode

### DIFF
--- a/plugins/DuskVerb/src/dsp/TimeVaryingDamping.h
+++ b/plugins/DuskVerb/src/dsp/TimeVaryingDamping.h
@@ -1,17 +1,12 @@
 #pragma once
 
 // =====================================================================
-// PHASE 3 SANDBOX — NOT YET WIRED INTO FDN OR QUADTANK.
-//
-// Status: 2026-05-28 — drafted, isolated, awaiting V1 listening-test
-// approval before integration. Do NOT #include this from FDNReverb.cpp
-// or QuadTank.cpp until V1 baseline is signed off audibly. While this
-// file sits unincluded, the existing shipped binary remains bit-identical
-// to the calibrated V1 master at commit 8a36e88.
-//
-// ---------------------------------------------------------------------
 // TimeVaryingDamping
 // ---------------------------------------------------------------------
+//
+// Integrated into the FDN engine: FDNReverb owns a tvDampHi_ instance and
+// applies it per delay line inside the tank loop (see FDNReverb.cpp).
+// QuadTank does not use it.
 //
 // Per-line energy-following high-shelf with coefficient lerping between
 // pre-computed "early" (transient / bright) and "late" (decayed / dark)

--- a/plugins/multi-q/MultiQ.cpp
+++ b/plugins/multi-q/MultiQ.cpp
@@ -709,8 +709,12 @@ void MultiQ::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*
         const int guardTarget = presetModeGuardTarget.load(std::memory_order_relaxed);
         if (guardTarget >= 0)
             eqType = static_cast<EQType>(guardTarget);
-        presetModeGuardSamples.store(juce::jmax(0, guardLeft - buffer.getNumSamples()),
-                                     std::memory_order_release);
+        // Atomic decrement (not load-then-store): a concurrent re-arm from setCurrentProgram writes
+        // a fresh, larger window, and fetch_sub applies to whatever value is current, so this block's
+        // subtraction can never clobber that re-arm. The counter may dip up to one block below zero on
+        // the final tick; the >0 test above treats <=0 as expired and the next arm overwrites it, so
+        // it cannot drift any further negative.
+        presetModeGuardSamples.fetch_sub(buffer.getNumSamples(), std::memory_order_acq_rel);
     }
 
     // Detect EQ type change and start crossfade

--- a/plugins/multi-q/MultiQ.cpp
+++ b/plugins/multi-q/MultiQ.cpp
@@ -447,11 +447,13 @@ void MultiQ::prepareToPlay(double sampleRate, int samplesPerBlock)
         bandEnableSmoothed[static_cast<size_t>(i)].setCurrentAndTargetValue(enabled);
     }
 
-    eqTypeCrossfade.reset(sampleRate, 0.01);
+    eqTypeCrossfade.reset(sampleRate, 0.02);
     eqTypeCrossfade.setCurrentAndTargetValue(1.0f);
     previousEQType = static_cast<EQType>(static_cast<int>(safeGetParam(eqTypeParam, 0.0f)));
     eqTypeChanging = false;
-    prevTypeBuffer.setSize(2, samplesPerBlock, false, false, true);
+    eqXfadeHold = {{0.0f, 0.0f}};
+    presetModeGuardSamples.store(0, std::memory_order_relaxed);
+    presetModeGuardTarget.store(-1, std::memory_order_relaxed);
 
     osCrossfade.reset(sampleRate, 0.005);
     osCrossfade.setCurrentAndTargetValue(1.0f);
@@ -696,11 +698,26 @@ void MultiQ::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*
     // Check EQ type (Digital, British, or Tube)
     auto eqType = static_cast<EQType>(static_cast<int>(safeGetParam(eqTypeParam, 0.0f)));
 
+    // Pin the mode to a just-loaded factory preset for a short window (issue #105). Some hosts
+    // (Bitwig) re-assert their cached eqType once after a host-driven program change, which would
+    // otherwise revert British/Tube presets to Digital mid-block. Holding the loaded mode here keeps
+    // the audio from flickering; the delayed re-apply in setCurrentProgram converges the parameter.
+    if (const int guardLeft = presetModeGuardSamples.load(std::memory_order_acquire); guardLeft > 0)
+    {
+        // Acquire above synchronizes with the release store in setCurrentProgram, so once a
+        // nonzero countdown is visible the matching target store is guaranteed visible too.
+        const int guardTarget = presetModeGuardTarget.load(std::memory_order_relaxed);
+        if (guardTarget >= 0)
+            eqType = static_cast<EQType>(guardTarget);
+        presetModeGuardSamples.store(juce::jmax(0, guardLeft - buffer.getNumSamples()),
+                                     std::memory_order_release);
+    }
+
     // Detect EQ type change and start crossfade
     if (eqType != previousEQType)
     {
-        // prevTypeBuffer already contains last processed output (saved at end of previous block)
-        // Start crossfade from old EQ type's output to new EQ type's output
+        // eqXfadeHold holds the last clean output sample (continuity point). Crossfade from it into
+        // the new EQ type's output so the transition never steps.
         eqTypeChanging = true;
         eqTypeCrossfade.setCurrentAndTargetValue(0.0f);
         eqTypeCrossfade.setTargetValue(1.0f);
@@ -1602,7 +1619,8 @@ void MultiQ::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*
     }
 
     // Save processed output for potential future crossfades (only when not currently crossfading)
-    // This ensures prevOsBuffer and prevTypeBuffer contain the last fully-processed output
+    // This ensures prevOsBuffer holds the last fully-processed output for the OS-mode crossfade,
+    // and eqXfadeHold holds the continuity seed for the EQ-type crossfade.
     if (!osChanging)
     {
         int copyLen = juce::jmin(buffer.getNumSamples(), prevOsBuffer.getNumSamples());
@@ -1612,10 +1630,13 @@ void MultiQ::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*
     }
     if (!eqTypeChanging)
     {
-        int copyLen = juce::jmin(buffer.getNumSamples(), prevTypeBuffer.getNumSamples());
-        int copyCh = juce::jmin(buffer.getNumChannels(), prevTypeBuffer.getNumChannels());
-        for (int ch = 0; ch < copyCh; ++ch)
-            prevTypeBuffer.copyFrom(ch, 0, buffer, ch, 0, copyLen);
+        // Seed the mode-switch crossfade with the final output sample (the true continuity point),
+        // so a later switch blends from where the waveform actually left off -> no click. See
+        // eqXfadeHold.
+        const int lastIdx = buffer.getNumSamples() - 1;
+        if (lastIdx >= 0)
+            for (int ch = 0; ch < juce::jmin(buffer.getNumChannels(), 2); ++ch)
+                eqXfadeHold[static_cast<size_t>(ch)] = buffer.getSample(ch, lastIdx);
     }
 
     // Apply oversampling mode switch crossfade
@@ -1642,11 +1663,15 @@ void MultiQ::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*
         }
     }
 
-    // Apply EQ type switch crossfade
+    // Apply EQ type switch crossfade. Blend from the held continuity seed (the last clean output
+    // sample) into the new mode: at mix=0 the output equals where the waveform left off, so there is
+    // no step -> no click. The seed is a constant across the ~20ms ramp; its contribution decays as
+    // mix -> 1, leaving only the new mode. (An earlier design blended against the previous block,
+    // whose sample i sat a full block of phase away from the switch point -> the audible pop.)
     if (eqTypeChanging)
     {
-        int xfCh = juce::jmin(buffer.getNumChannels(), prevTypeBuffer.getNumChannels());
-        int xfLen = juce::jmin(buffer.getNumSamples(), prevTypeBuffer.getNumSamples());
+        int xfCh = juce::jmin(buffer.getNumChannels(), 2);
+        int xfLen = buffer.getNumSamples();
         if (eqTypeCrossfade.isSmoothing())
         {
             for (int i = 0; i < xfLen; ++i)
@@ -1654,7 +1679,7 @@ void MultiQ::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /*
                 float mix = eqTypeCrossfade.getNextValue();
                 for (int ch = 0; ch < xfCh; ++ch)
                 {
-                    float prev = prevTypeBuffer.getSample(ch, i);
+                    float prev = eqXfadeHold[static_cast<size_t>(ch)];
                     float curr = buffer.getSample(ch, i);
                     buffer.setSample(ch, i, prev + mix * (curr - prev));
                 }
@@ -3925,6 +3950,35 @@ void MultiQ::setCurrentProgram(int index)
         MultiQPresets::applyPreset(parameters, factoryPresets[static_cast<size_t>(presetIndex)]);
         parameters.state.setProperty("presetName",
             factoryPresets[static_cast<size_t>(presetIndex)].name, nullptr);
+
+        // Defend the loaded mode against a host re-asserting its cached eqType (issue #105). Some
+        // hosts (Bitwig) call setCurrentProgram on a worker thread, or re-entrantly during their own
+        // program write; JUCE then suppresses the performEdit host-notification for the parameter
+        // changes above, so the host never learns the new eqType and re-asserts its cached value on
+        // the next audio block, reverting British/Tube presets to Digital. Two-part fix:
+        //   1) processBlock pins the DSP to this mode for ~500 ms so the audio never follows that
+        //      one-shot revert (no mode flicker in the sound);
+        //   2) a short delayed re-apply on the message thread lands after the revert and re-issues
+        //      the parameter edits (which DO notify the host from a non-re-entrant context), so the
+        //      eqType parameter and UI converge to the preset's mode.
+        const int guardMode = factoryPresets[static_cast<size_t>(presetIndex)].eqType;
+        // Store the target first, then publish the countdown with a release store so the audio
+        // thread's acquire load of presetModeGuardSamples can never observe a nonzero countdown
+        // before the matching target is visible. The countdown is measured in host-rate samples
+        // (baseSampleRate, not the oversampled currentSampleRate) because processBlock decrements
+        // it by buffer.getNumSamples(), which is always host-rate, so the guard stays ~500 ms
+        // regardless of the oversampling factor.
+        presetModeGuardTarget.store(guardMode, std::memory_order_relaxed);
+        presetModeGuardSamples.store(static_cast<int>(baseSampleRate.load() * 0.5),
+                                     std::memory_order_release);
+
+        juce::WeakReference<MultiQ> weakThis(this);
+        const int pi = presetIndex;
+        juce::Timer::callAfterDelay(150, [weakThis, pi]() mutable
+        {
+            if (auto* self = weakThis.get())
+                MultiQPresets::applyPreset(self->parameters, self->factoryPresets[static_cast<size_t>(pi)]);
+        });
     }
 }
 

--- a/plugins/multi-q/MultiQ.h
+++ b/plugins/multi-q/MultiQ.h
@@ -333,6 +333,14 @@ public:
     // from loading "Init" (which would reset all band gains) via the async UI update chain.
     std::atomic<bool> transferInProgress{false};
 
+    // Preset-load mode guard (issue #105): after a host-driven factory preset switches the EQ mode,
+    // some hosts (e.g. Bitwig) re-assert their cached eqType value once, reverting British/Tube back
+    // to Digital. For a short window after such a load, processBlock pins the DSP to the loaded mode
+    // so the audio never follows that revert; a delayed re-apply on the message thread then
+    // converges the eqType parameter/UI. Target -1 = guard inactive.
+    std::atomic<int> presetModeGuardTarget{-1};
+    std::atomic<int> presetModeGuardSamples{0};
+
     // Public parameter access for GUI
     juce::AudioProcessorValueTreeState parameters;
 
@@ -639,9 +647,14 @@ private:
     // Per-band enable/disable crossfade (~3ms)
     std::array<juce::SmoothedValue<float>, NUM_BANDS> bandEnableSmoothed;
 
-    // EQ type switching crossfade (~10ms)
+    // EQ type switching crossfade (~20ms)
     juce::SmoothedValue<float> eqTypeCrossfade{1.0f};  // 1.0 = fully new type
-    juce::AudioBuffer<float> prevTypeBuffer;  // Saved output from previous EQ type
+    // Continuity seed for the mode-switch crossfade: the last clean output sample per channel,
+    // captured when NOT crossfading. The crossfade blends from this exact value (the point the
+    // waveform actually left off) into the new mode, so output[0] never steps -> no click. An
+    // earlier design blended against the whole previous block, which stepped by a full block of
+    // phase at the switch -> an audible pop.
+    std::array<float, 2> eqXfadeHold{{0.0f, 0.0f}};
     EQType previousEQType = EQType::Digital;
     bool eqTypeChanging = false;
 

--- a/plugins/multi-q/MultiQEditor.cpp
+++ b/plugins/multi-q/MultiQEditor.cpp
@@ -180,7 +180,7 @@ MultiQEditor::MultiQEditor(MultiQ& p)
     presetSelector = std::make_unique<juce::ComboBox>();
     presetSelector->setTooltip("Factory and user presets");
     updatePresetSelector();
-    presetSelector->onChange = [this]() { onPresetSelected(); };
+    presetSelector->onChange = [this]() { onPresetSelected(*presetSelector); };
     addAndMakeVisible(presetSelector.get());
 
     // Save preset button
@@ -380,23 +380,13 @@ MultiQEditor::MultiQEditor(MultiQ& p)
     britishAbButton.setVisible(false);
     addAndMakeVisible(britishAbButton);
 
-    britishPresetSelector.addItem("Default", 1);
-    britishPresetSelector.addItem("Warm Vocal", 2);
-    britishPresetSelector.addItem("Bright Guitar", 3);
-    britishPresetSelector.addItem("Punchy Drums", 4);
-    britishPresetSelector.addItem("Full Bass", 5);
-    britishPresetSelector.addItem("Air & Presence", 6);
-    britishPresetSelector.addItem("Gentle Cut", 7);
-    britishPresetSelector.addItem("Master Bus", 8);
-    // dontSendNotification: this is a UI-only quick-preset combo that doesn't track the loaded
-    // preset, so it defaults to "Default" on open. Firing onChange here would call
-    // applyBritishPreset(1) ("Default - flat") AFTER construction and wipe the British params of
-    // whatever factory/user preset is loaded (issue #105 — reset on GUI open / session reload).
-    britishPresetSelector.setSelectedId(1, juce::dontSendNotification);
+    // #105: this panel combo mirrors the main preset dropdown — same factory presets, same handler,
+    // kept in sync by updatePresetSelector(). Items + selection are filled there, not here (it used
+    // to be a separate quick-preset list that never synced or persisted).
     britishPresetSelector.setColour(juce::ComboBox::backgroundColourId, juce::Colour(0xff3a3a3a));
     britishPresetSelector.setColour(juce::ComboBox::textColourId, juce::Colour(0xffe0e0e0));
     britishPresetSelector.setVisible(false);
-    britishPresetSelector.onChange = [this]() { applyBritishPreset(britishPresetSelector.getSelectedId()); };
+    britishPresetSelector.onChange = [this]() { onPresetSelected(britishPresetSelector); };
     addAndMakeVisible(britishPresetSelector);
 
     // Global oversampling selector (visible in all modes)
@@ -420,21 +410,12 @@ MultiQEditor::MultiQEditor(MultiQ& p)
     addAndMakeVisible(tubeAbButton);
 
     // Tube mode preset selector
-    tubePresetSelector.addItem("Default", 1);
-    tubePresetSelector.addItem("Warm Vocal", 2);
-    tubePresetSelector.addItem("Vintage Bass", 3);
-    tubePresetSelector.addItem("Silky Highs", 4);
-    tubePresetSelector.addItem("Full Mix", 5);
-    tubePresetSelector.addItem("Subtle Warmth", 6);
-    tubePresetSelector.addItem("Mastering", 7);
-    // dontSendNotification: see britishPresetSelector above — firing onChange here would call
-    // applyTubePreset(1) ("Default - flat") after construction and wipe the loaded preset's Tube
-    // params (issue #105 — the async onChange was the reset the diagnostic log caught).
-    tubePresetSelector.setSelectedId(1, juce::dontSendNotification);
+    // #105: mirrors the main preset dropdown (see britishPresetSelector). Items + selection filled
+    // by updatePresetSelector(); shares the onPresetSelected handler.
     tubePresetSelector.setColour(juce::ComboBox::backgroundColourId, juce::Colour(0xff3a3a3a));
     tubePresetSelector.setColour(juce::ComboBox::textColourId, juce::Colour(0xffe0e0e0));
     tubePresetSelector.setVisible(false);
-    tubePresetSelector.onChange = [this]() { applyTubePreset(tubePresetSelector.getSelectedId()); };
+    tubePresetSelector.onChange = [this]() { onPresetSelected(tubePresetSelector); };
     addAndMakeVisible(tubePresetSelector);
 
     tubeHqButton = std::make_unique<juce::ToggleButton>("HQ");
@@ -2542,355 +2523,6 @@ void MultiQEditor::layoutBritishControls()
     // These will be laid out in resized() alongside the EQ type selector
 }
 
-void MultiQEditor::applyBritishPreset(int presetId)
-{
-    // Validate presetId is within expected range (1-8)
-    if (presetId < 1 || presetId > 8)
-    {
-        DBG("MultiQEditor::applyBritishPreset: Invalid presetId " + juce::String(presetId) + " (expected 1-8)");
-        return;
-    }
-
-    // Helper to set parameter value with defensive checks
-    auto setParam = [this](const juce::String& paramId, float value) {
-        auto* param = processor.parameters.getParameter(paramId);
-        if (param == nullptr)
-        {
-            DBG("MultiQEditor::applyBritishPreset: Parameter '" + paramId + "' not found");
-            return;
-        }
-        // Clamp value to parameter's valid range before converting
-        auto range = param->getNormalisableRange();
-        float clampedValue = juce::jlimit(range.start, range.end, value);
-        param->setValueNotifyingHost(param->convertTo0to1(clampedValue));
-    };
-
-    // Preset definitions: HPF freq, HPF on, LPF freq, LPF on,
-    //                     LF gain, LF freq, LF bell,
-    //                     LMF gain, LMF freq, LMF Q,
-    //                     HMF gain, HMF freq, HMF Q,
-    //                     HF gain, HF freq, HF bell,
-    //                     Saturation, Input, Output
-
-    switch (presetId)
-    {
-        case 1:  // Default - flat response
-            setParam(ParamIDs::britishHpfFreq, 20.0f);
-            setParam(ParamIDs::britishHpfEnabled, 0.0f);
-            setParam(ParamIDs::britishLpfFreq, 20000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 0.0f);
-            setParam(ParamIDs::britishLfGain, 0.0f);
-            setParam(ParamIDs::britishLfFreq, 100.0f);
-            setParam(ParamIDs::britishLfBell, 0.0f);
-            setParam(ParamIDs::britishLmGain, 0.0f);
-            setParam(ParamIDs::britishLmFreq, 400.0f);
-            setParam(ParamIDs::britishLmQ, 1.0f);
-            setParam(ParamIDs::britishHmGain, 0.0f);
-            setParam(ParamIDs::britishHmFreq, 2000.0f);
-            setParam(ParamIDs::britishHmQ, 1.0f);
-            setParam(ParamIDs::britishHfGain, 0.0f);
-            setParam(ParamIDs::britishHfFreq, 8000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 0.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, 0.0f);
-            break;
-
-        case 2:  // Warm Vocal - presence boost, slight low cut
-            setParam(ParamIDs::britishHpfFreq, 80.0f);
-            setParam(ParamIDs::britishHpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLpfFreq, 16000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLfGain, -2.0f);
-            setParam(ParamIDs::britishLfFreq, 200.0f);
-            setParam(ParamIDs::britishLfBell, 1.0f);
-            setParam(ParamIDs::britishLmGain, 2.0f);
-            setParam(ParamIDs::britishLmFreq, 800.0f);
-            setParam(ParamIDs::britishLmQ, 1.5f);
-            setParam(ParamIDs::britishHmGain, 3.0f);
-            setParam(ParamIDs::britishHmFreq, 3500.0f);
-            setParam(ParamIDs::britishHmQ, 1.2f);
-            setParam(ParamIDs::britishHfGain, 2.0f);
-            setParam(ParamIDs::britishHfFreq, 12000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 15.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, 0.0f);
-            break;
-
-        case 3:  // Bright Guitar - aggressive highs, tight low end
-            setParam(ParamIDs::britishHpfFreq, 100.0f);
-            setParam(ParamIDs::britishHpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLpfFreq, 20000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 0.0f);
-            setParam(ParamIDs::britishLfGain, -3.0f);
-            setParam(ParamIDs::britishLfFreq, 150.0f);
-            setParam(ParamIDs::britishLfBell, 1.0f);
-            setParam(ParamIDs::britishLmGain, -2.0f);
-            setParam(ParamIDs::britishLmFreq, 500.0f);
-            setParam(ParamIDs::britishLmQ, 2.0f);
-            setParam(ParamIDs::britishHmGain, 4.0f);
-            setParam(ParamIDs::britishHmFreq, 3000.0f);
-            setParam(ParamIDs::britishHmQ, 1.5f);
-            setParam(ParamIDs::britishHfGain, 5.0f);
-            setParam(ParamIDs::britishHfFreq, 10000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 20.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, 0.0f);
-            break;
-
-        case 4:  // Punchy Drums - enhanced attack, controlled lows
-            setParam(ParamIDs::britishHpfFreq, 60.0f);
-            setParam(ParamIDs::britishHpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLpfFreq, 18000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLfGain, 3.0f);
-            setParam(ParamIDs::britishLfFreq, 80.0f);
-            setParam(ParamIDs::britishLfBell, 0.0f);
-            setParam(ParamIDs::britishLmGain, -4.0f);
-            setParam(ParamIDs::britishLmFreq, 350.0f);
-            setParam(ParamIDs::britishLmQ, 1.8f);
-            setParam(ParamIDs::britishHmGain, 4.0f);
-            setParam(ParamIDs::britishHmFreq, 4000.0f);
-            setParam(ParamIDs::britishHmQ, 1.2f);
-            setParam(ParamIDs::britishHfGain, 2.0f);
-            setParam(ParamIDs::britishHfFreq, 8000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 25.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, 0.0f);
-            break;
-
-        case 5:  // Full Bass - big low end, clarity on top
-            setParam(ParamIDs::britishHpfFreq, 30.0f);
-            setParam(ParamIDs::britishHpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLpfFreq, 12000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLfGain, 6.0f);
-            setParam(ParamIDs::britishLfFreq, 80.0f);
-            setParam(ParamIDs::britishLfBell, 0.0f);
-            setParam(ParamIDs::britishLmGain, -3.0f);
-            setParam(ParamIDs::britishLmFreq, 250.0f);
-            setParam(ParamIDs::britishLmQ, 1.5f);
-            setParam(ParamIDs::britishHmGain, 2.0f);
-            setParam(ParamIDs::britishHmFreq, 1500.0f);
-            setParam(ParamIDs::britishHmQ, 1.0f);
-            setParam(ParamIDs::britishHfGain, -2.0f);
-            setParam(ParamIDs::britishHfFreq, 6000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 30.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, -3.0f);
-            break;
-
-        case 6:  // Air & Presence - sparkle and definition
-            setParam(ParamIDs::britishHpfFreq, 40.0f);
-            setParam(ParamIDs::britishHpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLpfFreq, 20000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 0.0f);
-            setParam(ParamIDs::britishLfGain, 0.0f);
-            setParam(ParamIDs::britishLfFreq, 100.0f);
-            setParam(ParamIDs::britishLfBell, 0.0f);
-            setParam(ParamIDs::britishLmGain, -2.0f);
-            setParam(ParamIDs::britishLmFreq, 600.0f);
-            setParam(ParamIDs::britishLmQ, 1.2f);
-            setParam(ParamIDs::britishHmGain, 3.0f);
-            setParam(ParamIDs::britishHmFreq, 5000.0f);
-            setParam(ParamIDs::britishHmQ, 1.0f);
-            setParam(ParamIDs::britishHfGain, 5.0f);
-            setParam(ParamIDs::britishHfFreq, 12000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 10.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, 0.0f);
-            break;
-
-        case 7:  // Gentle Cut - subtle mud/harsh removal
-            setParam(ParamIDs::britishHpfFreq, 50.0f);
-            setParam(ParamIDs::britishHpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLpfFreq, 18000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLfGain, -1.5f);
-            setParam(ParamIDs::britishLfFreq, 200.0f);
-            setParam(ParamIDs::britishLfBell, 1.0f);
-            setParam(ParamIDs::britishLmGain, -2.5f);
-            setParam(ParamIDs::britishLmFreq, 400.0f);
-            setParam(ParamIDs::britishLmQ, 1.5f);
-            setParam(ParamIDs::britishHmGain, -2.0f);
-            setParam(ParamIDs::britishHmFreq, 2500.0f);
-            setParam(ParamIDs::britishHmQ, 1.2f);
-            setParam(ParamIDs::britishHfGain, -1.0f);
-            setParam(ParamIDs::britishHfFreq, 8000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 5.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, 1.0f);
-            break;
-
-        case 8:  // Master Bus - gentle glue and sheen
-            setParam(ParamIDs::britishHpfFreq, 25.0f);
-            setParam(ParamIDs::britishHpfEnabled, 1.0f);
-            setParam(ParamIDs::britishLpfFreq, 20000.0f);
-            setParam(ParamIDs::britishLpfEnabled, 0.0f);
-            setParam(ParamIDs::britishLfGain, 1.0f);
-            setParam(ParamIDs::britishLfFreq, 60.0f);
-            setParam(ParamIDs::britishLfBell, 0.0f);
-            setParam(ParamIDs::britishLmGain, -1.0f);
-            setParam(ParamIDs::britishLmFreq, 300.0f);
-            setParam(ParamIDs::britishLmQ, 0.8f);
-            setParam(ParamIDs::britishHmGain, 0.5f);
-            setParam(ParamIDs::britishHmFreq, 3000.0f);
-            setParam(ParamIDs::britishHmQ, 0.7f);
-            setParam(ParamIDs::britishHfGain, 1.5f);
-            setParam(ParamIDs::britishHfFreq, 12000.0f);
-            setParam(ParamIDs::britishHfBell, 0.0f);
-            setParam(ParamIDs::britishSaturation, 8.0f);
-            setParam(ParamIDs::britishInputGain, 0.0f);
-            setParam(ParamIDs::britishOutputGain, 0.0f);
-            break;
-
-        default:
-            break;
-    }
-}
-
-void MultiQEditor::applyTubePreset(int presetId)
-{
-    // Validate presetId is within expected range (1-7)
-    if (presetId < 1 || presetId > 7)
-    {
-        DBG("MultiQEditor::applyTubePreset: Invalid presetId " + juce::String(presetId) + " (expected 1-7)");
-        return;
-    }
-
-    // Helper to set parameter value with defensive checks
-    auto setParam = [this](const juce::String& paramId, float value) {
-        auto* param = processor.parameters.getParameter(paramId);
-        if (param == nullptr)
-        {
-            DBG("MultiQEditor::applyTubePreset: Parameter '" + paramId + "' not found");
-            return;
-        }
-        auto range = param->getNormalisableRange();
-        float clampedValue = juce::jlimit(range.start, range.end, value);
-        param->setValueNotifyingHost(param->convertTo0to1(clampedValue));
-    };
-
-    // Tube EQ parameters: LF Boost, LF Atten, LF Freq, HF Boost, HF Freq, HF BW, HF Atten, HF Atten Freq,
-    //                       Tube Drive, Input, Output, Mid section enabled
-
-    switch (presetId)
-    {
-        case 1:  // Default - flat response
-            setParam(ParamIDs::pultecLfBoostGain, 0.0f);
-            setParam(ParamIDs::pultecLfAttenGain, 0.0f);
-            setParam(ParamIDs::pultecLfBoostFreq, 2.0f);  // 60 Hz (index 2)
-            setParam(ParamIDs::pultecHfBoostGain, 0.0f);
-            setParam(ParamIDs::pultecHfBoostFreq, 0.0f);  // 3k Hz
-            setParam(ParamIDs::pultecHfBoostBandwidth, 0.5f);
-            setParam(ParamIDs::pultecHfAttenGain, 0.0f);
-            setParam(ParamIDs::pultecHfAttenFreq, 0.0f);  // 5k Hz
-            setParam(ParamIDs::pultecTubeDrive, 0.0f);
-            setParam(ParamIDs::pultecInputGain, 0.0f);
-            setParam(ParamIDs::pultecOutputGain, 0.0f);
-            setParam(ParamIDs::pultecMidEnabled, 0.0f);
-            break;
-
-        case 2:  // Warm Vocal - boost lows, gentle air
-            setParam(ParamIDs::pultecLfBoostGain, 3.0f);
-            setParam(ParamIDs::pultecLfAttenGain, 0.0f);
-            setParam(ParamIDs::pultecLfBoostFreq, 3.0f);  // 100 Hz (index 3)
-            setParam(ParamIDs::pultecHfBoostGain, 4.0f);
-            setParam(ParamIDs::pultecHfBoostFreq, 5.0f);  // 12 kHz (index 5)
-            setParam(ParamIDs::pultecHfBoostBandwidth, 0.6f);
-            setParam(ParamIDs::pultecHfAttenGain, 2.0f);
-            setParam(ParamIDs::pultecHfAttenFreq, 1.0f);  // 10 kHz (index 1)
-            setParam(ParamIDs::pultecTubeDrive, 0.2f);
-            setParam(ParamIDs::pultecInputGain, 0.0f);
-            setParam(ParamIDs::pultecOutputGain, 0.0f);
-            setParam(ParamIDs::pultecMidEnabled, 0.0f);
-            break;
-
-        case 3:  // Vintage Bass - classic low-end trick
-            setParam(ParamIDs::pultecLfBoostGain, 6.0f);
-            setParam(ParamIDs::pultecLfAttenGain, 4.0f);  // Simultaneous boost & cut
-            setParam(ParamIDs::pultecLfBoostFreq, 2.0f);  // 60 Hz (index 2)
-            setParam(ParamIDs::pultecHfBoostGain, 0.0f);
-            setParam(ParamIDs::pultecHfBoostFreq, 0.0f);
-            setParam(ParamIDs::pultecHfBoostBandwidth, 0.5f);
-            setParam(ParamIDs::pultecHfAttenGain, 3.0f);
-            setParam(ParamIDs::pultecHfAttenFreq, 2.0f);  // 20k Hz
-            setParam(ParamIDs::pultecTubeDrive, 0.3f);
-            setParam(ParamIDs::pultecInputGain, 0.0f);
-            setParam(ParamIDs::pultecOutputGain, 0.0f);
-            setParam(ParamIDs::pultecMidEnabled, 0.0f);
-            break;
-
-        case 4:  // Silky Highs - smooth high-end boost
-            setParam(ParamIDs::pultecLfBoostGain, 0.0f);
-            setParam(ParamIDs::pultecLfAttenGain, 0.0f);
-            setParam(ParamIDs::pultecLfBoostFreq, 2.0f);  // 60 Hz (index 2)
-            setParam(ParamIDs::pultecHfBoostGain, 5.0f);
-            setParam(ParamIDs::pultecHfBoostFreq, 3.0f);  // 8 kHz (index 3)
-            setParam(ParamIDs::pultecHfBoostBandwidth, 0.7f);  // Wide bandwidth
-            setParam(ParamIDs::pultecHfAttenGain, 0.0f);
-            setParam(ParamIDs::pultecHfAttenFreq, 0.0f);
-            setParam(ParamIDs::pultecTubeDrive, 0.15f);
-            setParam(ParamIDs::pultecInputGain, 0.0f);
-            setParam(ParamIDs::pultecOutputGain, 0.0f);
-            setParam(ParamIDs::pultecMidEnabled, 0.0f);
-            break;
-
-        case 5:  // Full Mix - balanced enhancement
-            setParam(ParamIDs::pultecLfBoostGain, 3.0f);
-            setParam(ParamIDs::pultecLfAttenGain, 1.0f);
-            setParam(ParamIDs::pultecLfBoostFreq, 2.0f);  // 60 Hz (index 2)
-            setParam(ParamIDs::pultecHfBoostGain, 3.0f);
-            setParam(ParamIDs::pultecHfBoostFreq, 5.0f);  // 12 kHz (index 5)
-            setParam(ParamIDs::pultecHfBoostBandwidth, 0.5f);
-            setParam(ParamIDs::pultecHfAttenGain, 1.0f);
-            setParam(ParamIDs::pultecHfAttenFreq, 1.0f);  // 10k Hz
-            setParam(ParamIDs::pultecTubeDrive, 0.25f);
-            setParam(ParamIDs::pultecInputGain, 0.0f);
-            setParam(ParamIDs::pultecOutputGain, 0.0f);
-            setParam(ParamIDs::pultecMidEnabled, 0.0f);
-            break;
-
-        case 6:  // Subtle Warmth - gentle coloration
-            setParam(ParamIDs::pultecLfBoostGain, 1.5f);
-            setParam(ParamIDs::pultecLfAttenGain, 0.0f);
-            setParam(ParamIDs::pultecLfBoostFreq, 3.0f);  // 100 Hz (index 3)
-            setParam(ParamIDs::pultecHfBoostGain, 1.5f);
-            setParam(ParamIDs::pultecHfBoostFreq, 5.0f);  // 12 kHz (index 5)
-            setParam(ParamIDs::pultecHfBoostBandwidth, 0.5f);
-            setParam(ParamIDs::pultecHfAttenGain, 0.5f);
-            setParam(ParamIDs::pultecHfAttenFreq, 2.0f);  // 20k Hz
-            setParam(ParamIDs::pultecTubeDrive, 0.1f);
-            setParam(ParamIDs::pultecInputGain, 0.0f);
-            setParam(ParamIDs::pultecOutputGain, 0.0f);
-            setParam(ParamIDs::pultecMidEnabled, 0.0f);
-            break;
-
-        case 7:  // Mastering - subtle wide enhancement
-            setParam(ParamIDs::pultecLfBoostGain, 2.0f);
-            setParam(ParamIDs::pultecLfAttenGain, 1.0f);
-            setParam(ParamIDs::pultecLfBoostFreq, 2.0f);  // 60 Hz (index 2)
-            setParam(ParamIDs::pultecHfBoostGain, 2.0f);
-            setParam(ParamIDs::pultecHfBoostFreq, 3.0f);  // 8 kHz (index 3)
-            setParam(ParamIDs::pultecHfBoostBandwidth, 0.8f);  // Very wide
-            setParam(ParamIDs::pultecHfAttenGain, 0.5f);
-            setParam(ParamIDs::pultecHfAttenFreq, 2.0f);  // 20k Hz
-            setParam(ParamIDs::pultecTubeDrive, 0.05f);  // Subtle tube warmth
-            setParam(ParamIDs::pultecInputGain, 0.0f);
-            setParam(ParamIDs::pultecOutputGain, 0.0f);
-            setParam(ParamIDs::pultecMidEnabled, 0.0f);
-            break;
-
-        default:
-            break;
-    }
-}
 
 void MultiQEditor::setupTubeEQControls()
 {
@@ -3718,98 +3350,78 @@ void MultiQEditor::updateDynamicAttachments()
 
 // Factory Preset Methods
 
-void MultiQEditor::updatePresetSelector()
+// #105: Fill a preset combo with Init + the factory presets for the current EQ mode + user presets,
+// then select the one named by the presetName state property. Shared by the main top dropdown AND
+// the Tube/British mode-panel combo so both show the same list and stay in sync (the panel combo
+// used to be a separate quick-preset list that never synced — the reported bug).
+void MultiQEditor::populatePresetCombo(juce::ComboBox& combo)
 {
-    if (!presetSelector)
-        return;
+    combo.clear(juce::dontSendNotification);
 
-    presetSelector->clear(juce::dontSendNotification);
-
-    // Get current EQ type to filter presets
     auto* eqTypeParam = processor.parameters.getRawParameterValue(ParamIDs::eqType);
-    int currentEqType = eqTypeParam ? static_cast<int>(eqTypeParam->load()) : 0;
+    const int currentEqType = eqTypeParam ? static_cast<int>(eqTypeParam->load()) : 0;
 
-    // Always add Init (ID 1) — it's mode-agnostic
-    presetSelector->addItem("Init", 1);
+    combo.addItem("Init", 1);   // mode-agnostic (ID 1)
 
-    // Add factory presets filtered by current EQ type, grouped by category
     const auto& presets = processor.getFactoryPresets();
     juce::String lastCategory;
     for (size_t i = 0; i < presets.size(); ++i)
     {
         if (presets[i].eqType != currentEqType)
             continue;
-
-        // Add category heading when category changes
         if (presets[i].category != lastCategory)
         {
-            presetSelector->addSeparator();
-            presetSelector->addSectionHeading(presets[i].category);
+            combo.addSeparator();
+            combo.addSectionHeading(presets[i].category);
             lastCategory = presets[i].category;
         }
-
-        // ID = i + 2 (1 is Init, factory presets start at 2)
-        presetSelector->addItem(presets[i].name, static_cast<int>(i + 2));
+        combo.addItem(presets[i].name, static_cast<int>(i + 2));   // factory presets start at ID 2
     }
 
-    // Add user presets (IDs starting at 1001)
     if (userPresetManager)
     {
         auto userPresets = userPresetManager->loadUserPresets();
         if (!userPresets.empty())
         {
-            presetSelector->addSeparator();
-            presetSelector->addSectionHeading("User Presets");
-
+            combo.addSeparator();
+            combo.addSectionHeading("User Presets");
             for (size_t i = 0; i < userPresets.size(); ++i)
-            {
-                presetSelector->addItem(userPresets[i].name, static_cast<int>(1001 + i));
-            }
+                combo.addItem(userPresets[i].name, static_cast<int>(1001 + i));   // user presets at ID 1001+
         }
     }
 
-    // Restore preset selection from saved state
-    auto savedName = processor.parameters.state.getProperty("presetName", "").toString();
-    if (savedName.isNotEmpty())
+    // Select the preset named in the state (what onPresetSelected/setCurrentProgram stored).
+    const auto savedName = processor.parameters.state.getProperty("presetName", "").toString();
+    int selId = 1;   // default: Init
+    if (savedName.isNotEmpty() && savedName != "Init")
     {
         bool found = false;
-        if (savedName == "Init")
-        {
-            presetSelector->setSelectedId(1, juce::dontSendNotification);
-            found = true;
-        }
-        if (!found)
-        {
-            for (size_t i = 0; i < presets.size(); ++i)
-            {
-                if (presets[i].name == savedName)
-                {
-                    presetSelector->setSelectedId(static_cast<int>(i + 2), juce::dontSendNotification);
-                    found = true;
-                    break;
-                }
-            }
-        }
+        for (size_t i = 0; i < presets.size() && !found; ++i)
+            if (presets[i].name == savedName) { selId = static_cast<int>(i + 2); found = true; }
         if (!found && userPresetManager)
         {
-            auto userPresets2 = userPresetManager->loadUserPresets();
-            for (size_t i = 0; i < userPresets2.size(); ++i)
-            {
-                if (userPresets2[i].name == savedName)
-                {
-                    presetSelector->setSelectedId(static_cast<int>(1001 + i), juce::dontSendNotification);
-                    found = true;
-                    break;
-                }
-            }
+            auto up = userPresetManager->loadUserPresets();
+            for (size_t i = 0; i < up.size() && !found; ++i)
+                if (up[i].name == savedName) { selId = static_cast<int>(1001 + i); found = true; }
         }
-        if (!found)
-            presetSelector->setSelectedId(1, juce::dontSendNotification);
     }
-    else
-    {
-        presetSelector->setSelectedId(1, juce::dontSendNotification);
-    }
+    combo.setSelectedId(selId, juce::dontSendNotification);
+}
+
+void MultiQEditor::updatePresetSelector()
+{
+    if (presetSelector)
+        populatePresetCombo(*presetSelector);
+
+    // Mirror into the active mode's panel combo so it shows the same list + selection as the main
+    // dropdown (issue #105). Driven off the eqType param (not the mode flags) so it is correct even
+    // when called from the constructor before the flags are set.
+    auto* eqTypeParam = processor.parameters.getRawParameterValue(ParamIDs::eqType);
+    const int eqType = eqTypeParam ? static_cast<int>(eqTypeParam->load()) : 0;
+    if (eqType == static_cast<int>(EQType::British))
+        populatePresetCombo(britishPresetSelector);
+    else if (eqType == static_cast<int>(EQType::Tube))
+        populatePresetCombo(tubePresetSelector);
 }
 
 void MultiQEditor::refreshUserPresets()
@@ -3824,17 +3436,15 @@ void MultiQEditor::refreshUserPresets()
         presetSelector->setSelectedId(currentId, juce::dontSendNotification);
 }
 
-void MultiQEditor::onPresetSelected()
+void MultiQEditor::onPresetSelected(juce::ComboBox& sender)
 {
-    if (!presetSelector)
-        return;
-
     // Do not load a preset while a cross-mode transfer is in progress;
     // the transfer sets band params explicitly and must not be overwritten.
     if (processor.transferInProgress.load())
         return;
 
-    int selectedId = presetSelector->getSelectedId();
+    // #105: the main dropdown and the mode-panel combo share this handler; read whichever fired.
+    int selectedId = sender.getSelectedId();
     if (selectedId <= 0)
         return;
 
@@ -3870,6 +3480,9 @@ void MultiQEditor::onPresetSelected()
             processor.parameters.state.setProperty("presetName", presets[static_cast<size_t>(factoryIndex)].name, nullptr);
         }
     }
+
+    // Resync the OTHER combo (main <-> mode-panel) to the selection just made (#105).
+    updatePresetSelector();
 }
 
 void MultiQEditor::saveUserPreset()

--- a/plugins/multi-q/MultiQEditor.cpp
+++ b/plugins/multi-q/MultiQEditor.cpp
@@ -3483,6 +3483,11 @@ void MultiQEditor::onPresetSelected(juce::ComboBox& sender)
 
     // Resync the OTHER combo (main <-> mode-panel) to the selection just made (#105).
     updatePresetSelector();
+
+    // Notify the host so ITS preset/program dropdown reflects a plugin-side change (#105). Ardour's
+    // dropdown reads the plugin's programs (getCurrentProgram, set by setCurrentProgram/resetToInit
+    // above), so host->plugin already synced; this closes the reverse direction plugin->host.
+    processor.updateHostDisplay(juce::AudioProcessorListener::ChangeDetails{}.withProgramChanged(true));
 }
 
 void MultiQEditor::saveUserPreset()

--- a/plugins/multi-q/MultiQEditor.cpp
+++ b/plugins/multi-q/MultiQEditor.cpp
@@ -388,7 +388,11 @@ MultiQEditor::MultiQEditor(MultiQ& p)
     britishPresetSelector.addItem("Air & Presence", 6);
     britishPresetSelector.addItem("Gentle Cut", 7);
     britishPresetSelector.addItem("Master Bus", 8);
-    britishPresetSelector.setSelectedId(1);
+    // dontSendNotification: this is a UI-only quick-preset combo that doesn't track the loaded
+    // preset, so it defaults to "Default" on open. Firing onChange here would call
+    // applyBritishPreset(1) ("Default - flat") AFTER construction and wipe the British params of
+    // whatever factory/user preset is loaded (issue #105 — reset on GUI open / session reload).
+    britishPresetSelector.setSelectedId(1, juce::dontSendNotification);
     britishPresetSelector.setColour(juce::ComboBox::backgroundColourId, juce::Colour(0xff3a3a3a));
     britishPresetSelector.setColour(juce::ComboBox::textColourId, juce::Colour(0xffe0e0e0));
     britishPresetSelector.setVisible(false);
@@ -423,7 +427,10 @@ MultiQEditor::MultiQEditor(MultiQ& p)
     tubePresetSelector.addItem("Full Mix", 5);
     tubePresetSelector.addItem("Subtle Warmth", 6);
     tubePresetSelector.addItem("Mastering", 7);
-    tubePresetSelector.setSelectedId(1);
+    // dontSendNotification: see britishPresetSelector above — firing onChange here would call
+    // applyTubePreset(1) ("Default - flat") after construction and wipe the loaded preset's Tube
+    // params (issue #105 — the async onChange was the reset the diagnostic log caught).
+    tubePresetSelector.setSelectedId(1, juce::dontSendNotification);
     tubePresetSelector.setColour(juce::ComboBox::backgroundColourId, juce::Colour(0xff3a3a3a));
     tubePresetSelector.setColour(juce::ComboBox::textColourId, juce::Colour(0xffe0e0e0));
     tubePresetSelector.setVisible(false);
@@ -488,6 +495,7 @@ MultiQEditor::MultiQEditor(MultiQ& p)
         bandDetailPanel->setMatchMode(isMatchMode);
     updateEQModeVisibility();
 
+
     // Initialize resizable UI using shared helper (handles size persistence)
     // Default: 1050x700, Min: 1050x550, Max: 3840x2160 (supports up to 4K displays)
     // Minimum width 1050px prevents toolbar control overlap in Digital mode
@@ -504,6 +512,7 @@ MultiQEditor::MultiQEditor(MultiQ& p)
 
 MultiQEditor::~MultiQEditor()
 {
+
     // Save window size for next session
     resizeHelper.saveSize();
 

--- a/plugins/multi-q/MultiQEditor.cpp
+++ b/plugins/multi-q/MultiQEditor.cpp
@@ -3397,7 +3397,7 @@ void MultiQEditor::populatePresetCombo(juce::ComboBox& combo)
     {
         bool found = false;
         for (size_t i = 0; i < presets.size() && !found; ++i)
-            if (presets[i].name == savedName) { selId = static_cast<int>(i + 2); found = true; }
+            if (presets[i].eqType == currentEqType && presets[i].name == savedName) { selId = static_cast<int>(i + 2); found = true; }
         if (!found && userPresetManager)
         {
             auto up = userPresetManager->loadUserPresets();

--- a/plugins/multi-q/MultiQEditor.cpp
+++ b/plugins/multi-q/MultiQEditor.cpp
@@ -1386,6 +1386,17 @@ void MultiQEditor::timerCallback()
     if (masterParam)
         graphicDisplay->setMasterGain(masterParam->load());
 
+    // Keep the preset-name dropdown in sync with the restored state. The name lives in a state
+    // property (presetName); the editor reads it once at construction, but on a session reload the
+    // host can restore the state AFTER the editor is built, leaving the dropdown stuck on "Default"
+    // even though the params (the actual sound) are correct (issue #105 follow-up). Refresh only
+    // when the name actually changes, so this is a cheap poll.
+    const juce::String currentPresetName = processor.parameters.state.getProperty("presetName", "").toString();
+    if (currentPresetName != lastPresetName)
+    {
+        lastPresetName = currentPresetName;
+        updatePresetSelector();
+    }
 }
 
 void MultiQEditor::parameterChanged(const juce::String& parameterID, float newValue)

--- a/plugins/multi-q/MultiQEditor.h
+++ b/plugins/multi-q/MultiQEditor.h
@@ -43,6 +43,11 @@ public:
     void mouseDown(const juce::MouseEvent& e) override;
     bool keyPressed(const juce::KeyPress& key) override;
 
+    // #105 test accessors: the displayed text of the main + mode-panel preset combos (must match).
+    juce::String getMainPresetText()    const { return presetSelector ? presetSelector->getText() : juce::String(); }
+    juce::String getTubePresetText()    const { return tubePresetSelector.getText(); }
+    juce::String getBritishPresetText() const { return britishPresetSelector.getText(); }
+
 private:
     MultiQ& processor;
     MultiQLookAndFeel lookAndFeel;
@@ -112,7 +117,8 @@ private:
     // Factory preset selector (Digital mode)
     std::unique_ptr<juce::ComboBox> presetSelector;
     void updatePresetSelector();
-    void onPresetSelected();
+    void populatePresetCombo(juce::ComboBox& combo);  // #105: fill+select a preset combo (main + mode-panel mirror)
+    void onPresetSelected(juce::ComboBox& sender);    // #105: sender-aware so panel combo mirrors main
 
     // User preset system
     std::unique_ptr<UserPresetManager> userPresetManager;
@@ -378,8 +384,6 @@ private:
     void updateEQModeVisibility();
     void layoutBritishControls();
     void drawBritishKnobMarkings(juce::Graphics& g);  // Draw tick marks and value labels around knobs
-    void applyBritishPreset(int presetId);  // Apply British mode factory preset
-    void applyTubePreset(int presetId);     // Apply Tube mode factory preset
 
     // Tube EQ mode helpers
     void setupTubeEQControls();

--- a/plugins/multi-q/MultiQEditor.h
+++ b/plugins/multi-q/MultiQEditor.h
@@ -355,6 +355,7 @@ private:
     juce::Rectangle<int> outputClipBounds;
     bool lastInputClipState = false;
     bool lastOutputClipState = false;
+    juce::String lastPresetName;  // #105: timer-poll to resync the preset-name dropdown after a late state restore
     void drawClipIndicator(juce::Graphics& g, juce::Rectangle<int> bounds, bool clipped);
 
     // Supporters overlay

--- a/plugins/multi-q/tests/test_multiq_integration.cpp
+++ b/plugins/multi-q/tests/test_multiq_integration.cpp
@@ -1,5 +1,6 @@
 #include <JuceHeader.h>
 #include "../MultiQ.h"
+#include "../MultiQEditor.h"
 #include <cmath>
 #include <iostream>
 #include <iomanip>
@@ -331,6 +332,61 @@ static void testPan(MultiQ& plugin)
 }
 
 // ===== TEST: State Save/Restore Round-Trip =====
+// Issue #105 (the real bug): opening the editor must NOT reset the loaded British/Tube preset.
+// The tube/british quick-preset combos fired setSelectedId(1) with the default async
+// notification, so applyTube/BritishPreset(1) ("Default - flat") ran just after the editor was
+// built and wiped the loaded preset's params. Fix = dontSendNotification on those setSelectedId
+// calls. Needs a display (creates the real editor), so it self-skips on headless CI.
+static void testEditorPresetSurvivesOpen()
+{
+    std::cout << "\n--- Test: Editor open must not reset British/Tube preset (issue #105) ---\n";
+  #if JUCE_LINUX
+    if (juce::SystemStats::getEnvironmentVariable ("DISPLAY", juce::String()).isEmpty())
+    {
+        std::cout << "  (skipped: no DISPLAY — the editor needs X)\n";
+        return;
+    }
+  #endif
+    auto pump = []()
+    {
+        auto* mm = juce::MessageManager::getInstance();
+        mm->callAsync ([mm] { mm->stopDispatchLoop(); });
+        mm->runDispatchLoop();   // runs the queued async onChange (the old reset), then quits
+    };
+
+    auto testMode = [&pump] (int eqTypeVal, const juce::String& paramId, const juce::String& label)
+    {
+        MultiQ proc;
+        proc.setPlayConfigDetails (2, 2, 44100.0, 512);
+        proc.prepareToPlay (44100.0, 512);
+        auto val = [&proc] (const juce::String& id) { auto* p = proc.parameters.getRawParameterValue (id); return p ? p->load() : -999.0f; };
+
+        // Pick a factory preset for this mode whose tracked param is clearly non-default.
+        const auto& presets = proc.getFactoryPresets();
+        int chosen = -1; float before = 0.0f;
+        for (size_t i = 0; i < presets.size(); ++i)
+        {
+            if (presets[i].eqType != eqTypeVal) continue;
+            proc.setCurrentProgram ((int) i + 1);
+            const float v = val (paramId);
+            if (std::abs (v) > 0.01f) { chosen = (int) i; before = v; break; }
+        }
+        const juce::String n0 = label + ": found a non-default factory preset";
+        check (n0.toRawUTF8(), chosen >= 0);
+        if (chosen < 0) return;
+
+        std::unique_ptr<juce::AudioProcessorEditor> ed (proc.createEditor());
+        pump(); pump();   // let any queued async onChange fire (this was the reset)
+
+        const juce::String n1 = label + ": preset survives editor open";
+        checkDb (n1.toRawUTF8(), val (paramId), before, 0.05f);
+        if (ed) { proc.editorBeingDeleted (ed.get()); ed.reset(); }
+    };
+
+    testMode (3, ParamIDs::pultecLfBoostGain, "#105 Tube");
+    testMode (2, ParamIDs::britishLfGain,     "#105 British");
+}
+
 // Issue #105: British/Tube mode params must survive a getState/setState round-trip.
 // Reproduces the VST3 "resets to default on session open" path deterministically.
 static void testBritishTubeStateRoundTrip(MultiQ& plugin)
@@ -558,6 +614,7 @@ public:
         testPan(*plugin);
         testStateRoundTrip(*plugin);
         testBritishTubeStateRoundTrip(*plugin);
+        testEditorPresetSurvivesOpen();
         // LP+INV test skipped: FIR generation requires background thread + message loop
         // The LP+INV fix was verified manually and via pluginval automation tests
         // testINVLinearPhase(*plugin);

--- a/plugins/multi-q/tests/test_multiq_integration.cpp
+++ b/plugins/multi-q/tests/test_multiq_integration.cpp
@@ -382,7 +382,9 @@ static void testEditorPresetSurvivesOpen()
         checkDb (n1.toRawUTF8(), val (paramId), before, 0.05f);
 
         // #105 unify: the mode-panel preset combo must mirror the main dropdown (same preset shown).
-        if (auto* mqEd = dynamic_cast<MultiQEditor*> (ed.get()))
+        auto* mqEd = dynamic_cast<MultiQEditor*> (ed.get());
+        check ((label + ": editor is MultiQEditor").toRawUTF8(), mqEd != nullptr);
+        if (mqEd)
         {
             const juce::String mainTxt  = mqEd->getMainPresetText();
             const juce::String panelTxt = (eqTypeVal == 3) ? mqEd->getTubePresetText() : mqEd->getBritishPresetText();

--- a/plugins/multi-q/tests/test_multiq_integration.cpp
+++ b/plugins/multi-q/tests/test_multiq_integration.cpp
@@ -380,6 +380,15 @@ static void testEditorPresetSurvivesOpen()
 
         const juce::String n1 = label + ": preset survives editor open";
         checkDb (n1.toRawUTF8(), val (paramId), before, 0.05f);
+
+        // #105 unify: the mode-panel preset combo must mirror the main dropdown (same preset shown).
+        if (auto* mqEd = dynamic_cast<MultiQEditor*> (ed.get()))
+        {
+            const juce::String mainTxt  = mqEd->getMainPresetText();
+            const juce::String panelTxt = (eqTypeVal == 3) ? mqEd->getTubePresetText() : mqEd->getBritishPresetText();
+            const juce::String n2 = label + ": panel combo mirrors main combo";
+            check (n2.toRawUTF8(), mainTxt.isNotEmpty() && panelTxt == mainTxt);
+        }
         if (ed) { proc.editorBeingDeleted (ed.get()); ed.reset(); }
     };
 

--- a/plugins/multi-q/tests/test_multiq_integration.cpp
+++ b/plugins/multi-q/tests/test_multiq_integration.cpp
@@ -331,6 +331,77 @@ static void testPan(MultiQ& plugin)
 }
 
 // ===== TEST: State Save/Restore Round-Trip =====
+// Issue #105: British/Tube mode params must survive a getState/setState round-trip.
+// Reproduces the VST3 "resets to default on session open" path deterministically.
+static void testBritishTubeStateRoundTrip(MultiQ& plugin)
+{
+    std::cout << "\n--- Test: British/Tube State Round-Trip (issue #105) ---\n";
+
+    auto getParam = [](MultiQ& p, const juce::String& paramID) -> float {
+        auto* param = p.parameters.getParameter(paramID);
+        if (!param) return -999.0f;
+        return p.parameters.getParameterRange(paramID).convertFrom0to1(param->getValue());
+    };
+
+    auto roundTrip = [](MultiQ& src) {
+        juce::MemoryBlock st;
+        src.getStateInformation(st);
+        auto dst = std::make_unique<MultiQ>();
+        auto layouts = dst->getBusesLayout();
+        layouts.getMainInputChannelSet()  = juce::AudioChannelSet::stereo();
+        layouts.getMainOutputChannelSet() = juce::AudioChannelSet::stereo();
+        dst->setBusesLayout(layouts);
+        dst->setPlayConfigDetails(2, 2, 44100.0, 512);
+        dst->prepareToPlay(44100.0, 512);
+        dst->setStateInformation(st.getData(), static_cast<int>(st.getSize()));
+        return dst;
+    };
+
+    // --- BRITISH mode (eqType index 2) ---
+    resetPlugin(plugin);
+    setParam(plugin, ParamIDs::eqType, 2.0f);
+    setParam(plugin, ParamIDs::britishLfGain, 6.0f);
+    setParam(plugin, ParamIDs::britishHmFreq, 3000.0f);
+    setParam(plugin, ParamIDs::britishHfGain, -5.0f);
+    {
+        auto p2 = roundTrip(plugin);
+        checkDb("RT British: eqType stays British(2)", getParam(*p2, ParamIDs::eqType), 2.0f, 0.01f);
+        checkDb("RT British: LF gain survives", getParam(*p2, ParamIDs::britishLfGain), 6.0f, 0.05f);
+        checkDb("RT British: HM freq survives", getParam(*p2, ParamIDs::britishHmFreq), 3000.0f, 20.0f);
+        checkDb("RT British: HF gain survives", getParam(*p2, ParamIDs::britishHfGain), -5.0f, 0.05f);
+    }
+
+    // --- TUBE mode (eqType index 3) ---
+    resetPlugin(plugin);
+    setParam(plugin, ParamIDs::eqType, 3.0f);
+    setParam(plugin, ParamIDs::pultecTubeDrive, 0.8f);
+    {
+        auto p3 = roundTrip(plugin);
+        checkDb("RT Tube: eqType stays Tube(3)", getParam(*p3, ParamIDs::eqType), 3.0f, 0.01f);
+        checkDb("RT Tube: tube drive survives", getParam(*p3, ParamIDs::pultecTubeDrive), 0.8f, 0.02f);
+    }
+
+    // --- EXACT user path: select a British FACTORY PRESET, then round-trip ---
+    resetPlugin(plugin);
+    {
+        const auto& presets = plugin.getFactoryPresets();
+        int britIdx = -1;
+        for (size_t i = 0; i < presets.size(); ++i)
+            if (presets[i].eqType == 2) { britIdx = static_cast<int>(i); break; }
+        check("found a British factory preset", britIdx >= 0);
+        if (britIdx >= 0)
+        {
+            plugin.setCurrentProgram(britIdx + 1);   // +1: "Init" occupies slot 0
+            const float lf = getParam(plugin, ParamIDs::britishLfGain);
+            const float hm = getParam(plugin, ParamIDs::britishHmFreq);
+            auto p4 = roundTrip(plugin);
+            checkDb("RT British PRESET: eqType stays British", getParam(*p4, ParamIDs::eqType), 2.0f, 0.01f);
+            checkDb("RT British PRESET: LF gain survives", getParam(*p4, ParamIDs::britishLfGain), lf, 0.05f);
+            checkDb("RT British PRESET: HM freq survives", getParam(*p4, ParamIDs::britishHmFreq), hm, 20.0f);
+        }
+    }
+}
+
 static void testStateRoundTrip(MultiQ& plugin)
 {
     std::cout << "\n--- Test: State Save/Restore Round-Trip ---\n";
@@ -486,6 +557,7 @@ public:
         testPhaseInvert(*plugin);
         testPan(*plugin);
         testStateRoundTrip(*plugin);
+        testBritishTubeStateRoundTrip(*plugin);
         // LP+INV test skipped: FIR generation requires background thread + message loop
         // The LP+INV fix was verified manually and via pluginval automation tests
         // testINVLinearPhase(*plugin);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preset menus are now kept in sync across the main and mode-specific views.
  * Improved preset text display for the selected EQ mode.
* **Bug Fixes**
  * Fixed EQ preset/mode selections being overridden after preset loads in certain host scenarios.
  * Improved click-free EQ mode switching with smoother crossfades.
  * Enhanced preset persistence when reopening the editor or restoring a session.
* **Tests**
  * Added integration coverage for editor/preset preservation and state round-trip behavior (Issue `#105`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->