### PR TITLE
TapeMachine 2 (DPF) + shared-dpf consolidation

### DIFF
--- a/plugins/4k-eq/dpf-plugin/FourKEQAccess.hpp
+++ b/plugins/4k-eq/dpf-plugin/FourKEQAccess.hpp
@@ -3,27 +3,22 @@
 // others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
 //
 // FourKEQAccess.hpp — UI-side accessors for same-process DSP data (meters +
-// spectrum). Declared weak so the split LV2 UI (which links without the DSP)
-// resolves them to null and falls back to the output parameters; in the
-// single-binary formats (CLAP, VST3, JACK, MONOLITHIC LV2) the strong
-// definitions in FourKEQPlugin.cpp resolve everywhere.
+// spectrum). Uses the shared weak-symbol bridge; see DuskAccessBridge.hpp for
+// the single-binary-vs-split-LV2 contract and the required UI-side null guard.
+// Strong definitions live in FourKEQPlugin.cpp.
 
 #pragma once
 
+#include "DuskAccessBridge.hpp"
+
 namespace duskaudio { class SpectrumRing; }
 
-#if defined(__GNUC__) || defined(__clang__)
-  #define DUSK_WEAK __attribute__((weak))
-#else
-  #define DUSK_WEAK
-#endif
-
 // Linear peak levels (0..~2), ~300 ms release.
-DUSK_WEAK float fourKEQGetInputPeakL(void* pluginInstancePointer) noexcept;
-DUSK_WEAK float fourKEQGetInputPeakR(void* pluginInstancePointer) noexcept;
-DUSK_WEAK float fourKEQGetOutputPeakL(void* pluginInstancePointer) noexcept;
-DUSK_WEAK float fourKEQGetOutputPeakR(void* pluginInstancePointer) noexcept;
+DUSK_ACCESS_DECL(float, fourKEQGetInputPeakL);
+DUSK_ACCESS_DECL(float, fourKEQGetInputPeakR);
+DUSK_ACCESS_DECL(float, fourKEQGetOutputPeakL);
+DUSK_ACCESS_DECL(float, fourKEQGetOutputPeakR);
 
 // Pointers to the DSP's lock-free spectrum rings (null when out-of-process).
-DUSK_WEAK const duskaudio::SpectrumRing* fourKEQGetPreSpectrum(void* pluginInstancePointer) noexcept;
-DUSK_WEAK const duskaudio::SpectrumRing* fourKEQGetPostSpectrum(void* pluginInstancePointer) noexcept;
+DUSK_ACCESS_DECL(const duskaudio::SpectrumRing*, fourKEQGetPreSpectrum);
+DUSK_ACCESS_DECL(const duskaudio::SpectrumRing*, fourKEQGetPostSpectrum);

--- a/plugins/TapeMachine/core/PORT_NOTES.md
+++ b/plugins/TapeMachine/core/PORT_NOTES.md
@@ -1,0 +1,230 @@
+# TapeMachine DSP Port Notes
+
+Framework-free (no-JUCE) port of the TapeMachine tape-emulation core for the DPF
+build. Source of truth:
+
+- `Source/ImprovedTapeEmulation.h` / `.cpp` — the DSP classes.
+- `Source/PluginProcessor.cpp` — `prepareToPlay`, `processBlock`, `updateFilters`,
+  and the `get*Characteristics` / `getJAParams` tables (the driving logic).
+
+Every formula, constant, coefficient and per-sample stage order is preserved.
+This document lists every substitution, judgment call and deviation.
+
+---
+
+## 1. Mechanical substitutions
+
+| JUCE | Port |
+|------|------|
+| `#include <JuceHeader.h>` | `<array> <atomic> <cmath> <cstdint> <random> <vector> <algorithm>` + shared dsp headers |
+| `juce::MathConstants<double>::pi` | `constexpr double kPiD = 3.14159265358979323846` |
+| `juce::MathConstants<float>::pi`  | `constexpr float  kPiF = 3.14159265358979323846f` |
+| `juce::Decibels::decibelsToGain(db)` | `dbToGain(db)` / `dbToGainD(db)` — `db > -100 ? pow(10, db*0.05) : 0` (JUCE default −100 dB floor) |
+| `juce::jlimit(lo,hi,v)` | `std::clamp(v,lo,hi)` |
+| `juce::SmoothedValue<float,Linear>` | `duskaudio::SmoothedValue` (exponential one-pole) |
+| `juce::dsp::StateVariableTPTFilter<float>` | `duskaudio::DuskSVF` |
+| `juce::dsp::Oversampling<float>` | `duskaudio::Oversampler` |
+| `juce::dsp::Gain<float>` | `duskaudio::SmoothedValue` scalar multiply |
+| `juce::ScopedNoDenormals` | `duskaudio::ScopedFlushDenormals` |
+| `juce::AudioBuffer` / `AudioBlock` / `ProcessContextReplacing` | plain `float* const*` loops |
+
+The custom DSP classes (`ChebyshevAntiAliasingFilter`, `SoftLimiter`,
+`SaturationSplitFilter`, `ThreeBandSplitter`, `JilesAthertonHysteresis`,
+`TapeEQFilter`, `PhaseSmearingFilter`, `ImprovedNoiseGenerator`,
+`WowFlutterProcessor`, `TransformerSaturation`, `PlaybackHeadResponse`,
+`MotorFlutter`) are ported **verbatim** — only the `juce::` constant/util
+references above were changed. All numeric tables (`getMachine/Tape/Speed
+Characteristics`, `getJAParams`, per-band drive ratios, `computeDrive`,
+`softClip`, the J-A / Langevin / Padé constants, NAB/CCIR/AES time constants,
+Paul-Kellett pink coefficients, etc.) are copied exactly.
+
+---
+
+## 2. Filter designer mapping (JUCE IIR → shared designer)
+
+The JUCE `updateFilters()` / `prepare()` build coefficients with
+`juce::dsp::IIR::Coefficients::make*`. `makeHighShelf` / `makePeakFilter` take a
+**linear** gain; the source always passes `decibelsToGain(X)`, so the equivalent
+dB argument to the shared/`DBiquad` designers is simply **X** (because
+`A = sqrt(gainLinear) = sqrt(10^(X/20)) = 10^(X/40)`, which is exactly what
+`Biquad::peak/shelf` compute from `gainDb`).
+
+| Source filter | Source call (file:line) | Port |
+|---------------|-------------------------|------|
+| headBump | `ImprovedTapeEmulation.cpp:341,712` `makePeakFilter(fs,f,Q, dbToGain(gainDb))` | `DBiquad::peak(fs,f,gainDb,Q)` |
+| hfLoss1 | `:347,722` `makeLowPass(fs,f,0.707)` | `DBiquad::lowPass(fs,f,0.707)` |
+| hfLoss2 | `:352,726` `makeHighShelf(fs,f,0.5, dbToGain(-2*hfLoss))` | `DBiquad::shelf(fs,f,-2*hfLoss,0.5,true)` |
+| gapLoss | `:358,735` `makeHighShelf(fs,f,0.707, dbToGain(gapLossAmount))` | `DBiquad::shelf(fs,f,gapLossAmount,0.707,true)` |
+| dcBlocker | `:370` `makeHighPass(fs,25,0.707)` | `DBiquad::highPass(fs,25,0.707)` |
+| biasFilter | `:364,744` `makeHighShelf(fs,f,0.707, dbToGain(biasAmount*3))` | `Biquad::shelf(fs,f,biasAmount*3,0.707,true)` |
+| recordHead1 | `:377` `makeLowPass(fs,fc,1.3066)` | `Biquad::lowPass(fs,fc,1.3066)` |
+| recordHead2 | `:379` `makeLowPass(fs,fc,0.5412)` | `Biquad::lowPass(fs,fc,0.5412)` |
+| tone highpass (SVF) | `PluginProcessor.cpp:530` `StateVariableTPTFilter highpass, res 0.707` | `DuskSVF` highpass, Q 0.707 |
+| tone lowpass (SVF) | `PluginProcessor.cpp:544` `StateVariableTPTFilter lowpass, res 0.707` | `DuskSVF` lowpass, Q 0.707 |
+
+### 2a. Double-precision filters → `DBiquad`
+
+`headBump`, `hfLoss1`, `hfLoss2`, `gapLoss`, `dcBlocker` are
+`juce::dsp::IIR::Filter<double>` in the source ("double for low-freq
+precision"), processed as `static_cast<double>(signal)`. The shared
+`duskaudio::Biquad` is **float only**, so I added a small header-only
+**`DBiquad`** (double TDF-II) that copies the *same* designer formulas the
+shared `Biquad` uses (which the shared header states match `juce::dsp::IIR`).
+This preserves the double precision that keeps the ~48 Hz high-Q head bump
+stable at 4x rates. `biasFilter`, `recordHead1/2` are `IIR::Filter<float>` in
+the source and map to the shared float `Biquad` directly.
+
+**Sub-ULP note:** the source computes the shelf/peak linear gain in *float*
+(`decibelsToGain`) then widens to double; `DBiquad` computes `A` in double from
+`gainDb`. These agree to within ~1 ULP — within A/B tolerance.
+
+---
+
+## 3. Deviations & judgment calls
+
+### 3.1 Oversampling filter differs (biggest A/B caveat)
+The source uses `juce::dsp::Oversampling` with **`filterHalfBandFIREquiripple`**;
+the port uses the shared **`Oversampler`** (polyphase-halfband, different taps).
+At 2x/4x the oversampled waveform therefore differs slightly, so the tape sees
+different intersample values and the null will **not** be exact at 2x/4x.
+**At 1x (factor 1) the `Oversampler` is a transparent passthrough**, so 1x is the
+closest match and the recommended setting for null testing.
+
+### 3.2 Inter-channel crosstalk moved to base rate
+Source applies crosstalk at the **oversampled** rate *between the tape core and
+the lowpass* (`PluginProcessor.cpp:1054`). The functor form processes channels
+independently, so — per the task's explicit allowance — crosstalk is applied at
+**base rate after** the per-channel oversampled chain (post LP + output gain).
+Bleed is −46 dB (Swiss800, 0.005) / −36 dB (Classic102, 0.015); the placement
+shift is inaudible and within A/B tolerance.
+
+### 3.3 `SmoothedValue` is exponential, not linear
+JUCE param smoothing is linear ramps; the shared `SmoothedValue` is an
+exponential one-pole. Tau chosen to settle in a similar time:
+
+| Smoother | JUCE ramp | Port tau | Notes |
+|----------|-----------|----------|-------|
+| input gain | 20 ms (dsp::Gain) | `kGainTau=0.0067` (~20 ms) | base-rate ramp |
+| output gain | 20 ms (dsp::Gain) | `kGainTau=0.0067` | OS-rate ramp |
+| saturation | 150 ms | `kSatTau=0.05` (~150 ms) | base-rate config, OS-rate stepped |
+| wow / flutter / noise | 20 ms | `kParamTau=0.0067` | base-rate config, OS-rate stepped |
+
+Steady-state values are exact; only ramp **shape** during automation moves
+differs. The param smoothers are configured at the **base** rate but advanced at
+the **oversampled** rate — this mirrors the JUCE structure
+(`smoothedSaturation.reset(baseRate)` advanced inside the OS-rate loop), so the
+number of steps-to-settle matches.
+
+### 3.4 Input-gain ramp time dilation not reproduced
+In the source, the input-gain `dsp::Gain` is *prepared* at the oversampled rate
+but *processed* at the base rate, so its 20 ms ramp dilates to ~20 ms × factor of
+real time. The port ramps input gain in ~20 ms regardless of factor. Ramp timing
+only; steady-state identical.
+
+### 3.5 Deterministic RNG (fixed seeds)
+Source seeds every generator with `std::random_device` (non-deterministic). The
+port seeds each `std::mt19937` with a distinct constant so renders are
+reproducible and channels stay decorrelated:
+
+| Generator | Seed |
+|-----------|------|
+| shared wow/flutter | 1 |
+| L noise / wow-flutter / motor | 1001 / 1002 / 1003 |
+| R noise / wow-flutter / motor | 2001 / 2002 / 2003 |
+
+Noise character (pink filter, scrape bandpass, modulation math) is unchanged.
+**Exact-off preserved:** when noise is gated off (`amount ≤ 0.05 %`) or
+wow/flutter is 0, the generators are never advanced and nothing is injected — the
+signal stays bit-clean, matching the source.
+
+### 3.6 `setSaturation()` is a no-op (dead param mirror)
+The `"saturation"` parameter (default 4 %) is **dead code** in the JUCE processor:
+it is never cached (`saturationParam` does not exist) and never read. Tape drive
+is derived entirely from **input gain**:
+`saturation% = clamp(((inputGainDb+12)/24)*100, 0, 100)`
+(`PluginProcessor.cpp:726`). `TapeMachineDSP::setSaturation()` stores the value
+but it does not affect the DSP — faithful to the source. Drive comes from
+`setInputGainDb()`.
+
+### 3.7 `setNoiseEnabled()` is a no-op (dead gate mirror)
+The `"noiseEnabled"` param is likewise dead in the source; the effective gate is
+`noiseAmountParam > 0.05` (`PluginProcessor.cpp:735`). The port mirrors this:
+`noiseEnabled = (noiseAmountPct > 0.05f)`; `setNoiseEnabled()` stores the bool but
+does not gate. (If the shell needs a real kill-switch, revisit here — but as
+written this guarantees the A/B match.)
+
+### 3.8 `TapeSaturator` not wired in (dead code)
+`ImprovedTapeEmulation::TapeSaturator::process()` is never called in the signal
+chain. It is **not** wired in (per instruction). The struct and its
+`updateCoefficients()` calls are kept only so `prepare()`/`updateFilters()` stay
+structurally faithful; they have no audible effect.
+
+### 3.9 VU meter = output peak with ~300 ms release
+The DPF contract asks for "linear peak, ~300 ms release". The source instead kept
+**300 ms RMS** on *separate* input and output meters. The port exposes the single
+`getVuL/R()` as an **output** peak follower with a 300 ms release coefficient
+(`exp(-1/(0.3*baseRate))`). Meter-only (cosmetic); does not affect audio, so it
+does not impact the A/B null.
+
+### 3.10 Oversampling-switch: no crossfade; forced coeff refresh
+- The source crossfades (S-curve) over 512 samples when the oversampling factor
+  changes to mask the filter-state reset. The port **omits** the crossfade
+  (transition-masking only; steady-state identical). A small click is possible on
+  a live OS switch — the DPF shell may add a crossfade if desired.
+- The source re-`prepare()`s the tape on OS change but leaves `m_last*` stale, so
+  the machine-specific coefficients are **not** re-applied until a machine param
+  changes (latent staleness → neutral head-bump/HF curves after an OS switch). The
+  port **forces** a full `updateFilters()` after any (re)prepare (invalidates
+  `m_last*`), so the correct machine coeffs are always applied at the new rate.
+  This only affects the OS-switch transient (A/B is presumably at a fixed OS
+  setting) and is strictly more correct.
+
+### 3.11 RT-safe OS-factor change (no reallocation)
+`setOversampling()` only stores an atomic; the reconfigure happens in
+`processBlock` via `applyFactor()`. To keep it allocation-free on the audio
+thread, the wow/flutter delay buffers are **pre-sized for the max factor (4x)**
+in `prepare()` (`WowFlutterProcessor::prepare(rate, factor, maxSampleRate)` sizes
+from `maxSampleRate`), so factor changes only re-zero (bounded `std::fill`) and
+recompute coefficients — never realloc. `baseDelay = 20*factor ≤ 80` always fits.
+
+### 3.12 Dropped `validateCoefficients()` NaN-guard
+The source guards each JUCE coeff assignment with a finite-check
+(`validateCoefficients`), keeping the previous coeffs if a designer returns NaN.
+All designer inputs are clamped to safe ranges (freqs to `nyquist*0.9`, Q/gain
+via `jlimit`), so the designers always yield finite coeffs; the guard is dropped.
+
+### 3.13 Tape-core metering atomics dropped
+`ImprovedTapeEmulation`'s `inputLevel/outputLevel/gainReduction` atomics are
+written per sample but never read by the shell (the shell computes its own RMS).
+They are dropped (no audio effect). The audio-affecting input/output denormal
+flushes (`|x| < 1e-8 → 0`) are **kept** verbatim.
+
+---
+
+## 4. Signal chain (preserved order)
+
+Base rate: **input gain** → *(upsample)* → per oversampled sample: **HP SVF →
+tape core → LP SVF (if `lpFreq < 19 kHz`) → output gain** → *(downsample)* →
+**crosstalk (base rate)** → VU. HP is always active (source sets
+`bypassHighpass = false` unconditionally).
+
+Tape core per-sample order (unchanged from `ImprovedTapeEmulation::processSample`):
+Thru early-out → input denormal → param-change `updateFilters` → calibration gain
+→ input transformer (Type B) → pre-emphasis EQ → **[tape: bias filter → soft
+limiter → record-head LP (OS>1) → 3-band J-A hysteresis → soft clip → gap-loss →
+wow/flutter → head bump → HF loss ×2 (+extra for Sync) → playback head]** →
+de-emphasis EQ → phase smear → output transformer (Type B) → noise (tape only) →
+DC blocker → anti-alias (OS>1) → output denormal.
+
+Shared wow/flutter modulation is computed **once per oversampled sample**
+(precomputed into `sharedModArr`) and consumed by both channels' own delay lines
+— preserving the stereo-coherent structure.
+
+---
+
+## 5. Verification
+`g++ -std=c++17 -fsyntax-only -I plugins/TapeMachine/core -I plugins/shared-dpf/dsp
+plugins/TapeMachine/core/TapeMachineDSP.cpp` — clean (also clean under
+`-O2 -Wall -Wextra`).
+
+No `// PORT-TODO` markers remain.

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -90,9 +90,11 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     // VU: linear peak with ~300 ms release (per the DPF contract; JUCE used a
     // 300 ms RMS on separate in/out meters — see PORT_NOTES).
     vuReleaseCoeff = std::exp (-1.0f / (0.3f * static_cast<float> (baseSampleRate)));
-    vuStateL = vuStateR = 0.0f;
+    vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     vuL.store (0.0f, std::memory_order_relaxed);
     vuR.store (0.0f, std::memory_order_relaxed);
+    inVuL.store (0.0f, std::memory_order_relaxed);
+    inVuR.store (0.0f, std::memory_order_relaxed);
 }
 
 //==============================================================================
@@ -112,9 +114,11 @@ void TapeMachineDSP::reset()
     sharedWowFlutter.randomUpdateCounter = 0;
 
     hpL.reset(); hpR.reset(); lpL.reset(); lpR.reset();
-    vuStateL = vuStateR = 0.0f;
+    vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     vuL.store (0.0f, std::memory_order_relaxed);
     vuR.store (0.0f, std::memory_order_relaxed);
+    inVuL.store (0.0f, std::memory_order_relaxed);
+    inVuR.store (0.0f, std::memory_order_relaxed);
 }
 
 //==============================================================================
@@ -173,6 +177,20 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             if (inputs[ch] != outputs[ch])
                 for (int n = 0; n < nSamples; ++n) outputs[ch][n] = inputs[ch][n];
         return;
+    }
+
+    // --- input VU (pre-processing peak, ~300 ms release; UI In/Out switch) ----
+    {
+        float sL = inVuStateL, sR = inVuStateR;
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float aL = std::abs (inputs[0][n]);
+            sL = aL > sL ? aL : sL * vuReleaseCoeff;
+            if (nCh >= 2) { const float aR = std::abs (inputs[1][n]); sR = aR > sR ? aR : sR * vuReleaseCoeff; }
+        }
+        inVuStateL = sL; inVuStateR = (nCh >= 2) ? sR : sL;
+        inVuL.store (inVuStateL, std::memory_order_relaxed);
+        inVuR.store (inVuStateR, std::memory_order_relaxed);
     }
 
     const auto signalPath = static_cast<TapeCore::SignalPath> (clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3));

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -179,19 +179,9 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         return;
     }
 
-    // --- input VU (pre-processing peak, ~300 ms release; UI In/Out switch) ----
-    {
-        float sL = inVuStateL, sR = inVuStateR;
-        for (int n = 0; n < nSamples; ++n)
-        {
-            const float aL = std::abs (inputs[0][n]);
-            sL = aL > sL ? aL : sL * vuReleaseCoeff;
-            if (nCh >= 2) { const float aR = std::abs (inputs[1][n]); sR = aR > sR ? aR : sR * vuReleaseCoeff; }
-        }
-        inVuStateL = sL; inVuStateR = (nCh >= 2) ? sR : sL;
-        inVuL.store (inVuStateL, std::memory_order_relaxed);
-        inVuR.store (inVuStateR, std::memory_order_relaxed);
-    }
+    // Input VU is metered POST-input-trim / PRE-saturation, inside the processing
+    // loops below (see item B): it reflects record/tape-drive level, not the raw
+    // incoming signal. Same 0 VU reference + ~300 ms release as the output VU.
 
     const auto signalPath = static_cast<TapeCore::SignalPath> (clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3));
 
@@ -212,6 +202,9 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         vuStateL = sL; vuStateR = (nCh >= 2) ? sR : sL;
         vuL.store (vuStateL, std::memory_order_relaxed);
         vuR.store (vuStateR, std::memory_order_relaxed);
+        inVuStateL = vuStateL; inVuStateR = vuStateR;   // Thru: input == output
+        inVuL.store (inVuStateL, std::memory_order_relaxed);
+        inVuR.store (inVuStateR, std::memory_order_relaxed);
         return;
     }
 
@@ -333,11 +326,13 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // --- per-channel oversampled processing ----------------------------------
     // Functor chain (at the oversampled rate): HP SVF -> tape core -> LP SVF ->
     // output gain. Input gain is applied at base rate before upsampling.
+    float inSL = inVuStateL, inSR = inVuStateR;   // input VU: peak of the post-trim record level
     {
         int osIdx = 0;
         for (int n = 0; n < nSamples; ++n)
         {
             const float x = inputs[0][n] * inGainArr[static_cast<size_t> (n)];
+            const float axL = std::abs (x); inSL = axL > inSL ? axL : inSL * vuReleaseCoeff;
             outputs[0][n] = osL.processSample (x, [&] (float s) noexcept
             {
                 const size_t si = static_cast<size_t> (osIdx);
@@ -359,6 +354,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         for (int n = 0; n < nSamples; ++n)
         {
             const float x = inputs[1][n] * inGainArr[static_cast<size_t> (n)];
+            const float axR = std::abs (x); inSR = axR > inSR ? axR : inSR * vuReleaseCoeff;
             outputs[1][n] = osR.processSample (x, [&] (float s) noexcept
             {
                 const size_t si = static_cast<size_t> (osIdx);
@@ -373,6 +369,11 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             });
         }
     }
+
+    // input VU store (post-trim / pre-sat record level)
+    inVuStateL = inSL; inVuStateR = (nCh >= 2) ? inSR : inSL;
+    inVuL.store (inVuStateL, std::memory_order_relaxed);
+    inVuR.store (inVuStateR, std::memory_order_relaxed);
 
     // --- crosstalk (base rate — deviation from JUCE's OS-rate placement) ------
     if (nCh >= 2)

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -1,0 +1,386 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// TapeMachineDSP.cpp — orchestration layer (port of PluginProcessor.cpp's
+// prepareToPlay / processBlock / updateFilters). See TapeMachineDSP.hpp and
+// core/PORT_NOTES.md.
+
+#include "TapeMachineDSP.hpp"
+
+namespace duskaudio
+{
+
+//==============================================================================
+// Tunable smoothing time-constants (exponential one-pole SmoothedValue replaces
+// juce::SmoothedValue<Linear>). Chosen to settle in a similar time to the JUCE
+// linear ramps (~3*tau ≈ ramp length). See PORT_NOTES for the shape change.
+//==============================================================================
+static constexpr float kGainTau  = 0.0067f; // ~20 ms settle (juce::dsp::Gain 20 ms ramp)
+static constexpr float kSatTau   = 0.05f;   // ~150 ms settle (smoothedSaturation 150 ms)
+static constexpr float kParamTau = 0.0067f; // ~20 ms settle (wow / flutter / noise 20 ms)
+
+//==============================================================================
+void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
+{
+    if (sampleRate <= 0.0) sampleRate = 44100.0;
+    if (maxBlockSize <= 0) maxBlockSize = 512;
+
+    baseSampleRate = sampleRate;
+    maxBlock       = maxBlockSize;
+    maxOsRate      = baseSampleRate * 4.0;
+
+    currentFactor = factorFromChoice (pOversampling.load (std::memory_order_relaxed));
+    currentOsRate = baseSampleRate * static_cast<double> (currentFactor);
+    lastFactor    = currentFactor;
+
+    // Deterministic RNG streams: distinct constant seeds per channel (PORT_NOTES).
+    coreL.setSeeds (1000u);
+    coreR.setSeeds (2000u);
+    sharedWowFlutter.setSeed (1u);
+
+    osL.setFactor (currentFactor);
+    osR.setFactor (currentFactor);
+    osL.reset();
+    osR.reset();
+
+    coreL.prepare (currentOsRate, currentFactor, maxOsRate);
+    coreR.prepare (currentOsRate, currentFactor, maxOsRate);
+    sharedWowFlutter.prepare (currentOsRate, currentFactor, maxOsRate);
+
+    const float hpFreq = pHighpassHz.load (std::memory_order_relaxed);
+    const float lpFreq = pLowpassHz.load (std::memory_order_relaxed);
+    hpL.prepare (currentOsRate, hpFreq, 0.707f); hpL.setType (DuskSVF::Type::highpass); hpL.reset();
+    hpR.prepare (currentOsRate, hpFreq, 0.707f); hpR.setType (DuskSVF::Type::highpass); hpR.reset();
+    lpL.prepare (currentOsRate, lpFreq, 0.707f); lpL.setType (DuskSVF::Type::lowpass);  lpL.reset();
+    lpR.prepare (currentOsRate, lpFreq, 0.707f); lpR.setType (DuskSVF::Type::lowpass);  lpR.reset();
+    bypassLowpass = (lpFreq >= 19000.0f);
+    lastHpFreq = hpFreq;
+    lastLpFreq = lpFreq;
+
+    // Smoothers: param smoothers configured at BASE rate but advanced at the
+    // oversampled rate (matches the JUCE structure — see PORT_NOTES). Output gain
+    // is advanced at the oversampled rate so it is configured there.
+    inGain.prepare  (baseSampleRate, kGainTau);
+    outGain.prepare (currentOsRate,  kGainTau);
+    smSat.prepare     (baseSampleRate, kSatTau);
+    smWow.prepare     (baseSampleRate, kParamTau);
+    smFlutter.prepare (baseSampleRate, kParamTau);
+    smNoise.prepare   (baseSampleRate, kParamTau);
+
+    // Initial (snap) values matching PluginProcessor::prepareToPlay.
+    const float inGainDb = pInputGainDb.load (std::memory_order_relaxed);
+    inGain.snap  (dbToGain (inGainDb));
+    outGain.snap (pAutoComp.load (std::memory_order_relaxed)
+                      ? dbToGain (-inGainDb + 3.08f)             // comp at inGainDb==0
+                      : dbToGain (pOutputGainDb.load (std::memory_order_relaxed)));
+    const float initSat = std::clamp (((inGainDb + 12.0f) / 24.0f) * 100.0f, 0.0f, 100.0f);
+    smSat.snap     (initSat);
+    smWow.snap     (pWow.load (std::memory_order_relaxed));
+    smFlutter.snap (pFlutter.load (std::memory_order_relaxed));
+    smNoise.snap   (pNoiseAmount.load (std::memory_order_relaxed) * 0.01f);
+
+    // Scratch buffers (allocated here; never on the audio thread).
+    inGainArr.assign  (static_cast<size_t> (maxBlock), 0.0f);
+    const size_t osCap = static_cast<size_t> (maxBlock) * 4u;
+    satArr.assign       (osCap, 0.0f);
+    wowFlutArr.assign   (osCap, 0.0f);
+    noiseArr.assign     (osCap, 0.0f);
+    sharedModArr.assign (osCap, 0.0f);
+    outGainArr.assign   (osCap, 0.0f);
+
+    // VU: linear peak with ~300 ms release (per the DPF contract; JUCE used a
+    // 300 ms RMS on separate in/out meters — see PORT_NOTES).
+    vuReleaseCoeff = std::exp (-1.0f / (0.3f * static_cast<float> (baseSampleRate)));
+    vuStateL = vuStateR = 0.0f;
+    vuL.store (0.0f, std::memory_order_relaxed);
+    vuR.store (0.0f, std::memory_order_relaxed);
+}
+
+//==============================================================================
+void TapeMachineDSP::reset()
+{
+    osL.reset(); osR.reset();
+    coreL.reset(); coreR.reset();
+    // sharedWowFlutter has no dedicated reset(); re-zero its consumed state.
+    if (! sharedWowFlutter.delayBuffer.empty())
+        std::fill (sharedWowFlutter.delayBuffer.begin(), sharedWowFlutter.delayBuffer.end(), 0.0f);
+    sharedWowFlutter.writeIndex = 0;
+    sharedWowFlutter.allpassState = 0.0f;
+    sharedWowFlutter.wowPhase = 0.0;
+    sharedWowFlutter.flutterPhase = 0.0;
+    sharedWowFlutter.randomCurrent = 0.0f;
+    sharedWowFlutter.randomTarget = 0.0f;
+    sharedWowFlutter.randomUpdateCounter = 0;
+
+    hpL.reset(); hpR.reset(); lpL.reset(); lpR.reset();
+    vuStateL = vuStateR = 0.0f;
+    vuL.store (0.0f, std::memory_order_relaxed);
+    vuR.store (0.0f, std::memory_order_relaxed);
+}
+
+//==============================================================================
+int TapeMachineDSP::latencySamples() const noexcept
+{
+    // Oversampler::latency() is in base-rate samples for the active factor.
+    return static_cast<int> (std::lround (osL.latency()));
+}
+
+//==============================================================================
+void TapeMachineDSP::applyFactor (int newFactor)
+{
+    currentFactor = newFactor;
+    currentOsRate = baseSampleRate * static_cast<double> (newFactor);
+
+    osL.setFactor (newFactor); osR.setFactor (newFactor);
+    osL.reset();               osR.reset();
+
+    // No reallocation: wow/flutter buffers are pre-sized for the max factor.
+    coreL.prepare (currentOsRate, newFactor, maxOsRate);
+    coreR.prepare (currentOsRate, newFactor, maxOsRate);
+    sharedWowFlutter.prepare (currentOsRate, newFactor, maxOsRate);
+
+    const float hpFreq = pHighpassHz.load (std::memory_order_relaxed);
+    const float lpFreq = pLowpassHz.load (std::memory_order_relaxed);
+    hpL.prepare (currentOsRate, hpFreq, 0.707f); hpL.setType (DuskSVF::Type::highpass);
+    hpR.prepare (currentOsRate, hpFreq, 0.707f); hpR.setType (DuskSVF::Type::highpass);
+    lpL.prepare (currentOsRate, lpFreq, 0.707f); lpL.setType (DuskSVF::Type::lowpass);
+    lpR.prepare (currentOsRate, lpFreq, 0.707f); lpR.setType (DuskSVF::Type::lowpass);
+
+    outGain.prepare (currentOsRate, kGainTau);   // re-config OS-rate ramp coeff
+
+    lastHpFreq = -1.0f;   // force SVF cutoff refresh below
+    lastLpFreq = -1.0f;
+    lastFactor = newFactor;
+}
+
+//==============================================================================
+void TapeMachineDSP::processBlock (const float* const* inputs, float* const* outputs,
+                                   int nCh, int nSamples) noexcept
+{
+    ScopedFlushDenormals denormalGuard;
+
+    if (nSamples <= 0) return;
+    nCh = clampI (nCh, 1, 2);
+
+    // --- oversampling factor change (RT-safe reconfigure, no allocation) ------
+    const int reqFactor = factorFromChoice (pOversampling.load (std::memory_order_relaxed));
+    if (reqFactor != currentFactor)
+        applyFactor (reqFactor);
+
+    // --- bypass: pure passthrough (matches JUCE early return, no meter update)-
+    if (pBypass.load (std::memory_order_relaxed))
+    {
+        for (int ch = 0; ch < nCh; ++ch)
+            if (inputs[ch] != outputs[ch])
+                for (int n = 0; n < nSamples; ++n) outputs[ch][n] = inputs[ch][n];
+        return;
+    }
+
+    const auto signalPath = static_cast<TapeCore::SignalPath> (clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3));
+
+    // --- Thru: passthrough + VU (input == output) ----------------------------
+    if (signalPath == TapeCore::Thru)
+    {
+        for (int ch = 0; ch < nCh; ++ch)
+            if (inputs[ch] != outputs[ch])
+                for (int n = 0; n < nSamples; ++n) outputs[ch][n] = inputs[ch][n];
+
+        float sL = vuStateL, sR = vuStateR;
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float aL = std::abs (inputs[0][n]);
+            sL = aL > sL ? aL : sL * vuReleaseCoeff;
+            if (nCh >= 2) { const float aR = std::abs (inputs[1][n]); sR = aR > sR ? aR : sR * vuReleaseCoeff; }
+        }
+        vuStateL = sL; vuStateR = (nCh >= 2) ? sR : sL;
+        vuL.store (vuStateL, std::memory_order_relaxed);
+        vuR.store (vuStateR, std::memory_order_relaxed);
+        return;
+    }
+
+    // --- tone SVF coefficient refresh (dirty) --------------------------------
+    const float hpFreq = pHighpassHz.load (std::memory_order_relaxed);
+    const float lpFreq = pLowpassHz.load (std::memory_order_relaxed);
+    bypassLowpass = (lpFreq >= 19000.0f);
+    if (std::abs (hpFreq - lastHpFreq) > 0.01f || std::abs (lpFreq - lastLpFreq) > 0.01f)
+    {
+        hpL.setType (DuskSVF::Type::highpass); hpL.setCutoff (hpFreq); hpL.setResonance (0.707f);
+        hpR.setType (DuskSVF::Type::highpass); hpR.setCutoff (hpFreq); hpR.setResonance (0.707f);
+        lpL.setType (DuskSVF::Type::lowpass);  lpL.setCutoff (lpFreq); lpL.setResonance (0.707f);
+        lpR.setType (DuskSVF::Type::lowpass);  lpR.setCutoff (lpFreq); lpR.setResonance (0.707f);
+        lastHpFreq = hpFreq;
+        lastLpFreq = lpFreq;
+    }
+
+    // --- block-constant parameter reads --------------------------------------
+    const auto machine = static_cast<TapeCore::TapeMachine> (clampI (pMachine.load (std::memory_order_relaxed), 0, 1));
+    const auto speed   = static_cast<TapeCore::TapeSpeed>   (clampI (pSpeed.load (std::memory_order_relaxed), 0, 2));
+    const auto type    = static_cast<TapeCore::TapeType>    (clampI (pType.load (std::memory_order_relaxed), 0, 3));
+    const auto eq      = static_cast<TapeCore::EQStandard>  (clampI (pEqStandard.load (std::memory_order_relaxed), 0, 2));
+
+    const float inputGainDb = pInputGainDb.load (std::memory_order_relaxed);
+    const float targetInputGain = dbToGain (inputGainDb);
+
+    float targetOutputGain;
+    if (pAutoComp.load (std::memory_order_relaxed))
+    {
+        float compressionCompensation;
+        if (inputGainDb <= 0.0f)
+            compressionCompensation = 0.0066667f * inputGainDb * inputGainDb
+                                    + 0.346667f  * inputGainDb + 3.08f;
+        else
+            compressionCompensation = 0.0498611f * inputGainDb * inputGainDb
+                                    + 0.0925f    * inputGainDb + 3.08f;
+        targetOutputGain = dbToGain (-inputGainDb + compressionCompensation);
+    }
+    else
+    {
+        targetOutputGain = dbToGain (pOutputGainDb.load (std::memory_order_relaxed));
+    }
+
+    inGain.setTarget (targetInputGain);
+    outGain.setTarget (targetOutputGain);
+
+    const float saturationAmount = std::clamp (((inputGainDb + 12.0f) / 24.0f) * 100.0f, 0.0f, 100.0f);
+    smSat.setTarget     (saturationAmount);
+    smWow.setTarget     (pWow.load (std::memory_order_relaxed));
+    smFlutter.setTarget (pFlutter.load (std::memory_order_relaxed));
+    smNoise.setTarget   (pNoiseAmount.load (std::memory_order_relaxed) * 0.01f);
+
+    // JUCE derives the noise gate from the amount knob (>0.05 %); the boolean
+    // noiseEnabled param is dead in the source, so we mirror that (PORT_NOTES).
+    const bool noiseEnabled = pNoiseAmount.load (std::memory_order_relaxed) > 0.05f;
+
+    const float calibrationDb = static_cast<float> (clampI (pCalibration.load (std::memory_order_relaxed), 0, 3)) * 3.0f;
+
+    // Bias: auto-cal (from type/speed) or manual — block-constant, matches JUCE.
+    float biasAmount;
+    if (pAutoCal.load (std::memory_order_relaxed))
+    {
+        float optimalBias = 0.5f;
+        switch (type)
+        {
+            case TapeCore::Type456: optimalBias = 0.50f; break;
+            case TapeCore::TypeGP9: optimalBias = 0.55f; break;
+            case TapeCore::Type911: optimalBias = 0.52f; break;
+            case TapeCore::Type250: optimalBias = 0.45f; break;
+        }
+        switch (speed)
+        {
+            case TapeCore::Speed_7_5_IPS: optimalBias *= 1.05f; break;
+            case TapeCore::Speed_15_IPS: break;
+            case TapeCore::Speed_30_IPS: optimalBias *= 0.95f; break;
+        }
+        biasAmount = std::clamp (optimalBias, 0.0f, 1.0f);
+    }
+    else
+    {
+        biasAmount = pBias.load (std::memory_order_relaxed) * 0.01f;
+    }
+
+    // Shared wow/flutter rates (block-constant, from speed).
+    float wowRate = 0.5f, flutterRate = 5.0f;
+    switch (speed)
+    {
+        case TapeCore::Speed_7_5_IPS: wowRate = 0.33f; flutterRate = 3.5f; break;
+        case TapeCore::Speed_15_IPS:  wowRate = 0.5f;  flutterRate = 5.0f; break;
+        case TapeCore::Speed_30_IPS:  wowRate = 0.8f;  flutterRate = 7.0f; break;
+    }
+
+    // --- precompute per-sample shared values ---------------------------------
+    const int factor = currentFactor;
+    const int osN = nSamples * factor;
+
+    for (int n = 0; n < nSamples; ++n)
+        inGainArr[static_cast<size_t> (n)] = inGain.next();
+
+    for (int i = 0; i < osN; ++i)
+    {
+        const float sat = smSat.next();
+        const float wv  = smWow.next();
+        const float fv  = smFlutter.next();
+        const float nv  = smNoise.next();
+        const float combined = wv + fv;
+        float sm = 0.0f;
+        if (combined > 0.0f)
+            sm = sharedWowFlutter.calculateModulation (wv * 0.01f, fv * 0.01f, wowRate, flutterRate, currentOsRate);
+
+        const size_t si = static_cast<size_t> (i);
+        satArr[si]       = sat * 0.01f;
+        wowFlutArr[si]   = combined * 0.01f;
+        noiseArr[si]     = nv * 100.0f;
+        sharedModArr[si] = sm;
+        outGainArr[si]   = outGain.next();
+    }
+
+    // --- per-channel oversampled processing ----------------------------------
+    // Functor chain (at the oversampled rate): HP SVF -> tape core -> LP SVF ->
+    // output gain. Input gain is applied at base rate before upsampling.
+    {
+        int osIdx = 0;
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float x = inputs[0][n] * inGainArr[static_cast<size_t> (n)];
+            outputs[0][n] = osL.processSample (x, [&] (float s) noexcept
+            {
+                const size_t si = static_cast<size_t> (osIdx);
+                s = hpL.process (s);
+                s = coreL.processSample (s, machine, speed, type, biasAmount,
+                                         satArr[si], wowFlutArr[si], noiseEnabled, noiseArr[si],
+                                         &sharedModArr[si], calibrationDb, eq, signalPath);
+                if (! bypassLowpass) s = lpL.process (s);
+                s *= outGainArr[si];
+                ++osIdx;
+                return s;
+            });
+        }
+    }
+
+    if (nCh >= 2)
+    {
+        int osIdx = 0;
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float x = inputs[1][n] * inGainArr[static_cast<size_t> (n)];
+            outputs[1][n] = osR.processSample (x, [&] (float s) noexcept
+            {
+                const size_t si = static_cast<size_t> (osIdx);
+                s = hpR.process (s);
+                s = coreR.processSample (s, machine, speed, type, biasAmount,
+                                         satArr[si], wowFlutArr[si], noiseEnabled, noiseArr[si],
+                                         &sharedModArr[si], calibrationDb, eq, signalPath);
+                if (! bypassLowpass) s = lpR.process (s);
+                s *= outGainArr[si];
+                ++osIdx;
+                return s;
+            });
+        }
+    }
+
+    // --- crosstalk (base rate — deviation from JUCE's OS-rate placement) ------
+    if (nCh >= 2)
+    {
+        const float crosstalkAmount = (machine == TapeCore::Swiss800) ? 0.005f : 0.015f;
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float tempL = outputs[0][n];
+            const float tempR = outputs[1][n];
+            outputs[0][n] += tempR * crosstalkAmount;
+            outputs[1][n] += tempL * crosstalkAmount;
+        }
+    }
+
+    // --- VU meter (output; linear peak, ~300 ms release) ---------------------
+    float sL = vuStateL, sR = vuStateR;
+    for (int n = 0; n < nSamples; ++n)
+    {
+        const float aL = std::abs (outputs[0][n]);
+        sL = aL > sL ? aL : sL * vuReleaseCoeff;
+        if (nCh >= 2) { const float aR = std::abs (outputs[1][n]); sR = aR > sR ? aR : sR * vuReleaseCoeff; }
+    }
+    vuStateL = sL;
+    vuStateR = (nCh >= 2) ? sR : sL;
+    vuL.store (vuStateL, std::memory_order_relaxed);
+    vuR.store (vuStateR, std::memory_order_relaxed);
+}
+
+} // namespace duskaudio

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -1506,6 +1506,9 @@ public:
 
     float getVuL() const noexcept { return vuL.load (std::memory_order_relaxed); }
     float getVuR() const noexcept { return vuR.load (std::memory_order_relaxed); }
+    // Pre-processing input peak (for a UI In/Out meter switch). Metering only.
+    float getInVuL() const noexcept { return inVuL.load (std::memory_order_relaxed); }
+    float getInVuR() const noexcept { return inVuR.load (std::memory_order_relaxed); }
 
 private:
     static int clampI (int v, int lo, int hi) noexcept { return v < lo ? lo : (v > hi ? hi : v); }
@@ -1551,7 +1554,9 @@ private:
 
     // --- metering ---
     std::atomic<float> vuL{0.0f}, vuR{0.0f};
+    std::atomic<float> inVuL{0.0f}, inVuR{0.0f};
     float vuStateL = 0.0f, vuStateR = 0.0f;
+    float inVuStateL = 0.0f, inVuStateR = 0.0f;
     float vuReleaseCoeff = 0.0f;
 };
 

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -1,0 +1,1558 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// TapeMachineDSP.hpp — framework-free (no-JUCE) port of the TapeMachine
+// tape-emulation DSP core, for the DPF build. This is a TRANSLATION of
+// Source/ImprovedTapeEmulation.{h,cpp} + the driving logic in
+// Source/PluginProcessor.cpp (prepareToPlay / processBlock / updateFilters).
+// Every formula, constant, coefficient and per-sample stage order is preserved
+// from the JUCE original. Substitutions and judgment calls are recorded in
+// core/PORT_NOTES.md.
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+#include <algorithm>
+
+#include "DuskFilters.hpp"     // Biquad (float) + designers, OnePole etc.
+#include "DuskSVF.hpp"         // DuskSVF (TPT SVF)
+#include "DuskSmoothed.hpp"    // SmoothedValue (exp one-pole)
+#include "DuskOversampler.hpp" // Oversampler
+#include "DuskDenormals.hpp"   // ScopedFlushDenormals
+
+namespace duskaudio
+{
+
+//==============================================================================
+// Constants and helpers replacing juce::MathConstants / juce::Decibels.
+//==============================================================================
+constexpr double kPiD    = 3.14159265358979323846;
+constexpr float  kPiF    = 3.14159265358979323846f;
+constexpr double kTwoPiD = 6.28318530717958647692;
+constexpr float  kTwoPiF = 6.28318530717958647692f;
+
+// juce::Decibels::decibelsToGain (default minus-infinity dB = -100).
+inline float  dbToGain (float db)  noexcept { return db > -100.0f ? std::pow (10.0f, db * 0.05f) : 0.0f; }
+inline double dbToGainD(double db) noexcept { return db > -100.0  ? std::pow (10.0,  db * 0.05)  : 0.0;  }
+
+//==============================================================================
+// DBiquad — DOUBLE-precision transposed-direct-form-II biquad.
+//
+// The JUCE original uses juce::dsp::IIR::Filter<double> for headBump / hfLoss1 /
+// hfLoss2 / gapLoss / dcBlocker ("double for low-freq precision"), processing
+// with static_cast<double>(signal). The shared duskaudio::Biquad is float-only,
+// so this is a double copy of the exact same designer formulas the shared
+// Biquad uses (which the shared header states match juce::dsp::IIR). Kept in
+// double so the low-frequency high-Q head-bump stays stable at 4x rates.
+//==============================================================================
+struct DBiquadCoeffs { double b0 = 1.0, b1 = 0.0, b2 = 0.0, a1 = 0.0, a2 = 0.0; };
+
+class DBiquad
+{
+public:
+    void setCoeffs (const DBiquadCoeffs& k) noexcept { c = k; }
+    void reset() noexcept { z1 = z2 = 0.0; }
+
+    double process (double x) noexcept
+    {
+        const double y = c.b0 * x + z1;
+        z1 = c.b1 * x - c.a1 * y + z2;
+        z2 = c.b2 * x - c.a2 * y;
+        return y;
+    }
+
+    // juce::dsp::IIR makePeakFilter (RBJ peaking EQ, alpha = sin(w0)/(2Q)).
+    static DBiquadCoeffs peak (double fs, double freq, double gainDb, double Q) noexcept
+    {
+        const double A     = std::pow (10.0, gainDb / 40.0);
+        const double w0    = kTwoPiD * freq / fs;
+        const double cw    = std::cos (w0), sw = std::sin (w0);
+        const double alpha = sw / (2.0 * Q);
+        const double b0 = 1.0 + alpha * A;
+        const double b1 = -2.0 * cw;
+        const double b2 = 1.0 - alpha * A;
+        const double a0 = 1.0 + alpha / A;
+        const double a1 = -2.0 * cw;
+        const double a2 = 1.0 - alpha / A;
+        const double inv = 1.0 / a0;
+        return { b0 * inv, b1 * inv, b2 * inv, a1 * inv, a2 * inv };
+    }
+
+    // juce::dsp::IIR makeLowPass(fs, freq, Q).
+    static DBiquadCoeffs lowPass (double fs, double freq, double Q) noexcept
+    {
+        const double n   = 1.0 / std::tan (kPiD * freq / fs);
+        const double nSq = n * n;
+        const double invQ = 1.0 / Q;
+        const double c1  = 1.0 / (1.0 + invQ * n + nSq);
+        return { c1, c1 * 2.0, c1, c1 * 2.0 * (1.0 - nSq), c1 * (1.0 - invQ * n + nSq) };
+    }
+
+    // juce::dsp::IIR makeHighPass(fs, freq, Q).
+    static DBiquadCoeffs highPass (double fs, double freq, double Q) noexcept
+    {
+        const double n   = std::tan (kPiD * freq / fs);
+        const double nSq = n * n;
+        const double invQ = 1.0 / Q;
+        const double c1  = 1.0 / (1.0 + invQ * n + nSq);
+        return { c1, c1 * -2.0, c1, c1 * 2.0 * (nSq - 1.0), c1 * (1.0 - invQ * n + nSq) };
+    }
+
+    // juce::dsp::IIR makeHighShelf / makeLowShelf (RBJ, alpha = sin(w0)/(2Q)).
+    static DBiquadCoeffs shelf (double fs, double freq, double gainDb, double Q, bool high) noexcept
+    {
+        const double A     = std::pow (10.0, gainDb / 40.0);
+        const double w0    = kTwoPiD * freq / fs;
+        const double cw    = std::cos (w0), sw = std::sin (w0);
+        const double alpha = sw / (2.0 * Q);
+        const double sqA2a = 2.0 * std::sqrt (A) * alpha;
+        double b0, b1, b2, a0, a1, a2;
+        if (high)
+        {
+            b0 =  A * ((A + 1.0) + (A - 1.0) * cw + sqA2a);
+            b1 = -2.0 * A * ((A - 1.0) + (A + 1.0) * cw);
+            b2 =  A * ((A + 1.0) + (A - 1.0) * cw - sqA2a);
+            a0 =      (A + 1.0) - (A - 1.0) * cw + sqA2a;
+            a1 =  2.0 * ((A - 1.0) - (A + 1.0) * cw);
+            a2 =      (A + 1.0) - (A - 1.0) * cw - sqA2a;
+        }
+        else
+        {
+            b0 =  A * ((A + 1.0) - (A - 1.0) * cw + sqA2a);
+            b1 =  2.0 * A * ((A - 1.0) - (A + 1.0) * cw);
+            b2 =  A * ((A + 1.0) - (A - 1.0) * cw - sqA2a);
+            a0 =      (A + 1.0) + (A - 1.0) * cw + sqA2a;
+            a1 = -2.0 * ((A - 1.0) + (A + 1.0) * cw);
+            a2 =      (A + 1.0) + (A - 1.0) * cw - sqA2a;
+        }
+        const double inv = 1.0 / a0;
+        return { b0 * inv, b1 * inv, b2 * inv, a1 * inv, a2 * inv };
+    }
+
+private:
+    DBiquadCoeffs c;
+    double z1 = 0.0, z2 = 0.0;
+};
+
+//==============================================================================
+// 8th-order Chebyshev Type I Anti-Aliasing Filter (verbatim port).
+//==============================================================================
+class ChebyshevAntiAliasingFilter
+{
+public:
+    static constexpr int NUM_SECTIONS = 4; // 4 biquads = 8th order
+
+    struct BiquadState { float z1 = 0.0f, z2 = 0.0f; };
+    struct BiquadCoeffs { float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f; float a1 = 0.0f, a2 = 0.0f; };
+
+    void prepare (double sampleRate, double cutoffHz)
+    {
+        cutoffHz = std::min (cutoffHz, sampleRate * 0.45);
+        cutoffHz = std::max (cutoffHz, 20.0);
+
+        constexpr int N = 8;
+        constexpr double rippleDb = 0.5;
+
+        const double epsilon = std::sqrt (std::pow (10.0, rippleDb / 10.0) - 1.0);
+        const double a = std::asinh (1.0 / epsilon) / N;
+        const double sinhA = std::sinh (a);
+        const double coshA = std::cosh (a);
+
+        const double C = 2.0 * sampleRate;
+        const double Wa = C * std::tan (kPiD * cutoffHz / sampleRate);
+
+        for (int k = 0; k < NUM_SECTIONS; ++k)
+        {
+            double theta = (2.0 * k + 1.0) * kPiD / (2.0 * N);
+            double sigma = -sinhA * std::sin (theta);
+            double omega = coshA * std::cos (theta);
+
+            double poleMagSq = sigma * sigma + omega * omega;
+            double A = Wa * Wa * poleMagSq;
+            double B = 2.0 * (-sigma) * Wa * C;
+            double a0 = C * C + B + A;
+            double a0_inv = 1.0 / a0;
+
+            coeffs[k].b0 = static_cast<float> (A * a0_inv);
+            coeffs[k].b1 = static_cast<float> (2.0 * A * a0_inv);
+            coeffs[k].b2 = coeffs[k].b0;
+            coeffs[k].a1 = static_cast<float> (2.0 * (A - C * C) * a0_inv);
+            coeffs[k].a2 = static_cast<float> ((C * C - B + A) * a0_inv);
+        }
+
+        reset();
+    }
+
+    void reset() { for (auto& state : states) state = BiquadState{}; }
+
+    float process (float input)
+    {
+        float signal = input;
+        for (int i = 0; i < NUM_SECTIONS; ++i)
+            signal = processBiquad (signal, coeffs[i], states[i]);
+        if (std::abs (signal) < 1e-15f) signal = 0.0f;
+        return signal;
+    }
+
+private:
+    std::array<BiquadCoeffs, NUM_SECTIONS> coeffs;
+    std::array<BiquadState, NUM_SECTIONS> states;
+
+    float processBiquad (float input, const BiquadCoeffs& c, BiquadState& s)
+    {
+        float output = c.b0 * input + s.z1;
+        s.z1 = c.b1 * input - c.a1 * output + s.z2;
+        s.z2 = c.b2 * input - c.a2 * output;
+        return output;
+    }
+};
+
+//==============================================================================
+// Soft Limiter (verbatim).
+//==============================================================================
+class SoftLimiter
+{
+public:
+    static constexpr float threshold = 0.95f;
+    float process (float x) const
+    {
+        if (x > threshold)  return threshold;
+        if (x < -threshold) return -threshold;
+        return x;
+    }
+};
+
+//==============================================================================
+// Saturation Split Filter — 2-pole Butterworth lowpass (verbatim).
+//==============================================================================
+class SaturationSplitFilter
+{
+public:
+    void prepare (double sampleRate, double cutoffHz = 5000.0)
+    {
+        const double w0 = 2.0 * kPiD * cutoffHz / sampleRate;
+        const double cosw0 = std::cos (w0);
+        const double sinw0 = std::sin (w0);
+        const double alpha = sinw0 / (2.0 * 0.7071);
+        const double a0 = 1.0 + alpha;
+
+        b0 = static_cast<float> (((1.0 - cosw0) / 2.0) / a0);
+        b1 = static_cast<float> ((1.0 - cosw0) / a0);
+        b2 = b0;
+        a1 = static_cast<float> ((-2.0 * cosw0) / a0);
+        a2 = static_cast<float> ((1.0 - alpha) / a0);
+        reset();
+    }
+
+    void reset() { z1 = z2 = 0.0f; }
+
+    float process (float input)
+    {
+        float output = b0 * input + z1;
+        z1 = b1 * input - a1 * output + z2;
+        z2 = b2 * input - a2 * output;
+        return output;
+    }
+
+private:
+    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f;
+    float a1 = 0.0f, a2 = 0.0f;
+    float z1 = 0.0f, z2 = 0.0f;
+};
+
+//==============================================================================
+// 3-Band Splitter (verbatim).
+//==============================================================================
+class ThreeBandSplitter
+{
+public:
+    void prepare (double sampleRate)
+    {
+        lr200.prepare (sampleRate, 200.0f);
+        lr5000.prepare (sampleRate, 5000.0f);
+    }
+    void reset() { lr200.reset(); lr5000.reset(); }
+
+    void split (float input, float& bass, float& mid, float& treble)
+    {
+        float lp200Out  = lr200.process (input);
+        float lp5000Out = lr5000.process (input);
+        bass   = lp200Out;
+        mid    = lp5000Out - lp200Out;
+        treble = input - lp5000Out;
+    }
+
+private:
+    struct LR2Filter
+    {
+        struct OnePoleLP
+        {
+            float state = 0.0f, coeff = 0.0f;
+            void prepare (double sampleRate, float cutoffHz)
+            {
+                float g = std::tan (kPiF * cutoffHz / static_cast<float> (sampleRate));
+                coeff = g / (1.0f + g);
+                state = 0.0f;
+            }
+            void reset() { state = 0.0f; }
+            float process (float input)
+            {
+                float v = (input - state) * coeff;
+                float output = v + state;
+                state = output + v;
+                return output;
+            }
+        };
+        OnePoleLP stage1, stage2;
+        void prepare (double sampleRate, float cutoffHz) { stage1.prepare (sampleRate, cutoffHz); stage2.prepare (sampleRate, cutoffHz); }
+        void reset() { stage1.reset(); stage2.reset(); }
+        float process (float input) { return stage2.process (stage1.process (input)); }
+    };
+
+    LR2Filter lr200, lr5000;
+};
+
+//==============================================================================
+// Jiles-Atherton Tape Hysteresis (verbatim RK4 J-A model).
+//==============================================================================
+class JilesAthertonHysteresis
+{
+public:
+    struct TapeFormulationParams
+    {
+        float Ms = 280.0f;    float a = 720.0f;   float alpha = 0.016f;
+        float k = 640.0f;     float c = 0.50f;
+    };
+
+    void prepare (double /*sampleRate*/, int /*oversamplingFactor*/ = 1) { prevM = 0.0f; prevH = 0.0f; }
+    void reset() { prevM = 0.0f; prevH = 0.0f; }
+    void setFormulation (TapeFormulationParams params) { currentParams = params; }
+    void setMachineType (bool isPrecision) { precisionMode = isPrecision; }
+
+    float processSample (float input, float drive, float biasLinearization)
+    {
+        if (drive < 0.001f) { prevM = 0.0f; prevH = 0.0f; return input; }
+
+        const float biasFactor = 1.0f + 0.6f * (0.5f - biasLinearization);
+        const float machineFactor = precisionMode ? 0.92f : 1.08f;
+        const float effectiveDrive = drive * biasFactor * machineFactor;
+
+        const float Ms    = currentParams.Ms;
+        const float a     = currentParams.a;
+        const float alpha = currentParams.alpha;
+        const float k     = currentParams.k;
+        const float c     = currentParams.c;
+
+        const float H  = input * effectiveDrive * fieldScale;
+        const float dH = H - prevH;
+        const float delta = (dH >= 0.0f) ? 1.0f : -1.0f;
+
+        auto dMdH = [&] (float Hx, float Mx) -> float
+        {
+            const float He     = Hx + alpha * Mx;
+            const float q      = He / a;
+            const float Man    = Ms * langevin (q);
+            const float dManHe = (Ms / a) * langevinDeriv (q);
+            const float Mdiff  = Man - Mx;
+            const bool  sameDir = (delta > 0.0f) ? (Mdiff > 0.0f) : (Mdiff < 0.0f);
+            const float deltaM = sameDir ? 1.0f : 0.0f;
+
+            float kap = (1.0f - c) * delta * k - alpha * Mdiff;
+            if (std::abs (kap) < 1e-4f) kap = (kap < 0.0f ? -1e-4f : 1e-4f);
+            const float irr = deltaM * Mdiff / kap;
+
+            const float num = (1.0f - c) * irr + c * dManHe;
+            float den = 1.0f - alpha * c * dManHe;
+            if (std::abs (den) < 1e-4f) den = (den < 0.0f ? -1e-4f : 1e-4f);
+            return num / den;
+        };
+
+        const float k1 = dMdH (prevH,             prevM);
+        const float k2 = dMdH (prevH + 0.5f * dH, prevM + 0.5f * dH * k1);
+        const float k3 = dMdH (prevH + 0.5f * dH, prevM + 0.5f * dH * k2);
+        const float k4 = dMdH (prevH + dH,        prevM + dH * k3);
+        float M = prevM + (dH / 6.0f) * (k1 + 2.0f * k2 + 2.0f * k3 + k4);
+
+        if (! std::isfinite (M)) { prevM = 0.0f; prevH = H; return input; }
+        const float Mlim = 1.5f * Ms;
+        M = (M > Mlim) ? Mlim : (M < -Mlim ? -Mlim : M);
+
+        prevM = M;
+        prevH = H;
+
+        const float loopOut   = M * 3.0f * a / (Ms * effectiveDrive * fieldScale);
+        const float anhystOut = 3.0f * langevin (H / a) * a / (effectiveDrive * fieldScale);
+        const float loopWeight = (1.0f - biasLinearization) * 0.5f;
+        const float output = anhystOut + loopWeight * (loopOut - anhystOut);
+        return std::isfinite (output) ? output : input;
+    }
+
+private:
+    TapeFormulationParams currentParams;
+    bool precisionMode = false;
+    float prevM = 0.0f, prevH = 0.0f;
+    static constexpr float fieldScale = 3200.0f;
+
+public:
+    static float langevin (float x)
+    {
+        if (std::abs (x) < 1e-4f) return x / 3.0f;
+        float ax = std::abs (x);
+        if (ax > 2.5f)
+        {
+            float sign = (x >= 0.0f) ? 1.0f : -1.0f;
+            return sign * (1.0f - 1.0f / ax);
+        }
+        float x2 = x * x;
+        float pade = x * (315.0f + 105.0f * x2) / (945.0f + 420.0f * x2 + 63.0f * x2 * x2);
+        if (ax <= 1.5f) return pade;
+        float sign = (x >= 0.0f) ? 1.0f : -1.0f;
+        float asympt = sign * (1.0f - 1.0f / ax);
+        float t = (ax - 1.5f);
+        return pade * (1.0f - t) + asympt * t;
+    }
+
+    static float langevinDeriv (float x)
+    {
+        const float ax = std::abs (x);
+        if (ax < 1.0e-4f) return 1.0f / 3.0f;
+        const float x2 = x * x;
+        const float N  = 315.0f * x + 105.0f * x * x2;
+        const float D  = 945.0f + 420.0f * x2 + 63.0f * x2 * x2;
+        const float Np = 315.0f + 315.0f * x2;
+        const float Dp = 840.0f * x + 252.0f * x * x2;
+        const float padeP = (Np * D - N * Dp) / (D * D);
+        if (ax <= 1.5f) return padeP;
+        const float asymptP = 1.0f / x2;
+        if (ax >= 2.5f) return asymptP;
+        const float s      = (x >= 0.0f) ? 1.0f : -1.0f;
+        const float pade   = N / D;
+        const float asympt = s - 1.0f / x;
+        const float t      = ax - 1.5f;
+        return padeP * (1.0f - t) + asymptP * t + s * (asympt - pade);
+    }
+};
+
+//==============================================================================
+// Tape EQ Filter — first-order time-constant network (verbatim).
+//==============================================================================
+class TapeEQFilter
+{
+public:
+    void prepare (double sampleRate) { fs = sampleRate; reset(); }
+    void reset() { z1 = 0.0f; }
+    void setPreEmphasis (float tau_num_us, float tau_den_us) { computeCoefficients (tau_num_us, tau_den_us); }
+    void setDeEmphasis  (float tau_num_us, float tau_den_us) { computeCoefficients (tau_num_us, tau_den_us); }
+
+    float processSample (float input)
+    {
+        float output = b0 * input + z1;
+        z1 = b1 * input - a1 * output;
+        return output;
+    }
+
+private:
+    double fs = 44100.0;
+    float b0 = 1.0f, b1 = 0.0f, a1 = 0.0f, z1 = 0.0f;
+
+    void computeCoefficients (float tau_num_us, float tau_den_us)
+    {
+        double tauNum = static_cast<double> (tau_num_us) * 1e-6;
+        double tauDen = static_cast<double> (tau_den_us) * 1e-6;
+        double T = 1.0 / fs;
+        double wNum = 2.0 * tauNum / T;
+        double wDen = 2.0 * tauDen / T;
+        double num0 = 1.0 + wNum;
+        double num1 = 1.0 - wNum;
+        double den0 = 1.0 + wDen;
+        double den1 = 1.0 - wDen;
+        double invDen0 = 1.0 / den0;
+        b0 = static_cast<float> (num0 * invDen0);
+        b1 = static_cast<float> (num1 * invDen0);
+        a1 = static_cast<float> (den1 * invDen0);
+    }
+};
+
+//==============================================================================
+// Phase Smearing Filter — 4 cascaded first-order allpass (verbatim).
+//==============================================================================
+class PhaseSmearingFilter
+{
+public:
+    static constexpr int NUM_STAGES = 4;
+
+    void prepare (double sampleRate) { currentSampleRate = sampleRate; reset(); }
+    void reset() { for (auto& stage : stages) stage.state = 0.0f; }
+
+    void setMachineCharacter (bool isPrecision)
+    {
+        float breakFreqs[NUM_STAGES];
+        if (isPrecision) { breakFreqs[0] = 60.0f;  breakFreqs[1] = 250.0f; breakFreqs[2] = 2000.0f; breakFreqs[3] = 8000.0f; }
+        else             { breakFreqs[0] = 40.0f;  breakFreqs[1] = 150.0f; breakFreqs[2] = 1200.0f; breakFreqs[3] = 6000.0f; }
+
+        for (int i = 0; i < NUM_STAGES; ++i)
+        {
+            float tanVal = std::tan (kPiF * breakFreqs[i] / static_cast<float> (currentSampleRate));
+            stages[i].coeff = (tanVal - 1.0f) / (tanVal + 1.0f);
+        }
+    }
+
+    float processSample (float input)
+    {
+        float signal = input;
+        for (auto& stage : stages)
+        {
+            float y = stage.coeff * signal + stage.state;
+            stage.state = signal - stage.coeff * y;
+            signal = y;
+        }
+        return signal;
+    }
+
+private:
+    struct AllpassStage { float coeff = 0.0f, state = 0.0f; };
+    std::array<AllpassStage, NUM_STAGES> stages;
+    double currentSampleRate = 44100.0;
+};
+
+//==============================================================================
+// Improved Noise Generator (verbatim; RNG made deterministic — see PORT_NOTES).
+//==============================================================================
+struct ImprovedNoiseGenerator
+{
+    float b0 = 0.0f, b1 = 0.0f, b2 = 0.0f;
+    float b3 = 0.0f, b4 = 0.0f, b5 = 0.0f, b6 = 0.0f;
+
+    float scrapeBP_z1 = 0.0f, scrapeBP_z2 = 0.0f;
+    float scrapeBP_b0 = 0.0f, scrapeBP_b1 = 0.0f, scrapeBP_b2 = 0.0f;
+    float scrapeBP_a1 = 0.0f, scrapeBP_a2 = 0.0f;
+
+    float envelope = 0.0f;
+    float envelopeCoeff = 0.999f;
+    float tiltState = 0.0f;
+    float tiltCoeff = 0.5f;
+
+    std::mt19937 rng;                                        // deterministic (fixed seed)
+    std::uniform_real_distribution<float> whiteDist{ -1.0f, 1.0f };
+
+    void setSeed (std::uint32_t s) { rng.seed (s); }
+
+    void prepare (double sampleRate, int tapeSpeed)
+    {
+        float tiltFreq = (tapeSpeed == 0) ? 800.0f : (tapeSpeed == 1) ? 1500.0f : 3000.0f;
+        tiltCoeff = 1.0f - std::exp (-2.0f * kPiF * tiltFreq / static_cast<float> (sampleRate));
+        envelopeCoeff = 1.0f - std::exp (-2.0f * kPiF * 100.0f / static_cast<float> (sampleRate));
+
+        float fc = 4000.0f, Q = 2.0f;
+        float w0 = 2.0f * kPiF * fc / static_cast<float> (sampleRate);
+        float cosw0 = std::cos (w0), sinw0 = std::sin (w0);
+        float alpha = sinw0 / (2.0f * Q);
+        float a0 = 1.0f + alpha;
+
+        scrapeBP_b0 = (alpha) / a0;
+        scrapeBP_b1 = 0.0f;
+        scrapeBP_b2 = (-alpha) / a0;
+        scrapeBP_a1 = (-2.0f * cosw0) / a0;
+        scrapeBP_a2 = (1.0f - alpha) / a0;
+        reset();
+    }
+
+    void reset()
+    {
+        b0 = b1 = b2 = b3 = b4 = b5 = b6 = 0.0f;
+        scrapeBP_z1 = scrapeBP_z2 = 0.0f;
+        envelope = 0.0f;
+        tiltState = 0.0f;
+    }
+
+    float generateNoise (float noiseFloor, float modulationAmount, float signal)
+    {
+        float white = whiteDist (rng);
+        b0 = 0.99886f * b0 + white * 0.0555179f;
+        b1 = 0.99332f * b1 + white * 0.0750759f;
+        b2 = 0.96900f * b2 + white * 0.1538520f;
+        b3 = 0.86650f * b3 + white * 0.3104856f;
+        b4 = 0.55000f * b4 + white * 0.5329522f;
+        b5 = -0.7616f * b5 - white * 0.0168980f;
+
+        float pink = (b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362f) * 0.11f;
+        b6 = white * 0.115926f;
+
+        tiltState += (pink - tiltState) * tiltCoeff;
+        float tiltedNoise = pink - tiltState * 0.5f;
+
+        float absSignal = std::abs (signal);
+        envelope += (absSignal - envelope) * envelopeCoeff;
+        float modNoise = tiltedNoise * (1.0f + envelope * modulationAmount * 8.0f);
+
+        float scrapeWhite = whiteDist (rng);
+        float scrapeOut = scrapeBP_b0 * scrapeWhite + scrapeBP_z1;
+        scrapeBP_z1 = scrapeBP_b1 * scrapeWhite - scrapeBP_a1 * scrapeOut + scrapeBP_z2;
+        scrapeBP_z2 = scrapeBP_b2 * scrapeWhite - scrapeBP_a2 * scrapeOut;
+
+        float totalNoise = modNoise * noiseFloor + scrapeOut * noiseFloor * 0.15f;
+        return totalNoise;
+    }
+};
+
+//==============================================================================
+// Wow & Flutter processor — shared between channels for stereo coherence.
+// Verbatim Thiran-allpass fractional-delay port. The delay buffer is sized for
+// the MAX oversampling rate once, so an oversampling-factor change never
+// reallocates on the audio thread (see PORT_NOTES). RNG is deterministic.
+//==============================================================================
+class WowFlutterProcessor
+{
+public:
+    std::vector<float> delayBuffer;
+    int writeIndex = 0;
+    double wowPhase = 0.0;
+    double flutterPhase = 0.0;
+    float randomPhase = 0.0f;
+    std::mt19937 rng;                                       // deterministic (fixed seed)
+    std::uniform_real_distribution<float> dist{ -1.0f, 1.0f };
+
+    float randomTarget = 0.0f;
+    float randomCurrent = 0.0f;
+    int randomUpdateCounter = 0;
+    static constexpr int RANDOM_UPDATE_INTERVAL = 64;
+
+    int oversamplingFactor = 1;
+    float smoothingAlpha = 0.01f;
+    float allpassState = 0.0f;
+
+    void setSeed (std::uint32_t s) { rng.seed (s); }
+
+    // sampleRate  = ACTIVE oversampled rate (drives coeffs / phase timing).
+    // osFactor    = ACTIVE oversampling factor.
+    // maxSampleRate = highest oversampled rate the plugin can run at; the buffer
+    //   is sized from THIS so factor changes never reallocate (only re-zero).
+    void prepare (double sampleRate, int osFactor, double maxSampleRate)
+    {
+        oversamplingFactor = std::max (1, osFactor);
+
+        smoothingAlpha = 1.0f - std::exp (-2.0f * kPiF * 70.0f / static_cast<float> (sampleRate));
+
+        static constexpr double MIN_SAMPLE_RATE = 8000.0;
+        static constexpr double MAX_SAMPLE_RATE = 768000.0;
+        static constexpr double MAX_DELAY_SECONDS = 0.05;
+
+        if (maxSampleRate <= 0.0 || !std::isfinite (maxSampleRate))
+            maxSampleRate = 44100.0;
+
+        maxSampleRate = std::clamp (maxSampleRate, MIN_SAMPLE_RATE, MAX_SAMPLE_RATE);
+
+        double bufferSizeDouble = maxSampleRate * MAX_DELAY_SECONDS;
+
+        static constexpr size_t MIN_BUFFER_SIZE = 64;
+        static constexpr size_t MAX_BUFFER_SIZE = 65536;
+
+        size_t bufferSize = static_cast<size_t> (bufferSizeDouble);
+        bufferSize = std::clamp (bufferSize, MIN_BUFFER_SIZE, MAX_BUFFER_SIZE);
+
+        if (delayBuffer.size() != bufferSize)
+            delayBuffer.assign (bufferSize, 0.0f);          // (re)allocate — setup thread only
+        else
+            std::fill (delayBuffer.begin(), delayBuffer.end(), 0.0f);
+
+        writeIndex = 0;
+        allpassState = 0.0f;
+    }
+
+    float calculateModulation (float wowAmount, float flutterAmount,
+                               float wowRate, float flutterRate, double sampleRate)
+    {
+        if (sampleRate <= 0.0) sampleRate = 44100.0;
+
+        float osScale = static_cast<float> (oversamplingFactor);
+
+        float wowMod = static_cast<float> (std::sin (wowPhase)) * wowAmount * 10.0f * osScale;
+        float flutterMod = static_cast<float> (std::sin (flutterPhase)) * flutterAmount * 2.0f * osScale;
+
+        int scaledInterval = RANDOM_UPDATE_INTERVAL * oversamplingFactor;
+        if (++randomUpdateCounter >= scaledInterval)
+        {
+            randomUpdateCounter = 0;
+            randomTarget = dist (rng);
+        }
+        randomCurrent += (randomTarget - randomCurrent) * smoothingAlpha;
+        float randomMod = randomCurrent * flutterAmount * 0.5f * osScale;
+
+        double safeSampleRate = std::max (1.0, sampleRate);
+        double wowIncrement = 2.0 * kPiD * wowRate / safeSampleRate;
+        double flutterIncrement = 2.0 * kPiD * flutterRate / safeSampleRate;
+
+        wowPhase += wowIncrement;
+        if (wowPhase > 2.0 * kPiD) wowPhase -= 2.0 * kPiD;
+
+        flutterPhase += flutterIncrement;
+        if (flutterPhase > 2.0 * kPiD) flutterPhase -= 2.0 * kPiD;
+
+        return wowMod + flutterMod + randomMod;
+    }
+
+    float processSample (float input, float modulationSamples)
+    {
+        if (delayBuffer.empty()) return input;
+        if (writeIndex < 0 || writeIndex >= static_cast<int> (delayBuffer.size())) writeIndex = 0;
+
+        delayBuffer[writeIndex] = input;
+
+        float baseDelay = 20.0f * static_cast<float> (oversamplingFactor);
+        float totalDelay = baseDelay + modulationSamples;
+        int bufferSize = static_cast<int> (delayBuffer.size());
+        if (bufferSize <= 0) return input;
+
+        totalDelay = std::max (1.5f, std::min (totalDelay, static_cast<float> (bufferSize - 2)));
+
+        int delaySamples = static_cast<int> (totalDelay);
+        float frac = totalDelay - static_cast<float> (delaySamples);
+
+        int readIndex0 = (writeIndex - delaySamples + bufferSize) % bufferSize;
+        int readIndex1 = (readIndex0 - 1 + bufferSize) % bufferSize;
+
+        readIndex0 = std::max (0, std::min (readIndex0, bufferSize - 1));
+        readIndex1 = std::max (0, std::min (readIndex1, bufferSize - 1));
+
+        float x_n  = delayBuffer[readIndex0];
+        float x_n1 = delayBuffer[readIndex1];
+
+        float d = std::clamp (frac, 0.1f, 0.9f);
+        float a1 = (1.0f - d) / (1.0f + d);
+
+        float output = a1 * x_n + x_n1 - a1 * allpassState;
+        allpassState = output;
+
+        if (std::abs (allpassState) < 1e-15f) allpassState = 0.0f;
+
+        writeIndex = (writeIndex + 1) % std::max (1, bufferSize);
+        return output;
+    }
+};
+
+//==============================================================================
+// Transformer saturation model (verbatim).
+//==============================================================================
+class TransformerSaturation
+{
+public:
+    void prepare (double sampleRate)
+    {
+        dcBlockCoeff = 1.0f - (20.0f * kPiF / static_cast<float> (sampleRate));
+        lfResonanceCoeff = 1.0f - std::exp (-2.0f * kPiF * 50.0f / static_cast<float> (sampleRate));
+        float targetDecayRate = 220.5f;
+        hystDecay = 1.0f - (targetDecayRate / static_cast<float> (sampleRate));
+        hystDecay = std::clamp (hystDecay, 0.95f, 0.9999f);
+        reset();
+    }
+
+    void reset() { dcState = 0.0f; hystState = 0.0f; prevInput = 0.0f; lfResonanceState = 0.0f; }
+
+    float process (float input, float driveAmount, bool isOutputStage)
+    {
+        float signal = input;
+
+        float dcBlocked = signal - dcState;
+        dcState = signal * (1.0f - dcBlockCoeff) + dcState * dcBlockCoeff;
+        signal = dcBlocked;
+
+        float asymmetryCoeff = 0.80f * driveAmount;
+        if (asymmetryCoeff > 0.0001f)
+            signal = signal * (1.0f + asymmetryCoeff * signal);
+
+        float absSignal = std::abs (signal);
+        float saturationThreshold = isOutputStage ? 0.92f : 0.95f;
+        if (absSignal > saturationThreshold)
+        {
+            float excess = absSignal - saturationThreshold;
+            float headroom = 1.0f - saturationThreshold;
+            float limited = saturationThreshold + headroom * (1.0f - std::exp (-excess * 2.0f / headroom));
+            signal = (signal >= 0.0f ? 1.0f : -1.0f) * limited;
+        }
+
+        if (isOutputStage && driveAmount > 0.01f)
+        {
+            float resonanceQ = 0.15f * driveAmount;
+            lfResonanceState += (signal - lfResonanceState) * lfResonanceCoeff;
+            signal += lfResonanceState * resonanceQ;
+        }
+
+        float hystAmount = isOutputStage ? 0.005f : 0.002f;
+        hystAmount *= driveAmount;
+        float hystDelta = signal - prevInput;
+        hystState = hystState * hystDecay + hystDelta * hystAmount;
+        signal += hystState;
+        prevInput = signal;
+
+        return signal;
+    }
+
+private:
+    float dcState = 0.0f;
+    float dcBlockCoeff = 0.9995f;
+    float hystState = 0.0f;
+    float hystDecay = 0.995f;
+    float prevInput = 0.0f;
+    float lfResonanceState = 0.0f;
+    float lfResonanceCoeff = 0.002f;
+};
+
+//==============================================================================
+// Playback head frequency response (verbatim).
+//==============================================================================
+class PlaybackHeadResponse
+{
+public:
+    void prepare (double sampleRate)
+    {
+        currentSampleRate = sampleRate;
+        constexpr float targetCutoff = 740.0f;
+        resonanceCoeff = 1.0f - std::exp (-2.0f * kPiF * targetCutoff / static_cast<float> (sampleRate));
+        reset();
+    }
+
+    void reset()
+    {
+        std::fill (gapDelayLine.begin(), gapDelayLine.end(), 0.0f);
+        gapDelayIndex = 0;
+        resonanceState1 = 0.0f;
+        resonanceState2 = 0.0f;
+    }
+
+    float process (float input, float gapWidth, float speed)
+    {
+        float speedCmPerSec = speed == 0 ? 19.05f : (speed == 1 ? 38.1f : 76.2f);
+        float gapMicrons = gapWidth;
+
+        float delayMs = (gapMicrons * 0.0001f) / speedCmPerSec * 1000.0f;
+        float delaySamples = delayMs * 0.001f * static_cast<float> (currentSampleRate);
+        delaySamples = std::min (delaySamples, static_cast<float> (gapDelayLine.size() - 1));
+
+        gapDelayLine[static_cast<size_t> (gapDelayIndex)] = input;
+
+        int readIndex = (gapDelayIndex - static_cast<int> (delaySamples) + static_cast<int> (gapDelayLine.size())) % static_cast<int> (gapDelayLine.size());
+        float delayedSignal = gapDelayLine[static_cast<size_t> (readIndex)];
+
+        gapDelayIndex = (gapDelayIndex + 1) % static_cast<int> (gapDelayLine.size());
+
+        float gapEffect = input * 0.98f + delayedSignal * 0.02f;
+
+        resonanceState1 += (gapEffect - resonanceState1) * resonanceCoeff;
+        resonanceState2 += (resonanceState1 - resonanceState2) * resonanceCoeff;
+
+        float resonanceBoost = (resonanceState1 - resonanceState2) * 0.15f;
+        return gapEffect + resonanceBoost;
+    }
+
+private:
+    std::array<float, 64> gapDelayLine{};
+    int gapDelayIndex = 0;
+    float resonanceState1 = 0.0f;
+    float resonanceState2 = 0.0f;
+    float resonanceCoeff = 0.1f;
+    double currentSampleRate = 44100.0;
+};
+
+//==============================================================================
+// Fast sine approximation used by MotorFlutter (verbatim).
+//==============================================================================
+inline float fastSin (float x)
+{
+    if (! std::isfinite (x)) return 0.0f;
+    constexpr float pi = 3.14159265f;
+    constexpr float twoPi = 6.28318530f;
+    x = std::fmod (x, twoPi);
+    if (x > pi) x -= twoPi;
+    else if (x < -pi) x += twoPi;
+    constexpr float B = 4.0f / pi;
+    constexpr float C = -4.0f / (pi * pi);
+    return B * x + C * x * std::abs (x);
+}
+
+//==============================================================================
+// Capstan/motor flutter (verbatim; deterministic RNG).
+//==============================================================================
+class MotorFlutter
+{
+public:
+    void setSeed (std::uint32_t s) { rng.seed (s); }
+
+    void prepare (double sr, int osFactor = 1)
+    {
+        sampleRate = sr;
+        oversamplingFactor = std::max (1, osFactor);
+        reset();
+    }
+
+    void reset() { phase1 = 0.0; phase2 = 0.0; phase3 = 0.0; }
+
+    float calculateFlutter (float motorQuality)
+    {
+        if (motorQuality < 0.001f) return 0.0f;
+
+        constexpr float twoPiF = 6.28318530f;
+        float inc1 = twoPiF * 50.0f / static_cast<float> (sampleRate);
+        float inc2 = twoPiF * 15.0f / static_cast<float> (sampleRate);
+        float inc3 = twoPiF * 3.0f / static_cast<float> (sampleRate);
+
+        phase1 += inc1; phase2 += inc2; phase3 += inc3;
+        if (phase1 > twoPiF) phase1 -= twoPiF;
+        if (phase2 > twoPiF) phase2 -= twoPiF;
+        if (phase3 > twoPiF) phase3 -= twoPiF;
+
+        float osScale = static_cast<float> (oversamplingFactor);
+        float baseFlutter = motorQuality * 0.0004f * osScale;
+
+        float motorComponent = fastSin (static_cast<float> (phase1)) * baseFlutter * 0.3f;
+        float bearingComponent = fastSin (static_cast<float> (phase2)) * baseFlutter * 0.5f;
+        float eccentricityComponent = fastSin (static_cast<float> (phase3)) * baseFlutter * 0.2f;
+
+        float randomComponent = jitter (rng) * baseFlutter * 0.1f / std::sqrt (osScale);
+
+        return motorComponent + bearingComponent + eccentricityComponent + randomComponent;
+    }
+
+private:
+    double phase1 = 0.0, phase2 = 0.0, phase3 = 0.0;
+    double sampleRate = 44100.0;
+    int oversamplingFactor = 1;
+    std::mt19937 rng;                                       // deterministic (fixed seed)
+    std::uniform_real_distribution<float> jitter{ -1.0f, 1.0f };
+};
+
+//==============================================================================
+// TapeCore — per-channel tape emulation. Direct port of ImprovedTapeEmulation
+// (Source/ImprovedTapeEmulation.{h,cpp}). One instance per channel. All filter
+// coefficient recompute (updateFilters) is plain float/double math and is
+// RT-safe, so — unlike the JUCE original, which allocated ref-counted
+// Coefficients on the audio thread — the internal dirty-check is kept as-is.
+//==============================================================================
+class TapeCore
+{
+public:
+    enum TapeMachine { Swiss800 = 0, Classic102 };
+    enum TapeSpeed   { Speed_7_5_IPS = 0, Speed_15_IPS, Speed_30_IPS };
+    enum TapeType    { Type456 = 0, TypeGP9, Type911, Type250 };
+    enum EQStandard  { NAB = 0, CCIR, AES };
+    enum SignalPath  { Repro = 0, Sync, Input, Thru };
+
+    TapeCore() { reset(); }
+
+    // seedBase distinguishes L/R RNG streams so noise/flutter are decorrelated.
+    void setSeeds (std::uint32_t seedBase)
+    {
+        improvedNoiseGen.setSeed (seedBase + 1u);
+        perChannelWowFlutter.setSeed (seedBase + 2u);
+        motorFlutter.setSeed (seedBase + 3u);
+    }
+
+    // osRate = oversampled sample rate; osFactor = oversampling factor;
+    // maxOsRate = highest oversampled rate (wow/flutter buffer sizing).
+    void prepare (double osRate, int osFactor, double maxOsRate)
+    {
+        if (osRate <= 0.0) osRate = 44100.0;
+        if (osFactor < 1) osFactor = 1;
+
+        currentSampleRate = osRate;
+        currentOversamplingFactor = osFactor;
+        baseSampleRate = osRate / static_cast<double> (osFactor);
+
+        double antiAliasingCutoff = baseSampleRate * 0.45;
+        antiAliasingFilter.prepare (osRate, antiAliasingCutoff);
+
+        threeBandSplitter.prepare (osRate);
+
+        hysteresisBass.prepare (osRate, osFactor);
+        hysteresisMid.prepare (osRate, osFactor);
+        hysteresisTreble.prepare (osRate, osFactor);
+
+        preEmphasisEQ.prepare (osRate);
+        deEmphasisEQ.prepare (osRate);
+        phaseSmear.prepare (osRate);
+        improvedNoiseGen.prepare (osRate, 1);
+        softClipSplitFilter.prepare (osRate, 5000.0);
+
+        perChannelWowFlutter.prepare (osRate, osFactor, maxOsRate);
+
+        inputTransformer.prepare (osRate);
+        outputTransformer.prepare (osRate);
+        playbackHead.prepare (osRate);
+        motorFlutter.prepare (osRate, osFactor);
+
+        reset();
+
+        auto nyquist = osRate * 0.5;
+        auto safeMaxFreq = nyquist * 0.9;
+        auto safeFreq = [safeMaxFreq] (float freq) { return std::min (freq, static_cast<float> (safeMaxFreq)); };
+
+        headBumpFilter.setCoeffs (DBiquad::peak (osRate, 60.0, 3.0, 1.5));
+        hfLossFilter1.setCoeffs  (DBiquad::lowPass (osRate, static_cast<double> (safeFreq (16000.0f)), 0.707));
+        hfLossFilter2.setCoeffs  (DBiquad::shelf (osRate, static_cast<double> (safeFreq (10000.0f)), -2.0, 0.5, true));
+        gapLossFilter.setCoeffs  (DBiquad::shelf (osRate, static_cast<double> (safeFreq (12000.0f)), -1.5, 0.707, true));
+        biasFilter.setCoeffs     (Biquad::shelf (osRate, safeFreq (8000.0f), 2.0f, 0.707f, true));
+        dcBlocker.setCoeffs      (DBiquad::highPass (osRate, 25.0, 0.707));
+
+        recordHeadCutoff = std::min (20000.0f, static_cast<float> (safeMaxFreq));
+        recordHeadFilter1.setCoeffs (Biquad::lowPass (osRate, recordHeadCutoff, 1.3066f));
+        recordHeadFilter2.setCoeffs (Biquad::lowPass (osRate, recordHeadCutoff, 0.5412f));
+
+        preEmphasisEQ.setPreEmphasis (125.0f, 50.0f);
+        deEmphasisEQ.setDeEmphasis   (50.0f, 125.0f);
+        phaseSmear.setMachineCharacter (true);
+        saturator.updateCoefficients (0.1f, 10.0f, osRate);
+
+        // Force a full updateFilters() on the next processSample so the machine-
+        // specific coefficients replace the neutral defaults above (also after an
+        // oversampling-factor change). See PORT_NOTES: the JUCE original left
+        // m_last* stale here, leaving neutral coeffs after an OS switch.
+        m_lastMachine = static_cast<TapeMachine> (-1);
+        m_lastSpeed   = static_cast<TapeSpeed> (-1);
+        m_lastType    = static_cast<TapeType> (-1);
+        m_lastEqStandard = static_cast<EQStandard> (-1);
+        m_lastBias    = -1.0f;
+    }
+
+    void reset()
+    {
+        headBumpFilter.reset(); hfLossFilter1.reset(); hfLossFilter2.reset();
+        gapLossFilter.reset(); biasFilter.reset(); dcBlocker.reset();
+        recordHeadFilter1.reset(); recordHeadFilter2.reset();
+        antiAliasingFilter.reset();
+        threeBandSplitter.reset(); softClipSplitFilter.reset();
+        hysteresisBass.reset(); hysteresisMid.reset(); hysteresisTreble.reset();
+        preEmphasisEQ.reset(); deEmphasisEQ.reset(); phaseSmear.reset();
+        improvedNoiseGen.reset();
+        saturator.envelope = 0.0f;
+
+        if (! perChannelWowFlutter.delayBuffer.empty())
+            std::fill (perChannelWowFlutter.delayBuffer.begin(), perChannelWowFlutter.delayBuffer.end(), 0.0f);
+        perChannelWowFlutter.writeIndex = 0;
+        perChannelWowFlutter.allpassState = 0.0f;
+
+        inputTransformer.reset(); outputTransformer.reset();
+        playbackHead.reset(); motorFlutter.reset();
+        crosstalkBuffer = 0.0f;
+    }
+
+    float processSample (float input,
+                         TapeMachine machine, TapeSpeed speed, TapeType type,
+                         float biasAmount, float saturationDepth, float wowFlutterAmount,
+                         bool noiseEnabled, float noiseAmount,
+                         float* sharedWowFlutterMod, float calibrationLevel,
+                         EQStandard eqStandard, SignalPath signalPath)
+    {
+        if (signalPath == Thru) return input;
+        if (std::abs (input) < denormalPrevention) return 0.0f;
+
+        if (machine != m_lastMachine || speed != m_lastSpeed || type != m_lastType ||
+            std::abs (biasAmount - m_lastBias) > 0.01f || eqStandard != m_lastEqStandard)
+        {
+            updateFilters (machine, speed, type, biasAmount, eqStandard);
+            m_lastMachine = machine; m_lastSpeed = speed; m_lastType = type;
+            m_lastBias = biasAmount; m_lastEqStandard = eqStandard;
+
+            m_cachedMachineChars = getMachineCharacteristics (machine);
+            m_cachedTapeChars = getTapeCharacteristics (type);
+            m_cachedSpeedChars = getSpeedCharacteristics (speed);
+            m_hasTransformers = (machine == Classic102);
+            m_gapWidth = (machine == Swiss800) ? 2.5f : 3.5f;
+        }
+
+        const auto& tapeChars = m_cachedTapeChars;
+        const auto& speedChars = m_cachedSpeedChars;
+
+        const bool processTape = (signalPath == Repro || signalPath == Sync);
+        const float playbackGapWidth = (signalPath == Sync) ? m_gapWidth * 2.0f : m_gapWidth;
+
+        float calibrationGain = dbToGain (calibrationLevel);
+        float signal = input * 0.95f / calibrationGain;
+
+        float transformerDrive = m_hasTransformers ? saturationDepth * 0.3f : 0.0f;
+        if (m_hasTransformers)
+            signal = inputTransformer.process (signal, transformerDrive, false);
+
+        signal = preEmphasisEQ.processSample (signal);
+
+        if (processTape)
+        {
+            if (biasAmount > 0.0f)
+                signal = biasFilter.process (signal);
+
+            signal = preSaturationLimiter.process (signal);
+
+            if (currentOversamplingFactor > 1)
+            {
+                signal = recordHeadFilter1.process (signal);
+                signal = recordHeadFilter2.process (signal);
+            }
+
+            float tapeFormScale = 2.0f * (1.0f - tapeChars.saturationPoint) + 0.6f;
+            float drive = computeDrive (saturationDepth, tapeFormScale);
+
+            if (drive > 0.001f)
+            {
+                float bass, mid, treble;
+                threeBandSplitter.split (signal, bass, mid, treble);
+                auto ratios = getBandDriveRatios (machine);
+                float biasLin = biasAmount;
+                float bassSat   = hysteresisBass.processSample (bass, drive * ratios.bass, biasLin);
+                float midSat    = hysteresisMid.processSample (mid, drive * ratios.mid, biasLin);
+                float trebleSat = hysteresisTreble.processSample (treble, drive * ratios.treble, biasLin);
+                signal = bassSat + midSat + trebleSat;
+            }
+
+            {
+                float lowFreq = softClipSplitFilter.process (signal);
+                float highFreq = signal - lowFreq;
+                lowFreq = softClip (lowFreq, 0.95f);
+                signal = lowFreq + highFreq;
+            }
+
+            signal = static_cast<float> (gapLossFilter.process (static_cast<double> (signal)));
+
+            if (wowFlutterAmount > 0.0f)
+            {
+                float motorQuality = (machine == Swiss800) ? 0.2f : 0.6f;
+                float motorFlutterMod = motorFlutter.calculateFlutter (motorQuality * wowFlutterAmount);
+
+                if (sharedWowFlutterMod != nullptr)
+                {
+                    float totalModulation = *sharedWowFlutterMod + motorFlutterMod * 5.0f;
+                    signal = perChannelWowFlutter.processSample (signal, totalModulation);
+                }
+                else
+                {
+                    float modulation = perChannelWowFlutter.calculateModulation (
+                        wowFlutterAmount * 0.7f, wowFlutterAmount * 0.3f,
+                        speedChars.wowRate, speedChars.flutterRate, currentSampleRate);
+                    float totalModulation = modulation + motorFlutterMod * 5.0f;
+                    signal = perChannelWowFlutter.processSample (signal, totalModulation);
+                }
+            }
+
+            signal = static_cast<float> (headBumpFilter.process (static_cast<double> (signal)));
+
+            signal = static_cast<float> (hfLossFilter1.process (static_cast<double> (signal)));
+            signal = static_cast<float> (hfLossFilter2.process (static_cast<double> (signal)));
+
+            if (signalPath == Sync)
+                signal = static_cast<float> (hfLossFilter1.process (static_cast<double> (signal)));
+
+            signal = playbackHead.process (signal, playbackGapWidth, static_cast<float> (speed));
+        }
+
+        signal = deEmphasisEQ.processSample (signal);
+        signal = phaseSmear.processSample (signal);
+
+        if (m_hasTransformers)
+            signal = outputTransformer.process (signal, transformerDrive * 0.5f, true);
+
+        if (processTape && noiseEnabled && noiseAmount > 0.001f)
+        {
+            float noiseLevel = dbToGain (tapeChars.noiseFloor) * speedChars.noiseReduction * noiseAmount;
+            float noise = improvedNoiseGen.generateNoise (noiseLevel, tapeChars.modulationNoise, signal);
+            signal += noise;
+        }
+
+        signal = static_cast<float> (dcBlocker.process (static_cast<double> (signal)));
+
+        if (currentOversamplingFactor > 1)
+            signal = antiAliasingFilter.process (signal);
+
+        if (std::abs (signal) < denormalPrevention) signal = 0.0f;
+        return signal;
+    }
+
+private:
+    double currentSampleRate = 44100.0;
+    int currentOversamplingFactor = 1;
+    double baseSampleRate = 44100.0;
+    float recordHeadCutoff = 15000.0f;
+
+    struct MachineCharacteristics
+    {
+        float headBumpFreq, headBumpGain, headBumpQ;
+        float hfRolloffFreq, hfRolloffSlope;
+        float saturationKnee, saturationHarmonics[5];
+        float compressionRatio, compressionAttack, compressionRelease;
+        float phaseShift, crosstalkAmount;
+    };
+    struct TapeCharacteristics
+    {
+        float coercivity, retentivity, saturationPoint;
+        float hysteresisAmount, hysteresisAsymmetry;
+        float noiseFloor, modulationNoise, lfEmphasis, hfLoss;
+    };
+    struct SpeedCharacteristics
+    {
+        float headBumpMultiplier, hfExtension, noiseReduction, flutterRate, wowRate;
+    };
+
+    JilesAthertonHysteresis hysteresisBass, hysteresisMid, hysteresisTreble;
+    TapeEQFilter preEmphasisEQ, deEmphasisEQ;
+    PhaseSmearingFilter phaseSmear;
+    ImprovedNoiseGenerator improvedNoiseGen;
+
+    DBiquad headBumpFilter;                 // juce IIR<double> in source
+    DBiquad hfLossFilter1, hfLossFilter2;   // juce IIR<double>
+    DBiquad gapLossFilter;                  // juce IIR<double>
+    Biquad  biasFilter;                     // juce IIR<float>
+    DBiquad dcBlocker;                       // juce IIR<double>
+    Biquad  recordHeadFilter1, recordHeadFilter2; // juce IIR<float>
+
+    ChebyshevAntiAliasingFilter antiAliasingFilter;
+    SoftLimiter preSaturationLimiter;
+    ThreeBandSplitter threeBandSplitter;
+    SaturationSplitFilter softClipSplitFilter;
+
+    TransformerSaturation inputTransformer, outputTransformer;
+    PlaybackHeadResponse playbackHead;
+    MotorFlutter motorFlutter;
+    WowFlutterProcessor perChannelWowFlutter;
+
+    float crosstalkBuffer = 0.0f;
+
+    // TapeSaturator: DEAD CODE in the source (process() is never called in the
+    // chain). Kept only so updateFilters()/prepare() stay structurally faithful;
+    // updateCoefficients() has no audible effect. See PORT_NOTES rule 10.
+    struct TapeSaturator
+    {
+        float envelope = 0.0f, attackCoeff = 0.0f, releaseCoeff = 0.0f;
+        void updateCoefficients (float attackMs, float releaseMs, double sampleRate)
+        {
+            if (sampleRate <= 0.0) sampleRate = 44100.0;
+            attackMs = std::max (0.001f, attackMs);
+            releaseMs = std::max (0.001f, releaseMs);
+            attackCoeff = std::exp (-1.0f / (attackMs * 0.001f * static_cast<float> (sampleRate)));
+            releaseCoeff = std::exp (-1.0f / (releaseMs * 0.001f * static_cast<float> (sampleRate)));
+        }
+    };
+    TapeSaturator saturator;
+
+    TapeMachine m_lastMachine = static_cast<TapeMachine> (-1);
+    TapeSpeed   m_lastSpeed = static_cast<TapeSpeed> (-1);
+    TapeType    m_lastType = static_cast<TapeType> (-1);
+    EQStandard  m_lastEqStandard = static_cast<EQStandard> (-1);
+    float m_lastBias = -1.0f;
+
+    MachineCharacteristics m_cachedMachineChars{};
+    TapeCharacteristics m_cachedTapeChars{};
+    SpeedCharacteristics m_cachedSpeedChars{};
+    bool m_hasTransformers = false;
+    float m_gapWidth = 3.0f;
+
+    static constexpr float denormalPrevention = 1e-8f;
+
+    struct BandDriveRatios { float bass, mid, treble; };
+    BandDriveRatios getBandDriveRatios (TapeMachine machine) const
+    {
+        if (machine == Swiss800) return { 0.55f, 1.0f, 0.20f };
+        return { 0.65f, 1.0f, 0.30f };
+    }
+
+    float computeDrive (float saturationDepth, float tapeFormulationScale) const
+    {
+        if (saturationDepth < 0.001f) return 0.0f;
+        return 0.62f * std::exp (1.8f * saturationDepth) * tapeFormulationScale;
+    }
+
+    JilesAthertonHysteresis::TapeFormulationParams getJAParams (TapeType type) const
+    {
+        switch (type)
+        {
+            case Type456: return { 280.0f, 720.0f, 0.016f, 640.0f, 0.50f };
+            case TypeGP9: return { 320.0f, 800.0f, 0.012f, 700.0f, 0.60f };
+            case Type911: return { 270.0f, 700.0f, 0.018f, 620.0f, 0.48f };
+            case Type250: return { 240.0f, 680.0f, 0.020f, 580.0f, 0.45f };
+            default:      return { 280.0f, 720.0f, 0.016f, 640.0f, 0.50f };
+        }
+    }
+
+    static float softClip (float input, float threshold)
+    {
+        float absInput = std::abs (input);
+        if (absInput < threshold) return input;
+        float sign = (input >= 0.0f) ? 1.0f : -1.0f;
+        float excess = absInput - threshold;
+        float headroom = 1.0f - threshold;
+        float normalized = excess / (headroom + 0.001f);
+        float smoothed = normalized / (1.0f + normalized);
+        float clipped = threshold + headroom * smoothed;
+        return clipped * sign;
+    }
+
+    MachineCharacteristics getMachineCharacteristics (TapeMachine machine)
+    {
+        MachineCharacteristics chars{};
+        switch (machine)
+        {
+            case Swiss800:
+                chars.headBumpFreq = 48.0f; chars.headBumpGain = 3.0f; chars.headBumpQ = 1.0f;
+                chars.hfRolloffFreq = 22000.0f; chars.hfRolloffSlope = -12.0f;
+                chars.saturationKnee = 0.92f;
+                chars.saturationHarmonics[0] = 0.003f; chars.saturationHarmonics[1] = 0.030f;
+                chars.saturationHarmonics[2] = 0.001f; chars.saturationHarmonics[3] = 0.005f;
+                chars.saturationHarmonics[4] = 0.0005f;
+                chars.compressionRatio = 0.03f; chars.compressionAttack = 0.08f; chars.compressionRelease = 40.0f;
+                chars.phaseShift = 0.015f; chars.crosstalkAmount = -70.0f;
+                break;
+            case Classic102:
+                chars.headBumpFreq = 62.0f; chars.headBumpGain = 4.5f; chars.headBumpQ = 1.4f;
+                chars.hfRolloffFreq = 18000.0f; chars.hfRolloffSlope = -18.0f;
+                chars.saturationKnee = 0.85f;
+                chars.saturationHarmonics[0] = 0.008f; chars.saturationHarmonics[1] = 0.032f;
+                chars.saturationHarmonics[2] = 0.003f; chars.saturationHarmonics[3] = 0.004f;
+                chars.saturationHarmonics[4] = 0.002f;
+                chars.compressionRatio = 0.05f; chars.compressionAttack = 0.15f; chars.compressionRelease = 80.0f;
+                chars.phaseShift = 0.04f; chars.crosstalkAmount = -55.0f;
+                break;
+        }
+        return chars;
+    }
+
+    TapeCharacteristics getTapeCharacteristics (TapeType type)
+    {
+        TapeCharacteristics chars{};
+        switch (type)
+        {
+            case Type456:
+                chars.coercivity = 0.78f; chars.retentivity = 0.82f; chars.saturationPoint = 0.88f;
+                chars.hysteresisAmount = 0.12f; chars.hysteresisAsymmetry = 0.02f;
+                chars.noiseFloor = -60.0f; chars.modulationNoise = 0.025f; chars.lfEmphasis = 1.12f; chars.hfLoss = 0.92f;
+                break;
+            case TypeGP9:
+                chars.coercivity = 0.92f; chars.retentivity = 0.95f; chars.saturationPoint = 0.96f;
+                chars.hysteresisAmount = 0.06f; chars.hysteresisAsymmetry = 0.01f;
+                chars.noiseFloor = -64.0f; chars.modulationNoise = 0.015f; chars.lfEmphasis = 1.05f; chars.hfLoss = 0.96f;
+                break;
+            case Type911:
+                chars.coercivity = 0.82f; chars.retentivity = 0.86f; chars.saturationPoint = 0.85f;
+                chars.hysteresisAmount = 0.14f; chars.hysteresisAsymmetry = 0.025f;
+                chars.noiseFloor = -58.0f; chars.modulationNoise = 0.028f; chars.lfEmphasis = 1.15f; chars.hfLoss = 0.90f;
+                break;
+            case Type250:
+                chars.coercivity = 0.70f; chars.retentivity = 0.75f; chars.saturationPoint = 0.80f;
+                chars.hysteresisAmount = 0.18f; chars.hysteresisAsymmetry = 0.035f;
+                chars.noiseFloor = -55.0f; chars.modulationNoise = 0.035f; chars.lfEmphasis = 1.18f; chars.hfLoss = 0.87f;
+                break;
+            default:
+                chars = getTapeCharacteristics (Type456);
+                break;
+        }
+        return chars;
+    }
+
+    SpeedCharacteristics getSpeedCharacteristics (TapeSpeed speed)
+    {
+        SpeedCharacteristics chars{};
+        switch (speed)
+        {
+            case Speed_7_5_IPS:
+                chars.headBumpMultiplier = 1.5f; chars.hfExtension = 0.7f; chars.noiseReduction = 1.0f;
+                chars.flutterRate = 3.5f; chars.wowRate = 0.33f;
+                break;
+            case Speed_15_IPS:
+                chars.headBumpMultiplier = 1.0f; chars.hfExtension = 1.0f; chars.noiseReduction = 0.7f;
+                chars.flutterRate = 5.0f; chars.wowRate = 0.5f;
+                break;
+            case Speed_30_IPS:
+                chars.headBumpMultiplier = 0.7f; chars.hfExtension = 1.3f; chars.noiseReduction = 0.5f;
+                chars.flutterRate = 7.0f; chars.wowRate = 0.8f;
+                break;
+            default:
+                chars = getSpeedCharacteristics (Speed_15_IPS);
+                break;
+        }
+        return chars;
+    }
+
+    void updateFilters (TapeMachine machine, TapeSpeed speed, TapeType type,
+                        float biasAmount, EQStandard eqStandard)
+    {
+        auto machineChars = getMachineCharacteristics (machine);
+        auto tapeChars = getTapeCharacteristics (type);
+        auto speedChars = getSpeedCharacteristics (speed);
+
+        float preEQ_tauNum = 125.0f;
+        float preEQ_tauDen = 50.0f;
+
+        switch (eqStandard)
+        {
+            case NAB:
+                switch (speed)
+                {
+                    case Speed_7_5_IPS: preEQ_tauNum = 225.0f; preEQ_tauDen = 90.0f; break;
+                    case Speed_15_IPS:  preEQ_tauNum = 125.0f; preEQ_tauDen = 50.0f; break;
+                    case Speed_30_IPS:  preEQ_tauNum = 44.0f;  preEQ_tauDen = 17.5f; break;
+                }
+                break;
+            case CCIR:
+                switch (speed)
+                {
+                    case Speed_7_5_IPS: preEQ_tauNum = 175.0f; preEQ_tauDen = 70.0f; break;
+                    case Speed_15_IPS:  preEQ_tauNum = 88.0f;  preEQ_tauDen = 35.0f; break;
+                    case Speed_30_IPS:  preEQ_tauNum = 36.0f;  preEQ_tauDen = 17.5f; break;
+                }
+                break;
+            case AES:
+                preEQ_tauNum = 35.0f; preEQ_tauDen = 17.5f;
+                break;
+        }
+
+        preEmphasisEQ.setPreEmphasis (preEQ_tauNum, preEQ_tauDen);
+        deEmphasisEQ.setDeEmphasis   (preEQ_tauDen, preEQ_tauNum);
+
+        auto jaParams = getJAParams (type);
+        bool isPrecision = (machine == Swiss800);
+
+        hysteresisBass.setFormulation (jaParams);   hysteresisBass.setMachineType (isPrecision);
+        hysteresisMid.setFormulation (jaParams);    hysteresisMid.setMachineType (isPrecision);
+        hysteresisTreble.setFormulation (jaParams); hysteresisTreble.setMachineType (isPrecision);
+
+        phaseSmear.setMachineCharacter (isPrecision);
+
+        improvedNoiseGen.prepare (currentSampleRate, static_cast<int> (speed));
+
+        float headBumpFreq = machineChars.headBumpFreq;
+        float headBumpGain = machineChars.headBumpGain * speedChars.headBumpMultiplier;
+        float headBumpQ = machineChars.headBumpQ;
+
+        switch (speed)
+        {
+            case Speed_7_5_IPS:
+                headBumpFreq = machineChars.headBumpFreq * 0.65f;
+                headBumpGain *= 1.4f; headBumpQ *= 1.3f;
+                break;
+            case Speed_15_IPS:
+                break;
+            case Speed_30_IPS:
+                headBumpFreq = machineChars.headBumpFreq * 1.5f;
+                headBumpGain *= 0.7f; headBumpQ *= 0.8f;
+                break;
+        }
+
+        headBumpGain *= tapeChars.lfEmphasis * 0.8f;
+
+        headBumpFreq = std::clamp (headBumpFreq, 30.0f, 120.0f);
+        headBumpQ    = std::clamp (headBumpQ, 0.7f, 2.0f);
+        headBumpGain = std::clamp (headBumpGain, 1.5f, 5.0f);
+
+        headBumpFilter.setCoeffs (DBiquad::peak (currentSampleRate,
+            static_cast<double> (headBumpFreq), static_cast<double> (headBumpGain),
+            static_cast<double> (headBumpQ)));
+
+        float maxFilterFreq = static_cast<float> (currentSampleRate * 0.45);
+        float hfCutoff = machineChars.hfRolloffFreq * speedChars.hfExtension * tapeChars.hfLoss;
+        hfCutoff = std::min (hfCutoff, maxFilterFreq);
+        hfLossFilter1.setCoeffs (DBiquad::lowPass (currentSampleRate, static_cast<double> (hfCutoff), 0.707));
+
+        float hfShelfFreq = std::min (hfCutoff * 0.6f, maxFilterFreq);
+        hfLossFilter2.setCoeffs (DBiquad::shelf (currentSampleRate, static_cast<double> (hfShelfFreq),
+            static_cast<double> (-2.0f * tapeChars.hfLoss), 0.5, true));
+
+        float gapLossFreq = speed == Speed_7_5_IPS ? 8000.0f : (speed == Speed_30_IPS ? 15000.0f : 12000.0f);
+        float gapLossAmount = speed == Speed_7_5_IPS ? -3.0f : (speed == Speed_30_IPS ? -0.5f : -1.5f);
+        gapLossFilter.setCoeffs (DBiquad::shelf (currentSampleRate, static_cast<double> (gapLossFreq),
+            static_cast<double> (gapLossAmount), 0.707, true));
+
+        float biasFreq = 6000.0f + (biasAmount * 4000.0f);
+        biasFilter.setCoeffs (Biquad::shelf (currentSampleRate, biasFreq, biasAmount * 3.0f, 0.707f, true));
+
+        saturator.updateCoefficients (machineChars.compressionAttack,
+                                      machineChars.compressionRelease, currentSampleRate);
+    }
+};
+
+//==============================================================================
+// TapeMachineDSP — framework-free equivalent of the JUCE PluginProcessor's
+// audio path. Public API is fixed by the DPF shell contract. Parameters are
+// stored in std::atomic (memory_order_relaxed) and are safe to set from any
+// thread; coefficient recompute happens at the top of processBlock().
+//==============================================================================
+class TapeMachineDSP
+{
+public:
+    static constexpr int kMaxChannels = 2;
+
+    void prepare (double sampleRate, int maxBlockSize);   // may allocate; setup thread only
+    void reset();
+    void processBlock (const float* const* inputs, float* const* outputs, int nCh, int nSamples) noexcept;
+    int  latencySamples() const noexcept;
+
+    void setTapeMachine (int idx)  noexcept { pMachine.store (clampI (idx, 0, 1), std::memory_order_relaxed); }
+    void setTapeSpeed   (int idx)  noexcept { pSpeed.store (clampI (idx, 0, 2), std::memory_order_relaxed); }
+    void setTapeType    (int idx)  noexcept { pType.store (clampI (idx, 0, 3), std::memory_order_relaxed); }
+    void setSignalPath  (int idx)  noexcept { pSignalPath.store (clampI (idx, 0, 3), std::memory_order_relaxed); }
+    void setEqStandard  (int idx)  noexcept { pEqStandard.store (clampI (idx, 0, 2), std::memory_order_relaxed); }
+    void setInputGainDb (float db) noexcept { pInputGainDb.store (db, std::memory_order_relaxed); }
+    void setSaturation  (float pct)noexcept { pSaturation.store (pct, std::memory_order_relaxed); }  // DEAD (see PORT_NOTES)
+    void setBias        (float pct)noexcept { pBias.store (pct, std::memory_order_relaxed); }
+    void setCalibration (int idx)  noexcept { pCalibration.store (clampI (idx, 0, 3), std::memory_order_relaxed); }
+    void setAutoCal     (bool b)   noexcept { pAutoCal.store (b, std::memory_order_relaxed); }
+    void setHighpassHz  (float hz) noexcept { pHighpassHz.store (hz, std::memory_order_relaxed); }
+    void setLowpassHz   (float hz) noexcept { pLowpassHz.store (hz, std::memory_order_relaxed); }
+    void setNoiseAmount (float pct)noexcept { pNoiseAmount.store (pct, std::memory_order_relaxed); }
+    void setNoiseEnabled(bool b)   noexcept { pNoiseEnabled.store (b, std::memory_order_relaxed); } // DEAD gate (see PORT_NOTES)
+    void setWow         (float pct)noexcept { pWow.store (pct, std::memory_order_relaxed); }
+    void setFlutter     (float pct)noexcept { pFlutter.store (pct, std::memory_order_relaxed); }
+    void setOutputGainDb(float db) noexcept { pOutputGainDb.store (db, std::memory_order_relaxed); }
+    void setAutoComp    (bool b)   noexcept { pAutoComp.store (b, std::memory_order_relaxed); }
+    void setOversampling(int idx)  noexcept { pOversampling.store (clampI (idx, 0, 2), std::memory_order_relaxed); }
+    void setBypass      (bool b)   noexcept { pBypass.store (b, std::memory_order_relaxed); }
+
+    float getVuL() const noexcept { return vuL.load (std::memory_order_relaxed); }
+    float getVuR() const noexcept { return vuR.load (std::memory_order_relaxed); }
+
+private:
+    static int clampI (int v, int lo, int hi) noexcept { return v < lo ? lo : (v > hi ? hi : v); }
+    static int factorFromChoice (int c) noexcept { return c == 0 ? 1 : (c == 1 ? 2 : 4); }
+
+    void applyFactor (int newFactor);   // reconfigure internal DSP for an OS-factor change
+
+    // --- parameters (atomics) ---
+    std::atomic<int>   pMachine{0}, pSpeed{1}, pType{0}, pSignalPath{0}, pEqStandard{0};
+    std::atomic<int>   pCalibration{0}, pOversampling{2};
+    std::atomic<float> pInputGainDb{0.0f}, pSaturation{4.0f}, pBias{50.0f};
+    std::atomic<float> pHighpassHz{20.0f}, pLowpassHz{20000.0f};
+    std::atomic<float> pNoiseAmount{0.0f}, pWow{7.0f}, pFlutter{3.0f}, pOutputGainDb{0.0f};
+    std::atomic<bool>  pAutoCal{true}, pNoiseEnabled{false}, pAutoComp{true}, pBypass{false};
+
+    // --- config ---
+    double baseSampleRate = 44100.0;
+    int    maxBlock = 512;
+    double maxOsRate = 176400.0;
+    int    currentFactor = 4;
+    double currentOsRate = 176400.0;
+
+    // --- per-channel DSP ---
+    TapeCore   coreL, coreR;
+    WowFlutterProcessor sharedWowFlutter;
+    Oversampler osL, osR;
+    DuskSVF hpL, hpR, lpL, lpR;
+
+    // --- smoothers ---
+    SmoothedValue inGain;                   // base-rate ramp (shared by L/R)
+    SmoothedValue outGain;                  // OS-rate ramp (shared by L/R)
+    SmoothedValue smSat, smWow, smFlutter, smNoise;
+
+    bool bypassLowpass = true;
+
+    // --- dirty tracking ---
+    float lastHpFreq = -1.0f, lastLpFreq = -1.0f;
+    int   lastFactor = -1;
+
+    // --- scratch (allocated in prepare) ---
+    std::vector<float> inGainArr;           // base-rate  [maxBlock]
+    std::vector<float> satArr, wowFlutArr, noiseArr, sharedModArr, outGainArr; // OS-rate [maxBlock*4]
+
+    // --- metering ---
+    std::atomic<float> vuL{0.0f}, vuR{0.0f};
+    float vuStateL = 0.0f, vuStateR = 0.0f;
+    float vuReleaseCoeff = 0.0f;
+};
+
+} // namespace duskaudio

--- a/plugins/TapeMachine/dpf-plugin/CMakeLists.txt
+++ b/plugins/TapeMachine/dpf-plugin/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+# Third-party components (DPF — ISC; Dear ImGui — MIT; and others) are attributed
+# in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+#
+# Standalone CMake for the DPF-based TapeMachine 2 plugin.
+#   cmake -B build -GNinja [-DDPF_PATH=/path/to/DPF]
+#   cmake --build build
+
+cmake_minimum_required(VERSION 3.15)
+project(TapeMachine2DPF VERSION 2.0.0)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/../../shared-dpf/cmake/DuskDpfPlugin.cmake")
+
+dpf_add_plugin(tape_machine_2
+    TARGETS clap vst3 lv2 jack au # au builds on macOS only, silently skipped elsewhere
+    MONOLITHIC
+    UI_TYPE opengl
+    FILES_DSP
+        TapeMachinePlugin.cpp
+        ../core/TapeMachineDSP.cpp
+    FILES_UI
+        TapeMachineUI.cpp
+        ${DUSK_DPF_UI_SOURCES})
+
+target_include_directories(tape_machine_2 PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../core"
+    ${DUSK_DPF_INCLUDE_DIRS})
+
+dusk_dpf_install_local(tape_machine_2)

--- a/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
@@ -29,8 +29,8 @@
 #define DISTRHO_UI_USE_CUSTOM           1
 #define DISTRHO_UI_CUSTOM_INCLUDE_PATH  "DearImGui.hpp"
 #define DISTRHO_UI_CUSTOM_WIDGET_TYPE   DGL_NAMESPACE::ImGuiTopLevelWidget
-#define DISTRHO_UI_DEFAULT_WIDTH        920
-#define DISTRHO_UI_DEFAULT_HEIGHT       480
+#define DISTRHO_UI_DEFAULT_WIDTH        800
+#define DISTRHO_UI_DEFAULT_HEIGHT       568
 #define DISTRHO_UI_USER_RESIZABLE       1
 
 // Oversampling adds FIR group delay -> report it to the host.

--- a/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
@@ -35,7 +35,7 @@
 
 // Oversampling adds FIR group delay -> report it to the host.
 #define DISTRHO_PLUGIN_WANT_LATENCY  1
-#define DISTRHO_PLUGIN_WANT_PROGRAMS 1
+#define DISTRHO_PLUGIN_WANT_PROGRAMS 0
 #define DISTRHO_PLUGIN_WANT_STATE    0
 
 #define DISTRHO_PLUGIN_CLAP_FEATURES   "audio-effect", "distortion", "filter", "stereo"

--- a/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
@@ -30,12 +30,12 @@
 #define DISTRHO_UI_CUSTOM_INCLUDE_PATH  "DearImGui.hpp"
 #define DISTRHO_UI_CUSTOM_WIDGET_TYPE   DGL_NAMESPACE::ImGuiTopLevelWidget
 #define DISTRHO_UI_DEFAULT_WIDTH        800
-#define DISTRHO_UI_DEFAULT_HEIGHT       568
+#define DISTRHO_UI_DEFAULT_HEIGHT       520
 #define DISTRHO_UI_USER_RESIZABLE       1
 
 // Oversampling adds FIR group delay -> report it to the host.
 #define DISTRHO_PLUGIN_WANT_LATENCY  1
-#define DISTRHO_PLUGIN_WANT_PROGRAMS 0
+#define DISTRHO_PLUGIN_WANT_PROGRAMS 1
 #define DISTRHO_PLUGIN_WANT_STATE    0
 
 #define DISTRHO_PLUGIN_CLAP_FEATURES   "audio-effect", "distortion", "filter", "stereo"

--- a/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
@@ -30,7 +30,7 @@
 #define DISTRHO_UI_CUSTOM_INCLUDE_PATH  "DearImGui.hpp"
 #define DISTRHO_UI_CUSTOM_WIDGET_TYPE   DGL_NAMESPACE::ImGuiTopLevelWidget
 #define DISTRHO_UI_DEFAULT_WIDTH        800
-#define DISTRHO_UI_DEFAULT_HEIGHT       520
+#define DISTRHO_UI_DEFAULT_HEIGHT       470
 #define DISTRHO_UI_USER_RESIZABLE       1
 
 // Oversampling adds FIR group delay -> report it to the host.

--- a/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/TapeMachine/dpf-plugin/DistrhoPluginInfo.h
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components (DPF — ISC; Dear ImGui — MIT; and others) are attributed
+// in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// DistrhoPluginInfo.h — DPF compile-time configuration for TapeMachine 2, the
+// DPF successor to the JUCE TapeMachine (v1.x). Distinct IDs from the JUCE build
+// (PLUGIN_CODE "Tape", URI .../tapemachine) so both can coexist in a session.
+
+#pragma once
+
+#define DISTRHO_PLUGIN_BRAND        "Dusk Audio"
+#define DISTRHO_PLUGIN_NAME         "TapeMachine 2"
+#define DISTRHO_PLUGIN_URI          "https://dusk-audio.github.io/plugins/tapemachine-2"
+#define DISTRHO_PLUGIN_CLAP_ID      "com.duskaudio.tapemachine2"
+
+#define DISTRHO_PLUGIN_BRAND_ID     Dusk
+#define DISTRHO_PLUGIN_UNIQUE_ID    DsTM
+
+#define DISTRHO_PLUGIN_NUM_INPUTS   2
+#define DISTRHO_PLUGIN_NUM_OUTPUTS  2
+#define DISTRHO_PLUGIN_HAS_UI       1
+#define DISTRHO_PLUGIN_IS_RT_SAFE   1
+// UI reads the VU meter atomics straight from the DSP when same-process (all
+// Linux formats); falls back to the output parameters otherwise.
+#define DISTRHO_PLUGIN_WANT_DIRECT_ACCESS 1
+#define DISTRHO_PLUGIN_WANT_TIMEPOS       0
+
+// Dear ImGui UI via DPF-Widgets: UI base class becomes ImGuiTopLevelWidget.
+#define DISTRHO_UI_USE_CUSTOM           1
+#define DISTRHO_UI_CUSTOM_INCLUDE_PATH  "DearImGui.hpp"
+#define DISTRHO_UI_CUSTOM_WIDGET_TYPE   DGL_NAMESPACE::ImGuiTopLevelWidget
+#define DISTRHO_UI_DEFAULT_WIDTH        920
+#define DISTRHO_UI_DEFAULT_HEIGHT       480
+#define DISTRHO_UI_USER_RESIZABLE       1
+
+// Oversampling adds FIR group delay -> report it to the host.
+#define DISTRHO_PLUGIN_WANT_LATENCY  1
+#define DISTRHO_PLUGIN_WANT_PROGRAMS 1
+#define DISTRHO_PLUGIN_WANT_STATE    0
+
+#define DISTRHO_PLUGIN_CLAP_FEATURES   "audio-effect", "distortion", "filter", "stereo"
+#define DISTRHO_PLUGIN_LV2_CATEGORY    "lv2:DistortionPlugin"
+#define DISTRHO_PLUGIN_VST3_CATEGORIES "Fx|Distortion|Stereo"

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// TapeMachineAccess.hpp — UI-side accessors for same-process DSP data (the two
+// VU meters). Uses the shared weak-symbol bridge; see DuskAccessBridge.hpp for
+// the single-binary-vs-split-LV2 contract and the required UI-side null guard.
+// Strong definitions live in TapeMachinePlugin.cpp.
+
+#pragma once
+
+#include "DuskAccessBridge.hpp"
+
+// Linear output peak per channel (0..~2), ~300 ms release. Null in split LV2 UI.
+DUSK_ACCESS_DECL(float, tapeMachineGetVuL);
+DUSK_ACCESS_DECL(float, tapeMachineGetVuR);

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
@@ -14,3 +14,6 @@
 // Linear output peak per channel (0..~2), ~300 ms release. Null in split LV2 UI.
 DUSK_ACCESS_DECL(float, tapeMachineGetVuL);
 DUSK_ACCESS_DECL(float, tapeMachineGetVuR);
+// Pre-processing input peak per channel (for the UI's In/Out meter switch).
+DUSK_ACCESS_DECL(float, tapeMachineGetInVuL);
+DUSK_ACCESS_DECL(float, tapeMachineGetInVuR);

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
@@ -70,25 +70,27 @@ struct TmParam
 
 static constexpr TmParam kTmParams[kParamCount] =
 {
-    { "tapeMachine",  "Tape Machine", 'c', 0.f, 1.f,     0.f,  "",   tmparams::kTapeMachine, 2 },
-    { "tapeSpeed",    "Tape Speed",   'c', 0.f, 2.f,     1.f,  "",   tmparams::kTapeSpeed,   3 },
-    { "tapeType",     "Tape Type",    'c', 0.f, 3.f,     0.f,  "",   tmparams::kTapeType,    4 },
-    { "signalPath",   "Signal Path",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kSignalPath,  4 },
-    { "eqStandard",   "EQ Standard",  'c', 0.f, 2.f,     0.f,  "",   tmparams::kEqStandard,  3 },
+    // choice counts derive from their arrays via tmparams::count() so they can't
+    // drift out of sync (guards initParameter / selector against OOB choice access).
+    { "tapeMachine",  "Tape Machine", 'c', 0.f, 1.f,     0.f,  "",   tmparams::kTapeMachine, tmparams::count(tmparams::kTapeMachine) },
+    { "tapeSpeed",    "Tape Speed",   'c', 0.f, 2.f,     1.f,  "",   tmparams::kTapeSpeed,   tmparams::count(tmparams::kTapeSpeed) },
+    { "tapeType",     "Tape Type",    'c', 0.f, 3.f,     0.f,  "",   tmparams::kTapeType,    tmparams::count(tmparams::kTapeType) },
+    { "signalPath",   "Signal Path",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kSignalPath,  tmparams::count(tmparams::kSignalPath) },
+    { "eqStandard",   "EQ Standard",  'c', 0.f, 2.f,     0.f,  "",   tmparams::kEqStandard,  tmparams::count(tmparams::kEqStandard) },
     { "inputGain",    "Input Gain",   'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
     { "bias",         "Bias",         'f', 0.f, 100.f,   50.f, "%",  nullptr, 0 },
-    { "calibration",  "Calibration",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kCalibration, 4 },
-    { "autoCal",      "Auto Calibration",'c',0.f,1.f,    1.f,  "",   tmparams::kOffOn,       2 },
+    { "calibration",  "Calibration",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kCalibration, tmparams::count(tmparams::kCalibration) },
+    { "autoCal",      "Auto Calibration",'c',0.f,1.f,    1.f,  "",   tmparams::kOffOn,       tmparams::count(tmparams::kOffOn) },
     { "highpassFreq", "Highpass Freq",'g', 20.f, 500.f,  20.f, "Hz", nullptr, 0 },
     { "lowpassFreq",  "Lowpass Freq", 'g', 3000.f,20000.f,20000.f,"Hz",nullptr,0 },
     { "noiseAmount",  "Noise Amount", 'f', 0.f, 100.f,   0.f,  "%",  nullptr, 0 },
-    { "noiseEnabled", "Noise Enabled",'c', 0.f, 1.f,     0.f,  "",   tmparams::kOffOn,       2 },
+    { "noiseEnabled", "Noise Enabled",'c', 0.f, 1.f,     0.f,  "",   tmparams::kOffOn,       tmparams::count(tmparams::kOffOn) },
     { "wowAmount",    "Wow",          'f', 0.f, 100.f,   7.f,  "%",  nullptr, 0 },
     { "flutterAmount","Flutter",      'f', 0.f, 100.f,   3.f,  "%",  nullptr, 0 },
     { "outputGain",   "Output Gain",  'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
-    { "autoComp",     "Auto Compensation",'c',0.f,1.f,   1.f,  "",   tmparams::kOffOn,       2 },
-    { "oversampling", "Oversampling", 'c', 0.f, 2.f,     2.f,  "",   tmparams::kOversampling,3 },
-    { "bypass",       "Bypass",       'b', 0.f, 1.f,     0.f,  "",   tmparams::kOffOn,       2 },
+    { "autoComp",     "Auto Compensation",'c',0.f,1.f,   1.f,  "",   tmparams::kOffOn,       tmparams::count(tmparams::kOffOn) },
+    { "oversampling", "Oversampling", 'c', 0.f, 2.f,     2.f,  "",   tmparams::kOversampling,tmparams::count(tmparams::kOversampling) },
+    { "bypass",       "Bypass",       'b', 0.f, 1.f,     0.f,  "",   tmparams::kOffOn,       tmparams::count(tmparams::kOffOn) },
     { "vuL",          "VU L",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
     { "vuR",          "VU R",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
 };

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
@@ -19,8 +19,7 @@ enum ParamId
     kParamTapeType,        // choice: 456 / GP9 / 911 / 250
     kParamSignalPath,      // choice: Repro / Sync / Input / Thru
     kParamEqStandard,      // choice: NAB / CCIR / AES
-    kParamInputGain,       // -12..12 dB
-    kParamSaturation,      // 0..100 %
+    kParamInputGain,       // -12..12 dB  (this is the real tape-drive control)
     kParamBias,            // 0..100 % (50 = optimal)
     kParamCalibration,     // choice: 0 / +3 / +6 / +9 dB
     kParamAutoCal,         // choice: Off / On
@@ -77,7 +76,6 @@ static constexpr TmParam kTmParams[kParamCount] =
     { "signalPath",   "Signal Path",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kSignalPath,  4 },
     { "eqStandard",   "EQ Standard",  'c', 0.f, 2.f,     0.f,  "",   tmparams::kEqStandard,  3 },
     { "inputGain",    "Input Gain",   'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
-    { "saturation",   "Saturation",   'f', 0.f, 100.f,   4.f,  "%",  nullptr, 0 },
     { "bias",         "Bias",         'f', 0.f, 100.f,   50.f, "%",  nullptr, 0 },
     { "calibration",  "Calibration",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kCalibration, 4 },
     { "autoCal",      "Auto Calibration",'c',0.f,1.f,    1.f,  "",   tmparams::kOffOn,       2 },

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
@@ -1,0 +1,96 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// TapeMachineParams.hpp — parameter ids, ranges and choice labels shared by the
+// DSP shell (initParameter / setParameterValue) and the UI.
+//
+// Order mirrors the JUCE TapeMachine parameter layout exactly (values are host-
+// automation indices, not display strings). Trademark tape-stock / machine
+// names are kept verbatim per the product owner's decision (this plugin is an
+// approved exception to the migration's no-trademark guideline).
+
+#pragma once
+
+enum ParamId
+{
+    kParamTapeMachine = 0, // choice: Swiss 800 / Classic 102
+    kParamTapeSpeed,       // choice: 7.5 / 15 / 30 IPS
+    kParamTapeType,        // choice: 456 / GP9 / 911 / 250
+    kParamSignalPath,      // choice: Repro / Sync / Input / Thru
+    kParamEqStandard,      // choice: NAB / CCIR / AES
+    kParamInputGain,       // -12..12 dB
+    kParamSaturation,      // 0..100 %
+    kParamBias,            // 0..100 % (50 = optimal)
+    kParamCalibration,     // choice: 0 / +3 / +6 / +9 dB
+    kParamAutoCal,         // choice: Off / On
+    kParamHighpassFreq,    // 20..500 Hz (skew 0.5)
+    kParamLowpassFreq,     // 3000..20000 Hz (skew 0.5)
+    kParamNoiseAmount,     // 0..100 %
+    kParamNoiseEnabled,    // choice: Off / On
+    kParamWow,             // 0..100 %
+    kParamFlutter,         // 0..100 %
+    kParamOutputGain,      // -12..12 dB
+    kParamAutoComp,        // choice: Off / On
+    kParamOversampling,    // choice: 1x / 2x / 4x
+    kParamBypass,          // host-designated bypass
+    // --- output-only (meters); kept as params for generic-UI fallback ---
+    kParamVuL,             // output: L peak level for the VU meter
+    kParamVuR,             // output: R peak level for the VU meter
+    kParamCount
+};
+
+// ---- choice label tables (index == parameter value) ------------------------
+namespace tmparams
+{
+    static constexpr const char* kTapeMachine[] = { "Swiss 800", "Classic 102" };
+    static constexpr const char* kTapeSpeed[]   = { "7.5 IPS", "15 IPS", "30 IPS" };
+    static constexpr const char* kTapeType[]    = { "Type 456", "Type GP9", "Type 911", "Type 250" };
+    static constexpr const char* kSignalPath[]  = { "Repro", "Sync", "Input", "Thru" };
+    static constexpr const char* kEqStandard[]  = { "NAB", "CCIR", "AES" };
+    static constexpr const char* kCalibration[] = { "0dB", "+3dB", "+6dB", "+9dB" };
+    static constexpr const char* kOffOn[]       = { "Off", "On" };
+    static constexpr const char* kOversampling[]= { "1x", "2x", "4x" };
+
+    template <int N> static constexpr int count(const char* const (&)[N]) { return N; }
+}
+
+// ---- unified parameter descriptor (drives initParameter) -------------------
+// kind: 'f' linear float, 'g' skewed float (log-ish), 'c' integer choice,
+// 'b' boolean/bypass, 'o' output (meter).
+struct TmParam
+{
+    const char*  id;
+    const char*  name;
+    char         kind;
+    float        min, max, def;
+    const char*  unit;
+    const char* const* choices; // non-null for 'c'/'b'
+    int          numChoices;
+};
+
+static constexpr TmParam kTmParams[kParamCount] =
+{
+    { "tapeMachine",  "Tape Machine", 'c', 0.f, 1.f,     0.f,  "",   tmparams::kTapeMachine, 2 },
+    { "tapeSpeed",    "Tape Speed",   'c', 0.f, 2.f,     1.f,  "",   tmparams::kTapeSpeed,   3 },
+    { "tapeType",     "Tape Type",    'c', 0.f, 3.f,     0.f,  "",   tmparams::kTapeType,    4 },
+    { "signalPath",   "Signal Path",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kSignalPath,  4 },
+    { "eqStandard",   "EQ Standard",  'c', 0.f, 2.f,     0.f,  "",   tmparams::kEqStandard,  3 },
+    { "inputGain",    "Input Gain",   'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
+    { "saturation",   "Saturation",   'f', 0.f, 100.f,   4.f,  "%",  nullptr, 0 },
+    { "bias",         "Bias",         'f', 0.f, 100.f,   50.f, "%",  nullptr, 0 },
+    { "calibration",  "Calibration",  'c', 0.f, 3.f,     0.f,  "",   tmparams::kCalibration, 4 },
+    { "autoCal",      "Auto Calibration",'c',0.f,1.f,    1.f,  "",   tmparams::kOffOn,       2 },
+    { "highpassFreq", "Highpass Freq",'g', 20.f, 500.f,  20.f, "Hz", nullptr, 0 },
+    { "lowpassFreq",  "Lowpass Freq", 'g', 3000.f,20000.f,20000.f,"Hz",nullptr,0 },
+    { "noiseAmount",  "Noise Amount", 'f', 0.f, 100.f,   0.f,  "%",  nullptr, 0 },
+    { "noiseEnabled", "Noise Enabled",'c', 0.f, 1.f,     0.f,  "",   tmparams::kOffOn,       2 },
+    { "wowAmount",    "Wow",          'f', 0.f, 100.f,   7.f,  "%",  nullptr, 0 },
+    { "flutterAmount","Flutter",      'f', 0.f, 100.f,   3.f,  "%",  nullptr, 0 },
+    { "outputGain",   "Output Gain",  'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
+    { "autoComp",     "Auto Compensation",'c',0.f,1.f,   1.f,  "",   tmparams::kOffOn,       2 },
+    { "oversampling", "Oversampling", 'c', 0.f, 2.f,     2.f,  "",   tmparams::kOversampling,3 },
+    { "bypass",       "Bypass",       'b', 0.f, 1.f,     0.f,  "",   tmparams::kOffOn,       2 },
+    { "vuL",          "VU L",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
+    { "vuR",          "VU R",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
+};

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -28,6 +28,8 @@ public:
     // same-process meter access for the UI bridge (TapeMachineAccess.hpp)
     float getVuLForUI() const noexcept { return dsp.getVuL(); }
     float getVuRForUI() const noexcept { return dsp.getVuR(); }
+    float getInVuLForUI() const noexcept { return dsp.getInVuL(); }
+    float getInVuRForUI() const noexcept { return dsp.getInVuR(); }
 
 protected:
     //--- metadata --------------------------------------------------------------
@@ -210,4 +212,14 @@ float tapeMachineGetVuR(void* const pluginInstancePointer) noexcept
 {
     auto* const p = static_cast<DISTRHO_NAMESPACE::TapeMachinePlugin*>(pluginInstancePointer);
     return p != nullptr ? p->getVuRForUI() : 0.0f;
+}
+float tapeMachineGetInVuL(void* const pluginInstancePointer) noexcept
+{
+    auto* const p = static_cast<DISTRHO_NAMESPACE::TapeMachinePlugin*>(pluginInstancePointer);
+    return p != nullptr ? p->getInVuLForUI() : 0.0f;
+}
+float tapeMachineGetInVuR(void* const pluginInstancePointer) noexcept
+{
+    auto* const p = static_cast<DISTRHO_NAMESPACE::TapeMachinePlugin*>(pluginInstancePointer);
+    return p != nullptr ? p->getInVuRForUI() : 0.0f;
 }

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -135,6 +135,17 @@ protected:
         updateLatency();
     }
 
+    // Re-size the DSP scratch buffers when the host changes the block size. DPF
+    // deactivate/activates around this when the plugin is active (so activate()
+    // already re-prepares), but a doCallback=false path can skip that; re-prepare
+    // here too so the scratch always matches the current block size. Matches 4k-eq.
+    void bufferSizeChanged(uint32_t newBufferSize) override
+    {
+        dsp.prepare(getSampleRate(), (int)newBufferSize);
+        pushAllParams();
+        updateLatency();
+    }
+
     //--- audio -----------------------------------------------------------------
     void run(const float** inputs, float** outputs, uint32_t frames) override
     {

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -139,7 +139,6 @@ private:
         case kParamSignalPath:  dsp.setSignalPath(iv);           break;
         case kParamEqStandard:  dsp.setEqStandard(iv);           break;
         case kParamInputGain:   dsp.setInputGainDb(v);           break;
-        case kParamSaturation:  dsp.setSaturation(v);            break;
         case kParamBias:        dsp.setBias(v);                  break;
         case kParamCalibration: dsp.setCalibration(iv);          break;
         case kParamAutoCal:     dsp.setAutoCal(v > 0.5f);        break;

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -1,0 +1,201 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// TapeMachinePlugin.cpp — DPF shell around the framework-free TapeMachineDSP core.
+
+#include "DistrhoPlugin.hpp"
+#include "TapeMachineAccess.hpp"
+#include "TapeMachineParams.hpp"
+#include "TapeMachineDSP.hpp"
+
+#include <atomic>
+#include <cmath>
+
+START_NAMESPACE_DISTRHO
+
+class TapeMachinePlugin : public Plugin
+{
+public:
+    TapeMachinePlugin()
+        : Plugin(kParamCount, 0, 0)
+    {
+        for (uint32_t i = 0; i < kParamCount; ++i)
+            values[i].store(kTmParams[i].def, std::memory_order_relaxed);
+    }
+
+    // same-process meter access for the UI bridge (TapeMachineAccess.hpp)
+    float getVuLForUI() const noexcept { return dsp.getVuL(); }
+    float getVuRForUI() const noexcept { return dsp.getVuR(); }
+
+protected:
+    //--- metadata --------------------------------------------------------------
+    const char* getLabel() const override    { return "TapeMachine2"; }
+    const char* getDescription() const override
+    {
+        return "Reel-to-reel tape machine emulation: Jiles-Atherton tape "
+               "saturation, head/gap EQ, wow & flutter, hiss, NAB/CCIR/AES.";
+    }
+    const char* getMaker() const override    { return "Dusk Audio"; }
+    const char* getHomePage() const override { return "https://dusk-audio.github.io/"; }
+    const char* getLicense() const override  { return "GPL-3.0-or-later"; }
+    uint32_t    getVersion() const override  { return d_version(2, 0, 0); }
+    int64_t     getUniqueId() const override { return d_cconst('D', 's', 'T', 'M'); } // matches DISTRHO_PLUGIN_UNIQUE_ID (DsTM)
+
+    //--- parameters ------------------------------------------------------------
+    void initParameter(uint32_t index, Parameter& p) override
+    {
+        if (index >= kParamCount)
+            return;
+        const TmParam& d = kTmParams[index];
+
+        switch (d.kind)
+        {
+        case 'b': // host-integrated bypass (shown as the UI POWER/tape-stop)
+            p.initDesignation(kParameterDesignationBypass);
+            return;
+        case 'o': // output-only meter
+            p.hints = kParameterIsAutomatable | kParameterIsOutput;
+            break;
+        case 'c': // discrete choice
+            p.hints = kParameterIsAutomatable | kParameterIsInteger;
+            break;
+        default:  // 'f' linear / 'g' skewed float (UI owns the skew feel)
+            p.hints = kParameterIsAutomatable;
+            break;
+        }
+
+        p.name   = d.name;
+        p.symbol = d.id;
+        p.unit   = d.unit;
+        p.ranges.def = d.def;
+        p.ranges.min = d.min;
+        p.ranges.max = d.max;
+
+        // Attach human-readable labels for choice parameters (generic hosts).
+        if (d.kind == 'c' && d.choices != nullptr && d.numChoices > 0)
+        {
+            p.enumValues.count = (uint8_t)d.numChoices;
+            p.enumValues.restrictedMode = true;
+            auto* const vals = new ParameterEnumerationValue[d.numChoices];
+            for (int i = 0; i < d.numChoices; ++i)
+            {
+                vals[i].value = (float)i;
+                vals[i].label = d.choices[i];
+            }
+            p.enumValues.values = vals; // DPF takes ownership (deletes[] on destroy)
+        }
+    }
+
+    float getParameterValue(uint32_t index) const override
+    {
+        if (index == kParamVuL) return dsp.getVuL();
+        if (index == kParamVuR) return dsp.getVuR();
+        return index < kParamCount ? values[index].load(std::memory_order_relaxed) : 0.0f;
+    }
+
+    // DSP setters are atomic stores — safe from whichever thread DPF uses.
+    void setParameterValue(uint32_t index, float value) override
+    {
+        if (index >= kParamVuL) // output/meter params are not settable
+            return;
+        values[index].store(value, std::memory_order_relaxed);
+        applyToDsp(index, value);
+    }
+
+    //--- lifecycle -------------------------------------------------------------
+    void activate() override
+    {
+        dsp.prepare(getSampleRate(), (int)getBufferSize());
+        pushAllParams();
+        updateLatency();
+    }
+
+    void deactivate() override { dsp.reset(); }
+
+    void sampleRateChanged(double newSampleRate) override
+    {
+        dsp.prepare(newSampleRate, (int)getBufferSize());
+        pushAllParams();
+        updateLatency();
+    }
+
+    //--- audio -----------------------------------------------------------------
+    void run(const float** inputs, float** outputs, uint32_t frames) override
+    {
+        dsp.processBlock(inputs, outputs, DISTRHO_PLUGIN_NUM_INPUTS, (int)frames);
+        updateLatency(); // oversampling factor changes reported latency
+    }
+
+private:
+    void applyToDsp(uint32_t index, float v)
+    {
+        const int iv = (int)(v + 0.5f);
+        switch (index)
+        {
+        case kParamTapeMachine: dsp.setTapeMachine(iv);           break;
+        case kParamTapeSpeed:   dsp.setTapeSpeed(iv);             break;
+        case kParamTapeType:    dsp.setTapeType(iv);              break;
+        case kParamSignalPath:  dsp.setSignalPath(iv);           break;
+        case kParamEqStandard:  dsp.setEqStandard(iv);           break;
+        case kParamInputGain:   dsp.setInputGainDb(v);           break;
+        case kParamSaturation:  dsp.setSaturation(v);            break;
+        case kParamBias:        dsp.setBias(v);                  break;
+        case kParamCalibration: dsp.setCalibration(iv);          break;
+        case kParamAutoCal:     dsp.setAutoCal(v > 0.5f);        break;
+        case kParamHighpassFreq:dsp.setHighpassHz(v);            break;
+        case kParamLowpassFreq: dsp.setLowpassHz(v);             break;
+        case kParamNoiseAmount: dsp.setNoiseAmount(v);           break;
+        case kParamNoiseEnabled:dsp.setNoiseEnabled(v > 0.5f);   break;
+        case kParamWow:         dsp.setWow(v);                   break;
+        case kParamFlutter:     dsp.setFlutter(v);               break;
+        case kParamOutputGain:  dsp.setOutputGainDb(v);          break;
+        case kParamAutoComp:    dsp.setAutoComp(v > 0.5f);       break;
+        case kParamOversampling:dsp.setOversampling(iv);         break;
+        case kParamBypass:      dsp.setBypass(v > 0.5f);         break;
+        }
+    }
+
+    void pushAllParams()
+    {
+        for (uint32_t i = 0; i < kParamVuL; ++i)
+            applyToDsp(i, values[i].load(std::memory_order_relaxed));
+    }
+
+    void updateLatency()
+    {
+        const int lat = dsp.latencySamples();
+        if (lat != lastLatency)
+        {
+            lastLatency = lat;
+            setLatency((uint32_t)(lat < 0 ? 0 : lat));
+        }
+    }
+
+    duskaudio::TapeMachineDSP dsp;
+    int lastLatency = -1;
+    // Parameter cache shared across threads (relaxed atomics), same pattern as
+    // the DSP core's own parameter atomics.
+    std::atomic<float> values[kParamCount] = {};
+
+    DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachinePlugin)
+};
+
+Plugin* createPlugin()
+{
+    return new TapeMachinePlugin();
+}
+
+END_NAMESPACE_DISTRHO
+
+// same-process UI accessors (see TapeMachineAccess.hpp)
+float tapeMachineGetVuL(void* const pluginInstancePointer) noexcept
+{
+    auto* const p = static_cast<DISTRHO_NAMESPACE::TapeMachinePlugin*>(pluginInstancePointer);
+    return p != nullptr ? p->getVuLForUI() : 0.0f;
+}
+float tapeMachineGetVuR(void* const pluginInstancePointer) noexcept
+{
+    auto* const p = static_cast<DISTRHO_NAMESPACE::TapeMachinePlugin*>(pluginInstancePointer);
+    return p != nullptr ? p->getVuRForUI() : 0.0f;
+}

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -7,6 +7,7 @@
 #include "DistrhoPlugin.hpp"
 #include "TapeMachineAccess.hpp"
 #include "TapeMachineParams.hpp"
+#include "TapeMachinePresets.hpp"
 #include "TapeMachineDSP.hpp"
 
 #include <atomic>
@@ -18,7 +19,7 @@ class TapeMachinePlugin : public Plugin
 {
 public:
     TapeMachinePlugin()
-        : Plugin(kParamCount, 0, 0)
+        : Plugin(kParamCount, kNumTmPresets, 0)
     {
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i].store(kTmParams[i].def, std::memory_order_relaxed);
@@ -101,6 +102,18 @@ protected:
             return;
         values[index].store(value, std::memory_order_relaxed);
         applyToDsp(index, value);
+    }
+
+    //--- programs (factory presets) --------------------------------------------
+    void initProgramName(uint32_t index, String& programName) override
+    {
+        if (index < (uint32_t)kNumTmPresets)
+            programName = kTmPresets[index].name;
+    }
+
+    void loadProgram(uint32_t index) override
+    {
+        tmApplyPreset((int)index, [this](uint32_t id, float v) { setParameterValue(id, v); });
     }
 
     //--- lifecycle -------------------------------------------------------------

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// TapeMachinePresets.hpp — factory presets, ported verbatim from the JUCE
+// TapeMachine build (plugins/TapeMachine/Source/TapeMachinePresets.h). Shared by
+// the DPF program interface (host preset menu) and the UI preset combo. Presets
+// only touch the parameters the JUCE presets set; everything else keeps default.
+
+#pragma once
+
+#include "TapeMachineParams.hpp"
+
+struct TmPreset
+{
+    const char* name;
+    const char* category;
+    int   tapeMachine, tapeSpeed, tapeType;
+    float inputGain, outputGain, bias;
+    bool  autoComp;
+    float highpassFreq, lowpassFreq, wow, flutter, noiseAmount;
+    bool  noiseEnabled;
+};
+
+static constexpr TmPreset kTmPresets[] =
+{
+    // name                 category      mch spd typ  in    out  bias  aComp  hp     lp      wow   flt   noise  nEn
+    { "Gentle Warmth",     "Subtle",      0,  2,  3,   2.f,  0.f, 50.f, true,  20.f,  20000.f, 3.f,  1.f,  0.f,   false },
+    { "Transparent Glue",  "Subtle",      0,  2,  1,   3.f,  0.f, 55.f, true,  20.f,  18000.f, 2.f,  1.f,  0.f,   false },
+    { "Mastering Touch",   "Subtle",      0,  2,  3,   1.f,  0.f, 50.f, true,  20.f,  20000.f, 1.f,  0.5f, 0.f,   false },
+    { "Classic Analog",    "Warm",        1,  1,  0,   5.f,  0.f, 50.f, true,  30.f,  16000.f, 7.f,  3.f,  5.f,   false },
+    { "Vintage Warmth",    "Warm",        1,  0,  0,   6.f,  0.f, 45.f, true,  40.f,  14000.f, 10.f, 5.f,  8.f,   false },
+    { "Tube Console",      "Warm",        1,  1,  2,   7.f,  0.f, 48.f, true,  25.f,  15000.f, 5.f,  2.f,  3.f,   false },
+    { "70s Rock",          "Character",   1,  1,  0,   8.f,  0.f, 42.f, true,  50.f,  12000.f, 12.f, 6.f,  10.f,  true  },
+    { "Tape Saturation",   "Character",   1,  1,  0,   10.f, 0.f, 40.f, true,  30.f,  14000.f, 8.f,  4.f,  5.f,   false },
+    { "Cassette Deck",     "Character",   1,  0,  2,   6.f,  0.f, 55.f, true,  60.f,  10000.f, 15.f, 8.f,  15.f,  true  },
+    { "Lo-Fi Warble",      "Lo-Fi",       1,  0,  0,   8.f,  0.f, 38.f, true,  80.f,  8000.f,  25.f, 12.f, 20.f,  true  },
+    { "Worn Tape",         "Lo-Fi",       1,  0,  2,   5.f,  0.f, 35.f, true,  100.f, 6000.f,  30.f, 15.f, 30.f,  true  },
+    { "Dusty Reel",        "Lo-Fi",       1,  0,  0,   4.f,  0.f, 42.f, true,  70.f,  9000.f,  20.f, 10.f, 40.f,  true  },
+    { "Master Bus Glue",   "Mastering",   0,  2,  3,   2.f,  0.f, 52.f, true,  20.f,  20000.f, 2.f,  1.f,  0.f,   false },
+    { "Analog Sheen",      "Mastering",   0,  2,  1,   3.f,  0.f, 50.f, true,  20.f,  18000.f, 3.f,  1.5f, 0.f,   false },
+    { "Vintage Master",    "Mastering",   0,  1,  0,   4.f,  0.f, 48.f, true,  25.f,  16000.f, 5.f,  2.f,  2.f,   false },
+};
+
+static constexpr int kNumTmPresets = (int)(sizeof(kTmPresets) / sizeof(kTmPresets[0]));
+
+// Apply a preset by invoking setter(paramId, value) for each parameter it owns.
+// Used by both the plugin (loadProgram) and the UI (preset combo) so the two
+// stay in lockstep. Parameters not listed keep their current value.
+template <class SetFn>
+inline void tmApplyPreset(int idx, SetFn&& set)
+{
+    if (idx < 0 || idx >= kNumTmPresets) return;
+    const TmPreset& p = kTmPresets[idx];
+    set(kParamTapeMachine,  (float)p.tapeMachine);
+    set(kParamTapeSpeed,    (float)p.tapeSpeed);
+    set(kParamTapeType,     (float)p.tapeType);
+    set(kParamInputGain,    p.inputGain);
+    set(kParamOutputGain,   p.outputGain);
+    set(kParamBias,         p.bias);
+    set(kParamAutoComp,     p.autoComp ? 1.f : 0.f);
+    set(kParamHighpassFreq, p.highpassFreq);
+    set(kParamLowpassFreq,  p.lowpassFreq);
+    set(kParamWow,          p.wow);
+    set(kParamFlutter,      p.flutter);
+    set(kParamNoiseAmount,  p.noiseAmount);
+    set(kParamNoiseEnabled, p.noiseEnabled ? 1.f : 0.f);
+}

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -180,7 +180,8 @@ private:
         ImGui::PopStyleColor(8);
 
         // bypass, kept clear of the top-right corner screw (~x784)
-        tmButton(dl, "bypass", kParamBypass, 648, 14, 736, 38, "BYPASS");
+        tmButton(dl, "bypass", kParamBypass, 648, 14, 736, 38, "BYPASS",
+                 "Bypass the plugin (host-integrated).");
     }
 
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
@@ -284,7 +285,7 @@ private:
     // cx = column centre; w = combo width (sized to fit its widest option +
     // the dropdown arrow). The combo is centred under its (centred) label.
     void selector(ImDrawList* dl, const char* id, uint32_t param, float cx, float y,
-                  float w, const char* title)
+                  float w, const char* title, const char* tip)
     {
         const TmParam& d = kTmParams[param];
         text(dl, cx, y, 9.0f, kColInk, title, 0, true);
@@ -301,7 +302,9 @@ private:
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(212, 213, 215, 255));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(178, 179, 181, 255));
         ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
-        if (ImGui::BeginCombo(id, d.choices[cur]))   // arrow shown -> reads as a dropdown
+        const bool open = ImGui::BeginCombo(id, d.choices[cur]);   // arrow -> reads as a dropdown
+        if (tip != nullptr && ImGui::IsItemHovered()) ImGui::SetTooltip("%s", tip);
+        if (open)
         {
             for (int i = 0; i < d.numChoices; ++i)
                 if (ImGui::Selectable(d.choices[i], i == cur))
@@ -317,18 +320,24 @@ private:
     void drawSelectors(ImDrawList* dl)
     {
         const float y = 216.0f;
-        // id, param, column-centre, width (fits widest option + arrow), title
-        struct Sel { const char* id; uint32_t p; float cx, w; const char* t; };
+        // id, param, column-centre, width (fits widest option + arrow), title, tooltip
+        struct Sel { const char* id; uint32_t p; float cx, w; const char* t; const char* tip; };
         static const Sel ss[6] = {
-            { "##machine", kParamTapeMachine,  83.f, 100.f, "MACHINE"      },
-            { "##speed",   kParamTapeSpeed,   210.f,  82.f, "TAPE SPEED"   },
-            { "##type",    kParamTapeType,    337.f,  90.f, "TAPE TYPE"    },
-            { "##path",    kParamSignalPath,  463.f,  78.f, "SIGNAL PATH"  },
-            { "##eq",      kParamEqStandard,  590.f,  70.f, "EQ STANDARD"  },
-            { "##os",      kParamOversampling,717.f,  62.f, "OVERSAMPLING" },
+            { "##machine", kParamTapeMachine,  83.f, 100.f, "MACHINE",
+              "Tape machine model: Swiss 800 (tighter/cleaner) or Classic 102 (warmer)." },
+            { "##speed",   kParamTapeSpeed,   210.f,  82.f, "TAPE SPEED",
+              "Tape speed. Faster = extended lows/highs, less head bump and noise." },
+            { "##type",    kParamTapeType,    337.f,  90.f, "TAPE TYPE",
+              "Tape formulation: affects saturation, headroom and noise floor." },
+            { "##path",    kParamSignalPath,  463.f,  78.f, "SIGNAL PATH",
+              "Repro = full tape path; Sync = repro w/ extra HF loss; Input = electronics only; Thru = bypass." },
+            { "##eq",      kParamEqStandard,  590.f,  70.f, "EQ STANDARD",
+              "Record/repro EQ curve: NAB (US), CCIR/IEC (EU), or AES (30 IPS)." },
+            { "##os",      kParamOversampling,717.f,  62.f, "OVERSAMPLING",
+              "Anti-alias oversampling. Higher = cleaner saturation, more CPU." },
         };
         for (const Sel& e : ss)
-            selector(dl, e.id, e.p, e.cx, y, e.w, e.t);
+            selector(dl, e.id, e.p, e.cx, y, e.w, e.t, e.tip);
     }
 
     //--- knob rows -------------------------------------------------------------

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -145,23 +145,75 @@ private:
                     IM_COL32(70, 70, 72, 255), 1.2f * s);
     }
 
+    // small silver chevron button (< or >) for preset stepping
+    bool chevron(ImDrawList* dl, const char* id, float cx, float cy, bool left, const char* tip)
+    {
+        const ImVec2 b0 = P(cx - 9, cy - 10), b1 = P(cx + 9, cy + 10);
+        ImGui::SetCursorScreenPos(b0);
+        ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+        const bool hov = ImGui::IsItemHovered();
+        if (tip != nullptr && hov) ImGui::SetTooltip("%s", tip);
+        dl->AddRectFilled(b0, b1, hov ? IM_COL32(214, 214, 216, 255) : IM_COL32(224, 224, 226, 255), 2.0f * s);
+        dl->AddRect(b0, b1, IM_COL32(120, 121, 123, 255), 2.0f * s, 0, 1.0f * s);
+        const ImVec2 c = P(cx, cy); const float d = 4.0f * s;
+        if (left) dl->AddTriangleFilled(ImVec2(c.x + d * 0.5f, c.y - d), ImVec2(c.x + d * 0.5f, c.y + d), ImVec2(c.x - d * 0.7f, c.y), kColInk);
+        else      dl->AddTriangleFilled(ImVec2(c.x - d * 0.5f, c.y - d), ImVec2(c.x - d * 0.5f, c.y + d), ImVec2(c.x + d * 0.7f, c.y), kColInk);
+        return ImGui::IsItemClicked();
+    }
+
+    // small silver text button
+    bool textButton(ImDrawList* dl, const char* id, float x0, float y0, float x1, float y1,
+                    const char* label, const char* tip)
+    {
+        const ImVec2 b0 = P(x0, y0), b1 = P(x1, y1);
+        ImGui::SetCursorScreenPos(b0);
+        ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+        if (tip != nullptr && ImGui::IsItemHovered()) ImGui::SetTooltip("%s", tip);
+        dl->AddRectFilledMultiColor(b0, b1, IM_COL32(226, 226, 228, 255), IM_COL32(226, 226, 228, 255),
+                                    IM_COL32(186, 186, 188, 255), IM_COL32(186, 186, 188, 255));
+        dl->AddRect(b0, b1, IM_COL32(90, 90, 92, 255), 2.0f * s, 0, 1.2f * s);
+        text(dl, 0.5f * (x0 + x1), y0 + 0.30f * (y1 - y0), 9.5f, kColInk, label, 0, true);
+        return ImGui::IsItemClicked();
+    }
+
+    void initDefaults()
+    {
+        currentPreset = -1;
+        for (uint32_t i = 0; i < kParamVuL; ++i)
+        {
+            if (i == kParamBypass) continue;   // don't fight host bypass on Init
+            const float d = kTmParams[i].def;
+            values[i] = d;
+            editParameter(i, true); setParameterValue(i, d); editParameter(i, false);
+        }
+    }
+
+    void stepPreset(int dir)
+    {
+        int i = currentPreset < 0 ? (dir < 0 ? 0 : -1) : currentPreset;
+        i += dir;
+        if (i < 0) i = 0; if (i >= kNumTmPresets) i = kNumTmPresets - 1;
+        applyPreset(i);
+    }
+
     void drawHeader(ImDrawList* dl)
     {
         dl->AddRectFilled(P(15, 12), P(232, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
         dl->AddRect(P(15, 12), P(232, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
         text(dl, 27, 17, 16, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
 
-        // preset selector (centre of header)
+        // preset browser: < [combo] >  INIT
         const char* cur = (currentPreset >= 0 && currentPreset < kNumTmPresets)
                               ? kTmPresets[currentPreset].name : "Presets...";
-        text(dl, 262, 8, 8.5f, kColInkDim, "PRESET", -1, true);
-        ImGui::SetCursorScreenPos(P(262, 18));
-        ImGui::SetNextItemWidth(300.0f * s);
+        text(dl, 375, 6, 8.0f, kColInkDim, "PRESET", 0, true);
+        if (chevron(dl, "##pv", 250, 28, true, "Previous preset")) stepPreset(-1);
+        ImGui::SetCursorScreenPos(P(264, 18));
+        ImGui::SetNextItemWidth(222.0f * s);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
         ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
         ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
         ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(150, 152, 156, 255));
-        ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(198, 199, 201, 255));        // arrow bg
+        ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(198, 199, 201, 255));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(212, 213, 215, 255));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(178, 179, 181, 255));
         ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
@@ -181,12 +233,14 @@ private:
             ImGui::EndCombo();
         }
         ImGui::PopStyleColor(8);
+        if (chevron(dl, "##nx", 500, 28, false, "Next preset")) stepPreset(+1);
+        if (textButton(dl, "##init", 516, 18, 560, 38, "INIT", "Reset all controls to their defaults")) initDefaults();
 
-        // meter source toggle (INPUT / OUTPUT) between the preset combo and bypass
+        // meter source toggle (INPUT / OUTPUT)
         {
             const bool out = meterSource != 0;
-            text(dl, 604, 6, 8.0f, kColInkDim, "METER", 0, true);
-            const ImVec2 b0 = P(575, 18), b1 = P(633, 38);
+            text(dl, 596, 6, 8.0f, kColInkDim, "METER", 0, true);
+            const ImVec2 b0 = P(568, 18), b1 = P(624, 38);
             ImGui::SetCursorScreenPos(b0);
             ImGui::InvisibleButton("metsrc", ImVec2(b1.x - b0.x, b1.y - b0.y));
             if (ImGui::IsItemClicked()) meterSource ^= 1;
@@ -194,7 +248,7 @@ private:
             dl->AddRectFilledMultiColor(b0, b1, IM_COL32(226, 226, 228, 255), IM_COL32(226, 226, 228, 255),
                                         IM_COL32(186, 186, 188, 255), IM_COL32(186, 186, 188, 255));
             dl->AddRect(b0, b1, IM_COL32(90, 90, 92, 255), 2.0f * s, 0, 1.2f * s);
-            text(dl, 604, 22, 9.5f, kColInk, out ? "OUTPUT" : "INPUT", 0, true);
+            text(dl, 596, 22, 9.5f, kColInk, out ? "OUTPUT" : "INPUT", 0, true);
         }
 
         // bypass, kept clear of the top-right corner screw (~x784)

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -327,19 +327,30 @@ private:
         }
         drawSaveModal();
 
-        // meter source toggle (INPUT / OUTPUT)
+        // segmented IN | OUT meter source switch (both cells visible)
         {
-            const bool out = meterSource != 0;
-            text(dl, 606, 6, 8.0f, kColInkDim, "METER", 0, true);
-            const ImVec2 b0 = P(578, 18), b1 = P(634, 38);
-            ImGui::SetCursorScreenPos(b0);
-            ImGui::InvisibleButton("metsrc", ImVec2(b1.x - b0.x, b1.y - b0.y));
-            if (ImGui::IsItemClicked()) meterSource ^= 1;
-            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Meter source: what the VU meters show (INPUT or OUTPUT level).");
-            dl->AddRectFilledMultiColor(b0, b1, IM_COL32(226, 226, 228, 255), IM_COL32(226, 226, 228, 255),
-                                        IM_COL32(186, 186, 188, 255), IM_COL32(186, 186, 188, 255));
-            dl->AddRect(b0, b1, IM_COL32(90, 90, 92, 255), 2.0f * s, 0, 1.2f * s);
-            text(dl, 606, 22, 9.5f, kColInk, out ? "OUTPUT" : "INPUT", 0, true);
+            const float mx0 = 576, mid = 610, mx1 = 644, my0 = 18, my1 = 38;
+            text(dl, mid, 6, 8.0f, kColInkDim, "METER", 0, true);
+            dl->AddRectFilled(P(mx0, my0), P(mx1, my1), IM_COL32(210, 211, 213, 255), 3.0f * s);
+
+            ImGui::SetCursorScreenPos(P(mx0, my0));
+            ImGui::InvisibleButton("mIn", ImVec2((mid - mx0) * s, (my1 - my0) * s));
+            if (ImGui::IsItemClicked()) meterSource = 0;
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Meter the INPUT (record / tape-drive) level.");
+            const bool inAct = meterSource == 0;
+            if (inAct) dl->AddRectFilled(P(mx0, my0), P(mid, my1), IM_COL32(150, 152, 156, 255), 3.0f * s);
+            text(dl, 0.5f * (mx0 + mid), 22, 9.0f, inAct ? IM_COL32(22, 22, 24, 255) : kColInkDim, "IN", 0, inAct);
+
+            ImGui::SetCursorScreenPos(P(mid, my0));
+            ImGui::InvisibleButton("mOut", ImVec2((mx1 - mid) * s, (my1 - my0) * s));
+            if (ImGui::IsItemClicked()) meterSource = 1;
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Meter the OUTPUT level (digital clip lamp active).");
+            const bool outAct = meterSource != 0;
+            if (outAct) dl->AddRectFilled(P(mid, my0), P(mx1, my1), IM_COL32(150, 152, 156, 255), 3.0f * s);
+            text(dl, 0.5f * (mid + mx1), 22, 9.0f, outAct ? IM_COL32(22, 22, 24, 255) : kColInkDim, "OUT", 0, outAct);
+
+            dl->AddLine(P(mid, my0 + 1), P(mid, my1 - 1), IM_COL32(120, 121, 123, 255), 1.0f * s);
+            dl->AddRect(P(mx0, my0), P(mx1, my1), IM_COL32(90, 90, 92, 255), 3.0f * s, 0, 1.2f * s);
         }
 
         // bypass, kept clear of the top-right corner screw (~x784)

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -299,6 +299,7 @@ private:
 
     void drawHeader(ImDrawList* dl)
     {
+        // Title nameplate + machine badge (left-anchored).
         dl->AddRectFilled(P(15, 12), P(232, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
         dl->AddRect(P(15, 12), P(232, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
         text(dl, 27, 17, 15, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
@@ -318,12 +319,12 @@ private:
             if (!std) dl->AddCircleFilled(P(225, 19), 2.6f * s, kColNonStd, 10); // non-standard dot
         }
 
-        // preset browser: < [combo] >  INIT  SAVE
+        // preset browser, centred between the title and the (right-anchored) bypass:
+        //   < [combo] >  INIT  SAVE          (all on the 18..38 band)
         const char* cur = currentPreset >= 0 ? kTmPresets[currentPreset].name
                         : (!currentUserName.empty() ? currentUserName.c_str() : "Presets...");
-        text(dl, 364, 6, 8.0f, kColInkDim, "PRESET", 0, true);
-        if (chevron(dl, "##pv", 250, 28, true, "Previous preset")) stepPreset(-1);
-        ImGui::SetCursorScreenPos(P(264, 18));
+        if (chevron(dl, "##pv", 298, 28, true, "Previous preset")) stepPreset(-1);
+        ImGui::SetCursorScreenPos(P(311, 18));
         ImGui::SetNextItemWidth(200.0f * s);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
         ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
@@ -356,44 +357,40 @@ private:
             ImGui::EndCombo();
         }
         ImGui::PopStyleColor(8);
-        if (chevron(dl, "##nx", 478, 28, false, "Next preset")) stepPreset(+1);
-        if (textButton(dl, "##init", 492, 18, 528, 38, "INIT", "Reset all controls to their defaults")) initDefaults();
-        if (textButton(dl, "##save", 532, 18, 568, 38, "SAVE", "Save the current settings as a user preset"))
+        if (chevron(dl, "##nx", 524, 28, false, "Next preset")) stepPreset(+1);
+        if (textButton(dl, "##init", 545, 18, 581, 38, "INIT", "Reset all controls to their defaults")) initDefaults();
+        if (textButton(dl, "##save", 587, 18, 623, 38, "SAVE", "Save the current settings as a user preset"))
         {
             std::snprintf(saveBuf, sizeof(saveBuf), "%s", currentUserName.c_str());
             ImGui::OpenPopup("Save Preset");
         }
         drawSaveModal();
 
-        // segmented IN | OUT meter source switch (both cells visible)
-        {
-            const float mx0 = 576, mid = 610, mx1 = 644, my0 = 18, my1 = 38;
-            text(dl, mid, 6, 8.0f, kColInkDim, "METER", 0, true);
-            dl->AddRectFilled(P(mx0, my0), P(mx1, my1), IM_COL32(210, 211, 213, 255), 3.0f * s);
-
-            ImGui::SetCursorScreenPos(P(mx0, my0));
-            ImGui::InvisibleButton("mIn", ImVec2((mid - mx0) * s, (my1 - my0) * s));
-            if (ImGui::IsItemClicked()) meterSource = 0;
-            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Meter the INPUT (record / tape-drive) level.");
-            const bool inAct = meterSource == 0;
-            if (inAct) dl->AddRectFilled(P(mx0, my0), P(mid, my1), IM_COL32(150, 152, 156, 255), 3.0f * s);
-            text(dl, 0.5f * (mx0 + mid), 22, 9.0f, inAct ? IM_COL32(22, 22, 24, 255) : kColInkDim, "IN", 0, inAct);
-
-            ImGui::SetCursorScreenPos(P(mid, my0));
-            ImGui::InvisibleButton("mOut", ImVec2((mx1 - mid) * s, (my1 - my0) * s));
-            if (ImGui::IsItemClicked()) meterSource = 1;
-            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Meter the OUTPUT level (digital clip lamp active).");
-            const bool outAct = meterSource != 0;
-            if (outAct) dl->AddRectFilled(P(mid, my0), P(mx1, my1), IM_COL32(150, 152, 156, 255), 3.0f * s);
-            text(dl, 0.5f * (mid + mx1), 22, 9.0f, outAct ? IM_COL32(22, 22, 24, 255) : kColInkDim, "OUT", 0, outAct);
-
-            dl->AddLine(P(mid, my0 + 1), P(mid, my1 - 1), IM_COL32(120, 121, 123, 255), 1.0f * s);
-            dl->AddRect(P(mx0, my0), P(mx1, my1), IM_COL32(90, 90, 92, 255), 3.0f * s, 0, 1.2f * s);
-        }
-
-        // bypass, kept clear of the top-right corner screw (~x784)
-        tmButton(dl, "bypass", kParamBypass, 648, 14, 736, 38, "BYPASS",
+        // bypass, right-anchored, clear of the top-right corner screw (~x784)
+        tmButton(dl, "bypass", kParamBypass, 680, 18, 768, 38, "BYPASS",
                  "Bypass the plugin (host-integrated).");
+    }
+
+    // Meter source IN|OUT switch. Removed from the UI by request; kept intact (the
+    // meterSource state + input-meter DSP path stay wired) so it can be reinstated.
+    void drawMeterSwitch(ImDrawList* dl)
+    {
+        const float mx0 = 576, mid = 610, mx1 = 644, my0 = 18, my1 = 38;
+        dl->AddRectFilled(P(mx0, my0), P(mx1, my1), IM_COL32(210, 211, 213, 255), 3.0f * s);
+        ImGui::SetCursorScreenPos(P(mx0, my0));
+        ImGui::InvisibleButton("mIn", ImVec2((mid - mx0) * s, (my1 - my0) * s));
+        if (ImGui::IsItemClicked()) meterSource = 0;
+        const bool inAct = meterSource == 0;
+        if (inAct) dl->AddRectFilled(P(mx0, my0), P(mid, my1), IM_COL32(150, 152, 156, 255), 3.0f * s);
+        text(dl, 0.5f * (mx0 + mid), 22, 9.0f, inAct ? IM_COL32(22, 22, 24, 255) : kColInkDim, "IN", 0, inAct);
+        ImGui::SetCursorScreenPos(P(mid, my0));
+        ImGui::InvisibleButton("mOut", ImVec2((mx1 - mid) * s, (my1 - my0) * s));
+        if (ImGui::IsItemClicked()) meterSource = 1;
+        const bool outAct = meterSource != 0;
+        if (outAct) dl->AddRectFilled(P(mid, my0), P(mx1, my1), IM_COL32(150, 152, 156, 255), 3.0f * s);
+        text(dl, 0.5f * (mid + mx1), 22, 9.0f, outAct ? IM_COL32(22, 22, 24, 255) : kColInkDim, "OUT", 0, outAct);
+        dl->AddLine(P(mid, my0 + 1), P(mid, my1 - 1), IM_COL32(120, 121, 123, 255), 1.0f * s);
+        dl->AddRect(P(mx0, my0), P(mx1, my1), IM_COL32(90, 90, 92, 255), 3.0f * s, 0, 1.2f * s);
     }
 
     void drawSaveModal()

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -544,7 +544,8 @@ private:
         panel.knobLabel(dl, cx, cy - 50.0f, l1);
         panel.knob(id, param, d.min, d.max, cx, cy, 32.0f, values[param], d.def,
                    false, true, fmt, suffix, 0, false,
-                   /*persistent*/ true, tip, /*rightClickReset*/ true, 1.0f, dispAdd);
+                   /*persistent*/ true, tip, /*rightClickReset*/ true, 1.0f, dispAdd,
+                   /*hover name*/ l1);
     }
 
     // Centred small-caps section header with an underline.

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -2,26 +2,28 @@
 // Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
 // others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
 //
-// TapeMachineUI.cpp — Dear ImGui UI for TapeMachine 2. Layout mirrors the JUCE
-// TapeMachine editor (800x568): header, a transport row with two reels flanking
-// a stereo VU bridge over two rows of three selectors, then a main knob row and
-// a character knob row. Recolored to a brushed-silver panel; the chrome knobs
-// (shared duskdpf::DuskPanel) and the cream JUCE VU meters are kept.
+// TapeMachineUI.cpp — Dear ImGui UI for TapeMachine 2 (800x520). Brushed-silver
+// panel: header (title, preset selector, bypass); two large Sifam-style VU
+// meters; a row of six tape/EQ selectors; a main knob row and a character knob
+// row. Chrome knobs via the shared duskdpf::DuskPanel. All drawn strings are
+// ASCII (the atlas font lacks some Unicode glyphs).
 
 #include "DistrhoUI.hpp"
 #include "TapeMachineAccess.hpp"
 #include "TapeMachineParams.hpp"
+#include "TapeMachinePresets.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiWidgets.hpp"
 
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 
 START_NAMESPACE_DISTRHO
 
 namespace {
     constexpr float kDesignW = 800.0f;
-    constexpr float kDesignH = 568.0f;
+    constexpr float kDesignH = 520.0f;
 
     constexpr ImU32 kColPanel   = IM_COL32(188, 189, 191, 255);
     constexpr ImU32 kColPanelHi = IM_COL32(206, 207, 209, 255);
@@ -29,8 +31,7 @@ namespace {
     constexpr ImU32 kColFrame   = IM_COL32(58, 58, 60, 255);
     constexpr ImU32 kColInk     = IM_COL32(34, 34, 37, 255);
     constexpr ImU32 kColInkDim  = IM_COL32(96, 97, 100, 255);
-    constexpr ImU32 kColScrew    = IM_COL32(120, 121, 123, 255);
-    constexpr ImU32 kColReel     = IM_COL32(158, 159, 162, 255);
+    constexpr ImU32 kColScrew   = IM_COL32(120, 121, 123, 255);
     constexpr ImU32 kColRed      = IM_COL32(190, 55, 40, 255);
 }
 
@@ -46,7 +47,7 @@ public:
     {
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kTmParams[i].def;
-        setGeometryConstraints(400, 284, true);
+        setGeometryConstraints(400, 260, true);
         labelFont = duskdpf::loadCrispFont(30.0f * getScaleFactor());
 
         duskdpf::Palette pal;
@@ -59,7 +60,10 @@ protected:
     void parameterChanged(uint32_t index, float value) override
     {
         if (index < kParamCount)
+        {
             values[index] = value;
+            if (index < kParamVuL) currentPreset = -1; // an edit deselects the preset
+        }
     }
 
     void onImGuiDisplay() override
@@ -69,7 +73,6 @@ protected:
         s   = std::min(winW / kDesignW, winH / kDesignH);
         org = ImVec2(0.5f * (winW - kDesignW * s), 0.5f * (winH - kDesignH * s));
         panel.begin(s, org, labelFont, this);
-        reelPhase += ImGui::GetIO().DeltaTime * reelSpeed();
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
@@ -83,12 +86,8 @@ protected:
         ImDrawList* dl = ImGui::GetWindowDrawList();
         drawPanel(dl, winW, winH);
         drawHeader(dl);
-
-        // transport: reels flank the centre column (VU + two selector rows)
-        drawReel(dl, 75, 167, 52);
-        drawReel(dl, 725, 167, 52);
-        drawVU(dl, 140, 68, 396, 184, meterLevel(0), needleL, "L");
-        drawVU(dl, 404, 68, 660, 184, meterLevel(1), needleR, "R");
+        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, "L");
+        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, "R");
         drawSelectors(dl);
         drawKnobs(dl);
 
@@ -112,11 +111,13 @@ private:
         return v;
     }
 
-    float reelSpeed() const
+    void applyPreset(int idx)
     {
-        if (values[kParamBypass] > 0.5f) return 0.0f;
-        const int sp = (int)(values[kParamTapeSpeed] + 0.5f);
-        return (sp == 2 ? 4.4f : sp == 1 ? 2.2f : 1.1f);
+        currentPreset = idx;
+        tmApplyPreset(idx, [this](uint32_t id, float v) {
+            values[id] = v;
+            editParameter(id, true); setParameterValue(id, v); editParameter(id, false);
+        });
     }
 
     void drawPanel(ImDrawList* dl, float winW, float winH)
@@ -143,39 +144,39 @@ private:
 
     void drawHeader(ImDrawList* dl)
     {
-        dl->AddRectFilled(P(15, 12), P(300, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
-        dl->AddRect(P(15, 12), P(300, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
-        text(dl, 28, 17, 17, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
-        text(dl, 690, 18, 13, kColInk, "Dusk Audio", 1, true);
-        tmButton(dl, "bypass", kParamBypass, 704, 14, 785, 38, "BYPASS");
-    }
+        dl->AddRectFilled(P(15, 12), P(232, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
+        dl->AddRect(P(15, 12), P(232, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
+        text(dl, 27, 17, 16, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
 
-    //--- transport -------------------------------------------------------------
-    void drawReel(ImDrawList* dl, float cx, float cy, float r)
-    {
-        const ImVec2 c = P(cx, cy);
-        dl->AddCircleFilled(c, r * s, kColReel, 56);
-        dl->AddCircle(c, r * s, IM_COL32(70, 70, 72, 255), 56, 2.0f * s);
-        dl->AddCircleFilled(c, r * 0.90f * s, IM_COL32(120, 120, 123, 255), 56);
-        dl->AddCircleFilled(c, r * 0.58f * s, kColReel, 48);
-        dl->AddCircle(c, r * 0.58f * s, IM_COL32(90, 90, 92, 255), 48, 1.4f * s);
-        const float a0 = reelPhase;
-        for (int i = 0; i < 3; ++i)
+        // preset selector (centre of header)
+        const char* cur = (currentPreset >= 0 && currentPreset < kNumTmPresets)
+                              ? kTmPresets[currentPreset].name : "Presets...";
+        text(dl, 262, 8, 8.5f, kColInkDim, "PRESET", -1, true);
+        ImGui::SetCursorScreenPos(P(262, 18));
+        ImGui::SetNextItemWidth(300.0f * s);
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
+        ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
+        ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(150, 152, 156, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
+        if (ImGui::BeginCombo("##preset", cur))
         {
-            const float a = a0 + i * (2.0944f);
-            const ImVec2 h(c.x + std::sin(a) * r * 0.72f * s, c.y - std::cos(a) * r * 0.72f * s);
-            dl->AddCircleFilled(h, r * 0.15f * s, IM_COL32(96, 96, 99, 255), 24);
-            dl->AddCircle(h, r * 0.15f * s, IM_COL32(70, 70, 72, 200), 24, 1.0f * s);
+            const char* lastCat = nullptr;
+            for (int i = 0; i < kNumTmPresets; ++i)
+            {
+                if (lastCat == nullptr || std::strcmp(lastCat, kTmPresets[i].category) != 0)
+                {
+                    lastCat = kTmPresets[i].category;
+                    ImGui::TextDisabled("%s", lastCat);
+                }
+                if (ImGui::Selectable(kTmPresets[i].name, i == currentPreset))
+                    applyPreset(i);
+            }
+            ImGui::EndCombo();
         }
-        dl->AddCircleFilled(c, r * 0.22f * s, IM_COL32(205, 205, 207, 255), 28);
-        dl->AddCircle(c, r * 0.22f * s, IM_COL32(80, 80, 82, 255), 28, 1.4f * s);
-        for (int i = 0; i < 3; ++i)
-        {
-            const float a = a0 + i * 2.0944f;
-            dl->AddLine(c, ImVec2(c.x + std::sin(a) * r * 0.20f * s, c.y - std::cos(a) * r * 0.20f * s),
-                        IM_COL32(90, 90, 92, 255), 1.4f * s);
-        }
-        dl->AddCircleFilled(c, r * 0.07f * s, IM_COL32(40, 40, 42, 255), 12);
+        ImGui::PopStyleColor(5);
+
+        tmButton(dl, "bypass", kParamBypass, 704, 14, 785, 38, "BYPASS");
     }
 
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
@@ -251,7 +252,7 @@ private:
         dl->AddCircleFilled(P(fx1 - 15, pivotY - L * 0.20f), 4.6f * s, IM_COL32(112, 40, 30, 255), 16);
         dl->AddCircleFilled(P(fx1 - 16, pivotY - L * 0.20f - 1), 1.5f * s, IM_COL32(210, 130, 110, 120), 10);
 
-        // VU legend (kept at its current position) + channel tag
+        // VU legend + channel tag
         text(dl, cx, pivotY - L * 0.46f, 11, ink, "VU", 0, true);
         text(dl, cx, pivotY - L * 0.46f + 13.0f, 8.5f, IM_COL32(90, 80, 64, 255), label, 0, true);
 
@@ -265,7 +266,7 @@ private:
                                   P(cx - bw * 0.5f * std::cos(perp), pivotY - bw * 0.5f * std::sin(perp)),
                                   IM_COL32(28, 24, 18, 255));
         }
-        dl->AddCircleFilled(P(cx, pivotY + 1), 8.0f * s, IM_COL32(40, 32, 22, 90), 20); // mound shadow
+        dl->AddCircleFilled(P(cx, pivotY + 1), 8.0f * s, IM_COL32(40, 32, 22, 90), 20);
         dl->AddCircleFilled(P(cx, pivotY), 4.6f * s, IM_COL32(24, 20, 14, 255), 18);
         dl->AddCircleFilled(P(cx - 1.2f * s, pivotY - 1.4f * s), 1.5f * s, IM_COL32(150, 140, 120, 150), 10);
 
@@ -275,12 +276,12 @@ private:
             IM_COL32(255, 255, 255, 0), IM_COL32(255, 255, 255, 0));
     }
 
-    //--- selectors (two rows of three, in the centre column) -------------------
+    //--- selectors (single row of six) -----------------------------------------
     void selector(ImDrawList* dl, const char* id, uint32_t param, float x, float y,
                   float w, const char* title)
     {
         const TmParam& d = kTmParams[param];
-        text(dl, x + 0.5f * w, y, 9.5f, kColInk, title, 0, true);
+        text(dl, x + 0.5f * w, y, 9.0f, kColInk, title, 0, true);
         int cur = (int)(values[param] + 0.5f);
         if (cur < 0) cur = 0; if (cur >= d.numChoices) cur = d.numChoices - 1;
 
@@ -306,14 +307,14 @@ private:
 
     void drawSelectors(ImDrawList* dl)
     {
-        const float W = 176.67f, x0 = 135.0f, w = W - 10.0f;
-        const float col[3] = { x0 + 5, x0 + W + 5, x0 + 2 * W + 5 };
-        selector(dl, "##machine", kParamTapeMachine, col[0], 190, w, "TAPE MACHINE");
-        selector(dl, "##speed",   kParamTapeSpeed,   col[1], 190, w, "TAPE SPEED");
-        selector(dl, "##type",    kParamTapeType,    col[2], 190, w, "TAPE TYPE");
-        selector(dl, "##path",    kParamSignalPath,  col[0], 238, w, "SIGNAL PATH");
-        selector(dl, "##eq",      kParamEqStandard,  col[1], 238, w, "EQ STANDARD");
-        selector(dl, "##os",      kParamOversampling,col[2], 238, w, "OVERSAMPLING");
+        const float w = 112.0f, y = 224.0f;
+        const float x[6] = { 20, 148, 276, 404, 532, 660 };
+        selector(dl, "##machine", kParamTapeMachine, x[0], y, w, "MACHINE");
+        selector(dl, "##speed",   kParamTapeSpeed,   x[1], y, w, "TAPE SPEED");
+        selector(dl, "##type",    kParamTapeType,    x[2], y, w, "TAPE TYPE");
+        selector(dl, "##path",    kParamSignalPath,  x[3], y, w, "SIGNAL PATH");
+        selector(dl, "##eq",      kParamEqStandard,  x[4], y, w, "EQ STANDARD");
+        selector(dl, "##os",      kParamOversampling,x[5], y, w, "OVERSAMPLING");
     }
 
     //--- knob rows -------------------------------------------------------------
@@ -328,22 +329,22 @@ private:
     void drawKnobs(ImDrawList* dl)
     {
         // main row: input, bias, wow, flutter, output
-        const float cy1 = 356.0f;
-        knob(dl, "input",  kParamInputGain, 116.67f, cy1, "INPUT",   "%.1f", " dB");
-        knob(dl, "bias",   kParamBias,      258.34f, cy1, "BIAS",    "%.0f", "%");
-        knob(dl, "wow",    kParamWow,       400.00f, cy1, "WOW",     "%.0f", "%");
-        knob(dl, "flut",   kParamFlutter,   541.67f, cy1, "FLUTTER", "%.0f", "%");
-        knob(dl, "output", kParamOutputGain,683.34f, cy1, "OUTPUT",  "%.1f", " dB");
+        const float cy1 = 330.0f;
+        knob(dl, "input",  kParamInputGain, 112.0f, cy1, "INPUT",   "%.1f", " dB");
+        knob(dl, "bias",   kParamBias,      256.0f, cy1, "BIAS",    "%.0f", "%");
+        knob(dl, "wow",    kParamWow,       400.0f, cy1, "WOW",     "%.0f", "%");
+        knob(dl, "flut",   kParamFlutter,   544.0f, cy1, "FLUTTER", "%.0f", "%");
+        knob(dl, "output", kParamOutputGain,688.0f, cy1, "OUTPUT",  "%.1f", " dB");
 
         // character row: hp, lp, noise, + auto-comp / auto-cal buttons
-        const float cy2 = 482.0f;
-        knob(dl, "hp",    kParamHighpassFreq, 110.0f, cy2, "HIGHPASS", "%.0f", " Hz");
-        knob(dl, "lp",    kParamLowpassFreq,  245.0f, cy2, "LOWPASS",  "%.0f", " Hz");
-        knob(dl, "noise", kParamNoiseAmount,  380.0f, cy2, "NOISE",    "%.0f", "%");
-        text(dl, 525, cy2 - 50.0f, 10, kColInk, "AUTO COMP", 0, true);
-        tmButton(dl, "autocomp", kParamAutoComp, 480, cy2 - 18, 570, cy2 + 18, "LINK");
-        text(dl, 680, cy2 - 50.0f, 10, kColInk, "AUTO CAL", 0, true);
-        tmButton(dl, "autocal",  kParamAutoCal,  630, cy2 - 18, 730, cy2 + 18, "AUTO");
+        const float cy2 = 448.0f;
+        knob(dl, "hp",    kParamHighpassFreq, 112.0f, cy2, "HIGHPASS", "%.0f", " Hz");
+        knob(dl, "lp",    kParamLowpassFreq,  256.0f, cy2, "LOWPASS",  "%.0f", " Hz");
+        knob(dl, "noise", kParamNoiseAmount,  400.0f, cy2, "NOISE",    "%.0f", "%");
+        text(dl, 544, cy2 - 50.0f, 10, kColInk, "AUTO COMP", 0, true);
+        tmButton(dl, "autocomp", kParamAutoComp, 500, cy2 - 18, 588, cy2 + 18, "LINK");
+        text(dl, 688, cy2 - 50.0f, 10, kColInk, "AUTO CAL", 0, true);
+        tmButton(dl, "autocal",  kParamAutoCal,  644, cy2 - 18, 732, cy2 + 18, "AUTO");
     }
 
     void tmButton(ImDrawList* dl, const char* id, uint32_t param, float x0, float y0,
@@ -373,8 +374,8 @@ private:
     float   values[kParamCount] = {};
     float   s = 1.0f;
     ImVec2  org = ImVec2(0, 0);
-    float   reelPhase = 0.0f;
     float   needleL = 0.0f, needleR = 0.0f;
+    int     currentPreset = -1;
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachineUI)
 };

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -184,76 +184,99 @@ private:
                 float level, float& needle, const char* label)
     {
         const float dB = 20.0f * std::log10(level > 1e-4f ? level : 1e-4f) + 18.0f;
-        float target = (dB + 20.0f) / 23.0f;
+        // deflection is linear in signal level (%), not dB: gives the classic
+        // log-spread VU scale (marks bunch at the bottom, open up near 0..+3).
+        float target = std::pow(10.0f, (dB - 3.0f) / 20.0f);
         target = target < 0.0f ? 0.0f : (target > 1.0f ? 1.0f : target);
         needle += (target - needle) * (1.0f - std::exp(-ImGui::GetIO().DeltaTime * 11.0f));
 
+        // warm tan bezel -> dark inner lip -> aged-cream face
         dl->AddRectFilledMultiColor(P(x0, y0), P(x1, y1),
-            IM_COL32(206, 199, 184, 255), IM_COL32(196, 189, 174, 255),
-            IM_COL32(168, 161, 146, 255), IM_COL32(160, 153, 138, 255));
-        dl->AddRectFilled(P(x0 + 3, y0 + 3), P(x1 - 3, y1 - 3), IM_COL32(58, 58, 58, 255), 3.0f * s);
-        const float fx0 = x0 + 6, fy0 = y0 + 6, fx1 = x1 - 6, fy1 = y1 - 6;
-        dl->AddRectFilled(P(fx0, fy0), P(fx1, fy1), IM_COL32(245, 240, 230, 255), 2.0f * s);
+            IM_COL32(170, 142, 100, 255), IM_COL32(158, 130, 88, 255),
+            IM_COL32(120, 96, 60, 255),  IM_COL32(110, 88, 54, 255));
+        dl->AddRect(P(x0, y0), P(x1, y1), IM_COL32(92, 72, 44, 255), 6.0f * s, 0, 1.4f * s);
+        dl->AddRectFilled(P(x0 + 4, y0 + 4), P(x1 - 4, y1 - 4), IM_COL32(56, 44, 30, 255), 4.0f * s);
+        const float fx0 = x0 + 7, fy0 = y0 + 7, fx1 = x1 - 7, fy1 = y1 - 7;
+        dl->AddRectFilled(P(fx0, fy0), P(fx1, fy1), IM_COL32(240, 231, 205, 255), 3.0f * s);
         dl->AddRectFilledMultiColor(P(fx0, fy0), P(fx1, fy1),
-            IM_COL32(255, 252, 244, 90), IM_COL32(255, 252, 244, 90),
-            IM_COL32(236, 228, 212, 90), IM_COL32(236, 228, 212, 90));
+            IM_COL32(252, 246, 226, 130), IM_COL32(252, 246, 226, 130),
+            IM_COL32(210, 194, 158, 150), IM_COL32(210, 194, 158, 150));
+        // corner vignette
+        for (float vx : { fx0, fx1 })
+            for (float vy : { fy0, fy1 })
+                dl->AddCircleFilled(P(vx, vy), (fy1 - fy0) * 0.45f * s, IM_COL32(120, 96, 62, 26), 20);
 
         const float cx = 0.5f * (fx0 + fx1);
-        const float pivotY = fy1 - 5.0f;
-        const float L = std::min((fx1 - fx0) * 0.48f, (fy1 - fy0) * 0.90f);
+        const float pivotY = fy1 - 4.0f;
+        const float L = std::min((fx1 - fx0) * 0.48f, (fy1 - fy0) * 0.92f);
         auto pt = [&](float r, float a) { return P(cx + r * std::cos(a), pivotY + r * std::sin(a)); };
+        ImFont* f = labelFont ? labelFont : ImGui::GetFont();
+        const ImU32 ink = IM_COL32(38, 32, 24, 255), red = IM_COL32(196, 42, 34, 255);
+        auto num = [&](float r, float a, const char* b, ImU32 c, float sz) {
+            ImVec2 ts = f->CalcTextSizeA(sz * s, FLT_MAX, 0, b);
+            ImVec2 tp = pt(r, a);
+            dl->AddText(f, sz * s, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f), c, b);
+        };
+        auto ang = [&](float db) { float n = std::pow(10.0f, (db - 3.0f) / 20.0f);
+                                   n = n < 0.0f ? 0.0f : (n > 1.0f ? 1.0f : n);
+                                   return kVuA0 + n * (kVuA1 - kVuA0); };
 
-        {
-            const float a0 = kVuA0 + (20.0f / 23.0f) * (kVuA1 - kVuA0);
-            dl->PathClear();
-            dl->PathArcTo(P(cx, pivotY), L * 0.86f * s, a0, kVuA1, 24);
-            dl->PathStroke(IM_COL32(212, 44, 44, 150), 0, 3.0f * s);
-        }
+        // bold red arc over the 0..+3 zone
+        dl->PathClear();
+        dl->PathArcTo(P(cx, pivotY), L * 0.90f * s, ang(0.0f), kVuA1, 26);
+        dl->PathStroke(red, 0, 3.4f * s);
+
+        // dB scale: ticks + numbers (black below 0, red above)
         const float dbv[11] = { -20, -10, -7, -5, -3, -2, -1, 0, 1, 2, 3 };
         for (int i = 0; i < 11; ++i)
         {
-            const float db = dbv[i];
-            const float a = kVuA0 + ((db + 20.0f) / 23.0f) * (kVuA1 - kVuA0);
+            const float db = dbv[i], a = ang(db);
             const bool major = !(db == -2 || db == 2);
-            const bool red = db >= 0.0f;
-            const float rt = L * 0.94f;
-            dl->AddLine(pt(rt, a), pt(rt + (major ? 8.0f : 5.0f), a),
-                        red ? IM_COL32(212, 44, 44, 255) : IM_COL32(42, 42, 42, 255), (major ? 1.7f : 1.0f) * s);
-            if (db == -20 || db == -10 || db == -5 || db == 0 || db == 3)
-            {
-                char b[6]; std::snprintf(b, sizeof(b), db == 0 ? "0" : db > 0 ? "+%d" : "%d", (int)db);
-                const ImVec2 tp = pt(L * 0.72f, a);
-                ImFont* f = labelFont ? labelFont : ImGui::GetFont();
-                const float fs2 = 10.0f * s; ImVec2 ts = f->CalcTextSizeA(fs2, FLT_MAX, 0, b);
-                dl->AddText(f, fs2, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f),
-                            red ? IM_COL32(190, 40, 40, 255) : IM_COL32(42, 42, 42, 255), b);
-            }
+            const bool rz = db > 0.0f;
+            const float rt = L * 0.90f;
+            dl->AddLine(pt(rt, a), pt(rt + (major ? 6.0f : 4.0f), a),
+                        rz ? red : ink, (major ? 1.6f : 1.0f) * s);
+            char b[6]; std::snprintf(b, sizeof(b), "%d", (int)std::abs(db));
+            num(L * 0.80f, a, b, rz ? red : ink, 9.5f);
         }
-        text(dl, cx, pivotY - L * 0.46f, 11, IM_COL32(42, 42, 42, 255), "VU", 0, true);
-        text(dl, cx, pivotY - L * 0.46f + 13.0f, 8.5f, IM_COL32(90, 90, 90, 255), label, 0, true);
-
-        const float na = kVuA0 + needle * (kVuA1 - kVuA0);
-        dl->AddLine(P(cx + 2, pivotY + 2), P(cx + 2 + L * 0.95f * std::cos(na), pivotY + 2 + L * 0.95f * std::sin(na)),
-                    IM_COL32(0, 0, 0, 60), 3.0f * s);
+        // percentage row (0..100) across the black zone, closer to the pivot
+        const float pct0 = std::pow(10.0f, -3.0f / 20.0f); // 0 VU == 100%
+        for (int k = 0; k <= 5; ++k)
         {
-            const float perp = na + 1.5707963f, bw = 3.5f;
+            const float aP = kVuA0 + (k / 5.0f) * pct0 * (kVuA1 - kVuA0);
+            char b[6]; std::snprintf(b, sizeof(b), "%d", k * 20);
+            num(L * 0.60f, aP, b, IM_COL32(70, 60, 46, 255), 7.5f);
+        }
+        // - (left) and + (red, right) marks in the top corners
+        text(dl, fx0 + 10, fy0 + 3, 15.0f, ink, "-", -1, true);
+        text(dl, fx1 - 10, fy0 + 3, 15.0f, red, "+", 1, true);
+
+        // peak LED (right)
+        dl->AddCircleFilled(P(fx1 - 15, pivotY - L * 0.20f), 4.6f * s, IM_COL32(112, 40, 30, 255), 16);
+        dl->AddCircleFilled(P(fx1 - 16, pivotY - L * 0.20f - 1), 1.5f * s, IM_COL32(210, 130, 110, 120), 10);
+
+        // VU legend (kept at its current position) + channel tag
+        text(dl, cx, pivotY - L * 0.46f, 11, ink, "VU", 0, true);
+        text(dl, cx, pivotY - L * 0.46f + 13.0f, 8.5f, IM_COL32(90, 80, 64, 255), label, 0, true);
+
+        // black needle with soft shadow + mound pivot
+        const float na = kVuA0 + needle * (kVuA1 - kVuA0);
+        dl->AddLine(P(cx + 2, pivotY + 1), pt(L * 0.95f, na), IM_COL32(60, 50, 36, 70), 4.0f * s);
+        {
+            const float perp = na + 1.5707963f, bw = 3.4f;
             dl->AddTriangleFilled(P(cx + bw * 0.5f * std::cos(perp), pivotY + bw * 0.5f * std::sin(perp)),
                                   pt(L * 0.95f, na),
                                   P(cx - bw * 0.5f * std::cos(perp), pivotY - bw * 0.5f * std::sin(perp)),
-                                  IM_COL32(204, 51, 51, 255));
+                                  IM_COL32(28, 24, 18, 255));
         }
-        dl->AddCircleFilled(P(cx, pivotY), 4.5f * s, IM_COL32(20, 20, 20, 255), 18);
-        dl->AddCircleFilled(P(cx - 1.2f * s, pivotY - 1.4f * s), 1.6f * s, IM_COL32(120, 120, 120, 160), 10);
+        dl->AddCircleFilled(P(cx, pivotY + 1), 8.0f * s, IM_COL32(40, 32, 22, 90), 20); // mound shadow
+        dl->AddCircleFilled(P(cx, pivotY), 4.6f * s, IM_COL32(24, 20, 14, 255), 18);
+        dl->AddCircleFilled(P(cx - 1.2f * s, pivotY - 1.4f * s), 1.5f * s, IM_COL32(150, 140, 120, 150), 10);
 
+        // glass top highlight
         dl->AddRectFilledMultiColor(P(fx0 + 4, fy0 + 2), P(fx1 - 4, fy0 + (fy1 - fy0) * 0.22f),
-            IM_COL32(255, 255, 255, 34), IM_COL32(255, 255, 255, 34),
+            IM_COL32(255, 255, 255, 30), IM_COL32(255, 255, 255, 30),
             IM_COL32(255, 255, 255, 0), IM_COL32(255, 255, 255, 0));
-        for (float sxx : { x0 + 9, x1 - 9 })
-            for (float syy : { y0 + 9, y1 - 9 })
-            {
-                dl->AddCircleFilled(P(sxx, syy), 3.0f * s, IM_COL32(176, 168, 152, 255), 14);
-                dl->AddLine(P(sxx - 2, syy), P(sxx + 2, syy), IM_COL32(26, 26, 24, 255), 1.2f * s);
-            }
     }
 
     //--- selectors (two rows of three, in the centre column) -------------------

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -95,8 +95,9 @@ protected:
         ImDrawList* dl = ImGui::GetWindowDrawList();
         drawPanel(dl, winW, winH);
         drawHeader(dl);
-        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, clipHoldL, "L");
-        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, clipHoldR, "R");
+        const bool clipEnabled = meterSource != 0;   // OUTPUT source only
+        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, clipHoldL, clipEnabled, "L");
+        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, clipHoldR, clipEnabled, "R");
         drawSelectors(dl);
         drawControls(dl);
 
@@ -374,7 +375,7 @@ private:
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
 
     void drawVU(ImDrawList* dl, float x0, float y0, float x1, float y1,
-                float level, float& needle, float& clipHold, const char* label)
+                float level, float& needle, float& clipHold, bool clipEnabled, const char* label)
     {
         const float dB = 20.0f * std::log10(level > 1e-4f ? level : 1e-4f) + 18.0f;
         // deflection is linear in signal level (%), not dB: gives the classic
@@ -440,10 +441,12 @@ private:
         text(dl, fx0 + 10, fy0 + 3, 15.0f, ink, "-", -1, true);
         text(dl, fx1 - 10, fy0 + 3, 15.0f, red, "+", 1, true);
 
-        // clip / over lamp (right): lights for ~1.2 s after any >= 0 dBFS peak
-        if (level > 1.0f) clipHold = 1.2f;
+        // over lamp (right). Only meaningful on the OUTPUT source, where it means a
+        // true >= 0 dBFS digital clip. On INPUT, being in the red is desirable tape
+        // drive, so the lamp is disabled (clipEnabled == false).
+        if (clipEnabled && level > 1.0f) clipHold = 1.2f;
         else if (clipHold > 0.0f) clipHold -= ImGui::GetIO().DeltaTime;
-        const bool over = clipHold > 0.0f;
+        const bool over = clipEnabled && clipHold > 0.0f;
         const ImVec2 lp = P(fx1 - 15, pivotY - L * 0.20f);
         if (over) dl->AddCircleFilled(lp, 8.0f * s, IM_COL32(230, 60, 40, 70), 20);   // glow
         dl->AddCircleFilled(lp, 5.0f * s, over ? IM_COL32(232, 60, 40, 255) : IM_COL32(96, 40, 32, 255), 16);

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -2,11 +2,11 @@
 // Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
 // others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
 //
-// TapeMachineUI.cpp — Dear ImGui UI for TapeMachine 2. Brushed-aluminium panel
-// in the classic Swiss multichannel-recorder style: two spinning reels (one
-// silver, one gold) flanking an amber dual VU bridge, a row of tape/EQ
-// selectors, a knob row, and light Studer-style function buttons. Continuous
-// controls render through the shared duskdpf::DuskPanel.
+// TapeMachineUI.cpp — Dear ImGui UI for TapeMachine 2. Layout mirrors the JUCE
+// TapeMachine editor (800x568): header, a transport row with two reels flanking
+// a stereo VU bridge over two rows of three selectors, then a main knob row and
+// a character knob row. Recolored to a brushed-silver panel; the chrome knobs
+// (shared duskdpf::DuskPanel) and the cream JUCE VU meters are kept.
 
 #include "DistrhoUI.hpp"
 #include "TapeMachineAccess.hpp"
@@ -20,20 +20,17 @@
 START_NAMESPACE_DISTRHO
 
 namespace {
-    constexpr float kDesignW = 920.0f;
-    constexpr float kDesignH = 480.0f;
-    constexpr float kPi = 3.14159265358979f;
+    constexpr float kDesignW = 800.0f;
+    constexpr float kDesignH = 568.0f;
 
-    // Brushed-aluminium palette (Studer-style silver panel, dark ink).
     constexpr ImU32 kColPanel   = IM_COL32(188, 189, 191, 255);
     constexpr ImU32 kColPanelHi = IM_COL32(206, 207, 209, 255);
     constexpr ImU32 kColPanelLo = IM_COL32(150, 151, 153, 255);
-    constexpr ImU32 kColFrame   = IM_COL32(58, 58, 60, 255);   // dark chassis edge
-    constexpr ImU32 kColInk     = IM_COL32(34, 34, 37, 255);   // dark text
+    constexpr ImU32 kColFrame   = IM_COL32(58, 58, 60, 255);
+    constexpr ImU32 kColInk     = IM_COL32(34, 34, 37, 255);
     constexpr ImU32 kColInkDim  = IM_COL32(96, 97, 100, 255);
     constexpr ImU32 kColScrew    = IM_COL32(120, 121, 123, 255);
-    constexpr ImU32 kColReelGold = IM_COL32(198, 166, 98, 255);
-    constexpr ImU32 kColReelSilv = IM_COL32(158, 159, 162, 255);
+    constexpr ImU32 kColReel     = IM_COL32(158, 159, 162, 255);
     constexpr ImU32 kColRed      = IM_COL32(190, 55, 40, 255);
 }
 
@@ -49,10 +46,9 @@ public:
     {
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kTmParams[i].def;
-        setGeometryConstraints(460, 240, true);
+        setGeometryConstraints(400, 284, true);
         labelFont = duskdpf::loadCrispFont(30.0f * getScaleFactor());
 
-        // Dark ink for labels/ticks/markers on the silver panel.
         duskdpf::Palette pal;
         pal.white    = kColInk;
         pal.whiteDim = kColInkDim;
@@ -73,7 +69,6 @@ protected:
         s   = std::min(winW / kDesignW, winH / kDesignH);
         org = ImVec2(0.5f * (winW - kDesignW * s), 0.5f * (winH - kDesignH * s));
         panel.begin(s, org, labelFont, this);
-
         reelPhase += ImGui::GetIO().DeltaTime * reelSpeed();
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
@@ -88,12 +83,14 @@ protected:
         ImDrawList* dl = ImGui::GetWindowDrawList();
         drawPanel(dl, winW, winH);
         drawHeader(dl);
-        drawSelectorRow(dl);
-        drawReel(dl, 108, 250, 68, +1.0f, kColReelSilv);
-        drawReel(dl, 812, 250, 68, -1.0f, kColReelGold);
-        drawMeterBridge(dl);
-        drawKnobRow(dl);
-        drawToggles(dl);
+
+        // transport: reels flank the centre column (VU + two selector rows)
+        drawReel(dl, 75, 167, 52);
+        drawReel(dl, 725, 167, 52);
+        drawVU(dl, 140, 68, 396, 184, meterLevel(0), needleL, "L");
+        drawVU(dl, 404, 68, 660, 184, meterLevel(1), needleR, "R");
+        drawSelectors(dl);
+        drawKnobs(dl);
 
         ImGui::End();
         ImGui::PopStyleVar(2);
@@ -101,9 +98,19 @@ protected:
 
 private:
     ImVec2 P(float x, float y) const { return ImVec2(org.x + x * s, org.y + y * s); }
-
     void text(ImDrawList* dl, float x, float y, float sz, ImU32 c, const char* t, int align, bool bold = false)
     { panel.text(dl, x, y, sz, c, t, align, bold); }
+
+    float meterLevel(int ch)
+    {
+        float v = values[ch == 0 ? kParamVuL : kParamVuR];
+       #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
+        if (tapeMachineGetVuL != nullptr && tapeMachineGetVuR != nullptr)
+            if (void* const inst = getPluginInstancePointer())
+                v = ch == 0 ? tapeMachineGetVuL(inst) : tapeMachineGetVuR(inst);
+       #endif
+        return v;
+    }
 
     float reelSpeed() const
     {
@@ -112,18 +119,17 @@ private:
         return (sp == 2 ? 4.4f : sp == 1 ? 2.2f : 1.1f);
     }
 
-    // Brushed-aluminium fill: base + faint horizontal grain + screws.
     void drawPanel(ImDrawList* dl, float winW, float winH)
     {
         dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), kColFrame);
         dl->AddRectFilledMultiColor(P(0, 0), P(kDesignW, kDesignH),
                                     kColPanelHi, kColPanelHi, kColPanelLo, kColPanelLo);
         dl->AddRectFilled(P(6, 6), P(kDesignW - 6, kDesignH - 6), kColPanel);
-        for (float y = 8.0f; y < kDesignH - 6.0f; y += 3.0f) // brushed grain
+        for (float y = 8.0f; y < kDesignH - 6.0f; y += 3.0f)
             dl->AddLine(P(8, y), P(kDesignW - 8, y), IM_COL32(255, 255, 255, 10), 1.0f);
-        const float sx[6] = { 16, kDesignW - 16, 16, kDesignW - 16, kDesignW * 0.5f, kDesignW * 0.5f };
-        const float sy[6] = { 16, 16, kDesignH - 16, kDesignH - 16, 16, kDesignH - 16 };
-        for (int i = 0; i < 6; ++i) screw(dl, sx[i], sy[i]);
+        const float sx[4] = { 16, kDesignW - 16, 16, kDesignW - 16 };
+        const float sy[4] = { 16, 16, kDesignH - 16, kDesignH - 16 };
+        for (int i = 0; i < 4; ++i) screw(dl, sx[i], sy[i]);
     }
 
     void screw(ImDrawList* dl, float x, float y) const
@@ -137,115 +143,51 @@ private:
 
     void drawHeader(ImDrawList* dl)
     {
-        // recessed dark nameplate (Studer-style: dark plate, light text)
-        dl->AddRectFilled(P(30, 10), P(300, 38), IM_COL32(30, 30, 32, 255), 3.0f * s);
-        dl->AddRect(P(30, 10), P(300, 38), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
-        text(dl, 44, 15, 17, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
-        text(dl, kDesignW - 30, 15, 14, kColInk, "Dusk Audio", 1, true);
+        dl->AddRectFilled(P(15, 12), P(300, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
+        dl->AddRect(P(15, 12), P(300, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
+        text(dl, 28, 17, 17, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
+        text(dl, 690, 18, 13, kColInk, "Dusk Audio", 1, true);
+        tmButton(dl, "bypass", kParamBypass, 704, 14, 785, 38, "BYPASS");
     }
 
-    void selector(ImDrawList* dl, const char* id, uint32_t param, float x, float y,
-                  float w, const char* title)
-    {
-        const TmParam& d = kTmParams[param];
-        text(dl, x + 0.5f * w, y, 9.5f, kColInk, title, 0, true);
-
-        int cur = (int)(values[param] + 0.5f);
-        if (cur < 0) cur = 0; if (cur >= d.numChoices) cur = d.numChoices - 1;
-
-        ImGui::SetCursorScreenPos(P(x, y + 13.0f));
-        ImGui::SetNextItemWidth(w * s);
-        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
-        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
-        ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
-        ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(180, 150, 90, 255));
-        ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
-        if (ImGui::BeginCombo(id, d.choices[cur], ImGuiComboFlags_NoArrowButton))
-        {
-            for (int i = 0; i < d.numChoices; ++i)
-                if (ImGui::Selectable(d.choices[i], i == cur))
-                {
-                    values[param] = (float)i;
-                    editParameter(param, true);
-                    setParameterValue(param, (float)i);
-                    editParameter(param, false);
-                }
-            ImGui::EndCombo();
-        }
-        ImGui::PopStyleColor(5);
-    }
-
-    void drawSelectorRow(ImDrawList* dl)
-    {
-        const float w = 112.0f, y = 54.0f;
-        const float xs[7] = { 18, 145, 272, 399, 526, 653, 780 };
-        selector(dl, "##machine", kParamTapeMachine, xs[0], y, w, "MACHINE");
-        selector(dl, "##speed",   kParamTapeSpeed,   xs[1], y, w, "TAPE SPEED");
-        selector(dl, "##type",    kParamTapeType,    xs[2], y, w, "TAPE TYPE");
-        selector(dl, "##path",    kParamSignalPath,  xs[3], y, w, "SIGNAL PATH");
-        selector(dl, "##eq",      kParamEqStandard,  xs[4], y, w, "EQ");
-        selector(dl, "##cal",     kParamCalibration, xs[5], y, w, "CALIBRATION");
-        selector(dl, "##os",      kParamOversampling,xs[6], y, w, "OVERSAMPLING");
-    }
-
-    void drawReel(ImDrawList* dl, float cx, float cy, float r, float dir, ImU32 flangeCol)
+    //--- transport -------------------------------------------------------------
+    void drawReel(ImDrawList* dl, float cx, float cy, float r)
     {
         const ImVec2 c = P(cx, cy);
-        dl->AddCircleFilled(c, r * s, flangeCol, 56);
+        dl->AddCircleFilled(c, r * s, kColReel, 56);
         dl->AddCircle(c, r * s, IM_COL32(70, 70, 72, 255), 56, 2.0f * s);
-        dl->AddCircleFilled(c, r * 0.90f * s, IM_COL32(74, 58, 40, 255), 56); // exposed tape pack
-        dl->AddCircleFilled(c, r * 0.58f * s, flangeCol, 48);
+        dl->AddCircleFilled(c, r * 0.90f * s, IM_COL32(120, 120, 123, 255), 56);
+        dl->AddCircleFilled(c, r * 0.58f * s, kColReel, 48);
         dl->AddCircle(c, r * 0.58f * s, IM_COL32(90, 90, 92, 255), 48, 1.4f * s);
-        // three large flange cutouts, rotating
-        const float a0 = reelPhase * dir;
+        const float a0 = reelPhase;
         for (int i = 0; i < 3; ++i)
         {
-            const float a = a0 + i * (2.0f * kPi / 3.0f);
+            const float a = a0 + i * (2.0944f);
             const ImVec2 h(c.x + std::sin(a) * r * 0.72f * s, c.y - std::cos(a) * r * 0.72f * s);
-            dl->AddCircleFilled(h, r * 0.15f * s, IM_COL32(74, 58, 40, 255), 24);
-            dl->AddCircle(h, r * 0.15f * s, IM_COL32(90, 90, 92, 200), 24, 1.0f * s);
+            dl->AddCircleFilled(h, r * 0.15f * s, IM_COL32(96, 96, 99, 255), 24);
+            dl->AddCircle(h, r * 0.15f * s, IM_COL32(70, 70, 72, 200), 24, 1.0f * s);
         }
-        // hub
-        dl->AddCircleFilled(c, r * 0.22f * s, IM_COL32(210, 210, 212, 255), 28);
-        dl->AddCircleFilled(c, r * 0.22f * s, IM_COL32(150, 150, 152, 255), 28);
+        dl->AddCircleFilled(c, r * 0.22f * s, IM_COL32(205, 205, 207, 255), 28);
         dl->AddCircle(c, r * 0.22f * s, IM_COL32(80, 80, 82, 255), 28, 1.4f * s);
-        for (int i = 0; i < 3; ++i) // hub spokes
+        for (int i = 0; i < 3; ++i)
         {
-            const float a = a0 * 1.0f + i * (2.0f * kPi / 3.0f);
+            const float a = a0 + i * 2.0944f;
             dl->AddLine(c, ImVec2(c.x + std::sin(a) * r * 0.20f * s, c.y - std::cos(a) * r * 0.20f * s),
                         IM_COL32(90, 90, 92, 255), 1.4f * s);
         }
         dl->AddCircleFilled(c, r * 0.07f * s, IM_COL32(40, 40, 42, 255), 12);
     }
 
-    void drawMeterBridge(ImDrawList* dl)
-    {
-        float lvlL = values[kParamVuL], lvlR = values[kParamVuR];
-       #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
-        if (tapeMachineGetVuL != nullptr && tapeMachineGetVuR != nullptr)
-            if (void* const inst = getPluginInstancePointer())
-            { lvlL = tapeMachineGetVuL(inst); lvlR = tapeMachineGetVuR(inst); }
-       #endif
-        // two framed cream VU meters side by side (ported from the JUCE
-        // AnalogVUMeter: silver frame, dark bezel, cream face, red needle,
-        // -20..+3 VU scale with red zone, deco screws, glass highlight).
-        drawVU(dl, 258, 148, 454, 296, lvlL, needleL, "L");
-        drawVU(dl, 466, 148, 662, 296, lvlR, needleR, "R");
-    }
-
-    // JUCE AnalogVUMeter palette.
-    static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f; // -20 .. +3 VU angles
+    static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
 
     void drawVU(ImDrawList* dl, float x0, float y0, float x1, float y1,
                 float level, float& needle, const char* label)
     {
-        // ballistics: 0 VU == -18 dBFS; needle 0..1 over -20..+3 VU.
         const float dB = 20.0f * std::log10(level > 1e-4f ? level : 1e-4f) + 18.0f;
         float target = (dB + 20.0f) / 23.0f;
         target = target < 0.0f ? 0.0f : (target > 1.0f ? 1.0f : target);
         needle += (target - needle) * (1.0f - std::exp(-ImGui::GetIO().DeltaTime * 11.0f));
 
-        // frame: silver bezel -> dark inner -> cream face
         dl->AddRectFilledMultiColor(P(x0, y0), P(x1, y1),
             IM_COL32(206, 199, 184, 255), IM_COL32(196, 189, 174, 255),
             IM_COL32(168, 161, 146, 255), IM_COL32(160, 153, 138, 255));
@@ -258,20 +200,15 @@ private:
 
         const float cx = 0.5f * (fx0 + fx1);
         const float pivotY = fy1 - 5.0f;
-        const float faceW = fx1 - fx0, faceH = fy1 - fy0;
-        const float L = std::min(faceW * 0.48f, faceH * 0.90f);
-
+        const float L = std::min((fx1 - fx0) * 0.48f, (fy1 - fy0) * 0.90f);
         auto pt = [&](float r, float a) { return P(cx + r * std::cos(a), pivotY + r * std::sin(a)); };
 
-        // red zone arc (0..+3 VU)
         {
             const float a0 = kVuA0 + (20.0f / 23.0f) * (kVuA1 - kVuA0);
-            const float rr = L * 0.86f;
             dl->PathClear();
-            dl->PathArcTo(P(cx, pivotY), rr * s, a0, kVuA1, 24);
+            dl->PathArcTo(P(cx, pivotY), L * 0.86f * s, a0, kVuA1, 24);
             dl->PathStroke(IM_COL32(212, 44, 44, 150), 0, 3.0f * s);
         }
-        // scale ticks + numbers
         const float dbv[11] = { -20, -10, -7, -5, -3, -2, -1, 0, 1, 2, 3 };
         for (int i = 0; i < 11; ++i)
         {
@@ -279,77 +216,117 @@ private:
             const float a = kVuA0 + ((db + 20.0f) / 23.0f) * (kVuA1 - kVuA0);
             const bool major = !(db == -2 || db == 2);
             const bool red = db >= 0.0f;
-            const float tick = major ? 8.0f : 5.0f;
             const float rt = L * 0.94f;
-            dl->AddLine(pt(rt, a), pt(rt + tick, a), red ? IM_COL32(212, 44, 44, 255) : IM_COL32(42, 42, 42, 255),
-                        (major ? 1.7f : 1.0f) * s);
-            const bool showNum = (db == -20 || db == -10 || db == -5 || db == 0 || db == 3);
-            if (showNum)
+            dl->AddLine(pt(rt, a), pt(rt + (major ? 8.0f : 5.0f), a),
+                        red ? IM_COL32(212, 44, 44, 255) : IM_COL32(42, 42, 42, 255), (major ? 1.7f : 1.0f) * s);
+            if (db == -20 || db == -10 || db == -5 || db == 0 || db == 3)
             {
                 char b[6]; std::snprintf(b, sizeof(b), db == 0 ? "0" : db > 0 ? "+%d" : "%d", (int)db);
                 const ImVec2 tp = pt(L * 0.72f, a);
-                const char* fnt = b; ImFont* f = labelFont ? labelFont : ImGui::GetFont();
-                const float fs2 = 10.0f * s; ImVec2 ts = f->CalcTextSizeA(fs2, FLT_MAX, 0, fnt);
+                ImFont* f = labelFont ? labelFont : ImGui::GetFont();
+                const float fs2 = 10.0f * s; ImVec2 ts = f->CalcTextSizeA(fs2, FLT_MAX, 0, b);
                 dl->AddText(f, fs2, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f),
                             red ? IM_COL32(190, 40, 40, 255) : IM_COL32(42, 42, 42, 255), b);
             }
         }
-        // "VU" legend
         text(dl, cx, pivotY - L * 0.46f, 11, IM_COL32(42, 42, 42, 255), "VU", 0, true);
         text(dl, cx, pivotY - L * 0.46f + 13.0f, 8.5f, IM_COL32(90, 90, 90, 255), label, 0, true);
 
-        // needle (red, with shadow) + pivot cap
         const float na = kVuA0 + needle * (kVuA1 - kVuA0);
         dl->AddLine(P(cx + 2, pivotY + 2), P(cx + 2 + L * 0.95f * std::cos(na), pivotY + 2 + L * 0.95f * std::sin(na)),
                     IM_COL32(0, 0, 0, 60), 3.0f * s);
         {
             const float perp = na + 1.5707963f, bw = 3.5f;
-            const ImVec2 tip = pt(L * 0.95f, na);
             dl->AddTriangleFilled(P(cx + bw * 0.5f * std::cos(perp), pivotY + bw * 0.5f * std::sin(perp)),
-                                  tip,
+                                  pt(L * 0.95f, na),
                                   P(cx - bw * 0.5f * std::cos(perp), pivotY - bw * 0.5f * std::sin(perp)),
                                   IM_COL32(204, 51, 51, 255));
         }
         dl->AddCircleFilled(P(cx, pivotY), 4.5f * s, IM_COL32(20, 20, 20, 255), 18);
         dl->AddCircleFilled(P(cx - 1.2f * s, pivotY - 1.4f * s), 1.6f * s, IM_COL32(120, 120, 120, 160), 10);
 
-        // glass highlight (top) + deco screws
-        dl->AddRectFilledMultiColor(P(fx0 + 4, fy0 + 2), P(fx1 - 4, fy0 + faceH * 0.22f),
+        dl->AddRectFilledMultiColor(P(fx0 + 4, fy0 + 2), P(fx1 - 4, fy0 + (fy1 - fy0) * 0.22f),
             IM_COL32(255, 255, 255, 34), IM_COL32(255, 255, 255, 34),
             IM_COL32(255, 255, 255, 0), IM_COL32(255, 255, 255, 0));
-        const float m = 9.0f;
-        for (float sx : { x0 + m, x1 - m })
-            for (float sy : { y0 + m, y1 - m })
+        for (float sxx : { x0 + 9, x1 - 9 })
+            for (float syy : { y0 + 9, y1 - 9 })
             {
-                dl->AddCircleFilled(P(sx, sy), 3.0f * s, IM_COL32(176, 168, 152, 255), 14);
-                dl->AddLine(P(sx - 2, sy), P(sx + 2, sy), IM_COL32(26, 26, 24, 255), 1.2f * s);
+                dl->AddCircleFilled(P(sxx, syy), 3.0f * s, IM_COL32(176, 168, 152, 255), 14);
+                dl->AddLine(P(sxx - 2, syy), P(sxx + 2, syy), IM_COL32(26, 26, 24, 255), 1.2f * s);
             }
     }
 
-    void knob(ImDrawList* dl, const char* id, uint32_t param, float cx, float cy,
-              const char* l1, const char* l2, const char* fmt, const char* suffix)
+    //--- selectors (two rows of three, in the centre column) -------------------
+    void selector(ImDrawList* dl, const char* id, uint32_t param, float x, float y,
+                  float w, const char* title)
     {
         const TmParam& d = kTmParams[param];
-        panel.knobLabel(dl, cx, cy - 46.0f, l1, l2);
-        panel.knob(id, param, d.min, d.max, cx, cy, 26.0f, values[param], d.def,
-                   false, true, fmt, suffix);
+        text(dl, x + 0.5f * w, y, 9.5f, kColInk, title, 0, true);
+        int cur = (int)(values[param] + 0.5f);
+        if (cur < 0) cur = 0; if (cur >= d.numChoices) cur = d.numChoices - 1;
+
+        ImGui::SetCursorScreenPos(P(x, y + 13.0f));
+        ImGui::SetNextItemWidth(w * s);
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
+        ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
+        ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(150, 152, 156, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
+        if (ImGui::BeginCombo(id, d.choices[cur], ImGuiComboFlags_NoArrowButton))
+        {
+            for (int i = 0; i < d.numChoices; ++i)
+                if (ImGui::Selectable(d.choices[i], i == cur))
+                {
+                    values[param] = (float)i;
+                    editParameter(param, true); setParameterValue(param, (float)i); editParameter(param, false);
+                }
+            ImGui::EndCombo();
+        }
+        ImGui::PopStyleColor(5);
     }
 
-    void drawKnobRow(ImDrawList* dl)
+    void drawSelectors(ImDrawList* dl)
     {
-        const float cy = 372.0f;
-        knob(dl, "input",  kParamInputGain,   80,  cy, "INPUT",   nullptr, "%.1f", " dB");
-        knob(dl, "bias",   kParamBias,        183, cy, "BIAS",    nullptr, "%.0f", "%");
-        knob(dl, "hp",     kParamHighpassFreq,286, cy, "HP",      nullptr, "%.0f", " Hz");
-        knob(dl, "lp",     kParamLowpassFreq, 389, cy, "LP",      nullptr, "%.0f", " Hz");
-        knob(dl, "noise",  kParamNoiseAmount, 492, cy, "NOISE",   nullptr, "%.0f", "%");
-        knob(dl, "wow",    kParamWow,         595, cy, "WOW",     nullptr, "%.0f", "%");
-        knob(dl, "flut",   kParamFlutter,     698, cy, "FLUTTER", nullptr, "%.0f", "%");
-        knob(dl, "output", kParamOutputGain,  825, cy, "OUTPUT",  nullptr, "%.1f", " dB");
+        const float W = 176.67f, x0 = 135.0f, w = W - 10.0f;
+        const float col[3] = { x0 + 5, x0 + W + 5, x0 + 2 * W + 5 };
+        selector(dl, "##machine", kParamTapeMachine, col[0], 190, w, "TAPE MACHINE");
+        selector(dl, "##speed",   kParamTapeSpeed,   col[1], 190, w, "TAPE SPEED");
+        selector(dl, "##type",    kParamTapeType,    col[2], 190, w, "TAPE TYPE");
+        selector(dl, "##path",    kParamSignalPath,  col[0], 238, w, "SIGNAL PATH");
+        selector(dl, "##eq",      kParamEqStandard,  col[1], 238, w, "EQ STANDARD");
+        selector(dl, "##os",      kParamOversampling,col[2], 238, w, "OVERSAMPLING");
     }
 
-    // Light Studer-style function button: raised silver cap, dark label, red
-    // legend + LED when engaged. Flips the (0/1) parameter.
+    //--- knob rows -------------------------------------------------------------
+    void knob(ImDrawList* dl, const char* id, uint32_t param, float cx, float cy,
+              const char* l1, const char* fmt, const char* suffix)
+    {
+        const TmParam& d = kTmParams[param];
+        panel.knobLabel(dl, cx, cy - 50.0f, l1);
+        panel.knob(id, param, d.min, d.max, cx, cy, 32.0f, values[param], d.def, false, true, fmt, suffix);
+    }
+
+    void drawKnobs(ImDrawList* dl)
+    {
+        // main row: input, bias, wow, flutter, output
+        const float cy1 = 356.0f;
+        knob(dl, "input",  kParamInputGain, 116.67f, cy1, "INPUT",   "%.1f", " dB");
+        knob(dl, "bias",   kParamBias,      258.34f, cy1, "BIAS",    "%.0f", "%");
+        knob(dl, "wow",    kParamWow,       400.00f, cy1, "WOW",     "%.0f", "%");
+        knob(dl, "flut",   kParamFlutter,   541.67f, cy1, "FLUTTER", "%.0f", "%");
+        knob(dl, "output", kParamOutputGain,683.34f, cy1, "OUTPUT",  "%.1f", " dB");
+
+        // character row: hp, lp, noise, + auto-comp / auto-cal buttons
+        const float cy2 = 482.0f;
+        knob(dl, "hp",    kParamHighpassFreq, 110.0f, cy2, "HIGHPASS", "%.0f", " Hz");
+        knob(dl, "lp",    kParamLowpassFreq,  245.0f, cy2, "LOWPASS",  "%.0f", " Hz");
+        knob(dl, "noise", kParamNoiseAmount,  380.0f, cy2, "NOISE",    "%.0f", "%");
+        text(dl, 525, cy2 - 50.0f, 10, kColInk, "AUTO COMP", 0, true);
+        tmButton(dl, "autocomp", kParamAutoComp, 480, cy2 - 18, 570, cy2 + 18, "LINK");
+        text(dl, 680, cy2 - 50.0f, 10, kColInk, "AUTO CAL", 0, true);
+        tmButton(dl, "autocal",  kParamAutoCal,  630, cy2 - 18, 730, cy2 + 18, "AUTO");
+    }
+
     void tmButton(ImDrawList* dl, const char* id, uint32_t param, float x0, float y0,
                   float x1, float y1, const char* label)
     {
@@ -364,20 +341,11 @@ private:
             setParameterValue(param, nv); editParameter(param, false);
         }
         dl->AddRectFilledMultiColor(b0, b1, IM_COL32(226, 226, 228, 255), IM_COL32(226, 226, 228, 255),
-                                    IM_COL32(188, 188, 190, 255), IM_COL32(188, 188, 190, 255));
+                                    IM_COL32(186, 186, 188, 255), IM_COL32(186, 186, 188, 255));
         dl->AddRect(b0, b1, IM_COL32(90, 90, 92, 255), 2.0f * s, 0, 1.4f * s);
-        if (on)
-            dl->AddCircleFilled(P(x0 + 8.0f, 0.5f * (y0 + y1)), 2.6f * s, kColRed, 12);
-        text(dl, 0.5f * (x0 + x1) + 5.0f, y0 + 0.30f * (y1 - y0), 9.5f,
+        if (on) dl->AddCircleFilled(P(x0 + 8.0f, 0.5f * (y0 + y1)), 2.6f * s, kColRed, 12);
+        text(dl, 0.5f * (x0 + x1) + 5.0f, y0 + 0.32f * (y1 - y0), 10.0f,
              on ? kColRed : kColInk, label, 0, true);
-    }
-
-    void drawToggles(ImDrawList* dl)
-    {
-        tmButton(dl, "autocal",  kParamAutoCal,      140, 430, 250, 452, "AUTO CAL");
-        tmButton(dl, "noiseen",  kParamNoiseEnabled, 452, 430, 552, 452, "NOISE");
-        tmButton(dl, "autocomp", kParamAutoComp,     660, 430, 790, 452, "AUTO COMP");
-        tmButton(dl, "bypass",   kParamBypass,       690, 12,  770, 34,  "BYPASS");
     }
 
     //--- state -----------------------------------------------------------------

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -34,8 +34,6 @@ namespace {
     constexpr ImU32 kColScrew    = IM_COL32(120, 121, 123, 255);
     constexpr ImU32 kColReelGold = IM_COL32(198, 166, 98, 255);
     constexpr ImU32 kColReelSilv = IM_COL32(158, 159, 162, 255);
-    constexpr ImU32 kColVuFace   = IM_COL32(228, 198, 126, 255); // amber VU glass
-    constexpr ImU32 kColVuInk    = IM_COL32(48, 38, 18, 255);
     constexpr ImU32 kColRed      = IM_COL32(190, 55, 40, 255);
 }
 
@@ -222,56 +220,110 @@ private:
 
     void drawMeterBridge(ImDrawList* dl)
     {
-        const float x0 = 250, y0 = 150, x1 = 670, y1 = 300;
-        dl->AddRectFilled(P(x0 - 4, y0 - 4), P(x1 + 4, y1 + 4), IM_COL32(60, 60, 62, 255), 5.0f * s);
-        dl->AddRectFilled(P(x0, y0), P(x1, y1), kColVuFace, 4.0f * s); // amber glass
-        dl->AddRectFilledMultiColor(P(x0, y0), P(x1, y0 + 30),
-                                    IM_COL32(255, 255, 255, 60), IM_COL32(255, 255, 255, 60),
-                                    IM_COL32(255, 255, 255, 0), IM_COL32(255, 255, 255, 0));
-
         float lvlL = values[kParamVuL], lvlR = values[kParamVuR];
        #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
         if (tapeMachineGetVuL != nullptr && tapeMachineGetVuR != nullptr)
             if (void* const inst = getPluginInstancePointer())
             { lvlL = tapeMachineGetVuL(inst); lvlR = tapeMachineGetVuR(inst); }
        #endif
-        vuMeter(dl, 360, lvlL, needleL, "L");
-        vuMeter(dl, 560, lvlR, needleR, "R");
+        // two framed cream VU meters side by side (ported from the JUCE
+        // AnalogVUMeter: silver frame, dark bezel, cream face, red needle,
+        // -20..+3 VU scale with red zone, deco screws, glass highlight).
+        drawVU(dl, 258, 148, 454, 296, lvlL, needleL, "L");
+        drawVU(dl, 466, 148, 662, 296, lvlR, needleR, "R");
     }
 
-    void vuMeter(ImDrawList* dl, float cx, float level, float& needle, const char* label)
+    // JUCE AnalogVUMeter palette.
+    static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f; // -20 .. +3 VU angles
+
+    void drawVU(ImDrawList* dl, float x0, float y0, float x1, float y1,
+                float level, float& needle, const char* label)
     {
-        const float dt = ImGui::GetIO().DeltaTime;
-        const float dB = 20.0f * std::log10(level > 1e-5f ? level : 1e-5f);
+        // ballistics: 0 VU == -18 dBFS; needle 0..1 over -20..+3 VU.
+        const float dB = 20.0f * std::log10(level > 1e-4f ? level : 1e-4f) + 18.0f;
         float target = (dB + 20.0f) / 23.0f;
         target = target < 0.0f ? 0.0f : (target > 1.0f ? 1.0f : target);
-        needle += (target - needle) * (1.0f - std::exp(-dt * 8.0f));
+        needle += (target - needle) * (1.0f - std::exp(-ImGui::GetIO().DeltaTime * 11.0f));
 
-        const ImVec2 pivot = P(cx, 300);
-        const float rArc = 128.0f * s;
-        const float aMin = -0.60f, aMax = 0.60f;
+        // frame: silver bezel -> dark inner -> cream face
+        dl->AddRectFilledMultiColor(P(x0, y0), P(x1, y1),
+            IM_COL32(206, 199, 184, 255), IM_COL32(196, 189, 174, 255),
+            IM_COL32(168, 161, 146, 255), IM_COL32(160, 153, 138, 255));
+        dl->AddRectFilled(P(x0 + 3, y0 + 3), P(x1 - 3, y1 - 3), IM_COL32(58, 58, 58, 255), 3.0f * s);
+        const float fx0 = x0 + 6, fy0 = y0 + 6, fx1 = x1 - 6, fy1 = y1 - 6;
+        dl->AddRectFilled(P(fx0, fy0), P(fx1, fy1), IM_COL32(245, 240, 230, 255), 2.0f * s);
+        dl->AddRectFilledMultiColor(P(fx0, fy0), P(fx1, fy1),
+            IM_COL32(255, 252, 244, 90), IM_COL32(255, 252, 244, 90),
+            IM_COL32(236, 228, 212, 90), IM_COL32(236, 228, 212, 90));
 
-        dl->PushClipRect(P(cx - 78, 152), P(cx + 78, 236), true);
-        for (int i = 0; i <= 10; ++i)
+        const float cx = 0.5f * (fx0 + fx1);
+        const float pivotY = fy1 - 5.0f;
+        const float faceW = fx1 - fx0, faceH = fy1 - fy0;
+        const float L = std::min(faceW * 0.48f, faceH * 0.90f);
+
+        auto pt = [&](float r, float a) { return P(cx + r * std::cos(a), pivotY + r * std::sin(a)); };
+
+        // red zone arc (0..+3 VU)
         {
-            const float a = aMin + (aMax - aMin) * (float)i / 10.0f;
-            const ImVec2 d(std::sin(a), -std::cos(a));
-            const bool red = i >= 8;
-            dl->AddLine(ImVec2(pivot.x + d.x * (rArc - 6 * s), pivot.y + d.y * (rArc - 6 * s)),
-                        ImVec2(pivot.x + d.x * (rArc + (i % 5 == 0 ? 4 : 1) * s),
-                               pivot.y + d.y * (rArc + (i % 5 == 0 ? 4 : 1) * s)),
-                        red ? kColRed : kColVuInk, (i % 5 == 0 ? 1.8f : 1.1f) * s);
+            const float a0 = kVuA0 + (20.0f / 23.0f) * (kVuA1 - kVuA0);
+            const float rr = L * 0.86f;
+            dl->PathClear();
+            dl->PathArcTo(P(cx, pivotY), rr * s, a0, kVuA1, 24);
+            dl->PathStroke(IM_COL32(212, 44, 44, 150), 0, 3.0f * s);
         }
-        text(dl, cx, 168, 11, kColVuInk, "VU", 0, true);
-        text(dl, cx, 210, 9, kColVuInk, label, 0, true);
+        // scale ticks + numbers
+        const float dbv[11] = { -20, -10, -7, -5, -3, -2, -1, 0, 1, 2, 3 };
+        for (int i = 0; i < 11; ++i)
         {
-            const float a = aMin + (aMax - aMin) * needle;
-            const ImVec2 d(std::sin(a), -std::cos(a));
-            dl->AddLine(ImVec2(pivot.x + d.x * 34 * s, pivot.y + d.y * 34 * s),
-                        ImVec2(pivot.x + d.x * (rArc + 4 * s), pivot.y + d.y * (rArc + 4 * s)),
-                        IM_COL32(40, 30, 20, 255), 1.8f * s);
+            const float db = dbv[i];
+            const float a = kVuA0 + ((db + 20.0f) / 23.0f) * (kVuA1 - kVuA0);
+            const bool major = !(db == -2 || db == 2);
+            const bool red = db >= 0.0f;
+            const float tick = major ? 8.0f : 5.0f;
+            const float rt = L * 0.94f;
+            dl->AddLine(pt(rt, a), pt(rt + tick, a), red ? IM_COL32(212, 44, 44, 255) : IM_COL32(42, 42, 42, 255),
+                        (major ? 1.7f : 1.0f) * s);
+            const bool showNum = (db == -20 || db == -10 || db == -5 || db == 0 || db == 3);
+            if (showNum)
+            {
+                char b[6]; std::snprintf(b, sizeof(b), db == 0 ? "0" : db > 0 ? "+%d" : "%d", (int)db);
+                const ImVec2 tp = pt(L * 0.72f, a);
+                const char* fnt = b; ImFont* f = labelFont ? labelFont : ImGui::GetFont();
+                const float fs2 = 10.0f * s; ImVec2 ts = f->CalcTextSizeA(fs2, FLT_MAX, 0, fnt);
+                dl->AddText(f, fs2, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f),
+                            red ? IM_COL32(190, 40, 40, 255) : IM_COL32(42, 42, 42, 255), b);
+            }
         }
-        dl->PopClipRect();
+        // "VU" legend
+        text(dl, cx, pivotY - L * 0.46f, 11, IM_COL32(42, 42, 42, 255), "VU", 0, true);
+        text(dl, cx, pivotY - L * 0.46f + 13.0f, 8.5f, IM_COL32(90, 90, 90, 255), label, 0, true);
+
+        // needle (red, with shadow) + pivot cap
+        const float na = kVuA0 + needle * (kVuA1 - kVuA0);
+        dl->AddLine(P(cx + 2, pivotY + 2), P(cx + 2 + L * 0.95f * std::cos(na), pivotY + 2 + L * 0.95f * std::sin(na)),
+                    IM_COL32(0, 0, 0, 60), 3.0f * s);
+        {
+            const float perp = na + 1.5707963f, bw = 3.5f;
+            const ImVec2 tip = pt(L * 0.95f, na);
+            dl->AddTriangleFilled(P(cx + bw * 0.5f * std::cos(perp), pivotY + bw * 0.5f * std::sin(perp)),
+                                  tip,
+                                  P(cx - bw * 0.5f * std::cos(perp), pivotY - bw * 0.5f * std::sin(perp)),
+                                  IM_COL32(204, 51, 51, 255));
+        }
+        dl->AddCircleFilled(P(cx, pivotY), 4.5f * s, IM_COL32(20, 20, 20, 255), 18);
+        dl->AddCircleFilled(P(cx - 1.2f * s, pivotY - 1.4f * s), 1.6f * s, IM_COL32(120, 120, 120, 160), 10);
+
+        // glass highlight (top) + deco screws
+        dl->AddRectFilledMultiColor(P(fx0 + 4, fy0 + 2), P(fx1 - 4, fy0 + faceH * 0.22f),
+            IM_COL32(255, 255, 255, 34), IM_COL32(255, 255, 255, 34),
+            IM_COL32(255, 255, 255, 0), IM_COL32(255, 255, 255, 0));
+        const float m = 9.0f;
+        for (float sx : { x0 + m, x1 - m })
+            for (float sy : { y0 + m, y1 - m })
+            {
+                dl->AddCircleFilled(P(sx, sy), 3.0f * s, IM_COL32(176, 168, 152, 255), 14);
+                dl->AddLine(P(sx - 2, sy), P(sx + 2, sy), IM_COL32(26, 26, 24, 255), 1.2f * s);
+            }
     }
 
     void knob(ImDrawList* dl, const char* id, uint32_t param, float cx, float cy,

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -86,8 +86,8 @@ protected:
         ImDrawList* dl = ImGui::GetWindowDrawList();
         drawPanel(dl, winW, winH);
         drawHeader(dl);
-        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, "L");
-        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, "R");
+        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, clipHoldL, "L");
+        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, clipHoldR, "R");
         drawSelectors(dl);
         drawControls(dl);
 
@@ -102,11 +102,14 @@ private:
 
     float meterLevel(int ch)
     {
-        float v = values[ch == 0 ? kParamVuL : kParamVuR];
+        const bool out = meterSource != 0;
+        float v = values[ch == 0 ? kParamVuL : kParamVuR]; // output params (generic-UI fallback)
        #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
-        if (tapeMachineGetVuL != nullptr && tapeMachineGetVuR != nullptr)
-            if (void* const inst = getPluginInstancePointer())
-                v = ch == 0 ? tapeMachineGetVuL(inst) : tapeMachineGetVuR(inst);
+        if (void* const inst = getPluginInstancePointer())
+        {
+            if (out) { if (tapeMachineGetVuL)   v = ch == 0 ? tapeMachineGetVuL(inst)   : tapeMachineGetVuR(inst); }
+            else     { if (tapeMachineGetInVuL) v = ch == 0 ? tapeMachineGetInVuL(inst) : tapeMachineGetInVuR(inst); }
+        }
        #endif
         return v;
     }
@@ -179,6 +182,21 @@ private:
         }
         ImGui::PopStyleColor(8);
 
+        // meter source toggle (INPUT / OUTPUT) between the preset combo and bypass
+        {
+            const bool out = meterSource != 0;
+            text(dl, 604, 6, 8.0f, kColInkDim, "METER", 0, true);
+            const ImVec2 b0 = P(575, 18), b1 = P(633, 38);
+            ImGui::SetCursorScreenPos(b0);
+            ImGui::InvisibleButton("metsrc", ImVec2(b1.x - b0.x, b1.y - b0.y));
+            if (ImGui::IsItemClicked()) meterSource ^= 1;
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("Meter source: what the VU meters show (INPUT or OUTPUT level).");
+            dl->AddRectFilledMultiColor(b0, b1, IM_COL32(226, 226, 228, 255), IM_COL32(226, 226, 228, 255),
+                                        IM_COL32(186, 186, 188, 255), IM_COL32(186, 186, 188, 255));
+            dl->AddRect(b0, b1, IM_COL32(90, 90, 92, 255), 2.0f * s, 0, 1.2f * s);
+            text(dl, 604, 22, 9.5f, kColInk, out ? "OUTPUT" : "INPUT", 0, true);
+        }
+
         // bypass, kept clear of the top-right corner screw (~x784)
         tmButton(dl, "bypass", kParamBypass, 648, 14, 736, 38, "BYPASS",
                  "Bypass the plugin (host-integrated).");
@@ -187,7 +205,7 @@ private:
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
 
     void drawVU(ImDrawList* dl, float x0, float y0, float x1, float y1,
-                float level, float& needle, const char* label)
+                float level, float& needle, float& clipHold, const char* label)
     {
         const float dB = 20.0f * std::log10(level > 1e-4f ? level : 1e-4f) + 18.0f;
         // deflection is linear in signal level (%), not dB: gives the classic
@@ -253,9 +271,15 @@ private:
         text(dl, fx0 + 10, fy0 + 3, 15.0f, ink, "-", -1, true);
         text(dl, fx1 - 10, fy0 + 3, 15.0f, red, "+", 1, true);
 
-        // peak LED (right)
-        dl->AddCircleFilled(P(fx1 - 15, pivotY - L * 0.20f), 4.6f * s, IM_COL32(112, 40, 30, 255), 16);
-        dl->AddCircleFilled(P(fx1 - 16, pivotY - L * 0.20f - 1), 1.5f * s, IM_COL32(210, 130, 110, 120), 10);
+        // clip / over lamp (right): lights for ~1.2 s after any >= 0 dBFS peak
+        if (level > 1.0f) clipHold = 1.2f;
+        else if (clipHold > 0.0f) clipHold -= ImGui::GetIO().DeltaTime;
+        const bool over = clipHold > 0.0f;
+        const ImVec2 lp = P(fx1 - 15, pivotY - L * 0.20f);
+        if (over) dl->AddCircleFilled(lp, 8.0f * s, IM_COL32(230, 60, 40, 70), 20);   // glow
+        dl->AddCircleFilled(lp, 5.0f * s, over ? IM_COL32(232, 60, 40, 255) : IM_COL32(96, 40, 32, 255), 16);
+        dl->AddCircleFilled(ImVec2(lp.x - 1.4f * s, lp.y - 1.6f * s), 1.6f * s,
+                            IM_COL32(255, 200, 180, over ? 210 : 90), 10);
 
         // VU legend + channel tag
         text(dl, cx, pivotY - L * 0.46f, 11, ink, "VU", 0, true);
@@ -439,6 +463,8 @@ private:
     float   s = 1.0f;
     ImVec2  org = ImVec2(0, 0);
     float   needleL = 0.0f, needleR = 0.0f;
+    float   clipHoldL = 0.0f, clipHoldR = 0.0f;
+    int     meterSource = 1;      // 0 = input, 1 = output
     int     currentPreset = -1;
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachineUI)

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -23,7 +23,7 @@ START_NAMESPACE_DISTRHO
 
 namespace {
     constexpr float kDesignW = 800.0f;
-    constexpr float kDesignH = 520.0f;
+    constexpr float kDesignH = 470.0f;
 
     constexpr ImU32 kColPanel   = IM_COL32(188, 189, 191, 255);
     constexpr ImU32 kColPanelHi = IM_COL32(206, 207, 209, 255);
@@ -89,7 +89,7 @@ protected:
         drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, "L");
         drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, "R");
         drawSelectors(dl);
-        drawKnobs(dl);
+        drawControls(dl);
 
         ImGui::End();
         ImGui::PopStyleVar(2);
@@ -316,7 +316,7 @@ private:
 
     void drawSelectors(ImDrawList* dl)
     {
-        const float y = 224.0f;
+        const float y = 216.0f;
         // id, param, column-centre, width (fits widest option + arrow), title
         struct Sel { const char* id; uint32_t p; float cx, w; const char* t; };
         static const Sel ss[6] = {
@@ -345,35 +345,60 @@ private:
                    /*persistent*/ true, tip, /*rightClickReset*/ true, 1.0f, dispAdd);
     }
 
-    void drawKnobs(ImDrawList* dl)
+    // Centred small-caps section header with an underline.
+    void sectionHeader(ImDrawList* dl, float cx, float y, const char* txt)
     {
-        // main row: input, bias, wow, flutter, output
-        const float cy1 = 330.0f;
-        knob(dl, "input",  kParamInputGain, 112.0f, cy1, "INPUT",   "%.1f", " dB",
-             "Drive into the tape stage. Higher = more saturation.");
-        knob(dl, "bias",   kParamBias,      256.0f, cy1, "BIAS",    "%+.0f", "%",
-             "Tape bias vs. optimal calibration. Under-bias = grittier, more distortion.", -50.0f);
-        knob(dl, "wow",    kParamWow,       400.0f, cy1, "WOW",     "%.0f", "%",
-             "Slow pitch drift (~0.5 Hz) from the transport.");
-        knob(dl, "flut",   kParamFlutter,   544.0f, cy1, "FLUTTER", "%.0f", "%",
-             "Faster pitch modulation (tape/motor flutter).");
-        knob(dl, "output", kParamOutputGain,688.0f, cy1, "OUTPUT",  "%.1f", " dB",
-             "Make-up gain after the tape stage.");
+        text(dl, cx, y, 9.5f, kColInkDim, txt, 0, true);
+        ImFont* f = labelFont ? labelFont : ImGui::GetFont();
+        const float w = f->CalcTextSizeA(9.5f * s, FLT_MAX, 0, txt).x;
+        const ImVec2 c = P(cx, y + 13.0f);
+        dl->AddLine(ImVec2(c.x - w * 0.5f, c.y), ImVec2(c.x + w * 0.5f, c.y),
+                    IM_COL32(120, 121, 123, 220), 1.2f * s);
+    }
 
-        // character row: hp, lp, noise, + auto-comp / auto-cal buttons
-        const float cy2 = 448.0f;
-        knob(dl, "hp",    kParamHighpassFreq, 112.0f, cy2, "HIGHPASS", "%.0f", " Hz",
-             "High-pass filter on the output.");
-        knob(dl, "lp",    kParamLowpassFreq,  256.0f, cy2, "LOWPASS",  "%.0f", " Hz",
-             "Low-pass filter on the output (tape HF roll-off).");
-        knob(dl, "noise", kParamNoiseAmount,  400.0f, cy2, "NOISE",    "%.0f", "%",
-             "Tape hiss level. 0% = clean/silent.");
-        text(dl, 544, cy2 - 50.0f, 10, kColInk, "AUTO COMP", 0, true);
-        tmButton(dl, "autocomp", kParamAutoComp, 500, cy2 - 18, 588, cy2 + 18, "LINK",
+    // Four functional groups: GAIN STAGING | TAPE CHARACTER | TRANSPORT | FILTERS.
+    // Auto-comp (gain link) sits with gain staging; auto-cal (auto bias) with tape
+    // character, matching how each toggle couples to its knobs.
+    void drawControls(ImDrawList* dl)
+    {
+        const float hy = 264.0f, cy = 336.0f, ty = 396.0f;
+
+        sectionHeader(dl, 115, hy, "GAIN STAGING");
+        sectionHeader(dl, 305, hy, "TAPE CHARACTER");
+        sectionHeader(dl, 495, hy, "TRANSPORT");
+        sectionHeader(dl, 685, hy, "FILTERS");
+        for (float dx : { 210.0f, 400.0f, 590.0f })
+            dl->AddLine(P(dx, hy - 2), P(dx, ty + 28), IM_COL32(150, 151, 153, 200), 1.0f * s);
+
+        // GAIN STAGING
+        knob(dl, "input",  kParamInputGain,  67.0f, cy, "INPUT",  "%.1f", " dB",
+             "Drive into the tape stage. Higher = more saturation.");
+        knob(dl, "output", kParamOutputGain,163.0f, cy, "OUTPUT", "%.1f", " dB",
+             "Make-up gain after the tape stage.");
+        text(dl, 115, ty, 9.0f, kColInk, "GAIN LINK", 0, true);
+        tmButton(dl, "autocomp", kParamAutoComp, 82, ty + 10, 148, ty + 30, "ON",
                  "Auto gain compensation: output tracks input so level stays matched.");
-        text(dl, 688, cy2 - 50.0f, 10, kColInk, "AUTO CAL", 0, true);
-        tmButton(dl, "autocal",  kParamAutoCal,  644, cy2 - 18, 732, cy2 + 18, "AUTO",
-                 "Auto bias calibration for the selected tape and speed.");
+
+        // TAPE CHARACTER
+        knob(dl, "bias",  kParamBias,       257.0f, cy, "BIAS",  "%+.0f", "%",
+             "Tape bias vs. optimal calibration. Under-bias = grittier, more distortion.", -50.0f);
+        knob(dl, "noise", kParamNoiseAmount,353.0f, cy, "NOISE", "%.0f", "%",
+             "Tape hiss level. 0% = clean/silent.");
+        text(dl, 305, ty, 9.0f, kColInk, "AUTO BIAS", 0, true);
+        tmButton(dl, "autocal", kParamAutoCal, 272, ty + 10, 338, ty + 30, "ON",
+                 "Auto bias calibration for the selected tape and speed (disables the BIAS knob).");
+
+        // TRANSPORT
+        knob(dl, "wow",  kParamWow,     447.0f, cy, "WOW",     "%.0f", "%",
+             "Slow pitch drift (~0.5 Hz) from the transport.");
+        knob(dl, "flut", kParamFlutter, 543.0f, cy, "FLUTTER", "%.0f", "%",
+             "Faster pitch modulation (tape/motor flutter).");
+
+        // FILTERS
+        knob(dl, "hp", kParamHighpassFreq, 637.0f, cy, "HIGHPASS", "%.0f", " Hz",
+             "High-pass filter on the output.");
+        knob(dl, "lp", kParamLowpassFreq,  733.0f, cy, "LOWPASS",  "%.0f", " Hz",
+             "Low-pass filter on the output (tape HF roll-off).");
     }
 
     void tmButton(ImDrawList* dl, const char* id, uint32_t param, float x0, float y0,

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -18,6 +18,13 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <filesystem>
+#include <algorithm>
+#include <cctype>
 
 START_NAMESPACE_DISTRHO
 
@@ -54,6 +61,8 @@ public:
         pal.white    = kColInk;
         pal.whiteDim = kColInkDim;
         panel.setPalette(pal);
+
+        scanUserPresets();
     }
 
 protected:
@@ -62,7 +71,7 @@ protected:
         if (index < kParamCount)
         {
             values[index] = value;
-            if (index < kParamVuL) currentPreset = -1; // an edit deselects the preset
+            if (index < kParamVuL) { currentPreset = -1; currentUserName.clear(); } // edit deselects preset
         }
     }
 
@@ -114,13 +123,81 @@ private:
         return v;
     }
 
+    void setP(uint32_t id, float v)
+    {
+        values[id] = v;
+        editParameter(id, true); setParameterValue(id, v); editParameter(id, false);
+    }
+
     void applyPreset(int idx)
     {
         currentPreset = idx;
-        tmApplyPreset(idx, [this](uint32_t id, float v) {
-            values[id] = v;
-            editParameter(id, true); setParameterValue(id, v); editParameter(id, false);
-        });
+        currentUserName.clear();
+        tmApplyPreset(idx, [this](uint32_t id, float v) { setP(id, v); });
+    }
+
+    //--- user preset file library (~/.config/DuskAudio/TapeMachine2/presets) ---
+    std::string configDir() const
+    {
+        const char* home = std::getenv("HOME");
+        return std::string(home ? home : ".") + "/.config/DuskAudio/TapeMachine2/presets";
+    }
+
+    void scanUserPresets()
+    {
+        userPresets.clear();
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        for (fs::directory_iterator it(configDir(), ec), end; !ec && it != end; it.increment(ec))
+        {
+            if (it->path().extension() != ".tmpreset") continue;
+            std::ifstream f(it->path());
+            std::string line, name;
+            if (std::getline(f, line) && line.rfind("name=", 0) == 0) name = line.substr(5);
+            else name = it->path().stem().string();
+            userPresets.push_back({ name, it->path().string() });
+        }
+        std::sort(userPresets.begin(), userPresets.end(),
+                  [](const auto& a, const auto& b) { return a.first < b.first; });
+    }
+
+    void saveUserPreset(const char* rawName)
+    {
+        std::string name(rawName);
+        while (!name.empty() && name.back() == ' ') name.pop_back();
+        if (name.empty()) return;
+        std::error_code ec;
+        std::filesystem::create_directories(configDir(), ec);
+        std::string fn;
+        for (char c : name) fn += std::isalnum((unsigned char)c) ? c : '_';
+        std::ofstream f(configDir() + "/" + fn + ".tmpreset", std::ios::trunc);
+        if (!f) return;
+        f << "name=" << name << "\n";
+        for (uint32_t i = 0; i < kParamVuL; ++i)
+            if (i != kParamBypass) f << kTmParams[i].id << "=" << values[i] << "\n";
+        f.close();
+        scanUserPresets();
+        currentPreset = -1;
+        currentUserName = name;
+    }
+
+    void loadUserPreset(const std::string& path, const std::string& name)
+    {
+        std::ifstream f(path);
+        if (!f) return;
+        std::string line;
+        while (std::getline(f, line))
+        {
+            const auto eq = line.find('=');
+            if (eq == std::string::npos) continue;
+            const std::string key = line.substr(0, eq);
+            if (key == "name") continue;
+            const float v = (float) std::atof(line.c_str() + eq + 1);
+            for (uint32_t i = 0; i < kParamVuL; ++i)
+                if (key == kTmParams[i].id) { setP(i, v); break; }
+        }
+        currentPreset = -1;
+        currentUserName = name;
     }
 
     void drawPanel(ImDrawList* dl, float winW, float winH)
@@ -202,13 +279,13 @@ private:
         dl->AddRect(P(15, 12), P(232, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
         text(dl, 27, 17, 16, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
 
-        // preset browser: < [combo] >  INIT
-        const char* cur = (currentPreset >= 0 && currentPreset < kNumTmPresets)
-                              ? kTmPresets[currentPreset].name : "Presets...";
-        text(dl, 375, 6, 8.0f, kColInkDim, "PRESET", 0, true);
+        // preset browser: < [combo] >  INIT  SAVE
+        const char* cur = currentPreset >= 0 ? kTmPresets[currentPreset].name
+                        : (!currentUserName.empty() ? currentUserName.c_str() : "Presets...");
+        text(dl, 364, 6, 8.0f, kColInkDim, "PRESET", 0, true);
         if (chevron(dl, "##pv", 250, 28, true, "Previous preset")) stepPreset(-1);
         ImGui::SetCursorScreenPos(P(264, 18));
-        ImGui::SetNextItemWidth(222.0f * s);
+        ImGui::SetNextItemWidth(200.0f * s);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
         ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
         ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
@@ -230,17 +307,30 @@ private:
                 if (ImGui::Selectable(kTmPresets[i].name, i == currentPreset))
                     applyPreset(i);
             }
+            if (!userPresets.empty())
+            {
+                ImGui::TextDisabled("User");
+                for (const auto& up : userPresets)
+                    if (ImGui::Selectable(up.first.c_str(), currentPreset < 0 && up.first == currentUserName))
+                        loadUserPreset(up.second, up.first);
+            }
             ImGui::EndCombo();
         }
         ImGui::PopStyleColor(8);
-        if (chevron(dl, "##nx", 500, 28, false, "Next preset")) stepPreset(+1);
-        if (textButton(dl, "##init", 516, 18, 560, 38, "INIT", "Reset all controls to their defaults")) initDefaults();
+        if (chevron(dl, "##nx", 478, 28, false, "Next preset")) stepPreset(+1);
+        if (textButton(dl, "##init", 492, 18, 528, 38, "INIT", "Reset all controls to their defaults")) initDefaults();
+        if (textButton(dl, "##save", 532, 18, 568, 38, "SAVE", "Save the current settings as a user preset"))
+        {
+            std::snprintf(saveBuf, sizeof(saveBuf), "%s", currentUserName.c_str());
+            ImGui::OpenPopup("Save Preset");
+        }
+        drawSaveModal();
 
         // meter source toggle (INPUT / OUTPUT)
         {
             const bool out = meterSource != 0;
-            text(dl, 596, 6, 8.0f, kColInkDim, "METER", 0, true);
-            const ImVec2 b0 = P(568, 18), b1 = P(624, 38);
+            text(dl, 606, 6, 8.0f, kColInkDim, "METER", 0, true);
+            const ImVec2 b0 = P(578, 18), b1 = P(634, 38);
             ImGui::SetCursorScreenPos(b0);
             ImGui::InvisibleButton("metsrc", ImVec2(b1.x - b0.x, b1.y - b0.y));
             if (ImGui::IsItemClicked()) meterSource ^= 1;
@@ -248,12 +338,37 @@ private:
             dl->AddRectFilledMultiColor(b0, b1, IM_COL32(226, 226, 228, 255), IM_COL32(226, 226, 228, 255),
                                         IM_COL32(186, 186, 188, 255), IM_COL32(186, 186, 188, 255));
             dl->AddRect(b0, b1, IM_COL32(90, 90, 92, 255), 2.0f * s, 0, 1.2f * s);
-            text(dl, 596, 22, 9.5f, kColInk, out ? "OUTPUT" : "INPUT", 0, true);
+            text(dl, 606, 22, 9.5f, kColInk, out ? "OUTPUT" : "INPUT", 0, true);
         }
 
         // bypass, kept clear of the top-right corner screw (~x784)
         tmButton(dl, "bypass", kParamBypass, 648, 14, 736, 38, "BYPASS",
                  "Bypass the plugin (host-integrated).");
+    }
+
+    void drawSaveModal()
+    {
+        ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(234, 234, 236, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(248, 249, 251, 255));
+        ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(206, 207, 209, 255));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(218, 219, 221, 255));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(190, 191, 193, 255));
+        if (ImGui::BeginPopupModal("Save Preset", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            ImGui::TextUnformatted("Preset name");
+            ImGui::SetNextItemWidth(240.0f * s);
+            if (ImGui::IsWindowAppearing()) ImGui::SetKeyboardFocusHere();
+            const bool enter = ImGui::InputText("##savename", saveBuf, sizeof(saveBuf),
+                                                ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll);
+            const bool doSave = ImGui::Button("Save") || enter;
+            ImGui::SameLine();
+            const bool cancel = ImGui::Button("Cancel");
+            if (doSave && saveBuf[0] != '\0') { saveUserPreset(saveBuf); ImGui::CloseCurrentPopup(); }
+            if (cancel) ImGui::CloseCurrentPopup();
+            ImGui::EndPopup();
+        }
+        ImGui::PopStyleColor(6);
     }
 
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
@@ -520,6 +635,10 @@ private:
     float   clipHoldL = 0.0f, clipHoldR = 0.0f;
     int     meterSource = 1;      // 0 = input, 1 = output
     int     currentPreset = -1;
+    std::string currentUserName;  // non-empty when a user preset is active
+    std::vector<std::pair<std::string, std::string>> userPresets; // (name, path)
+    char    saveBuf[64] = {};
+    bool    openSaveModal = false;
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachineUI)
 };

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// TapeMachineUI.cpp — PLACEHOLDER Dear ImGui UI for TapeMachine 2.
+//
+// This is a minimal, valid UI so the plugin builds/loads/pluginval-passes while
+// the DSP port is validated. The full reel-to-reel panel (dual VU, tape-speed
+// selector, saturation/bias/noise controls on duskdpf::DuskPanel) lands in the
+// dedicated UI phase.
+
+#include "DistrhoUI.hpp"
+#include "TapeMachineParams.hpp"
+#include "DuskImGuiFont.hpp"
+#include "DuskImGuiWidgets.hpp"
+
+#include <cmath>
+
+START_NAMESPACE_DISTRHO
+
+namespace {
+    constexpr float kDesignW = 920.0f;
+    constexpr float kDesignH = 480.0f;
+}
+
+class TapeMachineUI : public UI
+{
+public:
+    TapeMachineUI()
+        : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT)
+    {
+        for (uint32_t i = 0; i < kParamCount; ++i)
+            values[i] = kTmParams[i].def;
+        setGeometryConstraints(460, 240, true);
+        labelFont = duskdpf::loadCrispFont(30.0f * getScaleFactor());
+    }
+
+protected:
+    void parameterChanged(uint32_t index, float value) override
+    {
+        if (index < kParamCount)
+            values[index] = value;
+    }
+
+    void onImGuiDisplay() override
+    {
+        const float winW = (float)getWidth();
+        const float winH = (float)getHeight();
+        const float s = std::min(winW / kDesignW, winH / kDesignH);
+        const ImVec2 org(0.5f * (winW - kDesignW * s), 0.5f * (winH - kDesignH * s));
+
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::SetNextWindowPos(ImVec2(0, 0));
+        ImGui::SetNextWindowSize(ImVec2(winW, winH));
+        ImGui::Begin("TapeMachine2", nullptr,
+                     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+                     ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse |
+                     ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBackground);
+
+        ImDrawList* dl = ImGui::GetWindowDrawList();
+        auto P = [&](float x, float y) { return ImVec2(org.x + x * s, org.y + y * s); };
+
+        dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), IM_COL32(8, 8, 8, 255));
+        dl->AddRectFilled(P(0, 0), P(kDesignW, kDesignH), IM_COL32(26, 26, 28, 255));
+        dl->AddRectFilled(P(0, 0), P(kDesignW, 46), IM_COL32(16, 16, 17, 255));
+
+        ImFont* font = labelFont ? labelFont : ImGui::GetFont();
+        auto text = [&](float x, float y, float size, ImU32 c, const char* t) {
+            dl->AddText(font, size * s, P(x, y), c, t);
+        };
+        text(38, 12, 20, IM_COL32(238, 236, 228, 255), "TapeMachine 2");
+        text(kDesignW - 150, 14, 15, IM_COL32(238, 236, 228, 255), "Dusk Audio");
+        text(38, kDesignH * 0.5f - 8, 13, IM_COL32(150, 150, 152, 255),
+             "UI in progress \xE2\x80\x94 DSP validation build");
+
+        ImGui::End();
+        ImGui::PopStyleVar(2);
+    }
+
+private:
+    ImFont* labelFont = nullptr;
+    float   values[kParamCount] = {};
+
+    DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachineUI)
+};
+
+UI* createUI()
+{
+    return new TapeMachineUI();
+}
+
+END_NAMESPACE_DISTRHO

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -97,8 +97,9 @@ protected:
         drawPanel(dl, winW, winH);
         drawHeader(dl);
         const bool clipEnabled = meterSource != 0;   // OUTPUT source only
-        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, clipHoldL, clipEnabled, "L");
-        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, clipHoldR, clipEnabled, "R");
+        const ImU32 accent = accentCol();
+        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, clipHoldL, clipEnabled, accent, "L");
+        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, clipHoldR, clipEnabled, accent, "R");
         drawSelectors(dl);
         drawControls(dl);
 
@@ -293,7 +294,13 @@ private:
     {
         dl->AddRectFilled(P(15, 12), P(232, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
         dl->AddRect(P(15, 12), P(232, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
-        text(dl, 27, 17, 16, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
+        text(dl, 27, 17, 15, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
+        {   // machine badge (accent-tinted, right side of the nameplate)
+            const char* badge = isA800() ? "A800" : "ATR-102";
+            dl->AddRectFilled(P(178, 16), P(228, 34), accentCol(), 3.0f * s);
+            dl->AddRect(P(178, 16), P(228, 34), IM_COL32(0, 0, 0, 90), 3.0f * s, 0, 1.0f * s);
+            text(dl, 203, 20, 8.5f, IM_COL32(18, 18, 20, 255), badge, 0, true);
+        }
 
         // preset browser: < [combo] >  INIT  SAVE
         const char* cur = currentPreset >= 0 ? kTmPresets[currentPreset].name
@@ -401,7 +408,8 @@ private:
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
 
     void drawVU(ImDrawList* dl, float x0, float y0, float x1, float y1,
-                float level, float& needle, float& clipHold, bool clipEnabled, const char* label)
+                float level, float& needle, float& clipHold, bool clipEnabled,
+                ImU32 accent, const char* label)
     {
         const float dB = 20.0f * std::log10(level > 1e-4f ? level : 1e-4f) + 18.0f;
         // deflection is linear in signal level (%), not dB: gives the classic
@@ -415,6 +423,7 @@ private:
             IM_COL32(170, 142, 100, 255), IM_COL32(158, 130, 88, 255),
             IM_COL32(120, 96, 60, 255),  IM_COL32(110, 88, 54, 255));
         dl->AddRect(P(x0, y0), P(x1, y1), IM_COL32(92, 72, 44, 255), 6.0f * s, 0, 1.4f * s);
+        dl->AddLine(P(x0 + 6, y0 + 3), P(x1 - 6, y0 + 3), accent, 1.6f * s); // machine accent stripe
         dl->AddRectFilled(P(x0 + 4, y0 + 4), P(x1 - 4, y1 - 4), IM_COL32(56, 44, 30, 255), 4.0f * s);
         const float fx0 = x0 + 7, fy0 = y0 + 7, fx1 = x1 - 7, fy1 = y1 - 7;
         dl->AddRectFilled(P(fx0, fy0), P(fx1, fy1), IM_COL32(240, 231, 205, 255), 3.0f * s);
@@ -577,15 +586,23 @@ private:
                    /*hover name*/ l1);
     }
 
-    // Centred small-caps section header with an underline.
+    // Machine-aware accent: A800 (Swiss 800) cooler blue-grey, ATR-102 (Classic
+    // 102) warmer copper. Derived live from the machine parameter.
+    bool isA800() const { return (int)(values[kParamTapeMachine] + 0.5f) == 0; }
+    ImU32 accentCol() const
+    {
+        return isA800() ? IM_COL32(96, 120, 150, 255)    // cool blue-grey
+                        : IM_COL32(176, 116, 70, 255);    // warm copper
+    }
+
+    // Centred small-caps section header with an accent underline.
     void sectionHeader(ImDrawList* dl, float cx, float y, const char* txt)
     {
         text(dl, cx, y, 9.5f, kColInkDim, txt, 0, true);
         ImFont* f = labelFont ? labelFont : ImGui::GetFont();
         const float w = f->CalcTextSizeA(9.5f * s, FLT_MAX, 0, txt).x;
         const ImVec2 c = P(cx, y + 13.0f);
-        dl->AddLine(ImVec2(c.x - w * 0.5f, c.y), ImVec2(c.x + w * 0.5f, c.y),
-                    IM_COL32(120, 121, 123, 220), 1.2f * s);
+        dl->AddLine(ImVec2(c.x - w * 0.5f, c.y), ImVec2(c.x + w * 0.5f, c.y), accentCol(), 1.4f * s);
     }
 
     // Four functional groups: GAIN STAGING | TAPE CHARACTER | TRANSPORT | FILTERS.

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -302,11 +302,20 @@ private:
         dl->AddRectFilled(P(15, 12), P(232, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
         dl->AddRect(P(15, 12), P(232, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
         text(dl, 27, 17, 15, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
-        {   // machine badge (accent-tinted, right side of the nameplate)
+        {   // machine badge (accent-tinted) + non-standard indicator
             const char* badge = isA800() ? "A800" : "ATR-102";
+            const bool std = comboIsStd();
+            ImGui::SetCursorScreenPos(P(178, 16));
+            ImGui::InvisibleButton("badge", ImVec2(50.0f * s, 18.0f * s));
+            if (ImGui::IsItemHovered())
+                ImGui::SetTooltip(std ? "Tape machine: %s"
+                                      : "Tape machine: %s\nCurrent speed / EQ / tape combo is non-standard for\n"
+                                        "this machine (still fully modelled - nothing is disabled).",
+                                  isA800() ? "A800 - tight, clean, punchy" : "ATR-102 - warm, wide, silky");
             dl->AddRectFilled(P(178, 16), P(228, 34), accentCol(), 3.0f * s);
             dl->AddRect(P(178, 16), P(228, 34), IM_COL32(0, 0, 0, 90), 3.0f * s, 0, 1.0f * s);
             text(dl, 203, 20, 8.5f, IM_COL32(18, 18, 20, 255), badge, 0, true);
+            if (!std) dl->AddCircleFilled(P(225, 19), 2.6f * s, kColNonStd, 10); // non-standard dot
         }
 
         // preset browser: < [combo] >  INIT  SAVE
@@ -527,7 +536,8 @@ private:
                   float w, const char* title, const char* tip)
     {
         const TmParam& d = kTmParams[param];
-        text(dl, cx, y, 9.0f, kColInk, title, 0, true);
+        const bool std = selectorIsStd(param);
+        text(dl, cx, y, 9.0f, std ? kColInk : kColNonStd, title, 0, true);   // amber = non-standard for machine
         int cur = (int)(values[param] + 0.5f);
         if (cur < 0) cur = 0; if (cur >= d.numChoices) cur = d.numChoices - 1;
 
@@ -542,7 +552,12 @@ private:
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(178, 179, 181, 255));
         ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
         const bool open = ImGui::BeginCombo(id, d.choices[cur]);   // arrow -> reads as a dropdown
-        if (tip != nullptr && ImGui::IsItemHovered()) ImGui::SetTooltip("%s", tip);
+        if (ImGui::IsItemHovered())
+        {
+            if (!std) ImGui::SetTooltip("%s\n(non-standard for the %s - still fully modelled)",
+                                        tip ? tip : "", isA800() ? "A800" : "ATR-102");
+            else if (tip != nullptr) ImGui::SetTooltip("%s", tip);
+        }
         if (open)
         {
             for (int i = 0; i < d.numChoices; ++i)
@@ -602,6 +617,24 @@ private:
         return isA800() ? IM_COL32(96, 120, 150, 255)    // cool blue-grey
                         : IM_COL32(176, 116, 70, 255);    // warm copper
     }
+
+    // Confirmed authentic matrix (soft-signal only; nothing is hard-gated):
+    //   A800    : speed 15/30, EQ NAB/CCIR, type 456/GP9/911
+    //   ATR-102 : speed 15/30, EQ NAB/AES,  type 456/GP9/250
+    bool speedIsStd() const { const int v = (int)(values[kParamTapeSpeed] + 0.5f); return v == 1 || v == 2; }
+    bool eqIsStd()    const { const int v = (int)(values[kParamEqStandard] + 0.5f);
+                              return isA800() ? (v == 0 || v == 1) : (v == 0 || v == 2); }
+    bool typeIsStd()  const { const int v = (int)(values[kParamTapeType] + 0.5f);
+                              return isA800() ? (v == 0 || v == 1 || v == 2) : (v == 0 || v == 1 || v == 3); }
+    bool comboIsStd() const { return speedIsStd() && eqIsStd() && typeIsStd(); }
+    bool selectorIsStd(uint32_t p) const
+    {
+        if (p == kParamTapeSpeed)  return speedIsStd();
+        if (p == kParamEqStandard) return eqIsStd();
+        if (p == kParamTapeType)   return typeIsStd();
+        return true;   // machine / signal-path / oversampling: always "standard"
+    }
+    static constexpr ImU32 kColNonStd = IM_COL32(162, 118, 52, 255); // muted amber
 
     // Centred small-caps section header with an accent underline.
     void sectionHeader(ImDrawList* dl, float cx, float y, const char* txt)

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -201,10 +201,6 @@ private:
         dl->AddRectFilledMultiColor(P(fx0, fy0), P(fx1, fy1),
             IM_COL32(252, 246, 226, 130), IM_COL32(252, 246, 226, 130),
             IM_COL32(210, 194, 158, 150), IM_COL32(210, 194, 158, 150));
-        // corner vignette
-        for (float vx : { fx0, fx1 })
-            for (float vy : { fy0, fy1 })
-                dl->AddCircleFilled(P(vx, vy), (fy1 - fy0) * 0.45f * s, IM_COL32(120, 96, 62, 26), 20);
 
         const float cx = 0.5f * (fx0 + fx1);
         const float pivotY = fy1 - 4.0f;

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -158,6 +158,9 @@ private:
         ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
         ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
         ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(150, 152, 156, 255));
+        ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(198, 199, 201, 255));        // arrow bg
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(212, 213, 215, 255));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(178, 179, 181, 255));
         ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
         if (ImGui::BeginCombo("##preset", cur))
         {
@@ -174,9 +177,10 @@ private:
             }
             ImGui::EndCombo();
         }
-        ImGui::PopStyleColor(5);
+        ImGui::PopStyleColor(8);
 
-        tmButton(dl, "bypass", kParamBypass, 704, 14, 785, 38, "BYPASS");
+        // bypass, kept clear of the top-right corner screw (~x784)
+        tmButton(dl, "bypass", kParamBypass, 648, 14, 736, 38, "BYPASS");
     }
 
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
@@ -277,22 +281,27 @@ private:
     }
 
     //--- selectors (single row of six) -----------------------------------------
-    void selector(ImDrawList* dl, const char* id, uint32_t param, float x, float y,
+    // cx = column centre; w = combo width (sized to fit its widest option +
+    // the dropdown arrow). The combo is centred under its (centred) label.
+    void selector(ImDrawList* dl, const char* id, uint32_t param, float cx, float y,
                   float w, const char* title)
     {
         const TmParam& d = kTmParams[param];
-        text(dl, x + 0.5f * w, y, 9.0f, kColInk, title, 0, true);
+        text(dl, cx, y, 9.0f, kColInk, title, 0, true);
         int cur = (int)(values[param] + 0.5f);
         if (cur < 0) cur = 0; if (cur >= d.numChoices) cur = d.numChoices - 1;
 
-        ImGui::SetCursorScreenPos(P(x, y + 13.0f));
+        ImGui::SetCursorScreenPos(P(cx - 0.5f * w, y + 13.0f));
         ImGui::SetNextItemWidth(w * s);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
         ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
         ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
         ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(150, 152, 156, 255));
+        ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(198, 199, 201, 255));        // arrow bg
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(212, 213, 215, 255));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(178, 179, 181, 255));
         ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
-        if (ImGui::BeginCombo(id, d.choices[cur], ImGuiComboFlags_NoArrowButton))
+        if (ImGui::BeginCombo(id, d.choices[cur]))   // arrow shown -> reads as a dropdown
         {
             for (int i = 0; i < d.numChoices; ++i)
                 if (ImGui::Selectable(d.choices[i], i == cur))
@@ -302,19 +311,24 @@ private:
                 }
             ImGui::EndCombo();
         }
-        ImGui::PopStyleColor(5);
+        ImGui::PopStyleColor(8);
     }
 
     void drawSelectors(ImDrawList* dl)
     {
-        const float w = 112.0f, y = 224.0f;
-        const float x[6] = { 20, 148, 276, 404, 532, 660 };
-        selector(dl, "##machine", kParamTapeMachine, x[0], y, w, "MACHINE");
-        selector(dl, "##speed",   kParamTapeSpeed,   x[1], y, w, "TAPE SPEED");
-        selector(dl, "##type",    kParamTapeType,    x[2], y, w, "TAPE TYPE");
-        selector(dl, "##path",    kParamSignalPath,  x[3], y, w, "SIGNAL PATH");
-        selector(dl, "##eq",      kParamEqStandard,  x[4], y, w, "EQ STANDARD");
-        selector(dl, "##os",      kParamOversampling,x[5], y, w, "OVERSAMPLING");
+        const float y = 224.0f;
+        // id, param, column-centre, width (fits widest option + arrow), title
+        struct Sel { const char* id; uint32_t p; float cx, w; const char* t; };
+        static const Sel ss[6] = {
+            { "##machine", kParamTapeMachine,  83.f, 100.f, "MACHINE"      },
+            { "##speed",   kParamTapeSpeed,   210.f,  82.f, "TAPE SPEED"   },
+            { "##type",    kParamTapeType,    337.f,  90.f, "TAPE TYPE"    },
+            { "##path",    kParamSignalPath,  463.f,  78.f, "SIGNAL PATH"  },
+            { "##eq",      kParamEqStandard,  590.f,  70.f, "EQ STANDARD"  },
+            { "##os",      kParamOversampling,717.f,  62.f, "OVERSAMPLING" },
+        };
+        for (const Sel& e : ss)
+            selector(dl, e.id, e.p, e.cx, y, e.w, e.t);
     }
 
     //--- knob rows -------------------------------------------------------------

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -616,8 +616,12 @@ private:
         sectionHeader(dl, 305, hy, "TAPE CHARACTER");
         sectionHeader(dl, 495, hy, "TRANSPORT");
         sectionHeader(dl, 685, hy, "FILTERS");
+        // Frame the four groups as closed cells: dividers run to a shared bottom
+        // baseline so the two toggle-less sections read as balanced cells, not gaps.
+        const float cellTop = hy + 16.0f, cellBot = 452.0f;
         for (float dx : { 210.0f, 400.0f, 590.0f })
-            dl->AddLine(P(dx, hy - 2), P(dx, ty + 28), IM_COL32(150, 151, 153, 200), 1.0f * s);
+            dl->AddLine(P(dx, cellTop), P(dx, cellBot), IM_COL32(150, 151, 153, 170), 1.0f * s);
+        dl->AddLine(P(26, cellBot), P(774, cellBot), IM_COL32(150, 151, 153, 140), 1.0f * s);
 
         // GAIN STAGING
         knob(dl, "input",  kParamInputGain,  67.0f, cy, "INPUT",  "%.1f", " dB",

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -299,24 +299,24 @@ private:
 
     void drawHeader(ImDrawList* dl)
     {
-        // Title nameplate + machine badge (left-anchored).
-        dl->AddRectFilled(P(15, 12), P(232, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
-        dl->AddRect(P(15, 12), P(232, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
-        text(dl, 27, 17, 15, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
+        // Title nameplate + machine badge (left-anchored, clear of the top-left screw ~x22).
+        dl->AddRectFilled(P(30, 12), P(247, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
+        dl->AddRect(P(30, 12), P(247, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
+        text(dl, 42, 17, 15, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
         {   // machine badge (accent-tinted) + non-standard indicator
             const char* badge = isA800() ? "A800" : "ATR-102";
             const bool std = comboIsStd();
-            ImGui::SetCursorScreenPos(P(178, 16));
+            ImGui::SetCursorScreenPos(P(193, 16));
             ImGui::InvisibleButton("badge", ImVec2(50.0f * s, 18.0f * s));
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip(std ? "Tape machine: %s"
                                       : "Tape machine: %s\nCurrent speed / EQ / tape combo is non-standard for\n"
                                         "this machine (still fully modelled - nothing is disabled).",
                                   isA800() ? "A800 - tight, clean, punchy" : "ATR-102 - warm, wide, silky");
-            dl->AddRectFilled(P(178, 16), P(228, 34), accentCol(), 3.0f * s);
-            dl->AddRect(P(178, 16), P(228, 34), IM_COL32(0, 0, 0, 90), 3.0f * s, 0, 1.0f * s);
-            text(dl, 203, 20, 8.5f, IM_COL32(18, 18, 20, 255), badge, 0, true);
-            if (!std) dl->AddCircleFilled(P(225, 19), 2.6f * s, kColNonStd, 10); // non-standard dot
+            dl->AddRectFilled(P(193, 16), P(243, 34), accentCol(), 3.0f * s);
+            dl->AddRect(P(193, 16), P(243, 34), IM_COL32(0, 0, 0, 90), 3.0f * s, 0, 1.0f * s);
+            text(dl, 218, 20, 8.5f, IM_COL32(18, 18, 20, 255), badge, 0, true);
+            if (!std) dl->AddCircleFilled(P(240, 19), 2.6f * s, kColNonStd, 10); // non-standard dot
         }
 
         // preset browser, centred between the title and the (right-anchored) bypass:

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -64,6 +64,12 @@ public:
         fontSet   = duskdpf::loadCrispFontSet(kFontSizes, 6, getScaleFactor());
         labelFont = fontSet.primary();
         panel.setFontSet(fontSet);
+        // DECISION (not an oversight): the atlas is baked once, here, at the ctor-time
+        // scaleFactor. A runtime DPI-scale change (dragging the window between a Retina
+        // and non-Retina display mid-session) is intentionally NOT rebaked - it is rare
+        // and fails soft (text blurry until the editor is reopened; nothing strands).
+        // Bounded fix if ever needed: hook the wrapper's scale-change callback and
+        // rebuild the CrispFontSet.
 
         duskdpf::Palette pal;
         pal.white    = kColInk;

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -32,13 +32,14 @@ namespace {
     constexpr float kDesignW = 800.0f;
     constexpr float kDesignH = 470.0f;
 
-    constexpr ImU32 kColPanel   = IM_COL32(188, 189, 191, 255);
-    constexpr ImU32 kColPanelHi = IM_COL32(206, 207, 209, 255);
-    constexpr ImU32 kColPanelLo = IM_COL32(150, 151, 153, 255);
-    constexpr ImU32 kColFrame   = IM_COL32(58, 58, 60, 255);
-    constexpr ImU32 kColInk     = IM_COL32(34, 34, 37, 255);
-    constexpr ImU32 kColInkDim  = IM_COL32(96, 97, 100, 255);
-    constexpr ImU32 kColScrew   = IM_COL32(120, 121, 123, 255);
+    // Warmed painted-steel greys (a touch of warmth vs. the old cool neutral).
+    constexpr ImU32 kColPanel   = IM_COL32(190, 188, 183, 255);
+    constexpr ImU32 kColPanelHi = IM_COL32(214, 212, 206, 255);
+    constexpr ImU32 kColPanelLo = IM_COL32(150, 148, 143, 255);
+    constexpr ImU32 kColFrame   = IM_COL32(60, 58, 55, 255);
+    constexpr ImU32 kColInk     = IM_COL32(34, 33, 31, 255);
+    constexpr ImU32 kColInkDim  = IM_COL32(98, 96, 92, 255);
+    constexpr ImU32 kColScrew   = IM_COL32(126, 123, 118, 255);
     constexpr ImU32 kColRed      = IM_COL32(190, 55, 40, 255);
 }
 
@@ -204,11 +205,18 @@ private:
     void drawPanel(ImDrawList* dl, float winW, float winH)
     {
         dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), kColFrame);
-        dl->AddRectFilledMultiColor(P(0, 0), P(kDesignW, kDesignH),
+        // main panel: top-down painted-steel gradient (light top -> darker bottom)
+        dl->AddRectFilledMultiColor(P(6, 6), P(kDesignW - 6, kDesignH - 6),
                                     kColPanelHi, kColPanelHi, kColPanelLo, kColPanelLo);
-        dl->AddRectFilled(P(6, 6), P(kDesignW - 6, kDesignH - 6), kColPanel);
-        for (float y = 8.0f; y < kDesignH - 6.0f; y += 3.0f)
-            dl->AddLine(P(8, y), P(kDesignW - 8, y), IM_COL32(255, 255, 255, 10), 1.0f);
+        // fine horizontal brushed grain: alternating light/dark hairlines
+        for (float y = 8.0f; y < kDesignH - 6.0f; y += 2.0f)
+        {
+            dl->AddLine(P(8, y),        P(kDesignW - 8, y),        IM_COL32(255, 255, 255, 9), 1.0f);
+            dl->AddLine(P(8, y + 1.0f), P(kDesignW - 8, y + 1.0f), IM_COL32(0, 0, 0, 7), 1.0f);
+        }
+        // bevel: bright top-left edge, dark bottom-right edge
+        dl->AddLine(P(6, 7), P(kDesignW - 6, 7), IM_COL32(235, 234, 228, 130), 1.4f * s);
+        dl->AddLine(P(6, kDesignH - 7), P(kDesignW - 6, kDesignH - 7), IM_COL32(40, 39, 37, 90), 1.4f * s);
         const float sx[4] = { 16, kDesignW - 16, 16, kDesignW - 16 };
         const float sy[4] = { 16, 16, kDesignH - 16, kDesignH - 16 };
         for (int i = 0; i < 4; ++i) screw(dl, sx[i], sy[i]);
@@ -217,10 +225,17 @@ private:
     void screw(ImDrawList* dl, float x, float y) const
     {
         const ImVec2 c = P(x, y);
-        dl->AddCircleFilled(c, 5.0f * s, kColScrew, 16);
-        dl->AddCircle(c, 5.0f * s, IM_COL32(80, 80, 82, 255), 16, 1.0f * s);
-        dl->AddLine(ImVec2(c.x - 3 * s, c.y - 3 * s), ImVec2(c.x + 3 * s, c.y + 3 * s),
-                    IM_COL32(70, 70, 72, 255), 1.2f * s);
+        dl->AddCircleFilled(c, 6.2f * s, IM_COL32(70, 68, 64, 90), 20);            // recessed shadow
+        dl->AddCircleFilled(c, 5.0f * s, kColScrew, 20);                           // head
+        dl->AddCircleFilled(ImVec2(c.x - 1.2f * s, c.y - 1.4f * s), 4.3f * s,
+                            IM_COL32(198, 195, 188, 150), 20);                     // bevel highlight
+        dl->AddCircleFilled(c, 3.6f * s, kColScrew, 20);
+        dl->AddCircle(c, 5.0f * s, IM_COL32(72, 70, 66, 255), 20, 1.0f * s);       // rim
+        const float a = (x < kDesignW * 0.5f) ? 0.5f : -0.5f;                      // slot angle
+        const ImVec2 d(std::cos(a), std::sin(a));
+        dl->AddLine(ImVec2(c.x - d.x * 3.2f * s, c.y - d.y * 3.2f * s),
+                    ImVec2(c.x + d.x * 3.2f * s, c.y + d.y * 3.2f * s),
+                    IM_COL32(56, 54, 50, 255), 1.3f * s);
     }
 
     // small silver chevron button (< or >) for preset stepping

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -332,42 +332,58 @@ private:
     }
 
     //--- knob rows -------------------------------------------------------------
+    // Persistent value readout, right-click reset + tooltip inherited from the
+    // shared knob. dispAdd shifts the read-out (BIAS shows relative over/under).
     void knob(ImDrawList* dl, const char* id, uint32_t param, float cx, float cy,
-              const char* l1, const char* fmt, const char* suffix)
+              const char* l1, const char* fmt, const char* suffix,
+              const char* tip, float dispAdd = 0.0f)
     {
         const TmParam& d = kTmParams[param];
         panel.knobLabel(dl, cx, cy - 50.0f, l1);
-        panel.knob(id, param, d.min, d.max, cx, cy, 32.0f, values[param], d.def, false, true, fmt, suffix);
+        panel.knob(id, param, d.min, d.max, cx, cy, 32.0f, values[param], d.def,
+                   false, true, fmt, suffix, 0, false,
+                   /*persistent*/ true, tip, /*rightClickReset*/ true, 1.0f, dispAdd);
     }
 
     void drawKnobs(ImDrawList* dl)
     {
         // main row: input, bias, wow, flutter, output
         const float cy1 = 330.0f;
-        knob(dl, "input",  kParamInputGain, 112.0f, cy1, "INPUT",   "%.1f", " dB");
-        knob(dl, "bias",   kParamBias,      256.0f, cy1, "BIAS",    "%.0f", "%");
-        knob(dl, "wow",    kParamWow,       400.0f, cy1, "WOW",     "%.0f", "%");
-        knob(dl, "flut",   kParamFlutter,   544.0f, cy1, "FLUTTER", "%.0f", "%");
-        knob(dl, "output", kParamOutputGain,688.0f, cy1, "OUTPUT",  "%.1f", " dB");
+        knob(dl, "input",  kParamInputGain, 112.0f, cy1, "INPUT",   "%.1f", " dB",
+             "Drive into the tape stage. Higher = more saturation.");
+        knob(dl, "bias",   kParamBias,      256.0f, cy1, "BIAS",    "%+.0f", "%",
+             "Tape bias vs. optimal calibration. Under-bias = grittier, more distortion.", -50.0f);
+        knob(dl, "wow",    kParamWow,       400.0f, cy1, "WOW",     "%.0f", "%",
+             "Slow pitch drift (~0.5 Hz) from the transport.");
+        knob(dl, "flut",   kParamFlutter,   544.0f, cy1, "FLUTTER", "%.0f", "%",
+             "Faster pitch modulation (tape/motor flutter).");
+        knob(dl, "output", kParamOutputGain,688.0f, cy1, "OUTPUT",  "%.1f", " dB",
+             "Make-up gain after the tape stage.");
 
         // character row: hp, lp, noise, + auto-comp / auto-cal buttons
         const float cy2 = 448.0f;
-        knob(dl, "hp",    kParamHighpassFreq, 112.0f, cy2, "HIGHPASS", "%.0f", " Hz");
-        knob(dl, "lp",    kParamLowpassFreq,  256.0f, cy2, "LOWPASS",  "%.0f", " Hz");
-        knob(dl, "noise", kParamNoiseAmount,  400.0f, cy2, "NOISE",    "%.0f", "%");
+        knob(dl, "hp",    kParamHighpassFreq, 112.0f, cy2, "HIGHPASS", "%.0f", " Hz",
+             "High-pass filter on the output.");
+        knob(dl, "lp",    kParamLowpassFreq,  256.0f, cy2, "LOWPASS",  "%.0f", " Hz",
+             "Low-pass filter on the output (tape HF roll-off).");
+        knob(dl, "noise", kParamNoiseAmount,  400.0f, cy2, "NOISE",    "%.0f", "%",
+             "Tape hiss level. 0% = clean/silent.");
         text(dl, 544, cy2 - 50.0f, 10, kColInk, "AUTO COMP", 0, true);
-        tmButton(dl, "autocomp", kParamAutoComp, 500, cy2 - 18, 588, cy2 + 18, "LINK");
+        tmButton(dl, "autocomp", kParamAutoComp, 500, cy2 - 18, 588, cy2 + 18, "LINK",
+                 "Auto gain compensation: output tracks input so level stays matched.");
         text(dl, 688, cy2 - 50.0f, 10, kColInk, "AUTO CAL", 0, true);
-        tmButton(dl, "autocal",  kParamAutoCal,  644, cy2 - 18, 732, cy2 + 18, "AUTO");
+        tmButton(dl, "autocal",  kParamAutoCal,  644, cy2 - 18, 732, cy2 + 18, "AUTO",
+                 "Auto bias calibration for the selected tape and speed.");
     }
 
     void tmButton(ImDrawList* dl, const char* id, uint32_t param, float x0, float y0,
-                  float x1, float y1, const char* label)
+                  float x1, float y1, const char* label, const char* tip = nullptr)
     {
         const bool on = values[param] > 0.5f;
         const ImVec2 b0 = P(x0, y0), b1 = P(x1, y1);
         ImGui::SetCursorScreenPos(b0);
         ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+        if (tip != nullptr && ImGui::IsItemHovered()) ImGui::SetTooltip("%s", tip);
         if (ImGui::IsItemClicked())
         {
             const float nv = on ? 0.0f : 1.0f;

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -2,30 +2,50 @@
 // Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
 // others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
 //
-// TapeMachineUI.cpp — PLACEHOLDER Dear ImGui UI for TapeMachine 2.
-//
-// This is a minimal, valid UI so the plugin builds/loads/pluginval-passes while
-// the DSP port is validated. The full reel-to-reel panel (dual VU, tape-speed
-// selector, saturation/bias/noise controls on duskdpf::DuskPanel) lands in the
-// dedicated UI phase.
+// TapeMachineUI.cpp — Dear ImGui UI for TapeMachine 2. Brushed-aluminium panel
+// in the classic Swiss multichannel-recorder style: two spinning reels (one
+// silver, one gold) flanking an amber dual VU bridge, a row of tape/EQ
+// selectors, a knob row, and light Studer-style function buttons. Continuous
+// controls render through the shared duskdpf::DuskPanel.
 
 #include "DistrhoUI.hpp"
+#include "TapeMachineAccess.hpp"
 #include "TapeMachineParams.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiWidgets.hpp"
 
 #include <cmath>
+#include <cstdio>
 
 START_NAMESPACE_DISTRHO
 
 namespace {
     constexpr float kDesignW = 920.0f;
     constexpr float kDesignH = 480.0f;
+    constexpr float kPi = 3.14159265358979f;
+
+    // Brushed-aluminium palette (Studer-style silver panel, dark ink).
+    constexpr ImU32 kColPanel   = IM_COL32(188, 189, 191, 255);
+    constexpr ImU32 kColPanelHi = IM_COL32(206, 207, 209, 255);
+    constexpr ImU32 kColPanelLo = IM_COL32(150, 151, 153, 255);
+    constexpr ImU32 kColFrame   = IM_COL32(58, 58, 60, 255);   // dark chassis edge
+    constexpr ImU32 kColInk     = IM_COL32(34, 34, 37, 255);   // dark text
+    constexpr ImU32 kColInkDim  = IM_COL32(96, 97, 100, 255);
+    constexpr ImU32 kColScrew    = IM_COL32(120, 121, 123, 255);
+    constexpr ImU32 kColReelGold = IM_COL32(198, 166, 98, 255);
+    constexpr ImU32 kColReelSilv = IM_COL32(158, 159, 162, 255);
+    constexpr ImU32 kColVuFace   = IM_COL32(228, 198, 126, 255); // amber VU glass
+    constexpr ImU32 kColVuInk    = IM_COL32(48, 38, 18, 255);
+    constexpr ImU32 kColRed      = IM_COL32(190, 55, 40, 255);
 }
 
-class TapeMachineUI : public UI
+class TapeMachineUI : public UI, public duskdpf::ParamHost
 {
 public:
+    void beginEdit(uint32_t idx) override { editParameter(idx, true); }
+    void endEdit(uint32_t idx) override   { editParameter(idx, false); }
+    void setParam(uint32_t idx, float v) override { setParameterValue(idx, v); }
+
     TapeMachineUI()
         : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT)
     {
@@ -33,6 +53,12 @@ public:
             values[i] = kTmParams[i].def;
         setGeometryConstraints(460, 240, true);
         labelFont = duskdpf::loadCrispFont(30.0f * getScaleFactor());
+
+        // Dark ink for labels/ticks/markers on the silver panel.
+        duskdpf::Palette pal;
+        pal.white    = kColInk;
+        pal.whiteDim = kColInkDim;
+        panel.setPalette(pal);
     }
 
 protected:
@@ -46,8 +72,11 @@ protected:
     {
         const float winW = (float)getWidth();
         const float winH = (float)getHeight();
-        const float s = std::min(winW / kDesignW, winH / kDesignH);
-        const ImVec2 org(0.5f * (winW - kDesignW * s), 0.5f * (winH - kDesignH * s));
+        s   = std::min(winW / kDesignW, winH / kDesignH);
+        org = ImVec2(0.5f * (winW - kDesignW * s), 0.5f * (winH - kDesignH * s));
+        panel.begin(s, org, labelFont, this);
+
+        reelPhase += ImGui::GetIO().DeltaTime * reelSpeed();
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
@@ -59,28 +88,254 @@ protected:
                      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBackground);
 
         ImDrawList* dl = ImGui::GetWindowDrawList();
-        auto P = [&](float x, float y) { return ImVec2(org.x + x * s, org.y + y * s); };
-
-        dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), IM_COL32(8, 8, 8, 255));
-        dl->AddRectFilled(P(0, 0), P(kDesignW, kDesignH), IM_COL32(26, 26, 28, 255));
-        dl->AddRectFilled(P(0, 0), P(kDesignW, 46), IM_COL32(16, 16, 17, 255));
-
-        ImFont* font = labelFont ? labelFont : ImGui::GetFont();
-        auto text = [&](float x, float y, float size, ImU32 c, const char* t) {
-            dl->AddText(font, size * s, P(x, y), c, t);
-        };
-        text(38, 12, 20, IM_COL32(238, 236, 228, 255), "TapeMachine 2");
-        text(kDesignW - 150, 14, 15, IM_COL32(238, 236, 228, 255), "Dusk Audio");
-        text(38, kDesignH * 0.5f - 8, 13, IM_COL32(150, 150, 152, 255),
-             "UI in progress \xE2\x80\x94 DSP validation build");
+        drawPanel(dl, winW, winH);
+        drawHeader(dl);
+        drawSelectorRow(dl);
+        drawReel(dl, 108, 250, 68, +1.0f, kColReelSilv);
+        drawReel(dl, 812, 250, 68, -1.0f, kColReelGold);
+        drawMeterBridge(dl);
+        drawKnobRow(dl);
+        drawToggles(dl);
 
         ImGui::End();
         ImGui::PopStyleVar(2);
     }
 
 private:
+    ImVec2 P(float x, float y) const { return ImVec2(org.x + x * s, org.y + y * s); }
+
+    void text(ImDrawList* dl, float x, float y, float sz, ImU32 c, const char* t, int align, bool bold = false)
+    { panel.text(dl, x, y, sz, c, t, align, bold); }
+
+    float reelSpeed() const
+    {
+        if (values[kParamBypass] > 0.5f) return 0.0f;
+        const int sp = (int)(values[kParamTapeSpeed] + 0.5f);
+        return (sp == 2 ? 4.4f : sp == 1 ? 2.2f : 1.1f);
+    }
+
+    // Brushed-aluminium fill: base + faint horizontal grain + screws.
+    void drawPanel(ImDrawList* dl, float winW, float winH)
+    {
+        dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), kColFrame);
+        dl->AddRectFilledMultiColor(P(0, 0), P(kDesignW, kDesignH),
+                                    kColPanelHi, kColPanelHi, kColPanelLo, kColPanelLo);
+        dl->AddRectFilled(P(6, 6), P(kDesignW - 6, kDesignH - 6), kColPanel);
+        for (float y = 8.0f; y < kDesignH - 6.0f; y += 3.0f) // brushed grain
+            dl->AddLine(P(8, y), P(kDesignW - 8, y), IM_COL32(255, 255, 255, 10), 1.0f);
+        const float sx[6] = { 16, kDesignW - 16, 16, kDesignW - 16, kDesignW * 0.5f, kDesignW * 0.5f };
+        const float sy[6] = { 16, 16, kDesignH - 16, kDesignH - 16, 16, kDesignH - 16 };
+        for (int i = 0; i < 6; ++i) screw(dl, sx[i], sy[i]);
+    }
+
+    void screw(ImDrawList* dl, float x, float y) const
+    {
+        const ImVec2 c = P(x, y);
+        dl->AddCircleFilled(c, 5.0f * s, kColScrew, 16);
+        dl->AddCircle(c, 5.0f * s, IM_COL32(80, 80, 82, 255), 16, 1.0f * s);
+        dl->AddLine(ImVec2(c.x - 3 * s, c.y - 3 * s), ImVec2(c.x + 3 * s, c.y + 3 * s),
+                    IM_COL32(70, 70, 72, 255), 1.2f * s);
+    }
+
+    void drawHeader(ImDrawList* dl)
+    {
+        // recessed dark nameplate (Studer-style: dark plate, light text)
+        dl->AddRectFilled(P(30, 10), P(300, 38), IM_COL32(30, 30, 32, 255), 3.0f * s);
+        dl->AddRect(P(30, 10), P(300, 38), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
+        text(dl, 44, 15, 17, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
+        text(dl, kDesignW - 30, 15, 14, kColInk, "Dusk Audio", 1, true);
+    }
+
+    void selector(ImDrawList* dl, const char* id, uint32_t param, float x, float y,
+                  float w, const char* title)
+    {
+        const TmParam& d = kTmParams[param];
+        text(dl, x + 0.5f * w, y, 9.5f, kColInk, title, 0, true);
+
+        int cur = (int)(values[param] + 0.5f);
+        if (cur < 0) cur = 0; if (cur >= d.numChoices) cur = d.numChoices - 1;
+
+        ImGui::SetCursorScreenPos(P(x, y + 13.0f));
+        ImGui::SetNextItemWidth(w * s);
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(232, 232, 232, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(244, 244, 244, 255));
+        ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(238, 238, 238, 255));
+        ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(180, 150, 90, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, kColInk);
+        if (ImGui::BeginCombo(id, d.choices[cur], ImGuiComboFlags_NoArrowButton))
+        {
+            for (int i = 0; i < d.numChoices; ++i)
+                if (ImGui::Selectable(d.choices[i], i == cur))
+                {
+                    values[param] = (float)i;
+                    editParameter(param, true);
+                    setParameterValue(param, (float)i);
+                    editParameter(param, false);
+                }
+            ImGui::EndCombo();
+        }
+        ImGui::PopStyleColor(5);
+    }
+
+    void drawSelectorRow(ImDrawList* dl)
+    {
+        const float w = 112.0f, y = 54.0f;
+        const float xs[7] = { 18, 145, 272, 399, 526, 653, 780 };
+        selector(dl, "##machine", kParamTapeMachine, xs[0], y, w, "MACHINE");
+        selector(dl, "##speed",   kParamTapeSpeed,   xs[1], y, w, "TAPE SPEED");
+        selector(dl, "##type",    kParamTapeType,    xs[2], y, w, "TAPE TYPE");
+        selector(dl, "##path",    kParamSignalPath,  xs[3], y, w, "SIGNAL PATH");
+        selector(dl, "##eq",      kParamEqStandard,  xs[4], y, w, "EQ");
+        selector(dl, "##cal",     kParamCalibration, xs[5], y, w, "CALIBRATION");
+        selector(dl, "##os",      kParamOversampling,xs[6], y, w, "OVERSAMPLING");
+    }
+
+    void drawReel(ImDrawList* dl, float cx, float cy, float r, float dir, ImU32 flangeCol)
+    {
+        const ImVec2 c = P(cx, cy);
+        dl->AddCircleFilled(c, r * s, flangeCol, 56);
+        dl->AddCircle(c, r * s, IM_COL32(70, 70, 72, 255), 56, 2.0f * s);
+        dl->AddCircleFilled(c, r * 0.90f * s, IM_COL32(74, 58, 40, 255), 56); // exposed tape pack
+        dl->AddCircleFilled(c, r * 0.58f * s, flangeCol, 48);
+        dl->AddCircle(c, r * 0.58f * s, IM_COL32(90, 90, 92, 255), 48, 1.4f * s);
+        // three large flange cutouts, rotating
+        const float a0 = reelPhase * dir;
+        for (int i = 0; i < 3; ++i)
+        {
+            const float a = a0 + i * (2.0f * kPi / 3.0f);
+            const ImVec2 h(c.x + std::sin(a) * r * 0.72f * s, c.y - std::cos(a) * r * 0.72f * s);
+            dl->AddCircleFilled(h, r * 0.15f * s, IM_COL32(74, 58, 40, 255), 24);
+            dl->AddCircle(h, r * 0.15f * s, IM_COL32(90, 90, 92, 200), 24, 1.0f * s);
+        }
+        // hub
+        dl->AddCircleFilled(c, r * 0.22f * s, IM_COL32(210, 210, 212, 255), 28);
+        dl->AddCircleFilled(c, r * 0.22f * s, IM_COL32(150, 150, 152, 255), 28);
+        dl->AddCircle(c, r * 0.22f * s, IM_COL32(80, 80, 82, 255), 28, 1.4f * s);
+        for (int i = 0; i < 3; ++i) // hub spokes
+        {
+            const float a = a0 * 1.0f + i * (2.0f * kPi / 3.0f);
+            dl->AddLine(c, ImVec2(c.x + std::sin(a) * r * 0.20f * s, c.y - std::cos(a) * r * 0.20f * s),
+                        IM_COL32(90, 90, 92, 255), 1.4f * s);
+        }
+        dl->AddCircleFilled(c, r * 0.07f * s, IM_COL32(40, 40, 42, 255), 12);
+    }
+
+    void drawMeterBridge(ImDrawList* dl)
+    {
+        const float x0 = 250, y0 = 150, x1 = 670, y1 = 300;
+        dl->AddRectFilled(P(x0 - 4, y0 - 4), P(x1 + 4, y1 + 4), IM_COL32(60, 60, 62, 255), 5.0f * s);
+        dl->AddRectFilled(P(x0, y0), P(x1, y1), kColVuFace, 4.0f * s); // amber glass
+        dl->AddRectFilledMultiColor(P(x0, y0), P(x1, y0 + 30),
+                                    IM_COL32(255, 255, 255, 60), IM_COL32(255, 255, 255, 60),
+                                    IM_COL32(255, 255, 255, 0), IM_COL32(255, 255, 255, 0));
+
+        float lvlL = values[kParamVuL], lvlR = values[kParamVuR];
+       #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
+        if (tapeMachineGetVuL != nullptr && tapeMachineGetVuR != nullptr)
+            if (void* const inst = getPluginInstancePointer())
+            { lvlL = tapeMachineGetVuL(inst); lvlR = tapeMachineGetVuR(inst); }
+       #endif
+        vuMeter(dl, 360, lvlL, needleL, "L");
+        vuMeter(dl, 560, lvlR, needleR, "R");
+    }
+
+    void vuMeter(ImDrawList* dl, float cx, float level, float& needle, const char* label)
+    {
+        const float dt = ImGui::GetIO().DeltaTime;
+        const float dB = 20.0f * std::log10(level > 1e-5f ? level : 1e-5f);
+        float target = (dB + 20.0f) / 23.0f;
+        target = target < 0.0f ? 0.0f : (target > 1.0f ? 1.0f : target);
+        needle += (target - needle) * (1.0f - std::exp(-dt * 8.0f));
+
+        const ImVec2 pivot = P(cx, 300);
+        const float rArc = 128.0f * s;
+        const float aMin = -0.60f, aMax = 0.60f;
+
+        dl->PushClipRect(P(cx - 78, 152), P(cx + 78, 236), true);
+        for (int i = 0; i <= 10; ++i)
+        {
+            const float a = aMin + (aMax - aMin) * (float)i / 10.0f;
+            const ImVec2 d(std::sin(a), -std::cos(a));
+            const bool red = i >= 8;
+            dl->AddLine(ImVec2(pivot.x + d.x * (rArc - 6 * s), pivot.y + d.y * (rArc - 6 * s)),
+                        ImVec2(pivot.x + d.x * (rArc + (i % 5 == 0 ? 4 : 1) * s),
+                               pivot.y + d.y * (rArc + (i % 5 == 0 ? 4 : 1) * s)),
+                        red ? kColRed : kColVuInk, (i % 5 == 0 ? 1.8f : 1.1f) * s);
+        }
+        text(dl, cx, 168, 11, kColVuInk, "VU", 0, true);
+        text(dl, cx, 210, 9, kColVuInk, label, 0, true);
+        {
+            const float a = aMin + (aMax - aMin) * needle;
+            const ImVec2 d(std::sin(a), -std::cos(a));
+            dl->AddLine(ImVec2(pivot.x + d.x * 34 * s, pivot.y + d.y * 34 * s),
+                        ImVec2(pivot.x + d.x * (rArc + 4 * s), pivot.y + d.y * (rArc + 4 * s)),
+                        IM_COL32(40, 30, 20, 255), 1.8f * s);
+        }
+        dl->PopClipRect();
+    }
+
+    void knob(ImDrawList* dl, const char* id, uint32_t param, float cx, float cy,
+              const char* l1, const char* l2, const char* fmt, const char* suffix)
+    {
+        const TmParam& d = kTmParams[param];
+        panel.knobLabel(dl, cx, cy - 46.0f, l1, l2);
+        panel.knob(id, param, d.min, d.max, cx, cy, 26.0f, values[param], d.def,
+                   false, true, fmt, suffix);
+    }
+
+    void drawKnobRow(ImDrawList* dl)
+    {
+        const float cy = 372.0f;
+        knob(dl, "input",  kParamInputGain,   80,  cy, "INPUT",   nullptr, "%.1f", " dB");
+        knob(dl, "bias",   kParamBias,        183, cy, "BIAS",    nullptr, "%.0f", "%");
+        knob(dl, "hp",     kParamHighpassFreq,286, cy, "HP",      nullptr, "%.0f", " Hz");
+        knob(dl, "lp",     kParamLowpassFreq, 389, cy, "LP",      nullptr, "%.0f", " Hz");
+        knob(dl, "noise",  kParamNoiseAmount, 492, cy, "NOISE",   nullptr, "%.0f", "%");
+        knob(dl, "wow",    kParamWow,         595, cy, "WOW",     nullptr, "%.0f", "%");
+        knob(dl, "flut",   kParamFlutter,     698, cy, "FLUTTER", nullptr, "%.0f", "%");
+        knob(dl, "output", kParamOutputGain,  825, cy, "OUTPUT",  nullptr, "%.1f", " dB");
+    }
+
+    // Light Studer-style function button: raised silver cap, dark label, red
+    // legend + LED when engaged. Flips the (0/1) parameter.
+    void tmButton(ImDrawList* dl, const char* id, uint32_t param, float x0, float y0,
+                  float x1, float y1, const char* label)
+    {
+        const bool on = values[param] > 0.5f;
+        const ImVec2 b0 = P(x0, y0), b1 = P(x1, y1);
+        ImGui::SetCursorScreenPos(b0);
+        ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+        if (ImGui::IsItemClicked())
+        {
+            const float nv = on ? 0.0f : 1.0f;
+            editParameter(param, true); values[param] = nv;
+            setParameterValue(param, nv); editParameter(param, false);
+        }
+        dl->AddRectFilledMultiColor(b0, b1, IM_COL32(226, 226, 228, 255), IM_COL32(226, 226, 228, 255),
+                                    IM_COL32(188, 188, 190, 255), IM_COL32(188, 188, 190, 255));
+        dl->AddRect(b0, b1, IM_COL32(90, 90, 92, 255), 2.0f * s, 0, 1.4f * s);
+        if (on)
+            dl->AddCircleFilled(P(x0 + 8.0f, 0.5f * (y0 + y1)), 2.6f * s, kColRed, 12);
+        text(dl, 0.5f * (x0 + x1) + 5.0f, y0 + 0.30f * (y1 - y0), 9.5f,
+             on ? kColRed : kColInk, label, 0, true);
+    }
+
+    void drawToggles(ImDrawList* dl)
+    {
+        tmButton(dl, "autocal",  kParamAutoCal,      140, 430, 250, 452, "AUTO CAL");
+        tmButton(dl, "noiseen",  kParamNoiseEnabled, 452, 430, 552, 452, "NOISE");
+        tmButton(dl, "autocomp", kParamAutoComp,     660, 430, 790, 452, "AUTO COMP");
+        tmButton(dl, "bypass",   kParamBypass,       690, 12,  770, 34,  "BYPASS");
+    }
+
+    //--- state -----------------------------------------------------------------
+    duskdpf::DuskPanel panel;
     ImFont* labelFont = nullptr;
     float   values[kParamCount] = {};
+    float   s = 1.0f;
+    ImVec2  org = ImVec2(0, 0);
+    float   reelPhase = 0.0f;
+    float   needleL = 0.0f, needleR = 0.0f;
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachineUI)
 };

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -55,8 +55,15 @@ public:
     {
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kTmParams[i].def;
-        setGeometryConstraints(400, 260, true);
-        labelFont = duskdpf::loadCrispFont(30.0f * getScaleFactor());
+        setGeometryConstraints(400, 260, true);   // aspect-locked
+
+        // Bake the bold face at several native sizes (design px * DPI scaleFactor)
+        // so body text and headers each render from a near-1x face (crisp, not an
+        // upscaled single size). pickFont() chooses the nearest per draw.
+        static const float kFontSizes[] = { 8.5f, 10.f, 11.f, 13.f, 16.f, 22.f };
+        fontSet   = duskdpf::loadCrispFontSet(kFontSizes, 6, getScaleFactor());
+        labelFont = fontSet.primary();
+        panel.setFontSet(fontSet);
 
         duskdpf::Palette pal;
         pal.white    = kColInk;
@@ -438,9 +445,10 @@ private:
         ImFont* f = labelFont ? labelFont : ImGui::GetFont();
         const ImU32 ink = IM_COL32(38, 32, 24, 255), red = IM_COL32(196, 42, 34, 255);
         auto num = [&](float r, float a, const char* b, ImU32 c, float sz) {
-            ImVec2 ts = f->CalcTextSizeA(sz * s, FLT_MAX, 0, b);
+            ImFont* nf = panel.pickFont(sz * s); if (nf == nullptr) nf = f;   // nearest baked size -> crisp
+            ImVec2 ts = nf->CalcTextSizeA(sz * s, FLT_MAX, 0, b);
             ImVec2 tp = pt(r, a);
-            dl->AddText(f, sz * s, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f), c, b);
+            dl->AddText(nf, sz * s, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f), c, b);
         };
         auto ang = [&](float db) { float n = std::pow(10.0f, (db - 3.0f) / 20.0f);
                                    n = n < 0.0f ? 0.0f : (n > 1.0f ? 1.0f : n);
@@ -678,6 +686,7 @@ private:
 
     //--- state -----------------------------------------------------------------
     duskdpf::DuskPanel panel;
+    duskdpf::CrispFontSet fontSet;
     ImFont* labelFont = nullptr;
     float   values[kParamCount] = {};
     float   s = 1.0f;

--- a/plugins/shared-dpf/DuskAccessBridge.hpp
+++ b/plugins/shared-dpf/DuskAccessBridge.hpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// DuskAccessBridge.hpp — the same-process DSP-accessor pattern shared by every
+// Dusk DPF plugin.
+//
+// Why this exists
+// ---------------
+// CLAP never forwards output parameters to the UI and VST3's forwarding is
+// laggy, so meters/spectra/scopes are read straight off the DSP instance's
+// lock-free atomics on the UI thread. The UI reaches the DSP through a free
+// function that takes the DPF getPluginInstancePointer() and returns the live
+// value. That function is declared **weak** here and defined **strong** in the
+// plugin's DSP translation unit (<Name>Plugin.cpp):
+//
+//   * single-binary formats (CLAP, VST3, JACK standalone, and MONOLITHIC LV2)
+//     link the DSP and UI together, so the strong definition resolves the weak
+//     reference everywhere — the UI gets direct access.
+//   * the split LV2 UI links as a separate .so WITHOUT the DSP; the weak
+//     reference stays null, and the UI must fall back to the output parameter
+//     (LV2 forwards those via port events). Always guard the call:
+//
+//         float v = fallbackFromOutputParam;
+//        #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
+//         if (myAccessor != nullptr)                    // weak: null in split UI
+//             if (void* const inst = getPluginInstancePointer())
+//                 v = myAccessor(inst);
+//        #endif
+//
+// Keep the output parameter too, as the generic-UI / out-of-process fallback.
+//
+// Usage
+// -----
+//   // In <Name>Access.hpp (UI + DSP both include it):
+//   #include "DuskAccessBridge.hpp"
+//   DUSK_ACCESS_DECL(float, myGetOutputLevel);
+//   // (forward-declare any DSP types the signature needs, then more DECLs)
+//
+//   // In <Name>Plugin.cpp — the STRONG definition (no DUSK_WEAK):
+//   float myGetOutputLevel(void* p) noexcept
+//   { return static_cast<MyPlugin*>(p)->dsp.getOutputLevel(); }
+
+#pragma once
+
+// Weak linkage: a null-resolving reference when the strong definition is absent
+// (the split LV2 UI). MSVC has no portable equivalent, so direct access there
+// would need /alternatename; the Dusk plugins target GCC/Clang.
+#if defined(__GNUC__) || defined(__clang__)
+  #define DUSK_WEAK __attribute__((weak))
+#else
+  #define DUSK_WEAK
+#endif
+
+// Declare a weak UI-side accessor:  <ret> name(void* pluginInstancePointer).
+// The caller appends the semicolon (and provides any needed forward decls).
+#define DUSK_ACCESS_DECL(ret, name) \
+    DUSK_WEAK ret name(void* pluginInstancePointer) noexcept

--- a/plugins/shared-dpf/dsp/DuskFilters.hpp
+++ b/plugins/shared-dpf/dsp/DuskFilters.hpp
@@ -232,6 +232,43 @@ public:
         return { b0 * inv, b1 * inv, b2 * inv, a1 * inv, a2 * inv };
     }
 
+    // RBJ low/high shelf in shelf-slope form with S=1 (alpha = sin(w0)/2 * sqrt(2)).
+    // Deliberately a DIFFERENT float op-order than shelf(...,Q) above: at Q=1/sqrt(2)
+    // the two are algebraically equal but diverge by ~1 ULP in ~40% of frequencies,
+    // so this exact variant is kept to reproduce tape-echo's original ShelfFilter
+    // bit-for-bit (offline null-render requirement). high=false selects the low shelf.
+    static BiquadCoeffs shelfSlope1(double fs, float freq, float gainDb, bool high) noexcept
+    {
+        const float A     = std::pow(10.0f, gainDb / 40.0f);
+        const float w0    = kDuskTwoPi * freq / (float)fs;
+        const float cosw  = std::cos(w0);
+        const float sinw  = std::sin(w0);
+        const float alpha = 0.5f * sinw * std::sqrt(2.0f); // S = 1
+        const float sqA2a = 2.0f * std::sqrt(A) * alpha;
+
+        float b0f, b1f, b2f, a0f, a1f, a2f;
+        if (!high)
+        {
+            b0f =     A * ((A + 1) - (A - 1) * cosw + sqA2a);
+            b1f = 2 * A * ((A - 1) - (A + 1) * cosw);
+            b2f =     A * ((A + 1) - (A - 1) * cosw - sqA2a);
+            a0f =         (A + 1) + (A - 1) * cosw + sqA2a;
+            a1f =    -2 * ((A - 1) + (A + 1) * cosw);
+            a2f =         (A + 1) + (A - 1) * cosw - sqA2a;
+        }
+        else
+        {
+            b0f =     A * ((A + 1) + (A - 1) * cosw + sqA2a);
+            b1f =-2 * A * ((A - 1) + (A + 1) * cosw);
+            b2f =     A * ((A + 1) + (A - 1) * cosw - sqA2a);
+            a0f =         (A + 1) - (A - 1) * cosw + sqA2a;
+            a1f =     2 * ((A - 1) - (A + 1) * cosw);
+            a2f =         (A + 1) - (A - 1) * cosw - sqA2a;
+        }
+        const float inv = 1.0f / a0f;
+        return { b0f * inv, b1f * inv, b2f * inv, a1f * inv, a2f * inv };
+    }
+
 private:
     BiquadCoeffs c;
     float z1 = 0.0f, z2 = 0.0f;

--- a/plugins/shared-dpf/dsp/DuskSVF.hpp
+++ b/plugins/shared-dpf/dsp/DuskSVF.hpp
@@ -20,6 +20,10 @@
 namespace duskaudio
 {
 
+// M_PI is not guaranteed by the C++ standard (POSIX / needs _USE_MATH_DEFINES on
+// MSVC). Use a portable local constant, matching kDuskPi in DuskFilters.hpp.
+constexpr float kDuskSvfPi = 3.14159265358979323846f;
+
 class DuskSVF
 {
 public:
@@ -40,7 +44,7 @@ public:
         // clamp away from 0 and Nyquist exactly like JUCE's update()
         const float nyq = (float)(0.5 * fs);
         cutoff = cutoffHz < 20.0f ? 20.0f : (cutoffHz > nyq - 1.0f ? nyq - 1.0f : cutoffHz);
-        g = std::tan((float)M_PI * cutoff / (float)fs);
+        g = std::tan(kDuskSvfPi * cutoff / (float)fs);
         updateH();
     }
 

--- a/plugins/shared-dpf/dsp/DuskSVF.hpp
+++ b/plugins/shared-dpf/dsp/DuskSVF.hpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// DuskSVF.hpp — topology-preserving-transform state-variable filter.
+//
+// Framework-free replacement for juce::dsp::StateVariableTPTFilter
+// (Zavalishin/Cytomic TPT SVF). The per-sample recurrence and the g/R2/h
+// coefficient definitions are ported verbatim from JUCE's
+// StateVariableTPTFilter so a straight LP/BP/HP swap reproduces the JUCE
+// magnitude and phase response (A/B target, not bit-exact — trig is computed
+// in the same order but JUCE uses double internally for the coeffs).
+//
+// One SVF instance = one channel of state (ic1eq/ic2eq). Use one per channel.
+
+#pragma once
+
+#include <cmath>
+
+namespace duskaudio
+{
+
+class DuskSVF
+{
+public:
+    enum class Type { lowpass, bandpass, highpass };
+
+    void setType(Type t) noexcept { type = t; }
+
+    // Q is the resonance (JUCE: resonance = 1/R2). cutoff in Hz.
+    void prepare(double sampleRate, float cutoffHz, float Q) noexcept
+    {
+        fs = sampleRate;
+        setCutoff(cutoffHz);
+        setResonance(Q);
+    }
+
+    void setCutoff(float cutoffHz) noexcept
+    {
+        // clamp away from 0 and Nyquist exactly like JUCE's update()
+        const float nyq = (float)(0.5 * fs);
+        cutoff = cutoffHz < 20.0f ? 20.0f : (cutoffHz > nyq - 1.0f ? nyq - 1.0f : cutoffHz);
+        g = std::tan((float)M_PI * cutoff / (float)fs);
+        updateH();
+    }
+
+    void setResonance(float Q) noexcept
+    {
+        reso = Q < 0.05f ? 0.05f : Q;
+        R2 = 1.0f / reso;
+        updateH();
+    }
+
+    void reset() noexcept { ic1eq = ic2eq = 0.0f; }
+
+    float process(float x) noexcept
+    {
+        const float yHP = h * (x - (g + R2) * ic1eq - ic2eq);
+        const float yBP = g * yHP + ic1eq;
+        ic1eq = g * yHP + yBP;
+        const float yLP = g * yBP + ic2eq;
+        ic2eq = g * yBP + yLP;
+        switch (type)
+        {
+            case Type::lowpass:  return yLP;
+            case Type::bandpass: return yBP;
+            case Type::highpass: return yHP;
+        }
+        return yLP;
+    }
+
+private:
+    void updateH() noexcept { h = 1.0f / (1.0f + R2 * g + g * g); }
+
+    Type   type   = Type::lowpass;
+    double fs     = 44100.0;
+    float  cutoff = 1000.0f, reso = 0.70710678f;
+    float  g = 0.0f, R2 = 1.41421356f, h = 1.0f;
+    float  ic1eq = 0.0f, ic2eq = 0.0f;
+};
+
+} // namespace duskaudio

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -349,9 +349,18 @@ public:
                 const float fineStep = 0.0008f * range * (dispMul != 0.0f ? std::fabs(dispMul) : 1.0f);
                 int d = (int) std::ceil(-std::log10(fineStep > 1e-9f ? fineStep : 1e-9f));
                 d = d < 0 ? 0 : (d > 4 ? 4 : d);
-                bool plus = false; for (const char* p = fmt; *p; ++p) if (*p == '+') { plus = true; break; }
-                char f2[8]; std::snprintf(f2, sizeof(f2), plus ? "%%+.%df" : "%%.%df", d);
-                std::snprintf(num, sizeof(num), f2, value * dispMul + dispAdd);
+                // resting precision from fmt (digits after the '.'); never show FEWER
+                // decimals than at rest -> if fine-step isn't finer, leave as-is.
+                int restD = 0; for (const char* p = fmt; *p; ++p)
+                    if (*p == '.') { for (const char* q = p + 1; *q >= '0' && *q <= '9'; ++q) restD = restD * 10 + (*q - '0'); break; }
+                if (d <= restD)
+                    std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
+                else
+                {
+                    bool plus = false; for (const char* p = fmt; *p; ++p) if (*p == '+') { plus = true; break; }
+                    char f2[8]; std::snprintf(f2, sizeof(f2), plus ? "%%+.%df" : "%%.%df", d);
+                    std::snprintf(num, sizeof(num), f2, value * dispMul + dispAdd);
+                }
                 std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
                 valueBubble(dl, cx, cy, radius, buf);
             }

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -200,7 +200,8 @@ public:
               const char* fmt = "%.2f", const char* suffix = "",
               ImU32 faceColor = 0, bool bodyless = false,
               bool persistent = false, const char* tooltip = nullptr,
-              bool rightClickReset = false, float dispMul = 1.0f, float dispAdd = 0.0f)
+              bool rightClickReset = false, float dispMul = 1.0f, float dispAdd = 0.0f,
+              const char* name = nullptr)
     {
         ImDrawList* dl = ImGui::GetWindowDrawList();
         const float R  = radius * s;
@@ -338,10 +339,17 @@ public:
         }
         else if ((hovered || active) && valueEditId_ != id)
         {
-            char buf[48], num[32];
-            std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
-            std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
-            valueBubble(dl, cx, cy, radius, buf);
+            // dragging -> live value; just hovering -> the parameter name (if given,
+            // else fall back to the value so existing callers are unchanged).
+            if (active || name == nullptr)
+            {
+                char buf[48], num[32];
+                std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
+                std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
+                valueBubble(dl, cx, cy, radius, buf);
+            }
+            else
+                valueBubble(dl, cx, cy, radius, name);
         }
         if (persistent && valueEditId_ != id)
         {

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -339,17 +339,30 @@ public:
         }
         else if ((hovered || active) && valueEditId_ != id)
         {
-            // dragging -> live value; just hovering -> the parameter name (if given,
-            // else fall back to the value so existing callers are unchanged).
-            if (active || name == nullptr)
+            char buf[48], num[32];
+            if (active && name != nullptr)
             {
-                char buf[48], num[32];
+                // Dragging: show the value at the fine-drag step's resolution so
+                // shift-fine can land on values the resting readout rounds away
+                // (e.g. -2.0 dB at rest, -1.97 dB mid-drag). Precision follows the
+                // fine step (0.0008 * range in display units), not a fixed count.
+                const float fineStep = 0.0008f * range * (dispMul != 0.0f ? std::fabs(dispMul) : 1.0f);
+                int d = (int) std::ceil(-std::log10(fineStep > 1e-9f ? fineStep : 1e-9f));
+                d = d < 0 ? 0 : (d > 4 ? 4 : d);
+                bool plus = false; for (const char* p = fmt; *p; ++p) if (*p == '+') { plus = true; break; }
+                char f2[8]; std::snprintf(f2, sizeof(f2), plus ? "%%+.%df" : "%%.%df", d);
+                std::snprintf(num, sizeof(num), f2, value * dispMul + dispAdd);
+                std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
+                valueBubble(dl, cx, cy, radius, buf);
+            }
+            else if (name != nullptr && !active)   // hovering only -> parameter name
+                valueBubble(dl, cx, cy, radius, name);
+            else                                    // legacy callers (no name): caller fmt, unchanged
+            {
                 std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
                 std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
                 valueBubble(dl, cx, cy, radius, buf);
             }
-            else
-                valueBubble(dl, cx, cy, radius, name);
         }
         if (persistent && valueEditId_ != id)
         {

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -188,11 +188,19 @@ public:
     // render its own body (e.g. the brushed-metal 4K knob) while this still owns
     // all gestures (drag / shift-fine / wheel / double-click-type / Cmd-reset)
     // plus the value bubble + inline editor.
+    // Opt-in extras (all default-off so existing callers are unchanged):
+    //   persistent      : draw the value under the knob even when not hovered
+    //   tooltip         : ImGui::SetTooltip text on hover
+    //   rightClickReset : right-click resets to default (in addition to Cmd-click)
+    //   dispMul/dispAdd : the read-out / type-entry value is (value*dispMul+dispAdd)
+    //                     so e.g. a 0..100 bias can read as relative -50..+50.
     bool knob(const char* id, uint32_t param, float minV, float maxV,
               float cx, float cy, float radius, float& value, float defaultVal,
               bool stepped = false, bool panelTicks = true,
               const char* fmt = "%.2f", const char* suffix = "",
-              ImU32 faceColor = 0, bool bodyless = false)
+              ImU32 faceColor = 0, bool bodyless = false,
+              bool persistent = false, const char* tooltip = nullptr,
+              bool rightClickReset = false, float dispMul = 1.0f, float dispAdd = 0.0f)
     {
         ImDrawList* dl = ImGui::GetWindowDrawList();
         const float R  = radius * s;
@@ -204,6 +212,8 @@ public:
         ImGui::InvisibleButton(id, ImVec2(2.0f * R, 2.0f * R));
         const bool hovered = ImGui::IsItemHovered();
         const bool active  = ImGui::IsItemActive();
+        if (tooltip != nullptr && hovered && !active)
+            ImGui::SetTooltip("%s", tooltip);
 
         const bool editing = (valueEditId_ == id);
         const bool modKey = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
@@ -231,7 +241,7 @@ public:
 
             if (!modKey && (hovered || active) && ImGui::IsMouseDoubleClicked(0))
             {
-                openValueEdit(id, value); // double-click: type a value
+                openValueEdit(id, value * dispMul + dispAdd); // double-click: type a value
                 host->endEdit(param);     // close the gesture the press opened
             }
             else if (hovered && !active)
@@ -248,6 +258,11 @@ public:
                         host->setParam(param, nv); host->endEdit(param); changed = true;
                     }
                 }
+            }
+            if (rightClickReset && hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+            {
+                host->beginEdit(param); value = defaultVal;
+                host->setParam(param, value); host->endEdit(param); changed = true;
             }
         }
 
@@ -312,6 +327,7 @@ public:
         float typed;
         if (valueEdit(id, cx, cy, radius, typed))
         {
+            typed = (typed - dispAdd) / (dispMul != 0.0f ? dispMul : 1.0f); // display -> actual
             typed = typed < minV ? minV : (typed > maxV ? maxV : typed);
             if (stepped) typed = std::round(typed);
             if (typed != value)
@@ -322,11 +338,17 @@ public:
         }
         else if ((hovered || active) && valueEditId_ != id)
         {
-            char buf[48];
-            char num[32];
-            std::snprintf(num, sizeof(num), fmt, value);
+            char buf[48], num[32];
+            std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
             std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
             valueBubble(dl, cx, cy, radius, buf);
+        }
+        if (persistent && valueEditId_ != id)
+        {
+            char buf[48], num[32];
+            std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
+            std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
+            text(dl, cx, cy + radius + 8.0f, 9.5f, pal.whiteDim, buf, 0);
         }
         return changed;
     }

--- a/plugins/tape-echo/core/TapeEchoDSP.cpp
+++ b/plugins/tape-echo/core/TapeEchoDSP.cpp
@@ -1,47 +1,15 @@
 // TapeEchoDSP.cpp — vintage three-head tape echo emulation core (framework-free C++17).
 
 #include "TapeEchoDSP.hpp"
+#include "DuskDenormals.hpp"   // ScopedFlushDenormals (SSE + ARM64 FPCR)
 
 #include <algorithm>
-
-#if defined(__SSE__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)
-  #include <xmmintrin.h>
-  #define TAPEECHO_HAS_SSE 1
-#endif
 
 namespace duskaudio
 {
 
 namespace
 {
-    // RAII flush-to-zero / denormals-are-zero for the duration of a block
-    // (replaces juce::ScopedNoDenormals).
-    struct ScopedFlushDenormals
-    {
-#if TAPEECHO_HAS_SSE
-        unsigned int oldCsr;
-        ScopedFlushDenormals() noexcept : oldCsr(_mm_getcsr())
-        {
-            _mm_setcsr(oldCsr | 0x8040u); // FTZ | DAZ
-        }
-        ~ScopedFlushDenormals() noexcept { _mm_setcsr(oldCsr); }
-#elif defined(__aarch64__)
-        // ARM64 (Apple Silicon and others): set the FZ bit in FPCR
-        uint64_t oldFpcr;
-        ScopedFlushDenormals() noexcept
-        {
-            asm volatile("mrs %0, fpcr" : "=r"(oldFpcr));
-            asm volatile("msr fpcr, %0" :: "r"(oldFpcr | (1ULL << 24)));
-        }
-        ~ScopedFlushDenormals() noexcept
-        {
-            asm volatile("msr fpcr, %0" :: "r"(oldFpcr));
-        }
-#else
-        ScopedFlushDenormals() noexcept = default;
-#endif
-    };
-
     // 4-point, 3rd-order Hermite. Interpolates between x0 and x1 at `frac`.
     inline float hermite(float frac, float xm1, float x0, float x1, float x2) noexcept
     {
@@ -97,22 +65,9 @@ namespace
 }
 
 //==============================================================================
-// Oversampled preamp — halfband taps (scipy remez, see design notes)
+// Oversampled preamp — halfband taps now shared (plugins/shared-dpf/dsp/
+// DuskOversampler.hpp, duskaudio::hbtaps::kA/kB; scipy remez, identical values).
 //==============================================================================
-namespace
-{
-    // stage A: 47-tap halfband, transition 0.08, stopband -67 dB
-    constexpr float kHbTapsA[12] = {
-        0.3168690344f, -0.1018442627f, 0.0567777617f, -0.0362614803f,
-        0.0242159187f, -0.0162814078f, 0.0107858313f, -0.0069217143f,
-        0.0042343916f, -0.0024153268f, 0.0012438004f, -0.0006166386f,
-    };
-    // stage B: 15-tap halfband, transition 0.26, stopband -75 dB
-    constexpr float kHbTapsB[4] = {
-        0.3048934958f, -0.0712879483f, 0.0197218961f, -0.0034083969f,
-    };
-}
-
 float TapeEchoDSP::preampOversampled(Channel& ch, float x, float drive) noexcept
 {
     // 4x oversampled saturation: upsample (2 cascaded 2x halfbands), shape,
@@ -121,54 +76,22 @@ float TapeEchoDSP::preampOversampled(Channel& ch, float x, float drive) noexcept
     for (int p = 0; p < 2; ++p)
     {
         ch.upA.push(p == 0 ? x : 0.0f);
-        const float a = 2.0f * ch.upA.out(kHbTapsA);
+        const float a = 2.0f * ch.upA.out(hbtaps::kA);
         for (int q = 0; q < 2; ++q)
         {
             ch.upB.push(q == 0 ? a : 0.0f);
-            const float b = 2.0f * ch.upB.out(kHbTapsB);
+            const float b = 2.0f * ch.upB.out(hbtaps::kB);
             ch.downB.push(preampShape(b * drive));
         }
-        ch.downA.push(ch.downB.out(kHbTapsB));
+        ch.downA.push(ch.downB.out(hbtaps::kB));
     }
-    return ch.downA.out(kHbTapsA);
+    return ch.downA.out(hbtaps::kA);
 }
 
 //==============================================================================
-// ShelfFilter — RBJ audio EQ cookbook shelves
+// (ShelfFilter coefficient design moved to shared Biquad::shelfSlope1 — see
+//  plugins/shared-dpf/dsp/DuskFilters.hpp. Bit-identical float op-order.)
 //==============================================================================
-void ShelfFilter::configure(Type type, float freqHz, float gainDb, double fs) noexcept
-{
-    const float A     = std::pow(10.0f, gainDb / 40.0f);
-    const float w0    = kTwoPi * freqHz / (float)fs;
-    const float cosw  = std::cos(w0);
-    const float sinw  = std::sin(w0);
-    const float alpha = 0.5f * sinw * std::sqrt(2.0f); // S = 1
-    const float sqA2a = 2.0f * std::sqrt(A) * alpha;
-
-    float b0f, b1f, b2f, a0f, a1f, a2f;
-    if (type == Type::lowShelf)
-    {
-        b0f =     A * ((A + 1) - (A - 1) * cosw + sqA2a);
-        b1f = 2 * A * ((A - 1) - (A + 1) * cosw);
-        b2f =     A * ((A + 1) - (A - 1) * cosw - sqA2a);
-        a0f =         (A + 1) + (A - 1) * cosw + sqA2a;
-        a1f =    -2 * ((A - 1) + (A + 1) * cosw);
-        a2f =         (A + 1) + (A - 1) * cosw - sqA2a;
-    }
-    else
-    {
-        b0f =     A * ((A + 1) + (A - 1) * cosw + sqA2a);
-        b1f =-2 * A * ((A - 1) + (A + 1) * cosw);
-        b2f =     A * ((A + 1) + (A - 1) * cosw - sqA2a);
-        a0f =         (A + 1) - (A - 1) * cosw + sqA2a;
-        a1f =     2 * ((A - 1) - (A + 1) * cosw);
-        a2f =         (A + 1) - (A - 1) * cosw - sqA2a;
-    }
-
-    const float inv = 1.0f / a0f;
-    b0 = b0f * inv;  b1 = b1f * inv;  b2 = b2f * inv;
-    a1 = a1f * inv;  a2 = a2f * inv;
-}
 
 //==============================================================================
 // SpringReverb
@@ -423,10 +346,10 @@ void TapeEchoDSP::refreshBlockRateControls()
         // default while channels[0] is shelved — an L/R mismatch.
         for (int c = 0; c < kMaxChannels; ++c)
         {
-            channels[(size_t)c].bassShelf.configure(ShelfFilter::Type::lowShelf,
-                                                    100.0f, bass * 12.0f, fs);
-            channels[(size_t)c].trebleShelf.configure(ShelfFilter::Type::highShelf,
-                                                      3000.0f, treble * 12.0f, fs);
+            channels[(size_t)c].bassShelf.setCoeffs(
+                Biquad::shelfSlope1(fs, 100.0f, bass * 12.0f, /*high=*/false));
+            channels[(size_t)c].trebleShelf.setCoeffs(
+                Biquad::shelfSlope1(fs, 3000.0f, treble * 12.0f, /*high=*/true));
         }
     }
 }

--- a/plugins/tape-echo/core/TapeEchoDSP.hpp
+++ b/plugins/tape-echo/core/TapeEchoDSP.hpp
@@ -33,126 +33,26 @@
 #include <cstdint>
 #include <vector>
 
+// Shared DSP primitives (namespace duskaudio) — these replace the building
+// blocks that used to be defined locally here. All lifted from this very file
+// during the shared-dpf extraction, so consuming them is bit-identical.
+#include "DuskSmoothed.hpp"    // SmoothedValue
+#include "DuskFilters.hpp"     // OnePoleLP/HP, DCBlocker, Biquad (shelves)
+#include "DuskOversampler.hpp" // HalfbandFIR, hbtaps::kA/kB
+
 namespace duskaudio
 {
 
 //==============================================================================
-// Small framework-free building blocks
+// Small framework-free building blocks now live in plugins/shared-dpf/dsp:
+//   SmoothedValue            -> DuskSmoothed.hpp
+//   OnePoleLP / OnePoleHP    -> DuskFilters.hpp
+//   DCBlocker                -> DuskFilters.hpp (default R = 0.9975, ~20 Hz @ 48k;
+//                               tape-echo keeps the default, so it is unchanged)
+//   ShelfFilter              -> DuskFilters.hpp Biquad + Biquad::shelfSlope1()
+//   HalfbandFIR + hb taps    -> DuskOversampler.hpp (HalfbandFIR, hbtaps::kA/kB)
+// The shared versions were lifted from this file, so behavior is bit-identical.
 //==============================================================================
-
-// One-pole exponential parameter smoother (replaces juce::LinearSmoothedValue).
-class SmoothedValue
-{
-public:
-    void prepare(double sampleRate, float tauSeconds) noexcept
-    {
-        coeff = 1.0f - std::exp(-1.0f / (float)(tauSeconds * sampleRate));
-    }
-    void snap(float v) noexcept   { current = target = v; }
-    void setTarget(float v) noexcept { target = v; }
-    float next() noexcept         { current += coeff * (target - current); return current; }
-    float value() const noexcept  { return current; }
-
-private:
-    float current = 0.0f, target = 0.0f, coeff = 1.0f;
-};
-
-class OnePoleLP
-{
-public:
-    void setCutoff(float hz, double fs) noexcept
-    {
-        c = 1.0f - std::exp(-6.2831853f * hz / (float)fs);
-    }
-    void reset() noexcept { z = 0.0f; }
-    float process(float x) noexcept { z += c * (x - z); return z; }
-
-private:
-    float c = 1.0f, z = 0.0f;
-};
-
-class OnePoleHP
-{
-public:
-    void setCutoff(float hz, double fs) noexcept { lp.setCutoff(hz, fs); }
-    void reset() noexcept { lp.reset(); }
-    float process(float x) noexcept { return x - lp.process(x); }
-
-private:
-    OnePoleLP lp;
-};
-
-class DCBlocker
-{
-public:
-    void reset() noexcept { x1 = y1 = 0.0f; }
-    float process(float x) noexcept
-    {
-        const float y = x - x1 + 0.9975f * y1;
-        x1 = x;
-        y1 = y;
-        return y;
-    }
-
-private:
-    float x1 = 0.0f, y1 = 0.0f;
-};
-
-// Transposed direct-form II biquad, RBJ shelving coefficients.
-class ShelfFilter
-{
-public:
-    enum class Type { lowShelf, highShelf };
-
-    void configure(Type type, float freqHz, float gainDb, double fs) noexcept;
-    void reset() noexcept { z1 = z2 = 0.0f; }
-
-    float process(float x) noexcept
-    {
-        const float y = b0 * x + z1;
-        z1 = b1 * x - a1 * y + z2;
-        z2 = b2 * x - a2 * y;
-        return y;
-    }
-
-private:
-    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f, a1 = 0.0f, a2 = 0.0f;
-    float z1 = 0.0f, z2 = 0.0f;
-};
-
-//==============================================================================
-// Polyphase-friendly FIR halfband for 2x up/down sampling (ring convolution;
-// taps designed with scipy remez, halfband-exact: even offsets zero,
-// center 0.5). Used to run the preamp nonlinearity at 4x — saturating
-// full-band input at base rate folds harmonics of bright content straight
-// into the echo passband (measured up to -1.5 dBc before this).
-//==============================================================================
-template <int L, int NSide>
-class HalfbandFIR
-{
-public:
-    void reset() noexcept
-    {
-        for (float& v : buf) v = 0.0f;
-        pos = 0;
-    }
-    void push(float x) noexcept { pos = (pos + 1) & 63; buf[pos] = x; }
-    float out(const float* taps) const noexcept
-    {
-        constexpr int C = L / 2;
-        float acc = 0.5f * buf[(pos - C) & 63];
-        for (int i = 0; i < NSide; ++i)
-        {
-            const int k = 2 * i + 1;
-            acc += taps[i] * (buf[(pos - (C - k)) & 63] + buf[(pos - (C + k)) & 63]);
-        }
-        return acc;
-    }
-
-private:
-    float buf[64] = {};
-    int   pos = 0;
-};
 
 //==============================================================================
 // Spring reverb — simplified two-spring tank in the classic style.
@@ -297,8 +197,8 @@ private:
         OnePoleLP          recordLP;   // in-loop, darkens every repeat
         OnePoleLP          recordLP2;  // second pole: the record/repro chain of the
                                        // hardware rolls off steeper than 6 dB/oct
-        ShelfFilter        bassShelf;  // echo output path only
-        ShelfFilter        trebleShelf;
+        Biquad             bassShelf;  // echo output path only
+        Biquad             trebleShelf;
         SpringReverb       spring;
     };
 

--- a/plugins/tape-echo/dpf-plugin/CMakeLists.txt
+++ b/plugins/tape-echo/dpf-plugin/CMakeLists.txt
@@ -1,6 +1,9 @@
-# Standalone CMake project for the DPF-based Tape Echo plugin.
-# Not wired into the top-level JUCE build; configure this directory directly:
+# Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+# Third-party components (DPF — ISC; Dear ImGui — MIT; and others) are attributed
+# in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
 #
+# Standalone CMake for the DPF-based Tape Echo plugin.
+# Configure this directory directly:
 #   cmake -B build -GNinja [-DDPF_PATH=/path/to/DPF]
 #   cmake --build build
 
@@ -13,16 +16,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(DPF_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../DPF" CACHE PATH "Path to DISTRHO Plugin Framework")
-set(DPFWIDGETS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../DPF-Widgets" CACHE PATH "Path to DPF-Widgets (Dear ImGui wrapper)")
-if(NOT EXISTS "${DPF_PATH}/CMakeLists.txt")
-    message(FATAL_ERROR "DPF not found at ${DPF_PATH} — clone https://github.com/DISTRHO/DPF or pass -DDPF_PATH=...")
-endif()
-if(NOT EXISTS "${DPFWIDGETS_PATH}/opengl/DearImGui.cpp")
-    message(FATAL_ERROR "DPF-Widgets not found at ${DPFWIDGETS_PATH} — clone https://github.com/DISTRHO/DPF-Widgets or pass -DDPFWIDGETS_PATH=...")
-endif()
-
-add_subdirectory("${DPF_PATH}" dpf EXCLUDE_FROM_ALL)
+include("${CMAKE_CURRENT_SOURCE_DIR}/../../shared-dpf/cmake/DuskDpfPlugin.cmake")
 
 dpf_add_plugin(tape_echo
     TARGETS clap vst3 lv2 jack au # au builds on macOS only, silently skipped elsewhere
@@ -36,10 +30,13 @@ dpf_add_plugin(tape_echo
         ../core/TapeEchoDSP.cpp
     FILES_UI
         TapeEchoUI.cpp
-        "${DPFWIDGETS_PATH}/opengl/DearImGui.cpp")
+        ${DUSK_DPF_UI_SOURCES})
 
 target_include_directories(tape_echo PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/../core"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../shared-dpf/ui"  # shared DuskImGuiFont.hpp
-    "${DPFWIDGETS_PATH}/opengl")
+    ${DUSK_DPF_INCLUDE_DIRS})   # shared-dpf dsp/ui + DPF-Widgets opengl
+
+# Auto-deploy the built CLAP/VST3/LV2 into the user plugin dirs after each build
+# (disable with -DDUSK_DPF_INSTALL_LOCAL=OFF).
+dusk_dpf_install_local(tape_echo)

--- a/plugins/tape-echo/dpf-plugin/TapeEchoAccess.hpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoAccess.hpp
@@ -1,13 +1,15 @@
-// TapeEchoAccess.hpp — UI-side accessor for same-process DSP data.
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
 //
-// Declared weak: in single-binary formats (CLAP, VST3, JACK standalone) the
-// strong definition in TapeEchoPlugin.cpp resolves it; in the LV2 UI, which
-// links as a separate .so without the DSP, it resolves to null and the UI
-// falls back to the output parameter (LV2 forwards those via port events).
+// TapeEchoAccess.hpp — UI-side accessor for same-process DSP data (the VU/peak
+// meter). Uses the shared weak-symbol bridge; see DuskAccessBridge.hpp for the
+// single-binary-vs-split-LV2 contract and the required UI-side null guard.
+// Strong definition lives in TapeEchoPlugin.cpp.
 
 #pragma once
 
-#if defined(__GNUC__) || defined(__clang__)
-__attribute__((weak))
-#endif
-float tapeEchoGetOutputLevel(void* pluginInstancePointer) noexcept;
+#include "DuskAccessBridge.hpp"
+
+// Linear output peak (0..~3), ~300 ms release. Null in the split LV2 UI.
+DUSK_ACCESS_DECL(float, tapeEchoGetOutputLevel);

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -8,7 +8,8 @@
 #include "DistrhoUI.hpp"
 #include "TapeEchoAccess.hpp"
 #include "TapeEchoParams.hpp"
-#include "DuskImGuiFont.hpp"   // shared crisp-bold loader (candidate search + DPI)
+#include "DuskImGuiFont.hpp"      // shared crisp-bold loader (candidate search + DPI)
+#include "DuskImGuiWidgets.hpp"   // shared DuskPanel: chrome knob, LED, text, value bubble
 
 #include <cmath>
 #include <cstdio>
@@ -55,9 +56,14 @@ namespace
     constexpr float kPi = 3.14159265358979f;
 }
 
-class TapeEchoUI : public UI
+class TapeEchoUI : public UI, public duskdpf::ParamHost
 {
 public:
+    //--- duskdpf::ParamHost: forward the shared widgets' edits to the host ------
+    void beginEdit(uint32_t idx) override { editParameter(idx, true); }
+    void endEdit(uint32_t idx) override   { editParameter(idx, false); }
+    void setParam(uint32_t idx, float v) override { setParameterValue(idx, v); }
+
     TapeEchoUI()
         : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT)
     {
@@ -84,6 +90,10 @@ protected:
         const float winH = (float)getHeight();
         s   = std::min(winW / kDesignW, winH / kDesignH);
         org = ImVec2(0.5f * (winW - kDesignW * s), 0.5f * (winH - kDesignH * s));
+
+        // Bind the shared widget panel to this frame's scale/origin/font. `this`
+        // is the ParamHost the knob/LED gestures call back into.
+        panel.begin(s, org, labelFont, this);
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
@@ -114,169 +124,36 @@ private:
     //--- helpers -----------------------------------------------------------------
     ImVec2 P(float x, float y) const { return ImVec2(org.x + x * s, org.y + y * s); }
 
+    // Thin adapters onto the shared duskdpf::DuskPanel (all the chrome-knob
+    // drawing, LED, text crisping, gesture handling + value bubble live there
+    // now; every Dusk DPF plugin renders identical controls through it).
     void text(ImDrawList* dl, float x, float y, float size, ImU32 col,
               const char* txt, int align /* -1 left, 0 center, 1 right */,
               bool bold = false) const
     {
-        ImFont* font = labelFont != nullptr ? labelFont : ImGui::GetFont();
-        const float sz = size * s;
-        const ImVec2 ts = font->CalcTextSizeA(sz, FLT_MAX, 0.0f, txt);
-        ImVec2 pos = P(x, y);
-        if (align == 0) pos.x -= 0.5f * ts.x;
-        if (align == 1) pos.x -= ts.x;
-        dl->AddText(font, sz, pos, col, txt);
-        // faux-bold double draw only when stuck on the fallback font (the
-        // label font is a genuine bold face; double-drawing it smears)
-        if (bold && labelFont == nullptr)
-            dl->AddText(font, sz, ImVec2(pos.x + 0.6f * s, pos.y), col, txt);
+        panel.text(dl, x, y, size, col, txt, align, bold);
     }
 
     void led(ImDrawList* dl, float x, float y, bool on, float r = 5.0f) const
     {
-        const ImVec2 c = P(x, y);
-        dl->AddCircleFilled(c, (r + 2.5f) * s, IM_COL32(60, 60, 62, 255), 20);
-        dl->AddCircleFilled(c, (r + 1.0f) * s, IM_COL32(0, 0, 0, 255), 20);
-        if (on)
-        {
-            dl->AddCircleFilled(c, (r + 5.0f) * s, kColLedGlow, 20);
-            dl->AddCircleFilled(c, r * s, kColLedOn, 20);
-            dl->AddCircleFilled(ImVec2(c.x - 1.5f * s, c.y - 1.5f * s), 1.6f * s,
-                                IM_COL32(255, 215, 205, 230), 10);
-        }
-        else
-        {
-            dl->AddCircleFilled(c, r * s, kColLedOff, 20);
-        }
+        panel.led(dl, x, y, on, r);
     }
 
-    //--- chrome knob ---------------------------------------------------------------
-    static float knobAngle(float t) { return (-135.0f + 270.0f * t) * kPi / 180.0f; }
+    static float knobAngle(float t) { return duskdpf::DuskPanel::knobAngle(t); }
 
     void knob(const char* id, uint32_t param, float minV, float maxV,
               float cx, float cy, float radius, bool stepped = false,
               bool panelTicks = true)
     {
-        ImDrawList* dl = ImGui::GetWindowDrawList();
-        const float R  = radius * s;
-        const ImVec2 c = P(cx, cy);
-        const float range = maxV - minV;
-
-        // interaction -------------------------------------------------------------
-        ImGui::SetCursorScreenPos(ImVec2(c.x - R, c.y - R));
-        ImGui::InvisibleButton(id, ImVec2(2.0f * R, 2.0f * R));
-        const bool hovered = ImGui::IsItemHovered();
-        const bool active  = ImGui::IsItemActive();
-
-        if (ImGui::IsItemActivated())
-        {
-            editParameter(param, true);
-            dragValue = values[param];
-        }
-        if (active)
-        {
-            const float speed = ImGui::GetIO().KeyShift ? 0.0008f : 0.005f;
-            dragValue -= ImGui::GetIO().MouseDelta.y * speed * range;
-            dragValue = dragValue < minV ? minV : (dragValue > maxV ? maxV : dragValue);
-            const float nv = stepped ? std::round(dragValue) : dragValue;
-            if (nv != values[param])
-            {
-                values[param] = nv;
-                setParameterValue(param, nv);
-            }
-        }
-        if (ImGui::IsItemDeactivated())
-            editParameter(param, false);
-
-        if ((hovered || active) && ImGui::IsMouseDoubleClicked(0))
-        {
-            // The double-click activated the item this same frame, so the
-            // IsItemActivated branch above already opened the gesture and the
-            // IsItemDeactivated branch will close it on release — just set the
-            // value here; reopening/closing would nest the gesture.
-            values[param] = kParamDefaults[param];
-            dragValue = values[param];
-            setParameterValue(param, values[param]);
-        }
-        else if (hovered && !active)
-        {
-            const float wheel = ImGui::GetIO().MouseWheel;
-            if (wheel != 0.0f)
-            {
-                float nv = values[param] + wheel * (stepped ? 1.0f : range * 0.02f);
-                nv = nv < minV ? minV : (nv > maxV ? maxV : nv);
-                nv = stepped ? std::round(nv) : nv;
-                if (nv != values[param])
-                {
-                    editParameter(param, true);
-                    values[param] = nv;
-                    setParameterValue(param, nv);
-                    editParameter(param, false);
-                }
-            }
-        }
-
-        // drawing --------------------------------------------------------------------
-        const float t = range > 0.0f ? (values[param] - minV) / range : 0.0f;
-
-        if (panelTicks)
-        {
-            for (int i = 0; i <= 10; ++i)
-            {
-                const float a = knobAngle((float)i / 10.0f);
-                const ImVec2 dir(std::sin(a), -std::cos(a));
-                dl->AddLine(ImVec2(c.x + dir.x * (R + 2.5f * s), c.y + dir.y * (R + 2.5f * s)),
-                            ImVec2(c.x + dir.x * (R + 6.5f * s), c.y + dir.y * (R + 6.5f * s)),
-                            kColWhiteDim, 1.3f * s);
-            }
-        }
-
-        // scalloped chrome skirt
-        dl->AddCircleFilled(c, R, IM_COL32(70, 70, 73, 255), 48);
-        dl->AddCircleFilled(c, R * 0.97f, IM_COL32(128, 128, 132, 255), 48);
-        for (int i = 0; i < 24; ++i) // skirt ridges
-        {
-            const float a = (float)i / 24.0f * 2.0f * kPi;
-            const ImVec2 dir(std::sin(a), -std::cos(a));
-            dl->AddLine(ImVec2(c.x + dir.x * R * 0.82f, c.y + dir.y * R * 0.82f),
-                        ImVec2(c.x + dir.x * R * 0.97f, c.y + dir.y * R * 0.97f),
-                        IM_COL32(55, 55, 58, 130), 1.4f * s);
-        }
-
-        // domed chrome cap
-        const float capR = R * 0.72f;
-        dl->AddCircleFilled(c, capR, IM_COL32(96, 97, 100, 255), 40);
-        dl->AddCircleFilled(ImVec2(c.x - capR * 0.15f, c.y - capR * 0.20f),
-                            capR * 0.93f, IM_COL32(176, 178, 182, 255), 40);
-        dl->AddCircleFilled(ImVec2(c.x - capR * 0.25f, c.y - capR * 0.32f),
-                            capR * 0.55f, IM_COL32(225, 227, 231, 150), 40);
-        dl->AddCircleFilled(c, capR * 0.42f, IM_COL32(158, 160, 164, 255), 40);
-        dl->AddCircle(c, capR, IM_COL32(20, 20, 20, 255), 40, 1.4f * s);
-
-        // pointer line across the cap
-        const float a = knobAngle(t);
-        const ImVec2 dir(std::sin(a), -std::cos(a));
-        dl->AddLine(ImVec2(c.x + dir.x * capR * 0.15f, c.y + dir.y * capR * 0.15f),
-                    ImVec2(c.x + dir.x * capR * 0.95f, c.y + dir.y * capR * 0.95f),
-                    IM_COL32(25, 25, 27, 255), 3.0f * s);
-
-        if (hovered || active)
-        {
-            char buf[32];
-            std::snprintf(buf, sizeof(buf), stepped ? "%.0f" : "%.2f", values[param]);
-            text(dl, cx, cy + radius + 9.0f, 10.0f, kColWhiteDim, buf, 0);
-        }
+        panel.knob(id, param, minV, maxV, cx, cy, radius,
+                   values[param], kParamDefaults[param], stepped, panelTicks,
+                   stepped ? "%.0f" : "%.2f");
     }
 
-    // label above a knob with a triangle marker
     void knobLabel(ImDrawList* dl, float cx, float topY, const char* l1,
-                   const char* l2 = nullptr)
+                   const char* l2 = nullptr) const
     {
-        text(dl, cx, topY, 11.0f, kColWhite, l1, 0, true);
-        if (l2 != nullptr)
-            text(dl, cx, topY + 12.0f, 11.0f, kColWhite, l2, 0, true);
-        const float ty = topY + (l2 != nullptr ? 25.0f : 14.0f);
-        dl->AddTriangleFilled(P(cx - 4.0f, ty), P(cx + 4.0f, ty), P(cx, ty + 6.0f),
-                              kColWhite);
+        panel.knobLabel(dl, cx, topY, l1, l2);
     }
 
     //--- sections ---------------------------------------------------------------------
@@ -568,9 +445,9 @@ private:
         "HEADS 2+3 + REV", "HEADS 1+3 + REV", "ALL HEADS + REV", "REVERB ONLY",
     };
 
+    duskdpf::DuskPanel panel;
     ImFont* labelFont = nullptr;
     float  values[kParamCount] = {};
-    float  dragValue = 0.0f;
     float  needlePos = 0.0f;
     float  meterLevel = 0.0f;
     int    currentPreset = -1;


### PR DESCRIPTION
## Summary

Adds **TapeMachine 2** (the DPF/Dear-ImGui successor to the JUCE TapeMachine) and completes the **shared-dpf** extraction it builds on — tape-echo and 4k-eq are migrated onto the shared DSP/UI primitives with their audio and rendered UI proven unchanged.

> **Scope note:** this branch is **33 commits** off `main`, not only the TapeMachine work. It bundles three things (each in its own commits, independently revertable): the shared-dpf extraction, the tape-echo/4k-eq migration onto it, and TapeMachine 2. If you'd rather land the shared-dpf extraction as its own PR first, say so and I'll split.

## What's in it

**Shared-dpf extraction / consolidation**
- New shared DSP: `DuskSVF` (TPT SVF), `Biquad::shelfSlope1` (exact shelf), `DuskAccessBridge` (weak-symbol meter macro).
- **tape-echo** migrated to consume `shared-dpf/dsp` + render through `duskdpf::DuskPanel`; adopts `DuskDpfPlugin.cmake`.
- **4k-eq** `*Access.hpp` migrated onto `DuskAccessBridge`.

**TapeMachine 2 (new plugin)** — framework-free `TapeMachineDSP` ported from the JUCE `ImprovedTapeEmulation` (Jiles-Atherton hysteresis, NAB/CCIR/AES EQ, head/gap/bias filters, wow/flutter, 2×/4× oversampling), A/B-validated vs the JUCE build (THD within ~1%, midrange ±0.1 dB), pluginval strictness-8 SUCCESS. Distinct plugin IDs; JUCE build untouched.

**UI — Phase 1 (usability):** persistent value read-outs + full knob interaction (drag / shift-fine / wheel / double-click-type / right- & Cmd-reset) centralised in shared `DuskPanel::knob`; BIAS reads relative; functional grouping into GAIN STAGING / TAPE CHARACTER / TRANSPORT / FILTERS with tooltips; per-meter clip lamp; factory presets + prev/next/INIT + user Save (global file library).

**UI — Phase 2 (aesthetics):** brushed-metal chassis (pure-vector gradient, no new raster asset); machine-aware accent + badge (A800 cool / ATR-102 warm); section cells balance the toggle asymmetry.

**UI — Phase 3:** HiDPI multi-size crisp font atlas; machine authenticity **soft-signal** (off-machine speed/EQ/tape flagged amber + tooltip, never gated); IN/OUT meter switch and a drive visualiser were deliberately dropped (see decisions).

## Safety guarantee — tape-echo & 4k-eq behaviour unchanged

- **Parameter tables (AUDIT 1):** `TapeEchoParams/Plugin` and `FourKEQParams/Plugin` are **untouched** vs `main` (name-only diff empty; no `initParameter`/symbol/range/hint lines in the diff). TapeMachine's table is new (no `main` counterpart). Meter data uses atomics + weak accessors, **not** DPF parameters — so saved automation/state is unaffected.
- **Shared `DuskPanel::knob` is opt-in (AUDIT 2, source-authoritative):** the change is trailing default-off params (`persistent=false, tooltip=null, rightClickReset=false, dispMul=1, dispAdd=0, name=null`) + branches gated on them. tape-echo/4k-eq call-sites pass **none** of them. `DuskAccessBridge` expands to the identical weak declarations. `DuskSVF` is TapeMachine-only; `shelfSlope1` is additive (4k-eq unused).
- **AUDIT 2 binary:** the compiled `*UI.cpp.o` objects **differ** — expected and honest: `knob()` is an *inline* header method, so extending its body recompiles callers even when the new code is dead-for-them (gated branches never taken; `value*1.0f+0.0f` isn't FP-foldable to `value`). This is codegen, not behaviour. Confirmed behaviourally: tape-echo's rendered UI is **pixel-identical** (ImageMagick AE = **0**) between HEAD and the pre-UI-phase header.
- **tape-echo audio:** the earlier DSP consolidation is **bit-identical** to pre-consolidation (`max|diff| == 0` over the offline null probe). tape-echo's *UI* did intentionally move to `DuskPanel` (documented deltas: hover value bubble, double-click-to-type).

## Testing
- **Builds:** clean build of all three plugins, every Makefile format (CLAP/VST3/LV2/JACK) — **0 warnings from our code** (AUDIT 3; only pre-existing DPF/imgui dep warnings, present on `main`).
- **TapeMachine A/B** vs installed JUCE `TapeMachine.vst3` via the render tool; **pluginval s8 SUCCESS**; **user-preset Save verified end-to-end under Xvfb** (writes the correct `.tmpreset`, header shows it).
- **AUDIT 1** param-stability: empty diff for tape-echo/4k param tables.

## Decisions log
- **Machine authenticity = soft-signal, non-destructive.** Nothing is gated; a MACHINE switch re-evaluates the tag only and writes no other parameter (verified) — so it can't strand saved automation. Off-machine combos flag amber + "still fully modelled" tooltip on the dropdown itself.
- **Brushed metal = vector gradient**, not a baked texture — keeps the font atlas the only raster asset.
- **Single INPUT meter tapped post-input-trim / pre-saturation** (record/drive level); OUTPUT meter post-output-trim; over-lamp is OUTPUT-only (true ≥0 dBFS clip). INPUT red = wanted drive, so its lamp is disabled, not recalibrated.
- **Dropped the IN/OUT meter switch and the drive visualiser** as category integrity — this is a tape machine, not a distortion box; saturation comes from driving the input, which the INPUT meter already shows. Switch code kept (unused `drawMeterSwitch()`).

## Known limitation
- **Runtime DPI-scale change** (dragging the window between Retina/non-Retina mid-session) is intentionally not rebaked — rare, soft failure (blurry until reopen, nothing strands). Bounded fix = hook the wrapper's scale-change callback + rebuild the `CrispFontSet`. Documented at the ctor bake.

## Reverting
Per-item commits give independent revert handles — the Phase-2 aesthetics commits are separable from the Phase-1 UX commits, and the shared-dpf extraction is separable from TapeMachine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TapeMachine 2, including its standalone framework-free DSP core, DPF plugin, ImGui UI, and built-in preset system with VU metering.
  * Introduced a shared DSP/UI accessor bridge for same-process meter reads (used across 4k-eq and Tape Echo).
  * Added shared DSP building blocks and filter enhancements used by multiple plugins.
* **Bug Fixes**
  * Improved split-layout meter/access behavior by making UI accessors consistently safe to call.
  * Updated Tape Echo processing and UI rendering to use shared denormal handling, filters, and the shared panel widget system.
* **Documentation**
  * Added detailed porting notes for the TapeMachine DSP core.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->