### PR TITLE
fix: do not clutter home directory on linux

### DIFF
--- a/plugins/shared/ScalableEditorHelper.h
+++ b/plugins/shared/ScalableEditorHelper.h
@@ -212,12 +212,25 @@ private:
             options.applicationName = "DuskAudio";
             options.filenameSuffix = ".settings";
             options.osxLibrarySubFolder = "Application Support";
-            #if JUCE_LINUX
-               options.folderName = ".config/DuskAudio";
-            #else
-               options.folderName = "DuskAudio";
-            #endif
-               appProps.setStorageParameters(options);
+           #if JUCE_LINUX
+            options.folderName = ".config/DuskAudio";
+
+            // Older builds stored settings in ~/DuskAudio; move them so
+            // existing users keep their saved window sizes.
+            auto oldFile = juce::File::getSpecialLocation(juce::File::userHomeDirectory)
+                               .getChildFile("DuskAudio")
+                               .getChildFile("DuskAudio.settings");
+            auto newFile = options.getDefaultFile();
+            if (oldFile.existsAsFile() && !newFile.exists())
+            {
+                newFile.getParentDirectory().createDirectory();
+                if (oldFile.moveFileTo(newFile))
+                    oldFile.getParentDirectory().deleteFile(); // rmdir: only removes ~/DuskAudio if now empty
+            }
+           #else
+            options.folderName = "DuskAudio";
+           #endif
+            appProps.setStorageParameters(options);
             initialized = true;
         }
 

--- a/plugins/shared/ScalableEditorHelper.h
+++ b/plugins/shared/ScalableEditorHelper.h
@@ -210,10 +210,14 @@ private:
         {
             juce::PropertiesFile::Options options;
             options.applicationName = "DuskAudio";
-            options.folderName = "DuskAudio";
             options.filenameSuffix = ".settings";
             options.osxLibrarySubFolder = "Application Support";
-            appProps.setStorageParameters(options);
+            #if JUCE_LINUX
+               options.folderName = ".config/DuskAudio";
+            #else
+               options.folderName = "DuskAudio";
+            #endif
+               appProps.setStorageParameters(options);
             initialized = true;
         }
 


### PR DESCRIPTION
Hello and thank you for the plugins,

In this PR I include a shared fix for all plugins so that
* DuskAudio configuration folder gets created and used from `$HOME/.config/DuskAudio` instead  of `$HOME/DuskAudio`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated app settings storage on Linux to use the standard hidden configuration folder (improving consistency with other desktop apps).
  * Preserved existing settings behavior on other platforms.
  * Automatically migrates older Linux settings from the previous location to the new default path when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->