### PR TITLE
multi-comp: JUCE-free UniversalCompressorDSP core (Opto/FET/VCA/Bus)

### DIFF
--- a/plugins/multi-comp/core/BusCompressor.hpp
+++ b/plugins/multi-comp/core/BusCompressor.hpp
@@ -159,8 +159,9 @@ inline void BusCompressor::prepare (double sampleRate, int numChannels, int bloc
     calibrateHardwareGain();
 }
 
-// Lightweight sample rate update — only recalculates filter coefficients,
-// no memory allocation. Safe to call from audio thread when oversampling changes.
+// Control-thread only: recalibrates the emulation chain (thousands of samples
+// of warmup + measurement sine through the transformers) — far too heavy for
+// the audio callback. The top level calls it from prepare() only.
 inline void BusCompressor::updateSampleRate (double newSampleRate)
 {
     if (newSampleRate <= 0.0 || newSampleRate == sampleRate)

--- a/plugins/multi-comp/core/BusCompressor.hpp
+++ b/plugins/multi-comp/core/BusCompressor.hpp
@@ -1,0 +1,491 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// BusCompressor.hpp — no-framework port of UniversalCompressor::BusCompressor
+// (multicomp.cpp L2529–L2957). Every constant, coefficient and per-sample op
+// order preserved from the original. Substitutions recorded in core/PORT_NOTES.md.
+
+#pragma once
+
+#include "UniversalCompressorServices.hpp"
+#include "../HardwareEmulation/TransformerEmulation.h"
+#include "../HardwareEmulation/ConvolutionEngine.h"
+
+namespace duskaudio
+{
+
+class BusCompressor
+{
+public:
+    // NOTE: prepare() takes a blockSize (default 512) — the source sizes an
+    // internal RMS/scratch on it. The top level passes the oversampled block size.
+    void prepare (double sampleRate, int numChannels, int blockSize = 512);
+    void updateSampleRate (double newSampleRate);
+
+    // process(): RT / per-sample. Used for the unlinked / mono path.
+    //   threshold    : bus_threshold (dB)
+    //   ratio        : resolved ratio value (2.0 / 4.0 / 10.0) from bus_ratio choice
+    //   attackIndex  : bus_attack  choice index (0..5)
+    //   releaseIndex : bus_release choice index (0..4)
+    //   makeupGain   : bus_makeup (dB, 0 == unity; caller forces 0 under auto-makeup)
+    //   mixAmount    : bus_mix (0..1) — the mode's own parallel mix
+    float process (float input, int channel, float threshold, float ratio,
+                   int attackIndex, int releaseIndex, float makeupGain, float mixAmount = 1.0f,
+                   bool oversample = false, float sidechainSignal = 0.0f, bool useExternalSidechain = false);
+
+    // processStereoLinked(): RT / per-block. True stereo-link path — one shared
+    // sidechain drives both VCAs. postGain is the top level's compensationGain
+    // (1.0 on the non-oversampled strip path). extScL/extScR carry the pre-built
+    // linked sidechain (read only when useExternalSidechain is true).
+    void processStereoLinked (float* dataL, float* dataR, int numSamples,
+                              float threshold, float ratio,
+                              int attackIndex, int releaseIndex,
+                              float makeupGain, float postGain, float stereoLinkAmount,
+                              const float* extScL, const float* extScR,
+                              bool useExternalSidechain);
+
+    float getGainReduction (int channel) const;
+
+    void reset();
+
+private:
+    struct Detector
+    {
+        float envelope = 1.0f;
+        float rms = 0.0f;
+        float previousLevel = 0.0f; // For auto-release tracking
+        float hpState = 0.0f;       // Simple highpass filter state (1st pole)
+        float prevInput = 0.0f;     // Previous input for filter (1st pole)
+        float hpState2 = 0.0f;      // Second pole state (12dB/oct total)
+        float prevInput2 = 0.0f;    // Previous input for second pole
+        float prevCompressed = 0.0f; // Feedback topology: previous compressed output
+    };
+
+    // Feedback sidechain: 60Hz 2-pole HPF on the previous compressed output, rectified.
+    float busHpRectify (Detector& d)
+    {
+        const float fb = d.prevCompressed;
+        const float sr = static_cast<float> (sampleRate);
+        const float alpha = 1.0f / (1.0f + 6.2831853f * 60.0f / sr);
+        d.hpState   = alpha * (d.hpState + fb - d.prevInput);
+        d.prevInput = fb;
+        const float firstPole = d.hpState;
+        d.hpState2   = alpha * (d.hpState2 + firstPole - d.prevInput2);
+        d.prevInput2 = firstPole;
+        return std::abs (d.hpState2);
+    }
+
+    // RMS averaging of the rectified sidechain — the bus detector averages
+    // (RMS), it is not a peak follower; this is what gives the smooth "glue".
+    float busRms (Detector& d, float rectified)
+    {
+        const float sr = static_cast<float> (sampleRate);
+        const float rmsCoeff = std::exp (-1.0f / jmax (1.0f, Constants::BUS_RMS_TIME * sr));
+        d.rms = rmsCoeff * d.rms + (1.0f - rmsCoeff) * rectified * rectified;
+        return std::sqrt (jmax (0.0f, d.rms));
+    }
+
+    // Over-easy (soft-knee) gain computer over BUS_OVEREASY_KNEE_WIDTH dB — the
+    // bus knee, replacing the old hard knee.
+    float busReduction (float detectionLevel, float thresholdLin, float ratio)
+    {
+        const float overThreshDb = gainToDb (
+            jmax (detectionLevel, 1.0e-9f) / thresholdLin);
+        const float reductionRatio = 1.0f - 1.0f / ratio;
+        const float knee = Constants::BUS_OVEREASY_KNEE_WIDTH;
+        float reduction;
+        if (overThreshDb <= -knee * 0.5f)
+            reduction = 0.0f;
+        else if (overThreshDb >= knee * 0.5f)
+            reduction = overThreshDb * reductionRatio;
+        else
+        {
+            const float x = overThreshDb + knee * 0.5f;   // 0..knee inside the knee
+            reduction = reductionRatio * (x * x) / (2.0f * knee);
+        }
+        return jmin (reduction, Constants::BUS_MAX_REDUCTION_DB);
+    }
+
+    void calibrateHardwareGain();
+
+    std::vector<Detector> detectors;
+    double sampleRate = 0.0;  // Set by prepare() from DAW
+
+    // Hardware emulation components (VCA bus compressor style)
+    HardwareEmulation::TransformerEmulation inputTransformer;
+    HardwareEmulation::TransformerEmulation outputTransformer;
+    HardwareEmulation::StereoConvolution convolution;
+    float hardwareGainCompensation = 1.0f;
+};
+
+//==============================================================================
+inline void BusCompressor::prepare (double sampleRate, int numChannels, int blockSize)
+{
+    if (sampleRate <= 0.0 || numChannels <= 0 || blockSize <= 0)
+        return;
+
+    this->sampleRate = sampleRate;
+    detectors.clear();
+    detectors.resize ((size_t) numChannels);
+
+    for (int ch = 0; ch < numChannels; ++ch)
+    {
+        auto& detector = detectors[(size_t) ch];
+        detector.envelope = 1.0f;
+        detector.rms = 0.0f;
+        detector.previousLevel = 0.0f;
+        detector.hpState = 0.0f;
+        detector.prevInput = 0.0f;
+        detector.hpState2 = 0.0f;
+        detector.prevInput2 = 0.0f;
+        detector.prevCompressed = 0.0f;
+    }
+
+    // Hardware emulation components (VCA bus compressor style)
+    // Input transformer (console-style)
+    inputTransformer.prepare (sampleRate, numChannels);
+    inputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getConsoleBus().inputTransformer);
+    inputTransformer.setEnabled (true);
+
+    // Output transformer
+    outputTransformer.prepare (sampleRate, numChannels);
+    outputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getConsoleBus().outputTransformer);
+    outputTransformer.setEnabled (true);
+
+    // Short convolution for console coloration
+    convolution.prepare (sampleRate);
+    convolution.loadTransformerIR (HardwareEmulation::ShortConvolution::TransformerType::Console_Bus);
+
+    // Calibrate hardware gain compensation for the full analog chain
+    calibrateHardwareGain();
+}
+
+// Lightweight sample rate update — only recalculates filter coefficients,
+// no memory allocation. Safe to call from audio thread when oversampling changes.
+inline void BusCompressor::updateSampleRate (double newSampleRate)
+{
+    if (newSampleRate <= 0.0 || newSampleRate == sampleRate)
+        return;
+    sampleRate = newSampleRate;
+
+    // Update transformer and convolution filter coefficients
+    inputTransformer.prepare (sampleRate, static_cast<int> (detectors.size()));
+    inputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getConsoleBus().inputTransformer);
+    outputTransformer.prepare (sampleRate, static_cast<int> (detectors.size()));
+    outputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getConsoleBus().outputTransformer);
+    convolution.prepare (sampleRate);
+    convolution.loadTransformerIR (HardwareEmulation::ShortConvolution::TransformerType::Console_Bus);
+    calibrateHardwareGain();
+}
+
+inline float BusCompressor::process (float input, int channel, float threshold, float ratio,
+                                     int attackIndex, int releaseIndex, float makeupGain, float mixAmount,
+                                     bool oversample, float sidechainSignal, bool useExternalSidechain)
+{
+    if (channel >= static_cast<int> (detectors.size()))
+        return input;
+
+    // Safety check for sample rate
+    if (sampleRate <= 0.0)
+        return input;
+
+    auto& detector = detectors[(size_t) channel];
+
+    // Hardware emulation: Input transformer (console-style)
+    // Adds subtle saturation and frequency-dependent coloration
+    float transformedInput = inputTransformer.processSample (input, channel);
+
+    // Bus Compressor quad VCA topology
+    // Uses parallel detection path with feedback design (sidechain taps compressed output)
+
+    // Sidechain detection: external or feedback (HP-filtered previous output),
+    // RMS-averaged for the smooth/averaging response.
+    const float rectified = useExternalSidechain ? std::abs (sidechainSignal)
+                                                  : busHpRectify (detector);
+    float detectionLevel = busRms (detector, rectified);
+
+    // Bus Compressor specific ratios: 2:1, 4:1, 10:1
+    // ratio parameter already contains the actual ratio value (2.0, 4.0, or 10.0)
+    float actualRatio = ratio;
+
+    float thresholdLin = dbToGain (threshold);
+
+    // Over-easy (soft-knee) gain computer — the "glue" knee.
+    float reduction = busReduction (detectionLevel, thresholdLin, actualRatio);
+
+    // Bus Compressor attack and release times
+    std::array<float, 6> attackTimes = {0.1f, 0.3f, 1.0f, 3.0f, 10.0f, 30.0f}; // ms
+    std::array<float, 5> releaseTimes = {100.0f, 300.0f, 600.0f, 1200.0f, -1.0f}; // ms, -1 = auto
+
+    float attackTime = attackTimes[(size_t) jlimit (0, 5, attackIndex)] * 0.001f;
+    float releaseTime = releaseTimes[(size_t) jlimit (0, 4, releaseIndex)] * 0.001f;
+
+    // Bus Auto-release mode - program-dependent (150-450ms range)
+    if (releaseTime < 0.0f)
+    {
+        // Hardware-accurate Bus auto-release: 150ms to 450ms based on program
+        // Faster for transient-dense material, slower for sustained compression
+
+        // Track signal dynamics
+        float signalDelta = std::abs (detectionLevel - detector.previousLevel);
+        detector.previousLevel = detector.previousLevel * 0.95f + detectionLevel * 0.05f;
+
+        // Transient density: high delta = drums/percussion, low delta = sustained
+        float transientDensity = jlimit (0.0f, 1.0f, signalDelta * 20.0f);
+
+        // Compression amount factor: more compression = slower release
+        float compressionFactor = jlimit (0.0f, 1.0f, reduction / 12.0f); // 0dB to 12dB
+
+        // Bus auto-release formula (150ms to 450ms)
+        // Transient material: faster release (150-250ms)
+        // Sustained material with heavy compression: slower release (300-450ms)
+        float minRelease = 0.15f;  // 150ms
+        float maxRelease = 0.45f;  // 450ms
+
+        // Calculate release time based on material and compression
+        float sustainedFactor = (1.0f - transientDensity) * compressionFactor;
+        releaseTime = minRelease + (sustainedFactor * (maxRelease - minRelease));
+    }
+
+    // Bus Compressor envelope following with smooth response
+    float targetGain = dbToGain (-reduction);
+
+    if (targetGain < detector.envelope)
+    {
+        // Attack phase — exponential envelope for authentic snap
+        float attackCoeff = std::exp (-1.0f / jmax (1.0f, attackTime * static_cast<float> (sampleRate)));
+        detector.envelope = targetGain + (detector.envelope - targetGain) * attackCoeff;
+    }
+    else
+    {
+        // Release phase — exponential envelope for smooth recovery
+        float releaseCoeff = std::exp (-1.0f / jmax (1.0f, releaseTime * static_cast<float> (sampleRate)));
+        detector.envelope = targetGain + (detector.envelope - targetGain) * releaseCoeff;
+    }
+
+    // NaN/Inf safety check
+    if (std::isnan (detector.envelope) || std::isinf (detector.envelope))
+        detector.envelope = 1.0f;
+
+    // Apply the gain reduction envelope to the input signal
+    float compressed = transformedInput * detector.envelope;
+    detector.prevCompressed = compressed;  // Store for feedback sidechain
+
+    // Bus Compressor Output Stage - Subtle console saturation
+    // Spec from compressor_specs.json: < 0.3% THD
+    // The VCA bus is a clean VCA design, but the console path adds character.
+    // Console transformers add subtle 2nd harmonic warmth.
+    //
+    // Harmonic math: For input x = A*sin(wt)
+    // - k2*x^2 produces 2nd harmonic at (k2*A^2/2) amplitude
+    // - k3*x^3 produces 3rd harmonic at (3*k3*A^3)/4 amplitude
+    // Target: ~0.15-0.2% THD at typical levels
+
+    float processed = compressed;
+
+    // Console saturation - 2nd harmonic dominant from transformers
+    // k2 = 0.004 gives ~0.2% 2nd harmonic at moderate levels
+    // k3 = 0.003 gives subtle 3rd harmonic for "glue"
+    constexpr float k2 = 0.004f;   // 2nd harmonic coefficient (asymmetric warmth)
+    constexpr float k3 = 0.003f;   // 3rd harmonic coefficient (symmetric glue)
+
+    // Apply waveshaping: y = x + k2*x^2 + k3*x^3
+    float x2 = processed * processed;
+    float x3 = x2 * processed;
+    processed = processed + k2 * x2 + k3 * x3;
+
+    // Bus output transformer — console iron coloration
+    processed = outputTransformer.processSample (processed, channel);
+
+    // Console transformer frequency response (short convolution — 2.5kHz punch, HF extension)
+    processed = convolution.processSample (processed, channel);
+
+    // Hardware gain compensation (measured at prepare time)
+    processed *= hardwareGainCompensation;
+
+    // Apply makeup gain
+    float output = processed * dbToGain (makeupGain);
+
+    // Note: Mix/parallel compression is now handled globally at the end of processBlock
+    // for consistency across all compressor modes (mixAmount parameter kept for API compatibility)
+    (void) mixAmount;   // Suppress unused warning
+    (void) oversample;
+
+    // Final output limiting
+    return jlimit (-Constants::OUTPUT_HARD_LIMIT, Constants::OUTPUT_HARD_LIMIT, output);
+}
+
+// Stereo-linked bus processing — true stereo-link behaviour: the sidechain is
+// shared across the L/R pair so an asymmetric stereo signal never pulls the
+// image. The per-channel process() above runs in a channel-outer loop and so
+// can't share feedback state; this processes the L/R pair in lockstep.
+// Each channel's detection is blended toward the pair's max by
+// stereoLinkAmount: 100% = both see the max → identical gain (full link),
+// less = the channels partially diverge (matching the continuous link knob
+// the other modes honour). Feedback topology is preserved.
+inline void BusCompressor::processStereoLinked (float* dataL, float* dataR, int numSamples,
+                                                float threshold, float ratio,
+                                                int attackIndex, int releaseIndex,
+                                                float makeupGain, float postGain, float stereoLinkAmount,
+                                                const float* extScL, const float* extScR,
+                                                bool useExternalSidechain)
+{
+    if (detectors.size() < 2 || sampleRate <= 0.0)
+        return;
+
+    auto& dL = detectors[(size_t) 0];
+    auto& dR = detectors[(size_t) 1];
+    const float sr = static_cast<float> (sampleRate);
+    const float thresholdLin = dbToGain (threshold);
+    const float linkAmt = jlimit (0.0f, 1.0f, stereoLinkAmount);
+    const std::array<float, 6> attackTimes  = { 0.1f, 0.3f, 1.0f, 3.0f, 10.0f, 30.0f };
+    const std::array<float, 5> releaseTimes = { 100.0f, 300.0f, 600.0f, 1200.0f, -1.0f };
+    const float attackTime  = attackTimes[(size_t) jlimit (0, 5, attackIndex)] * 0.001f;
+    const float baseRelease = releaseTimes[(size_t) jlimit (0, 4, releaseIndex)] * 0.001f;
+    constexpr float k2 = 0.004f, k3 = 0.003f;
+
+    // Output stage (console harmonics + transformer + IR + makeup), per channel.
+    auto outStage = [this, k2, k3] (float compressed, int ch, float makeup)
+    {
+        float p = compressed;
+        const float x2 = p * p, x3 = x2 * p;
+        p = p + k2 * x2 + k3 * x3;
+        p = outputTransformer.processSample (p, ch);
+        p = convolution.processSample (p, ch);
+        p *= hardwareGainCompensation;
+        const float out = p * dbToGain (makeup);
+        return jlimit (-Constants::OUTPUT_HARD_LIMIT, Constants::OUTPUT_HARD_LIMIT, out);
+    };
+
+    // Advance one channel's envelope from its (link-blended) detection and
+    // return the gain. At link=100% both channels get the same detection and
+    // converge to identical gain (true link); below they partially diverge.
+    auto advance = [&] (Detector& d, float detUsed) -> float
+    {
+        const float reduction = busReduction (detUsed, thresholdLin, ratio);
+        float releaseTime = baseRelease;
+        if (releaseTime < 0.0f)   // Auto: program-dependent 150-450ms, per channel
+        {
+            const float signalDelta = std::abs (detUsed - d.previousLevel);
+            d.previousLevel = d.previousLevel * 0.95f + detUsed * 0.05f;
+            const float transientDensity  = jlimit (0.0f, 1.0f, signalDelta * 20.0f);
+            const float compressionFactor = jlimit (0.0f, 1.0f, reduction / 12.0f);
+            releaseTime = 0.15f + (1.0f - transientDensity) * compressionFactor * (0.45f - 0.15f);
+        }
+        const float targetGain = dbToGain (-reduction);
+        float& env = d.envelope;
+        if (targetGain < env)
+            env = targetGain + (env - targetGain) * std::exp (-1.0f / jmax (1.0f, attackTime  * sr));
+        else
+            env = targetGain + (env - targetGain) * std::exp (-1.0f / jmax (1.0f, releaseTime * sr));
+        if (std::isnan (env) || std::isinf (env))
+            env = 1.0f;
+        return env;
+    };
+
+    for (int i = 0; i < numSamples; ++i)
+    {
+        const float tL = inputTransformer.processSample (dataL[i], 0);
+        const float tR = inputTransformer.processSample (dataR[i], 1);
+
+        // Per-channel RMS detection (external or HP-filtered feedback), each
+        // blended toward the pair's max by the link amount.
+        const float detL = busRms (dL, useExternalSidechain ? std::abs (extScL[i]) : busHpRectify (dL));
+        const float detR = busRms (dR, useExternalSidechain ? std::abs (extScR[i]) : busHpRectify (dR));
+        const float linked = jmax (detL, detR);
+        const float useL = detL * (1.0f - linkAmt) + linked * linkAmt;
+        const float useR = detR * (1.0f - linkAmt) + linked * linkAmt;
+
+        const float envL = advance (dL, useL);
+        const float envR = advance (dR, useR);
+
+        const float cL = tL * envL;
+        const float cR = tR * envR;
+        dL.prevCompressed = cL;   // feedback taps
+        dR.prevCompressed = cR;
+
+        dataL[i] = outStage (cL, 0, makeupGain) * postGain;
+        dataR[i] = outStage (cR, 1, makeupGain) * postGain;
+    }
+}
+
+inline float BusCompressor::getGainReduction (int channel) const
+{
+    if (channel >= static_cast<int> (detectors.size()))
+        return 0.0f;
+    return gainToDb (detectors[(size_t) channel].envelope);
+}
+
+inline void BusCompressor::reset()
+{
+    for (auto& detector : detectors)
+    {
+        detector.envelope = 1.0f;
+        detector.rms = 0.0f;
+        detector.previousLevel = 0.0f;
+        detector.hpState = 0.0f;
+        detector.prevInput = 0.0f;
+        detector.hpState2 = 0.0f;
+        detector.prevInput2 = 0.0f;
+        detector.prevCompressed = 0.0f;
+    }
+    inputTransformer.reset();
+    outputTransformer.reset();
+    convolution.reset();
+}
+
+inline void BusCompressor::calibrateHardwareGain()
+{
+    constexpr int calibrationSamples = 4800;
+    constexpr float refAmplitude = 0.126f;
+    constexpr float refFreq = 1000.0f;
+
+    float sr = static_cast<float> (sampleRate);
+    float angularStep = 2.0f * kPiF * refFreq / sr;
+
+    inputTransformer.reset();
+    outputTransformer.reset();
+
+    // Calibrate using channel 0 only — both channels have identical IR
+    int warmup = static_cast<int> (sr * 0.05f);
+    for (int i = 0; i < warmup; ++i)
+    {
+        float x = refAmplitude * std::sin (angularStep * static_cast<float> (i));
+        x = inputTransformer.processSample (x, 0);
+        x = outputTransformer.processSample (x, 0);
+        convolution.processSample (x, 0);
+    }
+
+    double inputRmsSquared = 0.0;
+    double outputRmsSquared = 0.0;
+    for (int i = 0; i < calibrationSamples; ++i)
+    {
+        float phase = angularStep * static_cast<float> (warmup + i);
+        float input = refAmplitude * std::sin (phase);
+
+        float x = inputTransformer.processSample (input, 0);
+        x = outputTransformer.processSample (x, 0);
+        x = convolution.processSample (x, 0);
+
+        inputRmsSquared += static_cast<double> (input * input);
+        outputRmsSquared += static_cast<double> (x * x);
+    }
+
+    inputRmsSquared /= calibrationSamples;
+    outputRmsSquared /= calibrationSamples;
+
+    if (outputRmsSquared > 1e-12 && inputRmsSquared > 1e-12)
+    {
+        float chainGain = static_cast<float> (std::sqrt (outputRmsSquared / inputRmsSquared));
+        hardwareGainCompensation = 1.0f / chainGain;
+    }
+    else
+    {
+        hardwareGainCompensation = 1.0f;
+    }
+
+    inputTransformer.reset();
+    outputTransformer.reset();
+    convolution.reset();
+}
+
+} // namespace duskaudio

--- a/plugins/multi-comp/core/FETCompressor.hpp
+++ b/plugins/multi-comp/core/FETCompressor.hpp
@@ -1,0 +1,512 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// FETCompressor.hpp — no-JUCE port of UniversalCompressor::FETCompressor
+// (multicomp.cpp L1637–L2165).
+
+#pragma once
+
+#include "UniversalCompressorServices.hpp"   // LookupTables, TransientShaper, Constants
+
+#include "../HardwareEmulation/TransformerEmulation.h"   // + HardwareProfiles, WaveshaperCurves
+#include "../HardwareEmulation/ConvolutionEngine.h"      // StereoConvolution / ShortConvolution
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+namespace duskaudio
+{
+
+class FETCompressor
+{
+public:
+    void prepare (double sampleRate, int numChannels);
+    void updateSampleRate (double newSampleRate);
+
+    // process(): RT / per-sample. Multi-line signature preserved verbatim from
+    // the source; defaults match the JUCE original.
+    //   inputGainDb  : fet_input   (dB)
+    //   outputGainDb : fet_output  (dB, 0 == unity; caller forces 0 under auto-makeup)
+    //   attackMs     : fet_attack  (ms)
+    //   releaseMs    : fet_release (ms)
+    //   ratioIndex   : fet_ratio   (0=4:1,1=8:1,2=12:1,3=20:1,4=All)
+    //   lookupTables/transientShaper : owned by the top level, passed in
+    //   useMeasuredCurve : fet_curve_mode (0=Modern,1=Measured)
+    //   transientSensitivity : fet_transient (0..100; 0 on the strip path)
+    //   thresholdDb  : fet_threshold (dBFS), defaults to the fixed -10 dB
+    float process (float input, int channel, float inputGainDb, float outputGainDb,
+                   float attackMs, float releaseMs, int ratioIndex, bool oversample = false,
+                   const LookupTables* lookupTables = nullptr, TransientShaper* transientShaper = nullptr,
+                   bool useMeasuredCurve = false, float transientSensitivity = 0.0f,
+                   float sidechainSignal = 0.0f, bool useExternalSidechain = false,
+                   float thresholdDb = Constants::FET_THRESHOLD_DB);
+
+    float getGainReduction (int channel) const;
+
+    void reset();
+
+private:
+    struct Detector
+    {
+        float envelope = 1.0f;
+        float prevOutput = 0.0f;
+        float previousLevel = 0.0f;
+        float modulationPhase = 0.0f;
+        float modulationRate = 4.5f;
+        float dcState = 0.0f;
+        float prevSq = 0.0f;
+        float peakHold = 0.0f;
+        int transientCounter = 0;
+        float releaseMemory = 0.0f;
+        float voltageSag = 0.0f;
+        int sagCounter = 0;
+        float hfChokeState = 0.0f;
+        float tiltState = 0.0f;
+        float subBassHpState = 0.0f;
+    };
+
+    // Calibrate the analog chain (input xfmr + output xfmr + convolution) so it
+    // is level-neutral at unity. Main-thread only (sweeps a warm-up sine).
+    void calibrateHardwareGain()
+    {
+        constexpr int calibrationSamples = 4800;
+        constexpr float refAmplitude = 0.126f;  // -18dB peak
+        constexpr float refFreq = 1000.0f;
+
+        float sr = static_cast<float>(sampleRate);
+        float angularStep = 2.0f * kPiF * refFreq / sr;
+
+        inputTransformer.reset();
+        outputTransformer.reset();
+
+        int warmup = static_cast<int>(sr * 0.05f);
+        for (int i = 0; i < warmup; ++i)
+        {
+            float x = refAmplitude * std::sin(angularStep * static_cast<float>(i));
+            x = inputTransformer.processSample(x, 0);
+            x = outputTransformer.processSample(x, 0);
+            convolution.processSample(x, 0);
+        }
+
+        double inputRmsSquared = 0.0;
+        double outputRmsSquared = 0.0;
+        for (int i = 0; i < calibrationSamples; ++i)
+        {
+            float phase = angularStep * static_cast<float>(warmup + i);
+            float input = refAmplitude * std::sin(phase);
+
+            float x = inputTransformer.processSample(input, 0);
+            x = outputTransformer.processSample(x, 0);
+            x = convolution.processSample(x, 0);
+
+            inputRmsSquared += static_cast<double>(input * input);
+            outputRmsSquared += static_cast<double>(x * x);
+        }
+
+        inputRmsSquared /= calibrationSamples;
+        outputRmsSquared /= calibrationSamples;
+
+        if (outputRmsSquared > 1e-12 && inputRmsSquared > 1e-12)
+        {
+            float chainGain = static_cast<float>(std::sqrt(outputRmsSquared / inputRmsSquared));
+            hardwareGainCompensation = 1.0f / chainGain;
+        }
+        else
+        {
+            hardwareGainCompensation = 1.0f;
+        }
+
+        inputTransformer.reset();
+        outputTransformer.reset();
+        convolution.reset();
+    }
+
+    std::vector<Detector> detectors;
+    double sampleRate = 0.0;
+    float hardwareGainCompensation = 1.0f;
+    float tiltCoeff = 0.0f;
+
+    HardwareEmulation::TransformerEmulation inputTransformer;
+    HardwareEmulation::TransformerEmulation outputTransformer;
+    HardwareEmulation::StereoConvolution convolution;
+};
+
+inline void FETCompressor::prepare (double sampleRate, int numChannels)
+{
+    this->sampleRate = sampleRate;
+    detectors.resize(numChannels);
+    for (auto& detector : detectors)
+    {
+        detector.envelope = 1.0f;
+        detector.prevOutput = 0.0f;
+        detector.previousLevel = 0.0f;
+        detector.modulationPhase = 0.0f;
+        detector.dcState = 0.0f;
+        detector.prevSq = 0.0f;
+        detector.peakHold = 0.0f;
+        detector.transientCounter = 0;
+        detector.releaseMemory = 0.0f;
+        detector.voltageSag = 0.0f;
+        detector.sagCounter = 0;
+        detector.hfChokeState = 0.0f;
+        detector.tiltState = 0.0f;
+        detector.subBassHpState = 0.0f;
+    }
+
+    // 1176 sidechain tilt: ~3dB/octave via 1st-order HPF at 800Hz blended with original
+    {
+        float sr = static_cast<float>(sampleRate);
+        tiltCoeff = 1.0f - std::exp(-2.0f * 3.14159f * 800.0f / sr);
+    }
+
+    inputTransformer.prepare(sampleRate, numChannels);
+    inputTransformer.setProfile(HardwareEmulation::HardwareProfiles::getFETCompressor().inputTransformer);
+    inputTransformer.setEnabled(true);
+
+    outputTransformer.prepare(sampleRate, numChannels);
+    outputTransformer.setProfile(HardwareEmulation::HardwareProfiles::getFETCompressor().outputTransformer);
+    outputTransformer.setEnabled(true);
+
+    convolution.prepare(sampleRate);
+    convolution.loadTransformerIR(HardwareEmulation::ShortConvolution::TransformerType::FET);
+
+    calibrateHardwareGain();
+}
+
+inline void FETCompressor::updateSampleRate (double newSampleRate)
+{
+    if (newSampleRate <= 0.0 || newSampleRate == sampleRate)
+        return;
+    sampleRate = newSampleRate;
+    float sr = static_cast<float>(sampleRate);
+    tiltCoeff = 1.0f - std::exp(-2.0f * 3.14159f * 800.0f / sr);
+    int numCh = static_cast<int>(detectors.size());
+    inputTransformer.prepare(sampleRate, numCh);
+    inputTransformer.setProfile(HardwareEmulation::HardwareProfiles::getFETCompressor().inputTransformer);
+    outputTransformer.prepare(sampleRate, numCh);
+    outputTransformer.setProfile(HardwareEmulation::HardwareProfiles::getFETCompressor().outputTransformer);
+    convolution.prepare(sampleRate);
+    convolution.loadTransformerIR(HardwareEmulation::ShortConvolution::TransformerType::FET);
+    calibrateHardwareGain();
+}
+
+inline float FETCompressor::process (float input, int channel, float inputGainDb, float outputGainDb,
+                                     float attackMs, float releaseMs, int ratioIndex, bool /*oversample*/,
+                                     const LookupTables* lookupTables, TransientShaper* transientShaper,
+                                     bool useMeasuredCurve, float transientSensitivity,
+                                     float sidechainSignal, bool useExternalSidechain,
+                                     float thresholdDb)
+{
+    if (channel >= static_cast<int>(detectors.size()))
+        return input;
+
+    if (sampleRate <= 0.0)
+        return input;
+
+    auto& detector = detectors[channel];
+
+    float transformedInput = inputTransformer.processSample(input, channel);
+
+    float threshold = dbToGain(thresholdDb);
+
+    float inputGainLin = dbToGain(inputGainDb);
+    float amplifiedInput = transformedInput * inputGainLin;
+
+    // Measured Rev D 1176 ratios (not the nominal panel markings). All-buttons
+    // follows its own curve below; the table entry there only clamps.
+    std::array<float, 5> ratios = {3.85f, 7.40f, 12.50f, 21.50f, 21.50f};
+    float ratio = ratios[jlimit(0, 4, ratioIndex)];
+
+    // Feedback topology: apply the PREVIOUS envelope to get the compressed signal.
+    float compressed = amplifiedInput * detector.envelope;
+
+    // FET saturation (asymmetric) before feedback detection so its nonlinearity
+    // colors what the sidechain sees.
+    float saturated = compressed;
+    float sr = static_cast<float>(sampleRate);
+    {
+        float grDb = -gainToDb(detector.envelope + 0.001f);
+        float grNorm = jlimit(0.0f, 1.0f, grDb / 20.0f);
+
+        float k2, k3;
+        if (ratioIndex == 4)
+        {
+            k2 = 0.04f + grNorm * 0.04f;
+            k3 = 0.005f + grNorm * 0.010f;
+        }
+        else
+        {
+            k2 = 0.024f + grNorm * 0.026f;
+            k3 = 0.004f + grNorm * 0.008f;
+        }
+
+        float x = saturated;
+
+        float sq = x * x;
+
+        float alpha = 1.0f / (1.0f + 6.2831853f * 10.0f / sr);
+        float h2 = alpha * (detector.dcState + sq - detector.prevSq);
+        detector.dcState = h2;
+        detector.prevSq = sq;
+
+        float h3 = x * x * x;
+        saturated = x + k2 * h2 + k3 * h3;
+    }
+
+    // HF choke for sidechain detection (FET junction capacitance): detection-only LPF.
+    float chokedSignal = saturated;
+    {
+        float grDb = -gainToDb(detector.envelope + 0.001f);
+        float grNorm = jlimit(0.0f, 1.0f, grDb / 20.0f);
+        float cornerHz = 20000.0f - grNorm * 2000.0f;
+        float w = 6.2831853f * cornerHz / sr;
+        float lpCoeff = 1.0f - std::exp(-w);
+        detector.hfChokeState += lpCoeff * (saturated - detector.hfChokeState);
+        chokedSignal = detector.hfChokeState;
+    }
+
+    float detectionLevel;
+    if (useExternalSidechain)
+    {
+        detectionLevel = std::abs(sidechainSignal * inputGainLin);
+    }
+    else if (ratioIndex == 4)
+    {
+        float instantLevel = std::abs(chokedSignal);
+
+        float detCeiling = threshold * 1.5f;
+        if (instantLevel > detCeiling)
+            instantLevel = detCeiling + (instantLevel - detCeiling) / (1.0f + (instantLevel - detCeiling));
+
+        float peakAttackCoeff = std::exp(-1.0f / (0.00005f * sr));
+        float peakReleaseCoeff = std::exp(-1.0f / (0.005f * sr));
+        if (instantLevel > detector.peakHold)
+            detector.peakHold += (1.0f - peakAttackCoeff) * (instantLevel - detector.peakHold);
+        else
+            detector.peakHold += (1.0f - peakReleaseCoeff) * (instantLevel - detector.peakHold);
+        detectionLevel = detector.peakHold;
+    }
+    else
+    {
+        detectionLevel = std::abs(chokedSignal);
+    }
+
+    // 1176 sidechain tilt: 3dB/octave HF emphasis.
+    detector.tiltState += tiltCoeff * (detectionLevel - detector.tiltState);
+    float hfContent = detectionLevel - detector.tiltState;
+    detectionLevel = std::max(detectionLevel + hfContent * 0.35f, 0.0f);
+
+    float reduction = 0.0f;
+
+    if (ratioIndex == 4)
+    {
+        // ABI threshold shift: combined resistor networks lower effective threshold by ~6dB.
+        float abiThreshold = threshold * 0.5f;
+
+        if (detectionLevel > abiThreshold)
+        {
+            float overThreshDb = gainToDb(detectionLevel / abiThreshold);
+
+            if (lookupTables != nullptr)
+            {
+                reduction = lookupTables->getAllButtonsReduction(overThreshDb, useMeasuredCurve);
+            }
+            else
+            {
+                float knee = 4.0f;
+                if (overThreshDb < knee)
+                {
+                    float t = overThreshDb / knee;
+                    reduction = overThreshDb * t * 0.95f;
+                }
+                else
+                {
+                    float baseReduction = knee * 0.95f + (overThreshDb - knee) * 0.98f;
+
+                    float wrapOnset = 14.0f;
+                    float wrapFull = 16.0f;
+                    if (overThreshDb > wrapOnset)
+                    {
+                        float wrapT = jlimit(0.0f, 1.0f, (overThreshDb - wrapOnset) / (wrapFull - wrapOnset));
+                        float smooth = wrapT * wrapT * (3.0f - 2.0f * wrapT);
+                        float excess = overThreshDb - wrapOnset;
+                        baseReduction += excess * 0.05f * smooth;
+                    }
+                    reduction = baseReduction;
+                }
+            }
+
+            if (transientShaper != nullptr && transientSensitivity > 0.01f)
+            {
+                float transientMod = transientShaper->process(input, channel, transientSensitivity);
+                reduction /= transientMod;
+            }
+
+            reduction = jmin(reduction, 30.0f);
+        }
+    }
+    else if (detectionLevel > threshold)
+    {
+        float overThreshDb = gainToDb(detectionLevel / threshold);
+        reduction = overThreshDb * (1.0f - 1.0f / ratio);
+        reduction = jmin(reduction, Constants::FET_MAX_REDUCTION_DB);
+    }
+
+    const float minRelease = 0.05f;
+    const float maxRelease = 1.1f;
+    float attackTime = jmax(0.0001f, attackMs / 1000.0f);
+    float releaseNorm = jlimit(0.0f, 1.0f, releaseMs / 1100.0f);
+    float releaseTime = minRelease * std::pow(maxRelease / minRelease, releaseNorm);
+
+    if (ratioIndex == 4)
+    {
+        attackTime = jmax(0.0002f, attackTime * 2.0f);
+
+        float reductionFactor = jlimit(0.0f, 1.0f, reduction / 20.0f);
+        releaseTime *= (1.0f + reductionFactor * 0.5f);
+
+        // Release memory: transient onsets lengthen the slow tail (sidechain cap
+        // not fully discharging between hits).
+        float memoryDecay = std::exp(-1.0f / (0.5f * sr));
+        detector.releaseMemory *= memoryDecay;
+        if (detector.transientCounter == 0 && reduction > 3.0f)
+            detector.releaseMemory = jmin(1.0f, detector.releaseMemory + 0.15f);
+        releaseTime *= (1.0f + detector.releaseMemory * 0.3f);
+    }
+
+    float programFactor = jlimit(0.5f, 2.0f, 1.0f + reduction * 0.05f);
+    float signalDelta = std::abs(detectionLevel - detector.previousLevel);
+    detector.previousLevel = detectionLevel;
+
+    if (signalDelta > 0.1f)
+    {
+        attackTime *= 0.8f;
+        releaseTime *= 1.2f;
+    }
+    else
+    {
+        attackTime *= programFactor;
+        releaseTime *= programFactor;
+    }
+
+    float targetGain = dbToGain(-reduction);
+    float attackCoeff = std::exp(-1.0f / jmax(Constants::EPSILON, attackTime * sr));
+    float releaseCoeff = std::exp(-1.0f / jmax(Constants::EPSILON, releaseTime * sr));
+
+    if (ratioIndex == 4)
+    {
+        if (targetGain < detector.envelope)
+        {
+            // ABI program-dependent attack delay: first ~30 samples use a slower
+            // attack to let the transient poke through.
+            if (detector.transientCounter < 30)
+            {
+                float delayedAttack = attackCoeff * 0.5f + 0.5f;
+                detector.envelope = delayedAttack * detector.envelope + (1.0f - delayedAttack) * targetGain;
+                detector.transientCounter++;
+            }
+            else
+            {
+                detector.envelope = attackCoeff * detector.envelope + (1.0f - attackCoeff) * targetGain;
+            }
+        }
+        else
+        {
+            detector.transientCounter = 0;
+
+            float grDb = -gainToDb(detector.envelope + 0.001f);
+
+            float fastTimeBase = 0.05f;
+            float fastTimeMin = 0.025f;
+            float grScale = jlimit(0.0f, 1.0f, grDb / 20.0f);
+            float fastTime = fastTimeBase - grScale * (fastTimeBase - fastTimeMin);
+            float fastCoeff = std::exp(-1.0f / jmax(Constants::EPSILON, fastTime * sr));
+
+            float blend = grScale;
+            float effectiveCoeff = fastCoeff * blend + releaseCoeff * (1.0f - blend);
+            detector.envelope = effectiveCoeff * detector.envelope + (1.0f - effectiveCoeff) * targetGain;
+        }
+    }
+    else
+    {
+        if (targetGain < detector.envelope)
+            detector.envelope = attackCoeff * detector.envelope + (1.0f - attackCoeff) * targetGain;
+        else
+            detector.envelope = releaseCoeff * detector.envelope + (1.0f - releaseCoeff) * targetGain;
+    }
+
+    detector.envelope = jlimit(0.001f, 1.0f, detector.envelope);
+
+    if (std::isnan(detector.envelope) || std::isinf(detector.envelope))
+        detector.envelope = 1.0f;
+
+    // Voltage sag: PSU sag under sustained heavy load (GR > 15dB for >100ms drops
+    // the ceiling ~0.75dB, recovering slowly).
+    float sagGain = 1.0f;
+    if (ratioIndex == 4)
+    {
+        float grDb = -gainToDb(detector.envelope + 0.001f);
+        int sagThresholdSamples = static_cast<int>(sr * 0.1f);
+
+        if (grDb > 15.0f)
+        {
+            detector.sagCounter = jmin(detector.sagCounter + 1, sagThresholdSamples + 1);
+        }
+        else
+        {
+            detector.sagCounter = jmax(0, detector.sagCounter - 1);
+        }
+
+        float sagTarget = (detector.sagCounter > sagThresholdSamples) ? 0.75f : 0.0f;
+
+        float sagAttack = std::exp(-1.0f / (0.05f * sr));
+        float sagRelease = std::exp(-1.0f / (0.3f * sr));
+        if (sagTarget > detector.voltageSag)
+            detector.voltageSag += (1.0f - sagAttack) * (sagTarget - detector.voltageSag);
+        else
+            detector.voltageSag += (1.0f - sagRelease) * (sagTarget - detector.voltageSag);
+
+        sagGain = dbToGain(-detector.voltageSag);
+    }
+
+    float output = saturated;
+    output = outputTransformer.processSample(output, channel);
+    output = convolution.processSample(output, channel);
+    output *= hardwareGainCompensation;
+
+    output *= sagGain;
+
+    // Sub-bass tightening: GR-driven 1-pole HPF (cutoff 20Hz off → 80Hz at 20dB GR);
+    // LPF state tracks the low end, subtract to get the HPF output.
+    {
+        float grDbHpf = -gainToDb(detector.envelope + 0.001f);
+        float grScaleHpf = jlimit(0.0f, 1.0f, grDbHpf / 20.0f);
+        float hpfCutoffHz = 20.0f + grScaleHpf * 60.0f;
+        float alpha = 1.0f - std::exp(-2.0f * kPiF * hpfCutoffHz / sr);
+        detector.subBassHpState += alpha * (output - detector.subBassHpState);
+        output -= detector.subBassHpState;
+    }
+
+    float outputGainLin = dbToGain(outputGainDb);
+    float finalOutput = output * outputGainLin;
+
+    return jlimit(-Constants::OUTPUT_HARD_LIMIT, Constants::OUTPUT_HARD_LIMIT, finalOutput);
+}
+
+inline float FETCompressor::getGainReduction (int channel) const
+{
+    if (channel >= static_cast<int>(detectors.size()))
+        return 0.0f;
+    return gainToDb(detectors[channel].envelope);
+}
+
+inline void FETCompressor::reset()
+{
+    for (auto& detector : detectors)
+        detector = Detector{};
+    inputTransformer.reset();
+    outputTransformer.reset();
+    convolution.reset();
+}
+
+} // namespace duskaudio

--- a/plugins/multi-comp/core/OptoCompressor.hpp
+++ b/plugins/multi-comp/core/OptoCompressor.hpp
@@ -1,0 +1,409 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// OptoCompressor.hpp — no-JUCE port of UniversalCompressor::OptoCompressor
+// (multicomp.cpp L1180–L1636).
+//
+// The PUBLIC interface below is FINAL — the top-level UniversalCompressorDSP
+// calls exactly these. Every constant, coefficient and per-sample op order is
+// preserved from the source. See core/PORT_NOTES.md §Mode contracts.
+
+#pragma once
+
+#include "UniversalCompressorServices.hpp"
+#include "../HardwareEmulation/TransformerEmulation.h"
+#include "../HardwareEmulation/TubeEmulation.h"
+
+#include <cmath>
+#include <vector>
+
+namespace duskaudio
+{
+
+class OptoCompressor
+{
+public:
+    void prepare (double sr, int numChannels)
+    {
+        this->sampleRate = sr;
+        detectors.resize ((size_t) numChannels);
+        for (auto& det : detectors)
+        {
+            det.elPanelLevel = 0.0f;
+            det.cellCharge = 0.0f;
+            det.phosphorGlow = 0.0f;
+            det.phosphorAfterglow = 0.0f;
+            det.accumulatedCharge = 0.0f;
+            det.smoothedConductance = 0.0f;
+            det.t4bGain = 1.0f;
+            det.shelfX1 = 0.0f;
+            det.shelfY1 = 0.0f;
+            det.t4bDcState = 0.0f;
+        }
+
+        float srf = static_cast<float> (sampleRate);
+        invSampleRate = 1.0f / srf;
+        attackCoeff = std::exp (-1.0f / (Constants::T4B_ATTACK_TIME * srf));
+        fastReleaseCoeff = std::exp (-1.0f / (Constants::T4B_FAST_RELEASE_TIME * srf));
+        phosphorDecayCoeff = std::exp (-1.0f / (Constants::T4B_PHOSPHOR_BASE_DECAY * srf));
+        {
+            float wc = 2.0f * 3.14159f * 1000.0f / srf;
+            float A = std::pow (10.0f, 3.0f / 20.0f);
+            float alpha = std::tan (wc / 2.0f);
+            float sqrtA = std::sqrt (A);
+            float norm = 1.0f / (1.0f + alpha * sqrtA);
+            shelfB0 = (A + sqrtA * alpha) * norm;
+            shelfB1 = (sqrtA * alpha - A) * norm;
+            shelfA1 = (alpha * sqrtA - 1.0f) * norm;
+        }
+        phosphorAttackCoeff = std::pow (phosphorDecayCoeff, Constants::T4B_PHOSPHOR_ATTACK_RATIO);
+        condAttackCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_CONDUCTANCE_ATTACK_FREQ / srf);
+        condReleaseCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_CONDUCTANCE_RELEASE_FREQ / srf);
+        elPanelAttackCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_EL_PANEL_ATTACK_FREQ / srf);
+        elPanelReleaseCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_EL_PANEL_RELEASE_FREQ / srf);
+        scLevelSmoothCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::SC_LEVEL_SMOOTH_FREQ / srf);
+
+        inputTransformer.prepare (sampleRate, numChannels);
+        inputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getOptoCompressor().inputTransformer);
+        inputTransformer.setEnabled (true);
+
+        outputTransformer.prepare (sampleRate, numChannels);
+        outputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getOptoCompressor().outputTransformer);
+        outputTransformer.setEnabled (true);
+
+        tubeStage.prepare (sampleRate, numChannels);
+        tubeStage.setTubeType (HardwareEmulation::TubeEmulation::TubeType::Triode_12BH7);
+        tubeStage.setDrive (0.15f);
+
+        calibrateHardwareGain();
+    }
+
+    void updateSampleRate (double newSampleRate)
+    {
+        if (newSampleRate <= 0.0 || newSampleRate == sampleRate)
+            return;
+        sampleRate = newSampleRate;
+        int numCh = static_cast<int> (detectors.size());
+
+        float srf = static_cast<float> (sampleRate);
+        invSampleRate = 1.0f / srf;
+        attackCoeff = std::exp (-1.0f / (Constants::T4B_ATTACK_TIME * srf));
+        fastReleaseCoeff = std::exp (-1.0f / (Constants::T4B_FAST_RELEASE_TIME * srf));
+        phosphorDecayCoeff = std::exp (-1.0f / (Constants::T4B_PHOSPHOR_BASE_DECAY * srf));
+        {
+            float wc = 2.0f * 3.14159f * 1000.0f / srf;
+            float A = std::pow (10.0f, 3.0f / 20.0f);
+            float alpha = std::tan (wc / 2.0f);
+            float sqrtA = std::sqrt (A);
+            float norm = 1.0f / (1.0f + alpha * sqrtA);
+            shelfB0 = (A + sqrtA * alpha) * norm;
+            shelfB1 = (sqrtA * alpha - A) * norm;
+            shelfA1 = (alpha * sqrtA - 1.0f) * norm;
+        }
+        phosphorAttackCoeff = std::pow (phosphorDecayCoeff, Constants::T4B_PHOSPHOR_ATTACK_RATIO);
+        condAttackCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_CONDUCTANCE_ATTACK_FREQ / srf);
+        condReleaseCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_CONDUCTANCE_RELEASE_FREQ / srf);
+        elPanelAttackCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_EL_PANEL_ATTACK_FREQ / srf);
+        elPanelReleaseCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::T4B_EL_PANEL_RELEASE_FREQ / srf);
+        scLevelSmoothCoeff = 1.0f - std::exp (-2.0f * kPiF * Constants::SC_LEVEL_SMOOTH_FREQ / srf);
+
+        inputTransformer.prepare (sampleRate, numCh);
+        inputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getOptoCompressor().inputTransformer);
+        outputTransformer.prepare (sampleRate, numCh);
+        outputTransformer.setProfile (HardwareEmulation::HardwareProfiles::getOptoCompressor().outputTransformer);
+        tubeStage.prepare (sampleRate, numCh);
+        tubeStage.setTubeType (HardwareEmulation::TubeEmulation::TubeType::Triode_12BH7);
+        tubeStage.setDrive (0.15f);
+        calibrateHardwareGain();
+    }
+
+    float process (float input, int channel, float peakReduction, float gain, bool limitMode,
+                   bool oversample = false, float sidechainSignal = 0.0f, bool useExternalSidechain = false)
+    {
+        (void) oversample;
+        if (channel >= static_cast<int> (detectors.size()))
+            return input;
+        if (sampleRate <= 0.0)
+            return input;
+
+        peakReduction = jlimit (0.0f, 100.0f, peakReduction);
+        gain = jlimit (-40.0f, 40.0f, gain);
+
+        auto& det = detectors[(size_t) channel];
+
+        // Stage 1: Input transformer (UTC A-10)
+        float x = inputTransformer.processSample (input, channel);
+
+        // Stage 2: T4B gain cell — apply gain from previous sample's T4B state
+        float compressed = x * det.t4bGain;
+
+        // T4B even-harmonic distortion: proportional to gain reduction depth
+        float grAmount = 1.0f - det.t4bGain;
+        if (grAmount > 0.01f)
+        {
+            float sq = compressed * compressed;
+            det.t4bDcState = det.t4bDcState * 0.9999f + sq * 0.0001f;
+            float h2 = sq - det.t4bDcState;
+
+            float k2 = grAmount * 0.12f;
+            compressed = compressed + k2 * h2;
+        }
+
+        // Stage 3+4: Sidechain signal selection + frequency shaping
+        float scSignal;
+        if (useExternalSidechain)
+        {
+            scSignal = sidechainSignal;
+            det.shelfX1 = 0.0f;
+            det.shelfY1 = 0.0f;
+        }
+        else if (!limitMode)
+        {
+            scSignal = compressed;
+            float shelfOut = shelfB0 * scSignal + shelfB1 * det.shelfX1 - shelfA1 * det.shelfY1;
+            det.shelfX1 = scSignal;
+            det.shelfY1 = shelfOut;
+            scSignal = shelfOut;
+        }
+        else
+        {
+            scSignal = input * 0.5f + compressed * 0.5f;
+            det.shelfX1 = 0.0f;
+            det.shelfY1 = 0.0f;
+        }
+
+        // Stage 5: Peak Reduction = sidechain amplifier gain
+        float prNorm = peakReduction * 0.01f;
+        float peakReductionGain = prNorm * prNorm * prNorm * Constants::PEAK_REDUCTION_MAX_SC_GAIN;
+
+        // Stage 5b: 6AQ5 sidechain driver tube — soft-clips before the EL panel
+        float scDrive = std::abs (scSignal * peakReductionGain);
+
+        float effectiveDrive = std::max (0.0f, scDrive - Constants::SC_DRIVER_THRESHOLD);
+
+        float scLevel = std::tanh (effectiveDrive * Constants::SC_DRIVER_SATURATION)
+            * Constants::SC_DRIVER_OUTPUT_SCALE;
+
+        // Stage 6: Sidechain envelope smoothing + T4B cell update
+        det.scLevelSmoothed += scLevelSmoothCoeff * (scLevel - det.scLevelSmoothed);
+        updateT4BCell (det, det.scLevelSmoothed);
+
+        // Stage 7: Output stage
+        float makeupGain = dbToGain (gain);
+
+        float grCompensation = 1.0f / jmax (0.1f, det.t4bGain);
+        float tubeBoost = 1.0f + (grCompensation - 1.0f) * 0.7f;
+
+        float output = compressed * makeupGain * tubeBoost;
+
+        float dynamicDrive = 0.15f + grAmount * 0.3f;
+        tubeStage.setDrive (dynamicDrive);
+
+        output = tubeStage.processSample (output, channel);
+
+        output /= tubeBoost;
+
+        output = outputTransformer.processSample (output, channel);
+
+        output *= hardwareGainCompensation;
+
+        return jlimit (-Constants::OUTPUT_HARD_LIMIT, Constants::OUTPUT_HARD_LIMIT, output);
+    }
+
+    float getGainReduction (int channel) const
+    {
+        if (channel >= static_cast<int> (detectors.size()))
+            return 0.0f;
+        return gainToDb (detectors[(size_t) channel].t4bGain);
+    }
+
+    void reset()
+    {
+        for (auto& det : detectors)
+            det = Detector{};
+        inputTransformer.reset();
+        outputTransformer.reset();
+        tubeStage.reset();
+    }
+
+private:
+    struct Detector
+    {
+        float elPanelLevel = 0.0f;
+        float cellCharge = 0.0f;
+        float phosphorGlow = 0.0f;
+        float phosphorAfterglow = 0.0f;
+        float accumulatedCharge = 0.0f;
+        float smoothedConductance = 0.0f;
+        float t4bGain = 1.0f;
+        float shelfX1 = 0.0f;
+        float shelfY1 = 0.0f;
+        float scLevelSmoothed = 0.0f;
+        float t4bDcState = 0.0f;
+    };
+
+    void updateT4BCell (Detector& det, float scLevel)
+    {
+        // EL panel thermal response: asymmetric — heats fast, cools slowly
+        float elCoeff = (scLevel > det.elPanelLevel) ? elPanelAttackCoeff : elPanelReleaseCoeff;
+        det.elPanelLevel += elCoeff * (scLevel - det.elPanelLevel);
+
+        // CdS fast component: charge toward EL panel light level
+        float lightLevel = det.elPanelLevel;
+        if (lightLevel > det.cellCharge)
+        {
+            det.cellCharge = lightLevel + (det.cellCharge - lightLevel) * attackCoeff;
+        }
+        else
+        {
+            float progDepFactor = 1.0f + det.accumulatedCharge * Constants::T4B_PROG_DEP_RELEASE_SCALE;
+            float adjReleaseCoeff = std::pow (fastReleaseCoeff, 1.0f / progDepFactor);
+            det.cellCharge = lightLevel + (det.cellCharge - lightLevel) * adjReleaseCoeff;
+        }
+
+        // EL phosphor persistence: slow component creating two-stage release
+        if (lightLevel > det.phosphorGlow)
+        {
+            det.phosphorGlow = lightLevel + (det.phosphorGlow - lightLevel) * phosphorAttackCoeff;
+        }
+        else
+        {
+            float slowDecayTime = Constants::T4B_PHOSPHOR_BASE_DECAY
+                + det.accumulatedCharge * Constants::T4B_PROG_DEP_PHOSPHOR_SCALE;
+            float phosphorReleaseCoeff = std::exp (-invSampleRate / slowDecayTime);
+            det.phosphorGlow = lightLevel + (det.phosphorGlow - lightLevel) * phosphorReleaseCoeff;
+        }
+
+        // Secondary phosphor afterglow (dual-decay T4B)
+        if (lightLevel > det.phosphorAfterglow)
+        {
+            float afterglowAttackCoeff = std::pow (
+                std::exp (-1.0f / (Constants::T4B_PHOSPHOR_AFTERGLOW_DECAY * static_cast<float> (sampleRate))),
+                Constants::T4B_PHOSPHOR_AFTERGLOW_ATTACK_RATIO);
+            det.phosphorAfterglow = lightLevel
+                + (det.phosphorAfterglow - lightLevel) * afterglowAttackCoeff;
+        }
+        else
+        {
+            float afterglowDecayTime = Constants::T4B_PHOSPHOR_AFTERGLOW_DECAY
+                + det.accumulatedCharge * Constants::T4B_PROG_DEP_PHOSPHOR_SCALE;
+            float afterglowReleaseCoeff = std::exp (-invSampleRate / afterglowDecayTime);
+            det.phosphorAfterglow = lightLevel
+                + (det.phosphorAfterglow - lightLevel) * afterglowReleaseCoeff;
+        }
+
+        // Program-dependent charge accumulation
+        det.accumulatedCharge += det.cellCharge * Constants::T4B_PROG_DEP_CHARGE_RATE * invSampleRate
+            - det.accumulatedCharge * Constants::T4B_PROG_DEP_DISCHARGE_RATE * invSampleRate;
+        det.accumulatedCharge = jlimit (0.0f, 1.0f, det.accumulatedCharge);
+
+        // CdS resistance-to-gain mapping
+        float cellResponse = det.cellCharge
+                            + det.phosphorGlow * Constants::T4B_PHOSPHOR_COUPLING
+                            + det.phosphorAfterglow * Constants::T4B_PHOSPHOR_AFTERGLOW_COUPLING;
+        cellResponse = jlimit (0.0f, 1.0f, cellResponse);
+        float conductance = (cellResponse > 0.0f)
+            ? std::min (Constants::T4B_CONDUCTANCE_K * std::pow (cellResponse, Constants::T4B_GAMMA),
+                        Constants::T4B_MAX_CONDUCTANCE)
+            : 0.0f;
+
+        // Asymmetric conductance smoothing: fast attack, slow release
+        float condCoeff = (conductance > det.smoothedConductance) ? condAttackCoeff : condReleaseCoeff;
+        det.smoothedConductance += condCoeff * (conductance - det.smoothedConductance);
+        det.smoothedConductance = jlimit (0.0f, Constants::T4B_MAX_CONDUCTANCE, det.smoothedConductance);
+
+        // Voltage divider: gain = 1 / (1 + conductance)
+        float newGain = 1.0f / (1.0f + det.smoothedConductance);
+        newGain = jlimit (0.01f, 1.0f, newGain);
+
+        // Release slew limiter — CdS cell cannot recover faster than ~91ms; attack unrestricted.
+        float gainDelta = newGain - det.t4bGain;
+        if (gainDelta > 0.0f)
+        {
+            float maxReleaseDelta = Constants::T4B_MAX_GAIN_RELEASE_RATE * invSampleRate;
+            gainDelta = std::min (gainDelta, maxReleaseDelta);
+        }
+        det.t4bGain += gainDelta;
+
+        if (std::isnan (det.t4bGain) || std::isinf (det.t4bGain))
+            det.t4bGain = 1.0f;
+    }
+
+    void calibrateHardwareGain()
+    {
+        // Reference 1kHz sine at -18dB through the hardware chain; runs on the
+        // main thread from prepare(), never on the audio thread.
+        constexpr int calibrationSamples = 4800;
+        constexpr float refAmplitude = 0.126f;
+        constexpr float refFreq = 1000.0f;
+
+        float srf = static_cast<float> (sampleRate);
+        float angularStep = 2.0f * kPiF * refFreq / srf;
+
+        inputTransformer.reset();
+        tubeStage.reset();
+        outputTransformer.reset();
+
+        int warmup = static_cast<int> (srf * 0.05f);
+        for (int i = 0; i < warmup; ++i)
+        {
+            float xw = refAmplitude * std::sin (angularStep * static_cast<float> (i));
+            xw = inputTransformer.processSample (xw, 0);
+            xw = tubeStage.processSample (xw, 0);
+            outputTransformer.processSample (xw, 0);
+        }
+
+        double inputRmsSquared = 0.0;
+        double outputRmsSquared = 0.0;
+        for (int i = 0; i < calibrationSamples; ++i)
+        {
+            float phase = angularStep * static_cast<float> (warmup + i);
+            float in = refAmplitude * std::sin (phase);
+
+            float xr = inputTransformer.processSample (in, 0);
+            xr = tubeStage.processSample (xr, 0);
+            xr = outputTransformer.processSample (xr, 0);
+
+            inputRmsSquared += static_cast<double> (in * in);
+            outputRmsSquared += static_cast<double> (xr * xr);
+        }
+
+        inputRmsSquared /= calibrationSamples;
+        outputRmsSquared /= calibrationSamples;
+
+        if (outputRmsSquared > 1e-12 && inputRmsSquared > 1e-12)
+        {
+            float chainGain = static_cast<float> (std::sqrt (outputRmsSquared / inputRmsSquared));
+            hardwareGainCompensation = 1.0f / chainGain;
+        }
+        else
+        {
+            hardwareGainCompensation = 1.0f;
+        }
+
+        inputTransformer.reset();
+        tubeStage.reset();
+        outputTransformer.reset();
+    }
+
+    std::vector<Detector> detectors;
+    double sampleRate = 0.0;
+
+    float invSampleRate = 0.0f;
+    float attackCoeff = 0.0f;
+    float fastReleaseCoeff = 0.0f;
+    float phosphorDecayCoeff = 0.0f;
+    float shelfB0 = 1.0f, shelfB1 = 0.0f, shelfA1 = 0.0f;
+    float phosphorAttackCoeff = 0.0f;
+    float condAttackCoeff = 0.0f;
+    float condReleaseCoeff = 0.0f;
+    float elPanelAttackCoeff = 0.0f;
+    float elPanelReleaseCoeff = 0.0f;
+    float scLevelSmoothCoeff = 0.0f;
+    float hardwareGainCompensation = 1.0f;
+
+    HardwareEmulation::TransformerEmulation inputTransformer;
+    HardwareEmulation::TransformerEmulation outputTransformer;
+    HardwareEmulation::TubeEmulation tubeStage;
+};
+
+} // namespace duskaudio

--- a/plugins/multi-comp/core/PORT_NOTES.md
+++ b/plugins/multi-comp/core/PORT_NOTES.md
@@ -1,0 +1,189 @@
+# Multi-Comp core — port notes (scaffold phase)
+
+Framework-free (no-JUCE) port of `UniversalCompressor` (Multi-Comp), scoped to the
+four modes Dusk Studio's channel/bus/master strips use: **Opto, FET, VCA, Bus**.
+Source of truth: `plugins/multi-comp/multicomp.cpp` + `UniversalCompressor.h`.
+
+Goal: **bit-level A/B match vs the JUCE processor at the parameter subset Dusk
+Studio drives** (every other param at its JUCE default). This file is the
+designated judgment log; source comments stay sparse.
+
+This phase delivers the scaffold only: top-level flow, shared services, and the
+four mode-class *interfaces* (stubbed). The four mode bodies are transcribed next
+by parallel agents — see **§Mode contracts** and the interface headers.
+
+---
+
+## Scope (LOCKED)
+
+**In:** Opto (0), FET (1), VCA (2), Bus (3). **Out:** StudioFET, StudioVCA,
+Digital, Multiband; the noise generator; the output distortion stage; internal
+audio-path oversampling (AntiAliasing 2x/4x); true-peak detector; global +
+digital lookahead; sidechain shelf EQ; Mid-Side / Dual-Mono stereo-link modes.
+
+Everything "out" is either never reachable at the Dusk param subset, or is a
+verified no-op at its default value — see the default-trace table.
+
+---
+
+## §Oversampling & latency — RESOLVED (reference config locked)
+
+The reference config is the JUCE processor exactly as Dusk Studio's strips
+drive it (verified: `DuskStudio/src/dsp/ChannelStrip.cpp` L234–237, `BusStrip.cpp`,
+`MasterBus.cpp`, `MasteringChain.cpp`): `setMinimalProcessing(false)`,
+`setInternalOversamplingEnabled(false)`, `prepareToPlay(stripRate)`, all APVTS
+params at their defaults — in particular `"oversampling"` at its default
+**index 1 ("2x")**. Consequences, replicated by the core:
+
+- **Modes prepared at 2× the processing rate.** JUCE `prepareToPlay`
+  (multicomp.cpp:5075–5091) primes every mode at `stripRate*2`; runtime takes
+  the NON-oversampled path (gate at multicomp.cpp:6407) and processes at
+  `stripRate`; `updateSampleRate` only fires on a param *change*, which never
+  happens. The 2×-tuned coefficients are the shipped sound. Core:
+  `kModePrepareOversampleFactor = 2` (`UniversalCompressorDSP.cpp`); the top
+  level passes the doubled rate into `mode.prepare()`, so the mode
+  transcriptions need no special handling.
+- **Reported latency = 60 base-rate samples, always.** `updateLatencyReport`
+  (multicomp.cpp:7004) reports `AntiAliasing::getLatency()` (60) + global
+  lookahead (0) + Digital lookahead (0) from `prepareToPlay` onward and never
+  changes it in this config (the oversampling-factor change-detect never fires;
+  bypass deliberately keeps reporting it — multicomp.cpp:5323). The AA value is
+  the 4× FIR-equiripple latency (`lround(59.5) = 60`, rate-independent; JUCE
+  half-band equiripple stage orders 118/78 and 50/34 → 98/2 + 42/4 = 59.5; the
+  2×-only value would be 49). The runtime **wet** path has zero actual delay;
+  the dry-reference paths below are delayed by 60 to line up with the report.
+  Core: `getLatencySamples()` returns the same **60**.
+- **GR meter is block-delayed.** JUCE prepareToPlay (multicomp.cpp:5137–5143)
+  sets `grDelaySamples = min(ceil(60 / samplesPerBlock), 255)` **blocks**
+  (≥ 1 always), and the processBlock tail routes the displayed GR through a
+  one-value-per-block ring. So the reference's `getGainReduction()` lags the
+  audio by that many blocks even on the non-OS path. Core: replicated
+  (`kReportedAaLatencySamples = 60`, `grDelayBuffer` ring, delay computed in
+  `prepare` from `maxBlock`, advanced one slot per `processBlock` call).
+- The A/B harness drives the JUCE reference exactly as the strips do (config
+  above, param defaults untouched); the core needs no special configuration.
+
+### Formerly-flagged deviations — RESOLVED (coordinator ruling: replicate)
+
+- **Bypass + 0% mix:** replicated `emitLatencyAlignedDry` (multicomp.cpp:5271–5330)
+  — input-history ring fed every block (preWp semantics), dry emitted delayed by
+  the constant reported 60; ring sized like the reference (60 + 2×10 ms + block + 1);
+  out-of-spec blocks degrade to undelayed passthrough like the reference's guard.
+- **Partial mix (0 < mix < 1):** replicated `mixAtNormalRate`'s tier-2 dry ring
+  (shared/DryWetMixer.h L396: `totalDelay = 60`, 256-slot power-of-2 ring, one
+  shared write position advanced per sample) — dry is 60-sample-delayed before
+  the crossfade, stale/zero ring history after a mix engage included.
+- **Bypass → active transition:** replicated the 5 ms crossfade + state resets
+  (multicomp.cpp:5536–5564, 6846–6862): fade length `jlimit(64, 2048, sr*0.005)`,
+  dry captured per block via the delaySamples==0 memcpy branch (no lookahead in
+  scope), fade applied after auto-makeup; `smoothedAutoMakeupGain`/`smoothedGrDb`/
+  `primeGrAccumulator` reset on un-bypass; re-bypass cancels an in-progress fade.
+  Not enumerated in the ruling but reachable on every comp toggle and required
+  for bit-exact post-toggle auto-makeup trajectories.
+
+---
+
+## Default-trace table (param → default → service engaged at defaults → ported)
+
+Params Dusk drives are marked ✎. Defaults from `createParameterLayout`
+(multicomp.cpp L4459).
+
+| Param / service        | JUCE default        | Engaged at Dusk settings? | Ported? | Note |
+|------------------------|---------------------|---------------------------|---------|------|
+| `mode` ✎               | 0 (Opto)            | yes (dispatch)            | yes     | 0..3 only |
+| `bypass` ✎             | false               | gate                      | yes     | dry delayed 60 smp + 5 ms un-bypass fade — see §Oversampling resolved |
+| `mix` ✎                | 100 %               | crossfade when 0<mix<1    | yes     | dry ring-delayed 60 smp before crossfade — see §Oversampling resolved |
+| `auto_makeup` ✎        | 0 (Off)             | when On                   | yes     | GR-based, multiplicative smoother |
+| `sidechain_hp` ✎       | 0 Hz (Off)          | when ≥1 Hz                | yes     | `SidechainFilter` |
+| `stereo_link` ✎ (impl) | 100 %               | yes (numCh≥2)             | yes     | max-level link |
+| `stereo_link_mode`     | 0 (Stereo)          | Stereo path only          | yes(0)  | M/S, Dual-Mono unported (default off) |
+| opto_* ✎               | see layout          | yes                       | yes     | gain map `(g-50)*0.8`, jlimit −40..40 |
+| fet_* ✎                | see layout          | yes                       | yes     | `fet_transient` NOT driven → 0 |
+| vca_* ✎                | see layout          | yes                       | yes     | detector_mode default Adaptive(0) |
+| bus_* ✎                | see layout          | yes                       | yes     | ratio choice→{2,4,10}; mix→0..1 |
+| `sidechain_enable`     | false               | no (external SC off)      | n/a     | forces `hasExternalSidechain=false` |
+| `sc_low_gain`/`sc_high_gain` | 0 dB          | shelf runs but unity      | **no**  | RBJ shelf at 0 dB is exact unity (b==a) — verified numerically; not driven ⇒ skipped |
+| `true_peak_enable`     | false               | no                        | no      | detector never called |
+| `global_lookahead`     | 0 ms                | no                        | no      | delay line + PDC skipped |
+| `distortion_type`      | 0 (Off)             | no                        | no      | `applyDistortion` gate false |
+| `distortion_amount`    | 50 %                | no (type Off)             | no      | — |
+| `noise_enable`         | true (Dusk forces 0)| no                        | no      | −80 dB analog noise skipped |
+| `envelope_curve`       | 0 (Logarithmic)     | inside modes              | (mode)  | consumed by mode DSP, not top level |
+| `saturation_mode`      | 0 (Vintage)         | inside modes              | (mode)  | not a top-level param; modes read via ctor/defaults |
+| `oversampling`         | 1 (2x)              | prepare-rate + GR delay   | yes (quirk replicated) | modes prepared at 2×; GR meter block-delayed — see §Oversampling |
+
+---
+
+## Substitution table
+
+| JUCE                                                   | Replacement |
+|--------------------------------------------------------|-------------|
+| `_MM_SET_FLUSH_ZERO_MODE` / `ScopedNoDenormals` / `FloatVectorOperations::disableDenormalisedNumberSupport` | `duskaudio::ScopedFlushDenormals` (DuskDenormals.hpp) |
+| `juce::MathConstants<float>::pi`                        | `duskaudio::kPiF` |
+| `juce::jlimit / jmin / jmax`                            | `duskaudio::jlimit / jmin / jmax` (JUCE arg order preserved) |
+| `juce::Decibels::decibelsToGain` (−100 floor)          | `duskaudio::dbToGain` |
+| `juce::Decibels::gainToDecibels` (−100 floor)          | `duskaudio::gainToDb` |
+| `juce::SmoothedValue<float, Multiplicative>`           | `duskaudio::MultiplicativeSmoothedValue` (verbatim behavioural port, incl. `approximatelyEqual` early-return) |
+| `juce::approximatelyEqual`                             | `duskaudio::approximatelyEqual` (abs=FLT_MIN, rel=FLT_EPSILON) |
+| `SIMDHelpers::getPeakLevel`                            | local `getPeakLevel` (identical scalar loop) |
+| `SIMDHelpers::applyGain`                              | inline `data[i] *= gain` loop |
+| `juce::AudioBuffer<float>` scratch                     | `std::vector<float>[2]` sized in `prepare` |
+| `DuskAudio::DryWetMixer` (JUCE-coupled)                | inlined crossfade in `processBlock` — **not** used; see §Oversampling for the dropped dry-delay |
+| `juce::dsp::IIR` (SidechainFilter)                     | transcribed transposed-DF-II biquad (RBJ HP, Q=0.707) — already float, no designer swap needed |
+
+`plugins/multi-comp/HardwareEmulation/*.h` are already JUCE-free and are reused
+by include (the mode agents include them directly), **not** copied.
+
+---
+
+## Judgment calls
+
+- **Mono handling.** Dusk preps stereo (`setPlayConfigDetails(2,2,…)`) but may
+  pass a mono buffer. The core always prepares modes/services for 2 channels
+  (superset); mono processing touches only channel 0, whose detector state is
+  identical either way → bit-exact. Stereo linking requires `numChannels>=2`, so
+  mono skips it exactly as JUCE does.
+- **`reset()`.** The JUCE `UniversalCompressor` does not override
+  `AudioProcessor::reset()` (it is a no-op), and Dusk calls it once right after
+  `prepareToPlay` when state is already fresh — so `reset()` is A/B-irrelevant.
+  The core's `reset()` re-zeros DSP/detector/smoother state for hygiene; a mode
+  `reset()` method was added to each interface for this (not present in the JUCE
+  class — it is the one interface addition, used only by the core lifecycle).
+- **SidechainEQ skipped.** At `sc_low_gain = sc_high_gain = 0 dB` an RBJ shelf
+  has `b_k == a_k` after normalization, so `y[n] == x[n]` exactly from zero state
+  (the `a·x − a·y` terms cancel in float). Dusk never drives the sc-EQ params, so
+  omitting the class is bit-exact, not an approximation.
+- **Metering.** Input/output/sidechain peak meters and the GR meter are mirrored
+  as plain relaxed atomics (Dusk reads `getGainReduction()` etc.). The GR meter's
+  block-delay ring IS replicated (see §Oversampling — the reference delays the
+  displayed GR by `ceil(60/blockSize)` blocks). GR history (`grHistory`) is a
+  pure UI convenience and is not mirrored.
+- **Oversized blocks.** Scratch is sized to `maxBlock`. A block larger than that
+  yields a dry passthrough + early return (RT-safe degradation), mirroring the
+  oversampler's graceful bail; no audio-thread allocation.
+
+---
+
+## §Mode contracts (for the four transcription agents)
+
+Each mode lives in its own header (`OptoCompressor.hpp`, `FETCompressor.hpp`,
+`VCACompressor.hpp`, `BusCompressor.hpp`). The **public interface is final** —
+the top level calls exactly those signatures. Fill the private state + method
+bodies verbatim from the source line range; preserve every constant and
+per-sample op order. All four may include `UniversalCompressorServices.hpp`
+(Constants, LookupTables, TransientShaper, SidechainFilter) and the JUCE-free
+`../HardwareEmulation/*.h`. No JUCE anywhere under `core/`.
+
+| Mode | Source (multicomp.cpp) | Header to fill | Shared services it may use |
+|------|------------------------|----------------|----------------------------|
+| Opto | L1180–L1636 | `OptoCompressor.hpp` | Constants::T4B_*, HardwareEmulation (Tube/Transformer) |
+| FET  | L1637–L2165 | `FETCompressor.hpp`  | `LookupTables*`, `TransientShaper*` (passed by top level), Constants::FET_*, HardwareEmulation |
+| VCA  | L2166–L2528 | `VCACompressor.hpp`  | Constants::VCA_* |
+| Bus  | L2529–L2957 | `BusCompressor.hpp`  | Constants::BUS_*, HardwareEmulation |
+
+Prepare rate: the top level passes the rate to `mode.prepare()`; agents just
+transcribe `prepare(rate, …)` faithfully (do not hardcode any oversampling
+assumption — see §Oversampling).
+
+The exact interface each must implement is captured in the header stubs (final
+signatures + PORT_PENDING bodies) and repeated in the delivery message.

--- a/plugins/multi-comp/core/UniversalCompressorDSP.cpp
+++ b/plugins/multi-comp/core/UniversalCompressorDSP.cpp
@@ -1,0 +1,622 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// UniversalCompressorDSP.cpp — top-level flow port. Transcribes the active
+// subset of UniversalCompressor::prepareToPlay / processBlock (multicomp.cpp)
+// for the Opto/FET/VCA/Bus modes at the parameter subset Dusk Studio drives,
+// with everything else at its JUCE default. Judgment log: core/PORT_NOTES.md.
+
+#include "UniversalCompressorDSP.hpp"
+
+#include <cmath>
+#include <cstring>
+
+#include "DuskDenormals.hpp" // duskaudio::ScopedFlushDenormals
+
+namespace duskaudio
+{
+
+// Invariant: modes are prepared at 2x the processing rate. The reference
+// processor ships with its "oversampling" APVTS param at the default "2x" and
+// internal oversampling disabled, so JUCE prepareToPlay primes every mode at
+// rate*2 while processBlock runs them at the native rate (updateSampleRate only
+// fires on a param change, which never happens). Envelope/filter coefficients
+// depend on this.
+static constexpr int kModePrepareOversampleFactor = 2;
+
+// The reference's AntiAliasing::getLatency() in this config: the 4x
+// FIR-equiripple oversampler latency, lround(59.5) = 60 base-rate samples,
+// rate-independent (JUCE half-band equiripple max-quality stage orders
+// 118/78 and 50/34; (118+78)/2 / 2 + (50+34)/2 / 4 = 59.5). The runtime audio
+// path never runs the oversampler, but this value still sizes the reference's
+// GR-meter delay ring (one slot per block).
+static constexpr int kReportedAaLatencySamples = 60;
+
+namespace
+{
+    inline float getPeakLevel (const float* data, int numSamples) noexcept
+    {
+        float peak = 0.0f;
+        for (int i = 0; i < numSamples; ++i)
+            peak = jmax (peak, std::abs (data[i]));
+        return peak;
+    }
+}
+
+UniversalCompressorDSP::UniversalCompressorDSP() = default;
+
+void UniversalCompressorDSP::prepare (double sr, int block)
+{
+    if (sr <= 0.0 || block <= 0)
+        return;
+
+    sr = jlimit (8000.0, 384000.0, sr);
+    sampleRate = sr;
+    maxBlock = block;
+    numChannelsPrepared = 2; // Dusk drives the strip stereo (mono buffers reuse ch 0)
+    wasBypassedLastBlock = false;
+
+    const double modeRate  = sr * (double) kModePrepareOversampleFactor;
+    const int    modeBlock = block * kModePrepareOversampleFactor;
+
+    // Mode coefficients are computed for modeRate (see kModePrepareOversampleFactor).
+    opto.prepare (modeRate, numChannelsPrepared);
+    fet.prepare  (modeRate, numChannelsPrepared);
+    vca.prepare  (modeRate, numChannelsPrepared);
+    bus.prepare  (modeRate, numChannelsPrepared, modeBlock);
+
+    // Native-rate services.
+    sidechainFilter.prepare (sr, numChannelsPrepared);
+    transientShaper.prepare (sr, numChannelsPrepared);
+    lookupTables.initialize();
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        filteredSidechain[ch].assign ((size_t) block, 0.0f);
+        linkedSidechain[ch].assign   ((size_t) block, 0.0f);
+        normalDry[ch].assign         ((size_t) block, 0.0f);
+    }
+    smoothedGainBuffer.assign ((size_t) block, 1.0f);
+
+    smoothedAutoMakeupGain.reset (sr, 0.05);
+    smoothedAutoMakeupGain.setCurrentAndTargetValue (1.0f);
+
+    // GR-based auto-gain smoothing coefficient (~200 ms window at the block rate).
+    const float grTimeConstantSec = 0.043f;
+    const int   grBlockSize = jmax (1, block);
+    const double safeSampleRate = jlimit (8000.0, 384000.0, sr);
+    const float blocksPerSecond = (float) safeSampleRate / (float) grBlockSize;
+    grSmoothCoeff = 1.0f - std::exp (-1.0f / (blocksPerSecond * grTimeConstantSec));
+    grSmoothCoeff = jlimit (0.001f, 0.999f, grSmoothCoeff);
+    smoothedGrDb = 0.0f;
+    primeGrAccumulator = true;
+    lastMode = -1;
+
+    // GR-meter delay: the reference delays the displayed GR by the blocks
+    // covering its (constant) reported AA latency, even though the audio path
+    // has none in this config.
+    grDelayBuffer.fill (0.0f);
+    grDelayWritePos = 0;
+    grDelayBlocks = jmin ((kReportedAaLatencySamples + block - 1) / block, kMaxGrDelayBlocks - 1);
+
+    // Constant-latency report: the reference reports the AA latency from
+    // prepareToPlay onward regardless of the runtime path (updateLatencyReport;
+    // AA latency + lookahead 0 + non-Digital 0). The wet path has no actual
+    // delay; the bypass / 0%-mix / partial-mix dry paths are delayed by this
+    // amount instead.
+    latencySamples = kReportedAaLatencySamples;
+
+    // Input-history ring for the latency-aligned dry output on bypass / 0% mix.
+    // Sized like the reference: max reportable latency (AA 4x + 10 ms global
+    // lookahead + 10 ms Digital lookahead) + one block + 1.
+    {
+        const int laMax  = jlimit (0, 4096, (int) std::ceil (sr * 0.01));
+        const int digMax = jlimit (0, 4096, (int) std::ceil (sr * 0.01));
+        bypassAlignSize = kReportedAaLatencySamples + laMax + digMax + block + 1;
+        for (int ch = 0; ch < 2; ++ch)
+            bypassAlignBuf[ch].assign ((size_t) bypassAlignSize, 0.0f);
+        bypassAlignWritePos[0] = bypassAlignWritePos[1] = 0;
+    }
+
+    // Bypass -> active crossfade: base fade 5 ms; buffer sized for the 15 ms
+    // maximum (Digital fade extension, unreachable here but kept for the
+    // reference's min() clamps).
+    bypassFadeLengthSamples = jlimit (64, 2048, (int) (sr * 0.005));
+    {
+        const int maxFadeSamples = jlimit (64, 8192, (int) (sr * 0.015));
+        for (int ch = 0; ch < 2; ++ch)
+            bypassFadeBuffer[ch].assign ((size_t) maxFadeSamples, 0.0f);
+    }
+    bypassFadeActualLength = bypassFadeLengthSamples;
+    bypassFadeRemaining = 0;
+
+    for (auto& chBuf : mixDelayBuffer)
+        chBuf.fill (0.0f);
+    mixDelayWritePos = 0;
+}
+
+void UniversalCompressorDSP::reset()
+{
+    opto.reset();
+    fet.reset();
+    vca.reset();
+    bus.reset();
+    sidechainFilter.reset();
+    transientShaper.reset();
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        std::fill (filteredSidechain[ch].begin(), filteredSidechain[ch].end(), 0.0f);
+        std::fill (linkedSidechain[ch].begin(),   linkedSidechain[ch].end(),   0.0f);
+        std::fill (normalDry[ch].begin(),         normalDry[ch].end(),         0.0f);
+    }
+
+    smoothedAutoMakeupGain.setCurrentAndTargetValue (1.0f);
+    smoothedGrDb = 0.0f;
+    primeGrAccumulator = true;
+    lastMode = -1;
+
+    grDelayBuffer.fill (0.0f);
+    grDelayWritePos = 0;
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        std::fill (bypassAlignBuf[ch].begin(), bypassAlignBuf[ch].end(), 0.0f);
+        std::fill (bypassFadeBuffer[ch].begin(), bypassFadeBuffer[ch].end(), 0.0f);
+    }
+    bypassAlignWritePos[0] = bypassAlignWritePos[1] = 0;
+    bypassFadeRemaining = 0;
+    wasBypassedLastBlock = false;
+
+    for (auto& chBuf : mixDelayBuffer)
+        chBuf.fill (0.0f);
+    mixDelayWritePos = 0;
+}
+
+void UniversalCompressorDSP::processBlock (const float* const* in, float* const* out, int numChannels, int numSamples)
+{
+    ScopedFlushDenormals noDenormals;
+
+    if (numSamples <= 0 || numChannels <= 0)
+        return;
+
+    // Mirror JUCE's in-place buffer: copy input into the output, then process out.
+    for (int ch = 0; ch < numChannels; ++ch)
+        if (in[ch] != out[ch])
+            std::memcpy (out[ch], in[ch], (size_t) numSamples * sizeof (float));
+
+    // Oversized-block guard (RT-safe degradation): scratch is sized to maxBlock.
+    if (numSamples > maxBlock)
+        return; // out already holds the dry passthrough
+
+    const int nc = jmin (numChannels, 2);
+
+    // Feed the input-history ring every block so the bypass / 0%-mix passthrough
+    // can emit dry audio delayed by the CONSTANT reported latency. preWp = the
+    // per-channel write position BEFORE this block's write.
+    const int alignPreWp0 = bypassAlignWritePos[0];
+    const int alignPreWp1 = bypassAlignWritePos[1];
+    if (bypassAlignSize > 1)
+    {
+        for (int ch = 0; ch < nc; ++ch)
+        {
+            int wp = bypassAlignWritePos[ch];
+            const float* inData = out[ch];
+            float* ring = bypassAlignBuf[ch].data();
+            for (int i = 0; i < numSamples; ++i)
+            {
+                ring[wp] = inData[i];
+                wp = (wp + 1) % bypassAlignSize;
+            }
+            bypassAlignWritePos[ch] = wp;
+        }
+    }
+
+    // Overwrite out with the input delayed by the constant reported latency.
+    // D + numSamples >= ring size (out-of-spec block) degrades to the undelayed
+    // passthrough already in out — same fallback as the reference.
+    auto emitLatencyAlignedDry = [&]()
+    {
+        const int D = jlimit (0, jmax (0, bypassAlignSize - 1), latencySamples);
+        if (bypassAlignSize <= 1 || D + numSamples >= bypassAlignSize)
+            return;
+        for (int ch = 0; ch < nc; ++ch)
+        {
+            const int preWp = (ch == 0) ? alignPreWp0 : alignPreWp1;
+            const float* ring = bypassAlignBuf[ch].data();
+            float* o = out[ch];
+            for (int i = 0; i < numSamples; ++i)
+            {
+                const int rp = ((preWp + i - D) % bypassAlignSize + bypassAlignSize) % bypassAlignSize;
+                o[i] = ring[rp];
+            }
+        }
+    };
+
+    // Bypass: dry output delayed by the constant reported latency (the
+    // reference never zeroes its latency report on bypass).
+    if (pBypass.load (std::memory_order_relaxed))
+    {
+        bypassFadeRemaining = 0;   // cancel any in-progress fade if re-bypassed
+        wasBypassedLastBlock = true;
+        emitLatencyAlignedDry();
+        return;
+    }
+
+    // Bypass -> active transition: restart the crossfade and reset the
+    // auto-makeup accumulators (the Digital fade extension is unreachable).
+    if (wasBypassedLastBlock)
+    {
+        wasBypassedLastBlock = false;
+        bypassFadeActualLength = bypassFadeLengthSamples;
+        bypassFadeRemaining = bypassFadeActualLength;
+
+        smoothedAutoMakeupGain.setCurrentAndTargetValue (1.0f);
+        smoothedGrDb = 0.0f;
+        primeGrAccumulator = true;
+    }
+
+    const float stereoLinkAmount = pStereoLink.load (std::memory_order_relaxed) * 0.01f;
+    const float mixAmount        = pMix.load (std::memory_order_relaxed) * 0.01f;
+    const bool  needsDryBuffer   = (mixAmount > 0.001f && mixAmount < 0.999f);
+
+    // Save the dry signal for the bypass crossfade. No global lookahead in
+    // scope, so the raw input is already time-aligned with the wet path
+    // (the reference's delaySamples == 0 memcpy branch).
+    if (bypassFadeRemaining > 0)
+    {
+        const int fadeSamples = jmin (bypassFadeRemaining,
+                                      jmin (numSamples, (int) bypassFadeBuffer[0].size()));
+        for (int ch = 0; ch < nc; ++ch)
+            std::memcpy (bypassFadeBuffer[ch].data(), out[ch], (size_t) fadeSamples * sizeof (float));
+    }
+
+    // 100% dry: skip all processing; zero the GR meters; emit the dry input
+    // delayed by the constant reported latency.
+    if (mixAmount <= 0.001f)
+    {
+        linkedGainReduction[0].store (0.0f, std::memory_order_relaxed);
+        linkedGainReduction[1].store (0.0f, std::memory_order_relaxed);
+        grMeter.store (0.0f, std::memory_order_relaxed);
+        emitLatencyAlignedDry();
+        return;
+    }
+
+    const int modeInt = pMode.load (std::memory_order_relaxed);
+    if (modeInt < 0 || modeInt > (int) CompMode::Bus)
+        return; // unported mode -> passthrough (out already == input)
+    const CompMode mode = (CompMode) modeInt;
+
+    // sidechain_enable defaults false and is not driven by Dusk -> no external SC.
+    const bool autoMakeup = pAutoMakeup.load (std::memory_order_relaxed);
+    const bool hasExternalSidechain = false;
+
+    // Reset auto-gain state on mode change (JUCE: lastCompressorMode).
+    if (modeInt != lastMode)
+    {
+        lastMode = modeInt;
+        primeGrAccumulator = true;
+        smoothedAutoMakeupGain.setCurrentAndTargetValue (1.0f);
+    }
+
+    // --- per-mode parameter caching (mirrors the JUCE switch) -----------------
+    float cp[8] = { 0.0f };
+    switch (mode)
+    {
+        case CompMode::Opto:
+            cp[0] = jlimit (0.0f, 100.0f, pOptoPeakReduction.load (std::memory_order_relaxed));
+            if (autoMakeup) cp[1] = 0.0f;
+            else            cp[1] = jlimit (-40.0f, 40.0f, (jlimit (0.0f, 100.0f, pOptoGain.load (std::memory_order_relaxed)) - 50.0f) * 0.8f);
+            cp[2] = pOptoLimit.load (std::memory_order_relaxed) ? 1.0f : 0.0f;
+            break;
+
+        case CompMode::FET:
+            cp[0] = pFetInput.load (std::memory_order_relaxed);
+            cp[1] = autoMakeup ? 0.0f : pFetOutput.load (std::memory_order_relaxed);
+            cp[2] = pFetAttack.load (std::memory_order_relaxed);
+            cp[3] = pFetRelease.load (std::memory_order_relaxed);
+            cp[4] = (float) pFetRatio.load (std::memory_order_relaxed);
+            cp[5] = (float) pFetCurveMode.load (std::memory_order_relaxed);
+            cp[6] = pFetTransient.load (std::memory_order_relaxed);
+            cp[7] = pFetThreshold.load (std::memory_order_relaxed);
+            break;
+
+        case CompMode::VCA:
+            cp[0] = pVcaThreshold.load (std::memory_order_relaxed);
+            cp[1] = pVcaRatio.load (std::memory_order_relaxed);
+            cp[2] = pVcaAttack.load (std::memory_order_relaxed);
+            cp[3] = pVcaRelease.load (std::memory_order_relaxed);
+            cp[4] = autoMakeup ? 0.0f : pVcaOutput.load (std::memory_order_relaxed);
+            cp[5] = pVcaOverEasy.load (std::memory_order_relaxed) ? 1.0f : 0.0f;
+            vca.setDetectorClassic (pVcaDetectorMode.load (std::memory_order_relaxed) >= 1); // JUCE: index > 0.5
+            break;
+
+        case CompMode::Bus:
+        {
+            cp[0] = pBusThreshold.load (std::memory_order_relaxed);
+            const int ratioChoice = pBusRatio.load (std::memory_order_relaxed);
+            cp[1] = (ratioChoice == 1) ? 4.0f : (ratioChoice == 2) ? 10.0f : 2.0f;
+            cp[2] = (float) pBusAttack.load (std::memory_order_relaxed);
+            cp[3] = (float) pBusRelease.load (std::memory_order_relaxed);
+            cp[4] = autoMakeup ? 0.0f : pBusMakeup.load (std::memory_order_relaxed);
+            cp[5] = pBusMix.load (std::memory_order_relaxed) * 0.01f;
+            break;
+        }
+    }
+
+    // --- input metering -------------------------------------------------------
+    {
+        float inLevel = 0.0f, inL = 0.0f, inR = 0.0f;
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            const float peak = getPeakLevel (out[ch], numSamples);
+            inLevel = jmax (inLevel, peak);
+            if (ch == 0) inL = peak; else if (ch == 1) inR = peak;
+        }
+        inputMeter.store  (inLevel > 1e-5f ? gainToDb (inLevel) : -60.0f, std::memory_order_relaxed);
+        inputMeterL.store (inL > 1e-5f ? gainToDb (inL) : -60.0f, std::memory_order_relaxed);
+        inputMeterR.store (numChannels > 1 ? (inR > 1e-5f ? gainToDb (inR) : -60.0f)
+                                           : (inL > 1e-5f ? gainToDb (inL) : -60.0f), std::memory_order_relaxed);
+    }
+
+    // --- sidechain HP filter (internal sidechain = the input) -----------------
+    const float scHpFreq = pScHp.load (std::memory_order_relaxed);
+    const bool  scHpEnabled = scHpFreq >= 1.0f;
+    if (scHpEnabled)
+        sidechainFilter.setFrequency (scHpFreq);
+
+    for (int ch = 0; ch < nc; ++ch)
+    {
+        const float* inData = out[ch];
+        float* sc = filteredSidechain[ch].data();
+        if (scHpEnabled) sidechainFilter.processBlock (inData, sc, numSamples, ch);
+        else             std::memcpy (sc, inData, (size_t) numSamples * sizeof (float));
+    }
+    // NOTE: sidechain shelf EQ + true-peak detection run in the JUCE path but are
+    // no-ops at Dusk defaults (sc gains == 0 dB is exact unity; true_peak off).
+    // See PORT_NOTES §Default-off services.
+
+    // --- sidechain meter ------------------------------------------------------
+    {
+        float scLevel = 0.0f;
+        for (int ch = 0; ch < nc; ++ch)
+            scLevel = jmax (scLevel, getPeakLevel (filteredSidechain[ch].data(), numSamples));
+        sidechainMeter.store (scLevel > 1e-5f ? gainToDb (scLevel) : -60.0f, std::memory_order_relaxed);
+    }
+
+    // --- stereo linking (Stereo mode only; M/S + Dual-Mono unported) ----------
+    const int stereoLinkMode = pStereoLinkMode.load (std::memory_order_relaxed);
+    const bool useStereoLink = (stereoLinkMode == 0 && stereoLinkAmount > 0.01f) && (numChannels >= 2);
+    if (useStereoLink)
+    {
+        const float* scL = filteredSidechain[0].data();
+        const float* scR = filteredSidechain[1].data();
+        float* leftSC  = linkedSidechain[0].data();
+        float* rightSC = linkedSidechain[1].data();
+        for (int i = 0; i < numSamples; ++i)
+        {
+            const float lL = std::abs (scL[i]);
+            const float lR = std::abs (scR[i]);
+            const float linked = jmax (lL, lR);
+            leftSC[i]  = lL * (1.0f - stereoLinkAmount) + linked * stereoLinkAmount;
+            rightSC[i] = lR * (1.0f - stereoLinkAmount) + linked * stereoLinkAmount;
+        }
+    }
+
+    // --- mode processing (native rate; internal oversampling disabled) --------
+    const float compensationGain = 1.0f;
+
+    bool canMixNormal = false;
+    if (needsDryBuffer)
+    {
+        for (int ch = 0; ch < nc; ++ch)
+            std::memcpy (normalDry[ch].data(), out[ch], (size_t) numSamples * sizeof (float));
+        canMixNormal = true;
+    }
+
+    for (int ch = 0; ch < nc; ++ch)
+    {
+        float* data = out[ch];
+        switch (mode)
+        {
+            case CompMode::Opto:
+                for (int i = 0; i < numSamples; ++i)
+                {
+                    const float scSignal = useStereoLink ? linkedSidechain[ch][(size_t) i] : filteredSidechain[ch][(size_t) i];
+                    data[i] = opto.process (data[i], ch, cp[0], cp[1], cp[2] > 0.5f, false, scSignal, hasExternalSidechain) * compensationGain;
+                }
+                break;
+
+            case CompMode::FET:
+                for (int i = 0; i < numSamples; ++i)
+                {
+                    const float scSignal = useStereoLink ? linkedSidechain[ch][(size_t) i] : filteredSidechain[ch][(size_t) i];
+                    data[i] = fet.process (data[i], ch, cp[0], cp[1], cp[2], cp[3], (int) cp[4], false,
+                                           &lookupTables, &transientShaper,
+                                           cp[5] > 0.5f, cp[6], scSignal, hasExternalSidechain, cp[7]) * compensationGain;
+                }
+                break;
+
+            case CompMode::VCA:
+                for (int i = 0; i < numSamples; ++i)
+                {
+                    const float scSignal = useStereoLink ? linkedSidechain[ch][(size_t) i] : filteredSidechain[ch][(size_t) i];
+                    data[i] = vca.process (data[i], ch, cp[0], cp[1], cp[2], cp[3], cp[4], cp[5] > 0.5f, false, scSignal, hasExternalSidechain) * compensationGain;
+                }
+                break;
+
+            case CompMode::Bus:
+                if (useStereoLink && numChannels >= 2 && ch == 0)
+                {
+                    bus.processStereoLinked (out[0], out[1], numSamples,
+                                             cp[0], cp[1], (int) cp[2], (int) cp[3],
+                                             cp[4], compensationGain, stereoLinkAmount,
+                                             linkedSidechain[0].data(), linkedSidechain[1].data(),
+                                             hasExternalSidechain);
+                }
+                else if (useStereoLink && numChannels >= 2 && ch == 1)
+                {
+                    // Already processed by the ch==0 lockstep call.
+                }
+                else
+                {
+                    for (int i = 0; i < numSamples; ++i)
+                    {
+                        const float scSignal = useStereoLink ? linkedSidechain[ch][(size_t) i] : filteredSidechain[ch][(size_t) i];
+                        data[i] = bus.process (data[i], ch, cp[0], cp[1], (int) cp[2], (int) cp[3], cp[4], cp[5], false, scSignal, hasExternalSidechain) * compensationGain;
+                    }
+                }
+                break;
+        }
+        // Output distortion is default-Off (not driven by Dusk) -> skipped.
+    }
+
+    // --- dry/wet mix (normal-rate tier). The dry signal is ring-delayed by the
+    // constant reported latency before the crossfade, exactly like the
+    // reference's mixAtNormalRate (totalDelay = AA latency + 0 + 0). ------------
+    if (canMixNormal)
+    {
+        const float wetAmount = mixAmount;
+        const float dryAmount = 1.0f - mixAmount;
+        const int totalDelay = kReportedAaLatencySamples;
+        const int delayToApply = jmin (totalDelay, kMixDelaySamples - 1);
+
+        for (int i = 0; i < numSamples; ++i)
+        {
+            const int readPos = (mixDelayWritePos - delayToApply + kMixDelaySamples) & kMixDelayMask;
+            for (int ch = 0; ch < nc; ++ch)
+            {
+                float* wet = out[ch];
+                const float* dry = normalDry[ch].data();
+                const float delayedDry = mixDelayBuffer[(size_t) ch][(size_t) readPos];
+                mixDelayBuffer[(size_t) ch][(size_t) mixDelayWritePos] = dry[i];
+                wet[i] = wet[i] * wetAmount + delayedDry * dryAmount;
+            }
+            mixDelayWritePos = (mixDelayWritePos + 1) & kMixDelayMask;
+        }
+    }
+
+    // --- gain reduction read-back ---------------------------------------------
+    float grLeft = 0.0f, grRight = 0.0f;
+    switch (mode)
+    {
+        case CompMode::Opto: grLeft = opto.getGainReduction (0); grRight = (numChannels > 1) ? opto.getGainReduction (1) : grLeft; break;
+        case CompMode::FET:  grLeft = fet.getGainReduction (0);  grRight = (numChannels > 1) ? fet.getGainReduction (1)  : grLeft; break;
+        case CompMode::VCA:  grLeft = vca.getGainReduction (0);  grRight = (numChannels > 1) ? vca.getGainReduction (1)  : grLeft; break;
+        case CompMode::Bus:  grLeft = bus.getGainReduction (0);  grRight = (numChannels > 1) ? bus.getGainReduction (1)  : grLeft; break;
+    }
+    linkedGainReduction[0].store (grLeft, std::memory_order_relaxed);
+    linkedGainReduction[1].store (grRight, std::memory_order_relaxed);
+    const float gainReduction = jmin (grLeft, grRight);
+
+    // --- GR-based auto-makeup gain --------------------------------------------
+    {
+        float targetAutoGain = 1.0f;
+        if (autoMakeup)
+        {
+            const float avgGrDb = (grLeft + grRight) * 0.5f;
+
+            if (primeGrAccumulator)
+            {
+                smoothedGrDb = avgGrDb;
+                primeGrAccumulator = false;
+
+                float autoGainDb = -avgGrDb;
+                if (mode == CompMode::FET)  autoGainDb -= cp[0];
+                if (mode == CompMode::Opto) autoGainDb -= jmin (1.5f, std::abs (avgGrDb) * 0.25f);
+                autoGainDb = jlimit (-40.0f, 40.0f, autoGainDb);
+                float primedGain = dbToGain (autoGainDb);
+                primedGain = 1.0f + (primedGain - 1.0f) * mixAmount;
+                smoothedAutoMakeupGain.setCurrentAndTargetValue (primedGain);
+            }
+            else
+            {
+                smoothedGrDb += grSmoothCoeff * (avgGrDb - smoothedGrDb);
+            }
+
+            float autoGainDb = -smoothedGrDb;
+            if (mode == CompMode::FET)  autoGainDb -= cp[0];
+            if (mode == CompMode::Opto) autoGainDb -= jmin (1.5f, std::abs (smoothedGrDb) * 0.25f);
+            autoGainDb = jlimit (-40.0f, 40.0f, autoGainDb);
+            targetAutoGain = dbToGain (autoGainDb);
+            targetAutoGain = 1.0f + (targetAutoGain - 1.0f) * mixAmount;
+        }
+
+        smoothedAutoMakeupGain.setTargetValue (targetAutoGain);
+
+        if (smoothedAutoMakeupGain.isSmoothing())
+        {
+            const int samplesToProcess = jmin (numSamples, (int) smoothedGainBuffer.size());
+            for (int i = 0; i < samplesToProcess; ++i)
+                smoothedGainBuffer[(size_t) i] = smoothedAutoMakeupGain.getNextValue();
+            for (int ch = 0; ch < nc; ++ch)
+            {
+                float* data = out[ch];
+                for (int i = 0; i < samplesToProcess; ++i)
+                    data[i] *= smoothedGainBuffer[(size_t) i];
+            }
+        }
+        else
+        {
+            const float currentGain = smoothedAutoMakeupGain.getCurrentValue();
+            if (std::abs (currentGain - 1.0f) > 0.001f)
+                for (int ch = 0; ch < nc; ++ch)
+                {
+                    float* data = out[ch];
+                    for (int i = 0; i < numSamples; ++i)
+                        data[i] *= currentGain;
+                }
+        }
+    }
+
+    // Bypass -> active crossfade: blend the wet output against the dry captured
+    // at the top of the block.
+    if (bypassFadeRemaining > 0)
+    {
+        const int fadeSamples = jmin (bypassFadeRemaining, numSamples);
+        const float fadeLen = (float) bypassFadeActualLength;
+        for (int ch = 0; ch < nc; ++ch)
+        {
+            float* o = out[ch];
+            const float* dry = bypassFadeBuffer[ch].data();
+            for (int i = 0; i < fadeSamples; ++i)
+            {
+                const float wet = 1.0f - (float) (bypassFadeRemaining - i) / fadeLen;
+                o[i] = o[i] * wet + dry[i] * (1.0f - wet);
+            }
+        }
+        bypassFadeRemaining -= fadeSamples;
+    }
+
+    // --- output metering ------------------------------------------------------
+    {
+        float outLevel = 0.0f, outL = 0.0f, outR = 0.0f;
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            const float peak = getPeakLevel (out[ch], numSamples);
+            outLevel = jmax (outLevel, peak);
+            if (ch == 0) outL = peak; else if (ch == 1) outR = peak;
+        }
+        outputMeter.store  (outLevel > 1e-5f ? gainToDb (outLevel) : -60.0f, std::memory_order_relaxed);
+        outputMeterL.store (outL > 1e-5f ? gainToDb (outL) : -60.0f, std::memory_order_relaxed);
+        outputMeterR.store (numChannels > 1 ? (outR > 1e-5f ? gainToDb (outR) : -60.0f)
+                                            : (outL > 1e-5f ? gainToDb (outL) : -60.0f), std::memory_order_relaxed);
+    }
+
+    // Delay the displayed GR to match the reference's meter behaviour (one ring
+    // slot per processBlock call, delay computed in prepare from the reference's
+    // constant reported AA latency).
+    float delayedGR = gainReduction;
+    if (grDelayBlocks > 0)
+    {
+        grDelayBuffer[(size_t) grDelayWritePos] = gainReduction;
+        const int readPos = (grDelayWritePos - grDelayBlocks + kMaxGrDelayBlocks) % kMaxGrDelayBlocks;
+        delayedGR = grDelayBuffer[(size_t) readPos];
+        grDelayWritePos = (grDelayWritePos + 1) % kMaxGrDelayBlocks;
+    }
+    grMeter.store (delayedGR, std::memory_order_relaxed);
+
+    // GR history (UI 30 Hz) + analog noise are not mirrored: noise is forced off
+    // by Dusk (noise_enable = 0); history is a pure UI convenience. See PORT_NOTES.
+}
+
+} // namespace duskaudio

--- a/plugins/multi-comp/core/UniversalCompressorDSP.hpp
+++ b/plugins/multi-comp/core/UniversalCompressorDSP.hpp
@@ -1,0 +1,235 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// UniversalCompressorDSP.hpp — framework-free (no-JUCE) port of the Multi-Comp
+// (UniversalCompressor) DSP, scoped to the four modes Dusk Studio's strips use:
+// Opto, FET, VCA, Bus. Mirrors the driving logic in multicomp.cpp
+// (prepareToPlay / processBlock) for those modes at the parameter subset Dusk
+// Studio drives, with everything else at its JUCE default.
+//
+// RT contract:
+//   - prepare() / reset()  : main thread. Allocate + size here.
+//   - processBlock()       : real-time. No alloc / lock / IO. Denormals flushed.
+//   - set*() setters        : atomic, callable from any thread.
+//
+// Scope, default-trace and substitution decisions: core/PORT_NOTES.md.
+
+#pragma once
+
+#include <atomic>
+#include <vector>
+
+#include "UniversalCompressorServices.hpp"
+#include "OptoCompressor.hpp"
+#include "FETCompressor.hpp"
+#include "VCACompressor.hpp"
+#include "BusCompressor.hpp"
+
+namespace duskaudio
+{
+
+// Mode indices — match CompressorMode in UniversalCompressor.h (Opto/FET/VCA/Bus
+// are the only in-scope values; 4..7 are unported and treated as passthrough).
+enum class CompMode : int { Opto = 0, FET = 1, VCA = 2, Bus = 3 };
+
+class UniversalCompressorDSP
+{
+public:
+    UniversalCompressorDSP();
+
+    // --- lifecycle (main thread) ---------------------------------------------
+    void prepare (double sampleRate, int maxBlock);
+    void reset();
+
+    // --- audio (real-time) ---------------------------------------------------
+    // Stereo or mono. When in != out, in is copied to out first, then processed
+    // in place (mirrors the JUCE in-place buffer semantics). numChannels is 1 or 2.
+    void processBlock (const float* const* in, float* const* out, int numChannels, int numSamples);
+
+    // Reported processing latency in samples. Mirrors the reference's constant
+    // report: 60 (the 4x AA FIR latency) even though the runtime wet path has
+    // no actual delay — the bypass / 0%-mix / partial-mix dry paths ARE delayed
+    // by this amount to match. See PORT_NOTES §Oversampling & latency.
+    int getLatencySamples() const noexcept { return latencySamples; }
+
+    //==========================================================================
+    // Parameter setters. Ranges/units match the JUCE APVTS layout EXACTLY
+    // (multicomp.cpp createParameterLayout). Values are stored raw (SI/index),
+    // as Dusk Studio writes them to the donor's raw parameter atoms; the audio
+    // thread applies the same in-process clamps the JUCE processBlock does.
+    //==========================================================================
+
+    // mode: 0=Opto, 1=FET, 2=VCA, 3=Bus (choice index).
+    void setMode (int modeIndex) noexcept                { pMode.store (modeIndex, std::memory_order_relaxed); }
+    // bypass: on/off.
+    void setBypass (bool on) noexcept                    { pBypass.store (on, std::memory_order_relaxed); }
+    // mix: 0..100 %  (dry/wet; 100 = fully wet).
+    void setMix (float percent) noexcept                 { pMix.store (percent, std::memory_order_relaxed); }
+    // auto_makeup: off/on (GR-based auto makeup gain).
+    void setAutoMakeup (bool on) noexcept                { pAutoMakeup.store (on, std::memory_order_relaxed); }
+    // sidechain_hp: 0..500 Hz (0 = filter bypassed).
+    void setSidechainHp (float hz) noexcept              { pScHp.store (hz, std::memory_order_relaxed); }
+    // stereo_link: 0..100 %  (max-level link amount).
+    void setStereoLink (float percent) noexcept          { pStereoLink.store (percent, std::memory_order_relaxed); }
+    // stereo_link_mode: 0=Stereo, 1=Mid-Side, 2=Dual-Mono (default 0; only Stereo ported).
+    void setStereoLinkMode (int index) noexcept          { pStereoLinkMode.store (index, std::memory_order_relaxed); }
+
+    // Opto
+    void setOptoPeakReduction (float v) noexcept         { pOptoPeakReduction.store (v, std::memory_order_relaxed); } // 0..100
+    void setOptoGain (float v) noexcept                  { pOptoGain.store (v, std::memory_order_relaxed); }          // 0..100 (50 = unity)
+    void setOptoLimit (bool on) noexcept                 { pOptoLimit.store (on, std::memory_order_relaxed); }
+
+    // FET
+    void setFetInput (float db) noexcept                 { pFetInput.store (db, std::memory_order_relaxed); }         // -20..40 dB
+    void setFetOutput (float db) noexcept                { pFetOutput.store (db, std::memory_order_relaxed); }        // -20..20 dB
+    void setFetAttack (float ms) noexcept                { pFetAttack.store (ms, std::memory_order_relaxed); }        // 0.02..80 ms
+    void setFetRelease (float ms) noexcept               { pFetRelease.store (ms, std::memory_order_relaxed); }       // 50..1100 ms
+    void setFetRatio (int index) noexcept                { pFetRatio.store (index, std::memory_order_relaxed); }      // 0..4 (4:1..All)
+    void setFetThreshold (float dbfs) noexcept           { pFetThreshold.store (dbfs, std::memory_order_relaxed); }   // -60..0 dBFS
+    void setFetCurveMode (int index) noexcept            { pFetCurveMode.store (index, std::memory_order_relaxed); }  // 0=Modern (default), 1=Measured
+    void setFetTransient (float percent) noexcept        { pFetTransient.store (percent, std::memory_order_relaxed); }// 0..100 % (default)
+
+    // VCA
+    void setVcaThreshold (float db) noexcept             { pVcaThreshold.store (db, std::memory_order_relaxed); }     // -38..12 dB
+    void setVcaRatio (float ratio) noexcept              { pVcaRatio.store (ratio, std::memory_order_relaxed); }      // 1..120 :1
+    void setVcaAttack (float ms) noexcept                { pVcaAttack.store (ms, std::memory_order_relaxed); }        // 0.1..50 ms
+    void setVcaRelease (float ms) noexcept               { pVcaRelease.store (ms, std::memory_order_relaxed); }       // 10..5000 ms
+    void setVcaOutput (float db) noexcept                { pVcaOutput.store (db, std::memory_order_relaxed); }        // -20..20 dB
+    void setVcaOverEasy (bool on) noexcept               { pVcaOverEasy.store (on, std::memory_order_relaxed); }
+    void setVcaDetectorMode (int index) noexcept         { pVcaDetectorMode.store (index, std::memory_order_relaxed); }// 0=Adaptive,1=Classic
+
+    // Bus
+    void setBusThreshold (float db) noexcept             { pBusThreshold.store (db, std::memory_order_relaxed); }     // -30..15 dB
+    void setBusRatio (int index) noexcept                { pBusRatio.store (index, std::memory_order_relaxed); }      // 0..2 (2:1/4:1/10:1)
+    void setBusAttack (int index) noexcept               { pBusAttack.store (index, std::memory_order_relaxed); }     // 0..5 choice
+    void setBusRelease (int index) noexcept              { pBusRelease.store (index, std::memory_order_relaxed); }    // 0..4 choice
+    void setBusMakeup (float db) noexcept                { pBusMakeup.store (db, std::memory_order_relaxed); }        // 0..20 dB
+    void setBusMix (float percent) noexcept              { pBusMix.store (percent, std::memory_order_relaxed); }      // 0..100 %
+
+    //==========================================================================
+    // Metering (relaxed atomics, written on the audio thread, polled by the UI).
+    // Mirrors UniversalCompressor's public accessors Dusk Studio reads.
+    //==========================================================================
+    float getGainReduction() const noexcept   { return grMeter.load (std::memory_order_relaxed); }       // dB (<=0)
+    float getInputLevel() const noexcept       { return inputMeter.load (std::memory_order_relaxed); }    // dB
+    float getOutputLevel() const noexcept      { return outputMeter.load (std::memory_order_relaxed); }   // dB
+    float getInputLevelL() const noexcept      { return inputMeterL.load (std::memory_order_relaxed); }
+    float getInputLevelR() const noexcept      { return inputMeterR.load (std::memory_order_relaxed); }
+    float getOutputLevelL() const noexcept     { return outputMeterL.load (std::memory_order_relaxed); }
+    float getOutputLevelR() const noexcept     { return outputMeterR.load (std::memory_order_relaxed); }
+    float getSidechainLevel() const noexcept   { return sidechainMeter.load (std::memory_order_relaxed); }
+    float getLinkedGainReduction (int ch) const noexcept
+    {
+        return (ch >= 0 && ch < 2) ? linkedGainReduction[ch].load (std::memory_order_relaxed) : 0.0f;
+    }
+
+private:
+    // --- DSP units -----------------------------------------------------------
+    OptoCompressor opto;
+    FETCompressor  fet;
+    VCACompressor  vca;
+    BusCompressor  bus;
+
+    SidechainFilter sidechainFilter;
+    TransientShaper transientShaper;
+    LookupTables    lookupTables;
+
+    // --- config --------------------------------------------------------------
+    double sampleRate = 0.0;
+    int    maxBlock   = 0;
+    int    numChannelsPrepared = 2;
+    int    latencySamples = 0;
+
+    // --- per-block scratch (sized in prepare, never resized on the audio thread)
+    std::vector<float> filteredSidechain[2];
+    std::vector<float> linkedSidechain[2];
+    std::vector<float> normalDry[2];
+    std::vector<float> smoothedGainBuffer;
+
+    // --- auto-makeup state (native rate) -------------------------------------
+    MultiplicativeSmoothedValue smoothedAutoMakeupGain { 1.0f };
+    float smoothedGrDb = 0.0f;
+    float grSmoothCoeff = 0.0f;
+    bool  primeGrAccumulator = true;
+    int   lastMode = -1;
+
+    // --- GR-meter block-delay ring (mirrors the reference's grDelayBuffer:
+    // one GR value per block, delayed by the blocks covering the reference's
+    // constant reported AA latency) --------------------------------------------
+    static constexpr int kMaxGrDelayBlocks = 256;
+    std::array<float, kMaxGrDelayBlocks> grDelayBuffer {};
+    int grDelayWritePos = 0;
+    int grDelayBlocks = 0;
+
+    // --- bypass / 0%-mix latency-aligned dry ring (mirrors bypassAlignBuf:
+    // fed with raw input every block; bypass and 0%-mix read it back delayed by
+    // the constant reported latency) -------------------------------------------
+    std::vector<float> bypassAlignBuf[2];
+    int bypassAlignWritePos[2] { 0, 0 };
+    int bypassAlignSize = 0;
+
+    // --- bypass -> active crossfade (mirrors the bypassFadeBuffer machinery;
+    // the Digital-mode fade extension is unreachable in scope) -----------------
+    std::vector<float> bypassFadeBuffer[2];
+    int  bypassFadeLengthSamples = 256;
+    int  bypassFadeActualLength = 256;
+    int  bypassFadeRemaining = 0;
+    bool wasBypassedLastBlock = false;
+
+    // --- partial-mix dry-delay ring (mirrors DryWetMixer's tier-2 delayBuffer;
+    // the dry signal is delayed by the constant reported latency before the
+    // crossfade) ----------------------------------------------------------------
+    static constexpr int kMixDelaySamples = 256;               // power of 2
+    static constexpr int kMixDelayMask = kMixDelaySamples - 1;
+    std::array<std::array<float, kMixDelaySamples>, 2> mixDelayBuffer {};
+    int mixDelayWritePos = 0;
+
+    // --- parameter atoms (defaults == JUCE APVTS defaults) -------------------
+    std::atomic<int>   pMode { 0 };
+    std::atomic<bool>  pBypass { false };
+    std::atomic<float> pMix { 100.0f };
+    std::atomic<bool>  pAutoMakeup { false };
+    std::atomic<float> pScHp { 0.0f };
+    std::atomic<float> pStereoLink { 100.0f };
+    std::atomic<int>   pStereoLinkMode { 0 };
+
+    std::atomic<float> pOptoPeakReduction { 0.0f };
+    std::atomic<float> pOptoGain { 50.0f };
+    std::atomic<bool>  pOptoLimit { false };
+
+    std::atomic<float> pFetInput { 0.0f };
+    std::atomic<float> pFetOutput { 0.0f };
+    std::atomic<float> pFetAttack { 0.2f };
+    std::atomic<float> pFetRelease { 400.0f };
+    std::atomic<int>   pFetRatio { 0 };
+    std::atomic<float> pFetThreshold { -10.0f };
+    std::atomic<int>   pFetCurveMode { 0 };
+    std::atomic<float> pFetTransient { 0.0f };
+
+    std::atomic<float> pVcaThreshold { 0.0f };
+    std::atomic<float> pVcaRatio { 4.0f };
+    std::atomic<float> pVcaAttack { 1.0f };
+    std::atomic<float> pVcaRelease { 100.0f };
+    std::atomic<float> pVcaOutput { 0.0f };
+    std::atomic<bool>  pVcaOverEasy { false };
+    std::atomic<int>   pVcaDetectorMode { 0 };
+
+    std::atomic<float> pBusThreshold { 0.0f };
+    std::atomic<int>   pBusRatio { 0 };
+    std::atomic<int>   pBusAttack { 2 };
+    std::atomic<int>   pBusRelease { 1 };
+    std::atomic<float> pBusMakeup { 0.0f };
+    std::atomic<float> pBusMix { 100.0f };
+
+    // --- meters --------------------------------------------------------------
+    mutable std::atomic<float> grMeter { 0.0f };
+    mutable std::atomic<float> inputMeter { -60.0f };
+    mutable std::atomic<float> outputMeter { -60.0f };
+    mutable std::atomic<float> inputMeterL { -60.0f };
+    mutable std::atomic<float> inputMeterR { -60.0f };
+    mutable std::atomic<float> outputMeterL { -60.0f };
+    mutable std::atomic<float> outputMeterR { -60.0f };
+    mutable std::atomic<float> sidechainMeter { -60.0f };
+    mutable std::atomic<float> linkedGainReduction[2] { {0.0f}, {0.0f} };
+};
+
+} // namespace duskaudio

--- a/plugins/multi-comp/core/UniversalCompressorServices.hpp
+++ b/plugins/multi-comp/core/UniversalCompressorServices.hpp
@@ -1,0 +1,507 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// UniversalCompressorServices.hpp — framework-free (no-JUCE) port of the shared
+// DSP services used by the Opto / FET / VCA / Bus compressor modes, extracted
+// from plugins/multi-comp/multicomp.cpp. Every constant, coefficient and
+// sample-level op order is preserved from the JUCE original. Substitutions and
+// judgment calls are recorded in core/PORT_NOTES.md.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace duskaudio
+{
+
+//==============================================================================
+// Math constants + helpers replacing juce::MathConstants / juce::jlimit /
+// juce::Decibels. Kept as free functions so the mode transcriptions read the
+// same as the JUCE source (juce::jlimit(a,b,v) -> duskaudio::jlimit(a,b,v)).
+//==============================================================================
+constexpr float  kPiF    = 3.14159265358979323846f;
+constexpr double kPiD    = 3.14159265358979323846;
+constexpr float  kTwoPiF = 6.28318530717958647692f;
+constexpr double kTwoPiD = 6.28318530717958647692;
+
+template <typename T> inline T jmin (T a, T b) noexcept { return a < b ? a : b; }
+template <typename T> inline T jmax (T a, T b) noexcept { return a > b ? a : b; }
+
+// juce::jlimit(lowerBound, upperBound, value) — note the JUCE argument order.
+template <typename T> inline T jlimit (T lo, T hi, T v) noexcept
+{
+    return v < lo ? lo : (hi < v ? hi : v);
+}
+
+// juce::Decibels::decibelsToGain (default minus-infinity dB == -100).
+inline float dbToGain (float db) noexcept { return db > -100.0f ? std::pow (10.0f, db * 0.05f) : 0.0f; }
+
+// juce::Decibels::gainToDecibels (default minus-infinity dB == -100).
+inline float gainToDb (float gain) noexcept
+{
+    return gain > 0.0f ? jmax (-100.0f, std::log10 (gain) * 20.0f) : -100.0f;
+}
+
+// juce::approximatelyEqual(a, b) with the library-default tolerances
+// (absolute = FLT_MIN, relative = FLT_EPSILON). Used by MultiplicativeSmoothedValue.
+inline bool approximatelyEqual (float a, float b) noexcept
+{
+    if (! (std::isfinite (a) && std::isfinite (b)))
+        return a == b;
+    const float diff = std::abs (a - b);
+    return diff <= std::numeric_limits<float>::min()
+        || diff <= std::numeric_limits<float>::epsilon() * std::max (std::abs (a), std::abs (b));
+}
+
+//==============================================================================
+// Verbatim port of the multicomp.cpp file-scope Constants namespace. The mode
+// transcriptions reference these by the same names; keep the values identical.
+//==============================================================================
+namespace Constants
+{
+    // T4B Optical Cell — CdS photoresistor + electroluminescent panel
+    constexpr float T4B_ATTACK_TIME = 0.002f;
+    constexpr float T4B_FAST_RELEASE_TIME = 0.060f;
+    constexpr float T4B_PHOSPHOR_BASE_DECAY = 1.5f;
+    constexpr float T4B_PHOSPHOR_AFTERGLOW_DECAY = 5.0f;
+    constexpr float T4B_PHOSPHOR_AFTERGLOW_ATTACK_RATIO = 0.25f;
+    constexpr float T4B_PHOSPHOR_AFTERGLOW_COUPLING = 0.12f;
+    constexpr float T4B_PHOSPHOR_ATTACK_RATIO = 0.3f;
+    constexpr float T4B_GAMMA = 0.7f;
+    constexpr float T4B_CONDUCTANCE_K = 3.0f;
+    constexpr float T4B_PHOSPHOR_COUPLING = 0.40f;
+    constexpr float T4B_PROG_DEP_CHARGE_RATE = 0.15f;
+    constexpr float T4B_PROG_DEP_DISCHARGE_RATE = 0.12f;
+    constexpr float T4B_PROG_DEP_RELEASE_SCALE = 5.0f;
+    constexpr float T4B_PROG_DEP_PHOSPHOR_SCALE = 3.0f;
+    constexpr float SC_DRIVER_SATURATION = 0.8f;
+    constexpr float SC_DRIVER_OUTPUT_SCALE = 1.0f;
+    constexpr float T4B_EL_PANEL_ATTACK_FREQ = 150.0f;
+    constexpr float T4B_EL_PANEL_RELEASE_FREQ = 5.0f;
+    constexpr float T4B_CONDUCTANCE_ATTACK_FREQ = 150.0f;
+    constexpr float T4B_CONDUCTANCE_RELEASE_FREQ = 4.0f;
+    constexpr float SC_DRIVER_THRESHOLD = 0.03f;
+    constexpr float SC_LEVEL_SMOOTH_FREQ = 800.0f;
+    constexpr float PEAK_REDUCTION_MAX_SC_GAIN = 14.0f;
+    constexpr float T4B_MAX_CONDUCTANCE = 6.0f;
+    constexpr float T4B_MAX_GAIN_RELEASE_RATE = 10.0f;
+
+    // Vintage FET constants
+    constexpr float FET_THRESHOLD_DB = -10.0f;
+    constexpr float FET_MAX_REDUCTION_DB = 30.0f;
+    constexpr float FET_ALLBUTTONS_MIN_ATTACK = 0.0002f;
+    constexpr float FET_ALLBUTTONS_MAX_ATTACK = 0.002f;
+
+    // Classic VCA constants
+    constexpr float VCA_RMS_TIME_CONSTANT = 0.003f;
+    constexpr float VCA_RELEASE_RATE = 120.0f;
+    constexpr float VCA_MAX_REDUCTION_DB = 60.0f;
+
+    // Bus Compressor constants
+    constexpr float BUS_SIDECHAIN_HP_FREQ = 60.0f;
+    constexpr float BUS_MAX_REDUCTION_DB = 20.0f;
+    constexpr float BUS_OVEREASY_KNEE_WIDTH = 10.0f;
+    constexpr float BUS_RMS_TIME = 0.005f;
+
+    // Studio FET constants (out of port scope; kept for constant parity)
+    constexpr float STUDIO_FET_THRESHOLD_DB = -10.0f;
+    constexpr float STUDIO_FET_HARMONIC_SCALE = 0.3f;
+
+    // Studio VCA constants (out of port scope; kept for constant parity)
+    constexpr float STUDIO_VCA_MAX_REDUCTION_DB = 40.0f;
+    constexpr float STUDIO_VCA_SOFT_KNEE_DB = 6.0f;
+
+    // Global sidechain highpass filter frequency (user-adjustable)
+    constexpr float SIDECHAIN_HP_MIN = 20.0f;
+    constexpr float SIDECHAIN_HP_MAX = 500.0f;
+    constexpr float SIDECHAIN_HP_DEFAULT = 80.0f;
+
+    // Anti-aliasing (internal OS is out of scope; kept for constant parity)
+    constexpr float NYQUIST_SAFETY_FACTOR = 0.4f;
+    constexpr float MAX_CUTOFF_FREQ = 20000.0f;
+
+    // Safety limits
+    constexpr float OUTPUT_HARD_LIMIT = 2.0f;
+    constexpr float EPSILON = 0.0001f;
+}
+
+//==============================================================================
+// MultiplicativeSmoothedValue — verbatim behavioural port of
+// juce::SmoothedValue<float, ValueSmoothingTypes::Multiplicative>.
+//
+// Drives the GR-based auto-makeup gain in UniversalCompressorDSP::processBlock.
+// Ramp semantics (step = geometric factor, countdown in samples) match JUCE
+// exactly so the smoothed makeup curve is bit-identical.
+//==============================================================================
+class MultiplicativeSmoothedValue
+{
+public:
+    MultiplicativeSmoothedValue() = default;
+    explicit MultiplicativeSmoothedValue (float initial) noexcept : currentValue (initial), target (initial) {}
+
+    void reset (double sampleRate, double rampLengthInSeconds) noexcept
+    {
+        reset ((int) std::floor (rampLengthInSeconds * sampleRate));
+    }
+
+    void reset (int numSteps) noexcept
+    {
+        stepsToTarget = numSteps;
+        setCurrentAndTargetValue (target);
+    }
+
+    void setCurrentAndTargetValue (float newValue) noexcept
+    {
+        target = currentValue = newValue;
+        countdown = 0;
+    }
+
+    void setTargetValue (float newValue) noexcept
+    {
+        if (approximatelyEqual (newValue, target))
+            return;
+
+        if (stepsToTarget <= 0)
+        {
+            setCurrentAndTargetValue (newValue);
+            return;
+        }
+
+        target = newValue;
+        countdown = stepsToTarget;
+        step = std::exp ((std::log (std::abs (target)) - std::log (std::abs (currentValue))) / (float) countdown);
+    }
+
+    bool  isSmoothing()     const noexcept { return countdown > 0; }
+    float getCurrentValue() const noexcept { return currentValue; }
+    float getTargetValue()  const noexcept { return target; }
+
+    float getNextValue() noexcept
+    {
+        if (! isSmoothing())
+            return target;
+
+        --countdown;
+
+        if (isSmoothing())
+            currentValue *= step;
+        else
+            currentValue = target;
+
+        return currentValue;
+    }
+
+private:
+    float currentValue = 1.0f;
+    float target = 1.0f;
+    float step = 0.0f;
+    int   countdown = 0;
+    int   stepsToTarget = 0;
+};
+
+//==============================================================================
+// SidechainFilter — Butterworth (Q = 0.707) highpass, transposed Direct-Form-II.
+// Verbatim port of UniversalCompressor::SidechainFilter (multicomp.cpp L442).
+// Prepared at the NATIVE sample rate. Engaged only when the sidechain_hp
+// slider is >= 1 Hz; below that the caller bypasses it with a memcpy.
+//==============================================================================
+class SidechainFilter
+{
+public:
+    void prepare (double sr, int numChannels)
+    {
+        sampleRate = sr;
+        filterStates.resize ((size_t) numChannels);
+        for (auto& state : filterStates) { state.z1 = 0.0f; state.z2 = 0.0f; }
+        updateCoefficients (Constants::SIDECHAIN_HP_DEFAULT);
+    }
+
+    void reset()
+    {
+        for (auto& state : filterStates) { state.z1 = 0.0f; state.z2 = 0.0f; }
+    }
+
+    void setFrequency (float freq)
+    {
+        freq = jlimit (Constants::SIDECHAIN_HP_MIN, Constants::SIDECHAIN_HP_MAX, freq);
+        if (std::abs (freq - currentFreq) > 0.1f)
+            updateCoefficients (freq);
+    }
+
+    float process (float input, int channel)
+    {
+        if (channel < 0 || channel >= (int) filterStates.size())
+            return input;
+
+        auto& state = filterStates[(size_t) channel];
+        float output = b0 * input + state.z1;
+        state.z1 = b1 * input - a1 * output + state.z2;
+        state.z2 = b2 * input - a2 * output;
+        return output;
+    }
+
+    void processBlock (const float* input, float* output, int numSamples, int channel)
+    {
+        if (channel < 0 || channel >= (int) filterStates.size())
+        {
+            if (input != output)
+                std::memcpy (output, input, (size_t) numSamples * sizeof (float));
+            return;
+        }
+
+        auto& state = filterStates[(size_t) channel];
+        const float lb0 = b0, lb1 = b1, lb2 = b2;
+        const float la1 = a1, la2 = a2;
+        float z1 = state.z1, z2 = state.z2;
+
+        int i = 0;
+        for (; i + 4 <= numSamples; i += 4)
+        {
+            float out0 = lb0 * input[i] + z1;
+            z1 = lb1 * input[i] - la1 * out0 + z2;
+            z2 = lb2 * input[i] - la2 * out0;
+            output[i] = out0;
+
+            float out1 = lb0 * input[i+1] + z1;
+            z1 = lb1 * input[i+1] - la1 * out1 + z2;
+            z2 = lb2 * input[i+1] - la2 * out1;
+            output[i+1] = out1;
+
+            float out2 = lb0 * input[i+2] + z1;
+            z1 = lb1 * input[i+2] - la1 * out2 + z2;
+            z2 = lb2 * input[i+2] - la2 * out2;
+            output[i+2] = out2;
+
+            float out3 = lb0 * input[i+3] + z1;
+            z1 = lb1 * input[i+3] - la1 * out3 + z2;
+            z2 = lb2 * input[i+3] - la2 * out3;
+            output[i+3] = out3;
+        }
+        for (; i < numSamples; ++i)
+        {
+            float out = lb0 * input[i] + z1;
+            z1 = lb1 * input[i] - la1 * out + z2;
+            z2 = lb2 * input[i] - la2 * out;
+            output[i] = out;
+        }
+
+        state.z1 = z1;
+        state.z2 = z2;
+    }
+
+    float getFrequency() const { return currentFreq; }
+
+private:
+    void updateCoefficients (float freq)
+    {
+        currentFreq = freq;
+        if (sampleRate <= 0.0) return;
+
+        const float omega = 2.0f * kPiF * freq / (float) sampleRate;
+        const float cosOmega = std::cos (omega);
+        const float sinOmega = std::sin (omega);
+        const float alpha = sinOmega / (2.0f * 0.707f);
+        const float a0_inv = 1.0f / (1.0f + alpha);
+
+        b0 = ((1.0f + cosOmega) / 2.0f) * a0_inv;
+        b1 = -(1.0f + cosOmega) * a0_inv;
+        b2 = b0;
+        a1 = (-2.0f * cosOmega) * a0_inv;
+        a2 = (1.0f - alpha) * a0_inv;
+    }
+
+    struct FilterState { float z1 = 0.0f; float z2 = 0.0f; };
+
+    std::vector<FilterState> filterStates;
+    double sampleRate = 44100.0;
+    float currentFreq = Constants::SIDECHAIN_HP_DEFAULT;
+    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f, a1 = 0.0f, a2 = 0.0f;
+};
+
+//==============================================================================
+// TransientShaper — verbatim port of UniversalCompressor::TransientShaper
+// (multicomp.cpp L901). Prepared at the NATIVE sample rate. Only the FET mode
+// consumes it (via a pointer); at fet_transient == 0 it is a no-op modifier.
+//==============================================================================
+class TransientShaper
+{
+public:
+    void prepare (double sr, int numChannels)
+    {
+        sampleRate = sr;
+        channels.resize ((size_t) numChannels);
+        for (auto& ch : channels) { ch.fastEnvelope = 0.0f; ch.slowEnvelope = 0.0f; ch.peakHold = 0.0f; ch.holdCounter = 0; }
+
+        fastAttackCoeff  = std::exp (-1.0f / (0.0005f * (float) sampleRate));
+        fastReleaseCoeff = std::exp (-1.0f / (0.020f  * (float) sampleRate));
+        slowAttackCoeff  = std::exp (-1.0f / (0.010f  * (float) sampleRate));
+        slowReleaseCoeff = std::exp (-1.0f / (0.100f  * (float) sampleRate));
+        holdSamples = (int) (0.005f * (float) sampleRate);
+    }
+
+    float process (float input, int channel, float sensitivity)
+    {
+        if (channel < 0 || channel >= (int) channels.size())
+            return 1.0f;
+
+        auto& ch = channels[(size_t) channel];
+        float absInput = std::abs (input);
+
+        if (absInput > ch.fastEnvelope)
+            ch.fastEnvelope = fastAttackCoeff * ch.fastEnvelope + (1.0f - fastAttackCoeff) * absInput;
+        else
+            ch.fastEnvelope = fastReleaseCoeff * ch.fastEnvelope + (1.0f - fastReleaseCoeff) * absInput;
+
+        if (absInput > ch.slowEnvelope)
+            ch.slowEnvelope = slowAttackCoeff * ch.slowEnvelope + (1.0f - slowAttackCoeff) * absInput;
+        else
+            ch.slowEnvelope = slowReleaseCoeff * ch.slowEnvelope + (1.0f - slowReleaseCoeff) * absInput;
+
+        if (absInput > ch.peakHold)
+        {
+            ch.peakHold = absInput;
+            ch.holdCounter = holdSamples;
+        }
+        else if (ch.holdCounter > 0)
+        {
+            ch.holdCounter--;
+        }
+        else
+        {
+            ch.peakHold = ch.peakHold * 0.9995f;
+        }
+
+        float transientRatio = 1.0f;
+        if (ch.slowEnvelope > 0.0001f)
+            transientRatio = ch.fastEnvelope / ch.slowEnvelope;
+
+        float normalizedSensitivity = sensitivity / 100.0f;
+        float transientModifier = 1.0f;
+
+        if (transientRatio > 1.0f)
+        {
+            float transientAmount = jmin ((transientRatio - 1.0f) * 2.0f, 2.0f);
+            transientModifier = 1.0f + transientAmount * normalizedSensitivity;
+        }
+
+        return transientModifier;
+    }
+
+    void reset()
+    {
+        for (auto& ch : channels) { ch.fastEnvelope = 0.0f; ch.slowEnvelope = 0.0f; ch.peakHold = 0.0f; ch.holdCounter = 0; }
+    }
+
+private:
+    struct Channel { float fastEnvelope = 0.0f; float slowEnvelope = 0.0f; float peakHold = 0.0f; int holdCounter = 0; };
+
+    std::vector<Channel> channels;
+    double sampleRate = 44100.0;
+    float fastAttackCoeff = 0.0f, fastReleaseCoeff = 0.0f;
+    float slowAttackCoeff = 0.0f, slowReleaseCoeff = 0.0f;
+    int holdSamples = 0;
+};
+
+//==============================================================================
+// LookupTables — verbatim port of UniversalCompressor::LookupTables
+// (declaration in UniversalCompressor.h L304; initialize()/fastExp/fastLog/
+// getAllButtonsReduction bodies at multicomp.cpp L4834). Consumed by the FET
+// mode (fast exp/log + all-buttons transfer curve). Rate-independent — build
+// once in prepare().
+//==============================================================================
+class LookupTables
+{
+public:
+    static constexpr int TABLE_SIZE = 4096;
+    static constexpr int ALLBUTTONS_TABLE_SIZE = 512;
+
+    std::array<float, TABLE_SIZE> expTable {};
+    std::array<float, TABLE_SIZE> logTable {};
+    std::array<float, ALLBUTTONS_TABLE_SIZE> allButtonsModernCurve {};
+    std::array<float, ALLBUTTONS_TABLE_SIZE> allButtonsMeasuredCurve {};
+
+    void initialize()
+    {
+        for (int i = 0; i < TABLE_SIZE; ++i)
+        {
+            float x = -4.0f + (4.0f * i / (float) (TABLE_SIZE - 1));
+            expTable[(size_t) i] = std::exp (x);
+        }
+
+        for (int i = 0; i < TABLE_SIZE; ++i)
+        {
+            float x = 0.0001f + (0.9999f * i / (float) (TABLE_SIZE - 1));
+            logTable[(size_t) i] = std::log (x);
+        }
+
+        constexpr float measuredPoints[][2] = {
+            {0.0f, 0.0f}, {1.0f, 0.9f}, {2.0f, 1.9f}, {4.0f, 3.85f}, {6.0f, 5.8f},
+            {8.0f, 7.8f}, {10.0f, 9.8f}, {15.0f, 14.8f}, {20.0f, 19.7f}, {30.0f, 29.5f}
+        };
+        constexpr int numPoints = sizeof (measuredPoints) / sizeof (measuredPoints[0]);
+
+        for (int i = 0; i < ALLBUTTONS_TABLE_SIZE; ++i)
+        {
+            float overThreshDb = 30.0f * (float) i / (float) (ALLBUTTONS_TABLE_SIZE - 1);
+
+            if (overThreshDb < 1.0f)
+            {
+                float t = overThreshDb;
+                allButtonsModernCurve[(size_t) i] = overThreshDb * (0.7f + t * 0.28f);
+            }
+            else
+            {
+                allButtonsModernCurve[(size_t) i] = 0.98f + (overThreshDb - 1.0f) * 0.99f;
+            }
+            allButtonsModernCurve[(size_t) i] = jmin (allButtonsModernCurve[(size_t) i], 30.0f);
+
+            float measuredReduction = 0.0f;
+            for (int p = 0; p < numPoints - 1; ++p)
+            {
+                if (overThreshDb >= measuredPoints[p][0] && overThreshDb <= measuredPoints[p + 1][0])
+                {
+                    float t = (overThreshDb - measuredPoints[p][0]) /
+                              (measuredPoints[p + 1][0] - measuredPoints[p][0]);
+                    measuredReduction = measuredPoints[p][1] + t * (measuredPoints[p + 1][1] - measuredPoints[p][1]);
+                    break;
+                }
+            }
+            if (overThreshDb > measuredPoints[numPoints - 1][0])
+                measuredReduction = measuredPoints[numPoints - 1][1];
+            allButtonsMeasuredCurve[(size_t) i] = measuredReduction;
+        }
+    }
+
+    float fastExp (float x) const
+    {
+        x = jlimit (-4.0f, 0.0f, x);
+        int index = (int) ((x + 4.0f) * (TABLE_SIZE - 1) / 4.0f);
+        index = jlimit (0, TABLE_SIZE - 1, index);
+        return expTable[(size_t) index];
+    }
+
+    float fastLog (float x) const
+    {
+        x = jlimit (0.0001f, 1.0f, x);
+        int index = (int) ((x - 0.0001f) * (TABLE_SIZE - 1) / 0.9999f);
+        index = jlimit (0, TABLE_SIZE - 1, index);
+        return logTable[(size_t) index];
+    }
+
+    float getAllButtonsReduction (float overThreshDb, bool useMeasuredCurve) const
+    {
+        overThreshDb = jlimit (0.0f, 30.0f, overThreshDb);
+        float indexFloat = overThreshDb * (float) (ALLBUTTONS_TABLE_SIZE - 1) / 30.0f;
+        int index0 = (int) indexFloat;
+        int index1 = jmin (index0 + 1, ALLBUTTONS_TABLE_SIZE - 1);
+        float frac = indexFloat - (float) index0;
+        const auto& curve = useMeasuredCurve ? allButtonsMeasuredCurve : allButtonsModernCurve;
+        return curve[(size_t) index0] + frac * (curve[(size_t) index1] - curve[(size_t) index0]);
+    }
+};
+
+} // namespace duskaudio

--- a/plugins/multi-comp/core/VCACompressor.hpp
+++ b/plugins/multi-comp/core/VCACompressor.hpp
@@ -1,0 +1,329 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// VCACompressor.hpp — no-JUCE port of UniversalCompressor::VCACompressor
+// (multicomp.cpp L2166–L2528).
+//
+// The PUBLIC interface below is FINAL — the top-level UniversalCompressorDSP
+// calls exactly these. Every constant, coefficient and per-sample op order is
+// preserved from the source. See core/PORT_NOTES.md §Mode contracts.
+
+#pragma once
+
+#include "UniversalCompressorServices.hpp"
+
+namespace duskaudio
+{
+
+class VCACompressor
+{
+public:
+    // vca_detector_mode: choice 1 == "Classic" (fixed 10 ms RMS), 0 == "Adaptive".
+    // Pushed from the top level before process() so the process() signature stays fixed.
+    void setDetectorClassic (bool classic) noexcept;
+
+    void prepare (double sampleRate, int numChannels);
+
+    // process(): RT / per-sample.
+    //   threshold     : vca_threshold (dB)
+    //   ratio         : vca_ratio     (:1)
+    //   attackParam   : vca_attack    (ms)
+    //   releaseParam  : vca_release   (ms)
+    //   outputGain    : vca_output    (dB, 0 == unity; caller forces 0 under auto-makeup)
+    //   overEasy      : vca_overeasy toggle
+    float process (float input, int channel, float threshold, float ratio,
+                   float attackParam, float releaseParam, float outputGain,
+                   bool overEasy = false, bool oversample = false,
+                   float sidechainSignal = 0.0f, bool useExternalSidechain = false);
+
+    float getGainReduction (int channel) const;
+
+    void updateSampleRate (double newSampleRate);
+
+    void reset();
+
+private:
+    struct Detector
+    {
+        float envelope = 1.0f;
+        float rmsBuffer = 0.0f;
+        float previousReduction = 0.0f;
+        float signalEnvelope = 0.0f;
+        float envelopeRate = 0.0f;
+        float previousInput = 0.0f;
+        float overshootAmount = 0.0f;
+        float dcState = 0.0f;
+        float prevSq = 0.0f;
+    };
+
+    static void resetDetector (Detector& detector) noexcept
+    {
+        detector.envelope = 1.0f;
+        detector.rmsBuffer = 0.0f;
+        detector.previousReduction = 0.0f;
+        detector.signalEnvelope = 0.0f;
+        detector.envelopeRate = 0.0f;
+        detector.previousInput = 0.0f;
+        detector.overshootAmount = 0.0f;
+        detector.dcState = 0.0f;
+        detector.prevSq = 0.0f;
+    }
+
+    std::vector<Detector> detectors;
+    double sampleRate = 0.0;
+    bool detectorClassic = false;
+};
+
+inline void VCACompressor::setDetectorClassic (bool classic) noexcept
+{
+    detectorClassic = classic;
+}
+
+inline void VCACompressor::prepare (double sampleRate, int numChannels)
+{
+    this->sampleRate = sampleRate;
+    detectors.resize ((size_t) numChannels);
+    for (auto& detector : detectors)
+        resetDetector (detector);
+}
+
+inline void VCACompressor::reset()
+{
+    for (auto& detector : detectors)
+        resetDetector (detector);
+}
+
+inline float VCACompressor::process (float input, int channel, float threshold, float ratio,
+                                     float attackParam, float releaseParam, float outputGain,
+                                     bool overEasy, bool /*oversample*/,
+                                     float sidechainSignal, bool useExternalSidechain)
+{
+    if (channel >= static_cast<int>(detectors.size()))
+        return input;
+
+    if (sampleRate <= 0.0)
+        return input;
+
+    auto& detector = detectors[(size_t) channel];
+
+    float detectionLevel;
+    if (useExternalSidechain)
+        detectionLevel = std::abs (sidechainSignal);
+    else
+        detectionLevel = std::abs (input);
+
+    float signalDelta = std::abs (detectionLevel - detector.previousInput);
+    detector.envelopeRate = detector.envelopeRate * 0.95f + signalDelta * 0.05f;
+    detector.previousInput = detectionLevel;
+
+    float rmsTimeMs;
+    if (detectorClassic)
+    {
+        rmsTimeMs = 0.010f;
+    }
+    else
+    {
+        float levelDb = gainToDb (jmax (detectionLevel, 0.0001f));
+        float levelAboveRef = jlimit (0.0f, 30.0f, levelDb + 20.0f);
+        float levelFactor = levelAboveRef / 30.0f;
+        rmsTimeMs = 0.005f + 0.030f * std::exp (-3.0f * levelFactor);
+    }
+    const float rmsAlpha = std::exp (-1.0f / (jmax (0.0001f, rmsTimeMs) * static_cast<float>(sampleRate)));
+    detector.rmsBuffer = detector.rmsBuffer * rmsAlpha + detectionLevel * detectionLevel * (1.0f - rmsAlpha);
+    float rmsLevel = std::sqrt (detector.rmsBuffer);
+
+    const float envelopeAlpha = 0.99f;
+    detector.signalEnvelope = detector.signalEnvelope * envelopeAlpha + rmsLevel * (1.0f - envelopeAlpha);
+
+    float thresholdLin = dbToGain (threshold);
+
+    float reduction = 0.0f;
+    float overThreshDb = gainToDb (jmax (Constants::EPSILON, rmsLevel) / thresholdLin);
+
+    if (overEasy)
+    {
+        float kneeWidth = 10.0f;
+        float kneeStart = -kneeWidth * 0.5f;
+        float kneeEnd = kneeWidth * 0.5f;
+
+        if (overThreshDb <= kneeStart)
+        {
+            reduction = 0.0f;
+        }
+        else if (overThreshDb < kneeEnd)
+        {
+            float x = overThreshDb - kneeStart;
+            reduction = (1.0f - 1.0f / ratio) * (x * x) / (2.0f * kneeWidth);
+        }
+        else
+        {
+            reduction = overThreshDb * (1.0f - 1.0f / ratio);
+        }
+    }
+    else
+    {
+        if (rmsLevel > thresholdLin)
+            reduction = overThreshDb * (1.0f - 1.0f / ratio);
+    }
+
+    reduction = jmin (jmax (0.0f, reduction), Constants::VCA_MAX_REDUCTION_DB);
+
+    float attackTime, releaseTime;
+
+    float userAttackScale = attackParam / 15.0f;
+
+    float programAttackTime;
+    if (reduction > 0.1f)
+    {
+        if (reduction <= 10.0f)
+            programAttackTime = 0.015f;
+        else if (reduction <= 20.0f)
+            programAttackTime = 0.005f;
+        else
+            programAttackTime = 0.003f;
+    }
+    else
+    {
+        programAttackTime = 0.015f;
+    }
+
+    attackTime = programAttackTime * userAttackScale;
+    attackTime = jlimit (0.0001f, 0.050f, attackTime);
+
+    float userReleaseTime = releaseParam / 1000.0f;
+
+    const float releaseRate = 120.0f;
+    float programReleaseTime;
+    if (reduction > 0.1f)
+    {
+        programReleaseTime = reduction / releaseRate;
+        programReleaseTime = jmax (0.008f, programReleaseTime);
+    }
+    else
+    {
+        programReleaseTime = 0.008f;
+    }
+
+    float blendFactor = jlimit (0.0f, 1.0f, (userReleaseTime - 0.01f) / 0.5f);
+    releaseTime = programReleaseTime * (1.0f - blendFactor) + userReleaseTime * blendFactor;
+
+    float targetGain = dbToGain (-reduction);
+
+    float attackCoeff = std::exp (-1.0f / (jmax (Constants::EPSILON, attackTime * static_cast<float>(sampleRate))));
+
+    if (targetGain < detector.envelope)
+    {
+        detector.envelope = targetGain + (detector.envelope - targetGain) * attackCoeff;
+
+        if (attackTime < 0.005f && reduction > 5.0f)
+        {
+            float overshootFactor = (0.005f - attackTime) / 0.004f;
+            float reductionFactor = jlimit (0.0f, 1.0f, reduction / 20.0f);
+
+            detector.overshootAmount = overshootFactor * reductionFactor * 0.02f;
+        }
+        else
+        {
+            detector.overshootAmount *= 0.95f;
+        }
+    }
+    else
+    {
+        float currentDb = gainToDb (jmax (0.0001f, detector.envelope));
+        float targetDb = gainToDb (jmax (0.0001f, targetGain));
+
+        float effectiveRate;
+        if (reduction > 0.1f)
+            effectiveRate = reduction / jmax (0.001f, releaseTime);
+        else
+            effectiveRate = 120.0f;
+
+        float releaseStepDb = effectiveRate / static_cast<float>(sampleRate);
+        currentDb = jmin (currentDb + releaseStepDb, targetDb);
+        detector.envelope = dbToGain (currentDb);
+
+        detector.overshootAmount *= 0.98f;
+    }
+
+    detector.envelope = jlimit (0.0001f, 1.0f, detector.envelope);
+
+    if (std::isnan (detector.envelope) || std::isinf (detector.envelope))
+        detector.envelope = 1.0f;
+
+    detector.previousReduction = reduction;
+
+    float envelopeWithOvershoot = detector.envelope * (1.0f + detector.overshootAmount);
+    envelopeWithOvershoot = jlimit (0.0001f, 1.0f, envelopeWithOvershoot);
+
+    float compressed = input * envelopeWithOvershoot;
+
+    float processed = compressed;
+    float absLevel = std::abs (processed);
+
+    float harmonicLevelDb = gainToDb (jmax (0.0001f, absLevel));
+
+    if (absLevel > 0.01f)
+    {
+        float sign = (processed < 0.0f) ? -1.0f : 1.0f;
+
+        float h2_level = 0.0f;
+        float h3_level = 0.0f;
+
+        float circuitH2 = 0.0003f;
+        float circuitH3 = 0.0006f;
+
+        h2_level = circuitH2;
+        h3_level = circuitH3;
+
+        if (harmonicLevelDb > -30.0f && reduction > 2.0f)
+        {
+            float compressionFactor = jmin (1.0f, reduction / 30.0f);
+
+            float h2_comp = 0.001f * compressionFactor;
+            h2_level += h2_comp;
+
+            if (reduction > 10.0f)
+            {
+                float h3_comp = 0.0008f * compressionFactor;
+                h3_level += h3_comp;
+            }
+        }
+
+        processed = compressed;
+
+        float sq = compressed * compressed;
+        float hpAlpha = 1.0f / (1.0f + 6.2831853f * 10.0f / static_cast<float>(sampleRate));
+        float h2_signal = hpAlpha * (detector.dcState + sq - detector.prevSq);
+        detector.dcState = h2_signal;
+        detector.prevSq = sq;
+        processed += h2_signal * h2_level;
+
+        float h3_signal = compressed * compressed * compressed;
+        processed += h3_signal * h3_level;
+
+        if (absLevel > 1.5f)
+        {
+            float excess = absLevel - 1.5f;
+            float vcaSat = 1.5f + std::tanh (excess * 0.3f) * 0.2f;
+            processed = sign * vcaSat * (processed / absLevel);
+        }
+    }
+
+    float output = processed * dbToGain (outputGain);
+
+    return jlimit (-Constants::OUTPUT_HARD_LIMIT, Constants::OUTPUT_HARD_LIMIT, output);
+}
+
+inline float VCACompressor::getGainReduction (int channel) const
+{
+    if (channel >= static_cast<int>(detectors.size()))
+        return 0.0f;
+    return gainToDb (detectors[(size_t) channel].envelope);
+}
+
+inline void VCACompressor::updateSampleRate (double newSampleRate)
+{
+    if (newSampleRate > 0.0 && newSampleRate != sampleRate)
+        sampleRate = newSampleRate;
+}
+
+} // namespace duskaudio


### PR DESCRIPTION
Adds plugins/multi-comp/core/ — a framework-free transcription of the four strip compressor modes plus the top-level processing flow, namespace duskaudio, following the TapeMachineDSP/MultiQTube core pattern.

- Verbatim ports: OptoCompressor, FETCompressor, VCACompressor, BusCompressor, shared services (sidechain HP, transient shaper, lookup tables, multiplicative smoother, dB helpers).
- Replicates the shipped host configuration exactly so embedding is bit-exact: modes prepared at 2x the processing rate (the "oversampling" param default with internal oversampling disabled), constant 60-sample latency report, latency-aligned bypass/partial-mix dry rings, 5 ms un-bypass crossfade.
- Out of scope (default-off on the strip path): Studio FET/VCA, Digital, Multiband, noise, distortion, internal audio-path oversampling. PORT_NOTES.md carries the default-trace table and judgment log.

Proven bit-exact against the JUCE UniversalCompressor by Dusk Studio's A/B harness (tests/comp_core_ab.cpp there): 0.0 max-abs-diff across Opto/FET/VCA/Bus static curves, timing, detector modes, stereo-link blends, auto-makeup, bypass toggling, partial mix, block-size invariance, 44.1/48/96k — audio and GR meter alike.

Dusk Studio's dejuce/strip-donor-cores PR consumes these headers; its CI clones this repo's main, so this merges first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added framework-independent Multi-Comp compression with Opto, FET, VCA, and Bus modes.
  * Introduced a new real-time compressor processing engine with lifecycle control and latency reporting.
  * Added adjustable compression parameters (threshold/ratio/attack/release/makeup), mix/bypass, stereo link, and optional external sidechain support.
  * Enabled gain reduction and level metering, including latency-aligned dry/wet mixing and smooth bypass transitions.
* **Documentation**
  * Added mode/parameter “port notes” covering scope, defaults, and framework-compatibility decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->