### PR TITLE
TapeMachine 2: program-band tone matching + parity calibration data

### DIFF
--- a/manuals/tapemachine-2.md
+++ b/manuals/tapemachine-2.md
@@ -129,7 +129,7 @@ substantially change a preset's match and saturation reading.
 
 - Fat 456 Master
 - GP9 Drum Bus
-- Massive Bass
+- Bass Bump
 - Bright & Sizzly
 
 ### Swiss mix

--- a/plugins/TapeMachine/README.md
+++ b/plugins/TapeMachine/README.md
@@ -34,7 +34,7 @@ American:
 - Clean 900 Master
 - Fat 456 Master
 - GP9 Drum Bus
-- Massive Bass
+- Bass Bump
 - Bright & Sizzly
 - Sunbaked Cassette
 - Analog Warmth

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -123,13 +123,15 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
 
     const float hpFreq = pHighpassHz.load (std::memory_order_relaxed);
     const float lpFreq = pLowpassHz.load (std::memory_order_relaxed);
+    const float lpQ    = pLpQ.load (std::memory_order_relaxed);   // preset LP resonance (0.707 = historic fixed Q)
     hpL.prepare (currentOsRate, hpFreq, 0.707f); hpL.setType (DuskSVF::Type::highpass); hpL.reset();
     hpR.prepare (currentOsRate, hpFreq, 0.707f); hpR.setType (DuskSVF::Type::highpass); hpR.reset();
-    lpL.prepare (currentOsRate, lpFreq, 0.707f); lpL.setType (DuskSVF::Type::lowpass);  lpL.reset();
-    lpR.prepare (currentOsRate, lpFreq, 0.707f); lpR.setType (DuskSVF::Type::lowpass);  lpR.reset();
+    lpL.prepare (currentOsRate, lpFreq, lpQ);   lpL.setType (DuskSVF::Type::lowpass);  lpL.reset();
+    lpR.prepare (currentOsRate, lpFreq, lpQ);   lpR.setType (DuskSVF::Type::lowpass);  lpR.reset();
     bypassLowpass = (lpFreq >= 19000.0f);
     lastHpFreq = hpFreq;
     lastLpFreq = lpFreq;
+    lastLpQ    = lpQ;
 
     // Smoothers: param smoothers configured at BASE rate but advanced at the
     // oversampled rate (matches the JUCE structure — see PORT_NOTES). Output gain
@@ -198,12 +200,20 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     // hit, not a block later) while smoothing the |x| ripple of low tones.
     m_levelRelCoeff = std::exp (-1.0f / (0.030f * static_cast<float> (baseSampleRate)));
     m_levelEnv = 0.0f;
+    // Program-band envelope LP (Phase C): 500 Hz 2-pole Butterworth per channel, base rate.
+    // Corner chosen so the hottest THD step (-3 dBFS 1 kHz) reads ~-15 dBFS after the LP,
+    // a >3 dB margin below the -12 anchor => progFactor floored to 0 => byte-identical THD.
+    m_progLpL.setCoeffs (DBiquad::lowPass (baseSampleRate, 500.0, 0.70710678));
+    m_progLpR.setCoeffs (DBiquad::lowPass (baseSampleRate, 500.0, 0.70710678));
+    m_progLpL.reset(); m_progLpR.reset();
+    m_progEnv = 0.0f;
     // Level-comp factor smoother: fast attack (~4 ms) so tone shifts ON a transient, slower
     // release (~30 ms) tracking the detector. Per-sample coeffs (1-exp form); the block-rate
     // update raises (1-coeff) to nSamples so the effective TC is block-size-independent.
     m_levelFactAtkCoeff = 1.0f - std::exp (-1.0f / (0.004f * static_cast<float> (baseSampleRate)));
     m_levelFactRelCoeff = 1.0f - std::exp (-1.0f / (0.030f * static_cast<float> (baseSampleRate)));
     m_levelFactorSm = 0.0f;
+    m_progFactorSm = 0.0f;    // program-band factor starts neutral (bypassed until sub-500 Hz program engages)
     m_driveDecaySm  = 1.0f;   // neutral (no below-anchor decay until the signal drops below -12)
     vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     inPeakStateL = inPeakStateR = 0.0f;
@@ -239,6 +249,9 @@ void TapeMachineDSP::reset()
     hpL.reset(); hpR.reset(); lpL.reset(); lpR.reset();
     m_levelEnv = 0.0f;
     m_levelFactorSm = 0.0f;
+    m_progLpL.reset(); m_progLpR.reset();
+    m_progEnv = 0.0f;
+    m_progFactorSm = 0.0f;
     m_driveDecaySm  = 1.0f;
     vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     inPeakStateL = inPeakStateR = 0.0f;
@@ -292,15 +305,17 @@ void TapeMachineDSP::applyFactor (int newFactor)
 
     const float hpFreq = pHighpassHz.load (std::memory_order_relaxed);
     const float lpFreq = pLowpassHz.load (std::memory_order_relaxed);
+    const float lpQ    = pLpQ.load (std::memory_order_relaxed);
     hpL.prepare (currentOsRate, hpFreq, 0.707f); hpL.setType (DuskSVF::Type::highpass);
     hpR.prepare (currentOsRate, hpFreq, 0.707f); hpR.setType (DuskSVF::Type::highpass);
-    lpL.prepare (currentOsRate, lpFreq, 0.707f); lpL.setType (DuskSVF::Type::lowpass);
-    lpR.prepare (currentOsRate, lpFreq, 0.707f); lpR.setType (DuskSVF::Type::lowpass);
+    lpL.prepare (currentOsRate, lpFreq, lpQ);   lpL.setType (DuskSVF::Type::lowpass);
+    lpR.prepare (currentOsRate, lpFreq, lpQ);   lpR.setType (DuskSVF::Type::lowpass);
 
     outGain.prepare (currentOsRate, kGainTau);   // re-config OS-rate ramp coeff
 
     lastHpFreq = -1.0f;   // force SVF cutoff refresh below
     lastLpFreq = -1.0f;
+    lastLpQ    = -1.0f;
     lastFactor = newFactor;
 }
 
@@ -382,15 +397,18 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // --- tone SVF coefficient refresh (dirty) --------------------------------
     const float hpFreq = pHighpassHz.load (std::memory_order_relaxed);
     const float lpFreq = pLowpassHz.load (std::memory_order_relaxed);
+    const float lpQ    = pLpQ.load (std::memory_order_relaxed);   // preset LP resonance (HP stays fixed 0.707)
     bypassLowpass = (lpFreq >= 19000.0f);
-    if (std::abs (hpFreq - lastHpFreq) > 0.01f || std::abs (lpFreq - lastLpFreq) > 0.01f)
+    if (std::abs (hpFreq - lastHpFreq) > 0.01f || std::abs (lpFreq - lastLpFreq) > 0.01f
+        || std::abs (lpQ - lastLpQ) > 0.0001f)
     {
         hpL.setType (DuskSVF::Type::highpass); hpL.setCutoff (hpFreq); hpL.setResonance (0.707f);
         hpR.setType (DuskSVF::Type::highpass); hpR.setCutoff (hpFreq); hpR.setResonance (0.707f);
-        lpL.setType (DuskSVF::Type::lowpass);  lpL.setCutoff (lpFreq); lpL.setResonance (0.707f);
-        lpR.setType (DuskSVF::Type::lowpass);  lpR.setCutoff (lpFreq); lpR.setResonance (0.707f);
+        lpL.setType (DuskSVF::Type::lowpass);  lpL.setCutoff (lpFreq); lpL.setResonance (lpQ);
+        lpR.setType (DuskSVF::Type::lowpass);  lpR.setCutoff (lpFreq); lpR.setResonance (lpQ);
         lastHpFreq = hpFreq;
         lastLpFreq = lpFreq;
+        lastLpQ    = lpQ;
     }
 
     // --- block-constant parameter reads --------------------------------------
@@ -498,6 +516,30 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         envDbPre = 20.0f * std::log10 (std::max (blockPk, 1e-9f));   // PRE-gain level in dBFS
     }
 
+    // --- program-band envelope (Phase C: SAME pre-gain node, 500 Hz-LP'd per channel) --------
+    // Each raw sample is 2-pole-LP'd at 500 Hz BEFORE rectification so the follower tracks
+    // sub-500 Hz PROGRAM energy, not a lone HF/mid tone (filtering the already-rectified peak
+    // would leak the tone's DC term and defeat the anchor). Keyed by the identical anchor law
+    // below (progFluxDb), so a lone 1 kHz THD/alias tone reads below the -12 anchor and the
+    // prog trims stay bypassed; sustained low-corner program pushes progFactor positive.
+    float progEnvDbPre;
+    {
+        float pe = m_progEnv, progBlockPk = m_progEnv;
+        for (int n = 0; n < nSamples; ++n)
+        {
+            float a = std::abs (static_cast<float> (m_progLpL.process (static_cast<double> (inputs[0][n]))));
+            if (nCh >= 2)
+            {
+                const float aR = std::abs (static_cast<float> (m_progLpR.process (static_cast<double> (inputs[1][n]))));
+                if (aR > a) a = aR;
+            }
+            if (a > pe) pe = a; else pe *= m_levelRelCoeff;
+            if (pe > progBlockPk) progBlockPk = pe;
+        }
+        m_progEnv = pe;
+        progEnvDbPre = 20.0f * std::log10 (std::max (progBlockPk, 1e-9f));   // PRE-gain program-band level
+    }
+
     // Drive-linked HF restore + signal-level FR compensation. The memoryless tape core's
     // FR drifts with RECORD FLUX (signal level + input-gain + cal + bias): above the
     // -12 dBFS reference operating level the HF droops (waveshaper HF compression) and the
@@ -563,6 +605,13 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         return std::pow (t, kRampPow);
     };
     const float levelFactorTarget = std::max (0.0f, ramp (signalFluxDb) - ramp (knobFluxDb));
+    // Program-band factor (Phase C): identical anchor construction as levelFactor, but keyed off
+    // the 500 Hz-LP'd program envelope (progEnvDbPre). At/below the -12 anchor the increment is 0
+    // (a lone 1 kHz THD tone lands there) so the prog trims stay bypassed; sustained sub-500 Hz
+    // program pushes it positive and engages them. Reuses the SAME ramp/knobFluxDb, so the
+    // input-gain/cal/bias terms cancel at the anchor exactly like the level-comp factor.
+    const float progFluxDb = progEnvDbPre + smInGainDb + 12.0f + kCalFluxDb + biasFluxDb;
+    const float progFactorTarget = std::max (0.0f, ramp (progFluxDb) - ramp (knobFluxDb));
     // Smooth the factor before it drives the shelf coeffs. A raw per-block factor jumps several
     // dB on a drum hit -> a biquad coeff discontinuity (zipper / click). One-pole with a FAST
     // (~4 ms) attack so the tone still shifts ON the hit (Phase A showed the transient window
@@ -577,6 +626,16 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         m_levelFactorSm += blockCoeff * (levelFactorTarget - m_levelFactorSm);
     }
     const float levelFactor  = m_levelFactorSm;
+    // Smooth the program-band factor with the SAME fast-attack/slow-release coeffs (block-size-
+    // independent). At/below the -12 anchor the target is a steady 0, so it sits at 0 and the
+    // prog crossfade stays exactly dry (byte-identical THD/sweep/alias).
+    {
+        const float perSampleCoeff = (progFactorTarget > m_progFactorSm)
+                                         ? m_levelFactAtkCoeff : m_levelFactRelCoeff;
+        const float blockCoeff = 1.0f - std::pow (1.0f - perSampleCoeff, static_cast<float> (nSamples));
+        m_progFactorSm += blockCoeff * (progFactorTarget - m_progFactorSm);
+    }
+    const float progFactor = m_progFactorSm;
     const float kLevelHfGain = (machine == TapeCore::Swiss) ? kLevelHfSwiss   : kLevelHfAmerican;
     const float kLevelLfGain = (machine == TapeCore::Swiss) ? kLevelLfSwiss   : kLevelLfAmerican;
     const float levelHfDb    = std::min (9.0f, kLevelHfGain * levelFactor);   // HF restore (>=0)
@@ -621,14 +680,38 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     coreR.setDriveHfComp (driveHfCompFinal);
     coreL.setLevelComp (machine, levelHfDb, levelLfDb);
     coreR.setLevelComp (machine, levelHfDb, levelLfDb);
+    const float presetLevelHmfDb = pLevelHmfTrim.load (std::memory_order_relaxed);
+    const float presetLevelHfDb  = pLevelHfTrim.load  (std::memory_order_relaxed);
+    const float presetLevelHfFactor = std::pow (levelFactor, 0.25f);
+    coreL.setPresetLevelEq (presetLevelHmfDb, presetLevelHfDb, levelFactor, presetLevelHfFactor);
+    coreR.setPresetLevelEq (presetLevelHmfDb, presetLevelHfDb, levelFactor, presetLevelHfFactor);
+    // Program-band above-anchor trims (Phase C wall-breaker; re-based on PROGRAM in the EAR-GREEN
+    // pass): the SAME 6.3k/11k pair as the preset-level EQ, but crossfaded by the PROGRAM-BAND factor
+    // so a lone 1 kHz THD tone stays exactly dry (progFactor 0). Mix = pow(progFactor, 0.25) (the
+    // shipped expansion idiom), shared by both bands. Most factory presets now carry a nonzero HF
+    // trim (cut on bright presets, positive boost on the dark ones); a 0/0 preset gets setProgEq
+    // bypassed exactly (byte-identical). Same idiom drives the deep-sub bloom below.
+    const float progHmfDb = pProgHmfTrim.load (std::memory_order_relaxed);
+    const float progHfDb  = pProgHfTrim.load  (std::memory_order_relaxed);
+    const float progMix   = std::pow (progFactor, 0.25f);
+    coreL.setProgEq (progHmfDb, progHfDb, progMix, progMix);
+    coreR.setProgEq (progHmfDb, progHfDb, progMix, progMix);
+    // Program-level deep-sub bloom restore (EAR-GREEN): the reference decks thicken the deep sub
+    // (25-50 Hz) on program above the -12 anchor (a tape LF enhancement mine lacked). Same progMix
+    // crossfade => byte-null on the -12 sweep / 1 kHz THD tone. Per-preset gain (progLfTrim); 0 on
+    // clean / 30-IPS presets => exact bypass.
+    const float progLfDb = pProgLfTrim.load (std::memory_order_relaxed);
+    coreL.setProgLf (progLfDb, progMix);
+    coreR.setProgLf (progLfDb, progMix);
 
     // Advanced repro-head 4-band EQ (block-constant; 0 dB = neutral).
     const float rLf  = pReproLf.load  (std::memory_order_relaxed);
     const float rLmf = pReproLmf.load (std::memory_order_relaxed);
     const float rHmf = pReproHmf.load (std::memory_order_relaxed);
     const float rHf  = pReproHf.load  (std::memory_order_relaxed);
-    coreL.setReproEq (rLf, rLmf, rHmf, rHf);
-    coreR.setReproEq (rLf, rLmf, rHmf, rHf);
+    const float rSub = pReproSubBell.load (std::memory_order_relaxed); // per-preset 31 Hz Q2.5 sub-bell (0 = exact bypass)
+    coreL.setReproEq (rLf, rLmf, rHmf, rHf, rSub);
+    coreR.setReproEq (rLf, rLmf, rHmf, rHf, rSub);
 
     // Classic Transformer switch (American only): Off bypasses the output transformer, which
     // EXTENDS the deep bass (measured Classic On->Off = +3.4/+1.0/+0.4 dB @30/60/100 Hz, flat
@@ -754,12 +837,13 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // --- crosstalk (base rate — deviation from JUCE's OS-rate placement) ------
     if (nCh >= 2)
     {
-        // Swiss: the reference stereo instance models no L/R adjacent-track bleed, so the
-        // Swiss crosstalk is essentially nil. American matches the reference American's
-        // modelled "Crosstalk On" bleed (~-51 dB L->R).
-        // Classic Crosstalk switch (American only): Off removes the modelled adjacent-track
-        // bleed. On (default) or the Swiss => the current bleed (byte-identical).
-        float crosstalkAmount = (machine == TapeCore::Swiss) ? 0.0006f : 0.0027f;
+        // Swiss: the reference stereo instance models NO L/R adjacent-track bleed (measured:
+        // an L-only tone leaves the R channel at digital silence), so Swiss crosstalk is 0.
+        // American: the reference "Crosstalk On" bleed measures -51..-55 dB L->R across presets;
+        // 0.00224 (~-53 dB) is the single-scalar midpoint that lands every On preset within tol.
+        // Crosstalk switch (American only): Off removes the bleed (the reference's On/Off per
+        // preset is honoured by the preset table); On => the modelled bleed.
+        float crosstalkAmount = (machine == TapeCore::Swiss) ? 0.0f : 0.00224f;
         if (isClassic && ! crosstalkOn) crosstalkAmount = 0.0f;
         for (int n = 0; n < nSamples; ++n)
         {

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -1108,12 +1108,10 @@ public:
             m_lastBias = biasAmount; m_lastEqStandard = eqStandard; m_lastHeadWidth = headWidth;
 
             m_cachedMachineChars = getMachineCharacteristics (machine);
-            m_cachedTapeChars = getTapeCharacteristics (type);
             m_cachedSpeedChars = getSpeedCharacteristics (speed);
             m_gapWidth = (machine == Swiss) ? 2.5f : 3.5f;
         }
 
-        const auto& tapeChars = m_cachedTapeChars;
         const auto& speedChars = m_cachedSpeedChars;
 
         const bool processTape = (signalPath == Repro || signalPath == Sync);
@@ -1392,7 +1390,9 @@ private:
     bool    reproSubBellActive = false;     // EXACT bypass at 0 dB: an always-on 0-dB peak biquad is NOT bit-identity
                                             // (numerator==denominator cancels in exact math, not in float rounding), so
                                             // skip the process call entirely when the band is 0 => byte-identical to no band.
-    float   reproSubBellLast = 0.0f;        // last-configured sub-bell dB; reset filter state on any change (incl. (de)activation)
+    float   reproSubBellLast = 999.0f;      // last-configured sub-bell dB; reset filter state on any change (incl. (de)activation).
+                                            // 999 = the same "never configured" sentinel the other rebuild caches use, so the
+                                            // first setReproEq always rebuilds even if prepare() stops pre-seeding it.
     DBiquad slowModernPresencePeak;             // measured Classic 3.75 IPS / modern formulation presence resonance
     DBiquad transformerLfShelf;             // Transformer-Off LF restore (neutral at 0 dB = Transformer On)
     // Emphasis-rebalance G / 1-G pair wrapping ONLY the shaper (per-machine, always active).
@@ -1427,7 +1427,6 @@ private:
     int   m_lastHeadWidth = -1;
 
     MachineCharacteristics m_cachedMachineChars{};
-    TapeCharacteristics m_cachedTapeChars{};
     SpeedCharacteristics m_cachedSpeedChars{};
     float m_gapWidth = 3.0f;
     // Per-machine linear trim making the tape core unity-gain (compensates the input

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -778,10 +778,25 @@ public:
         driveHfShelf.setCoeffs   (DBiquad::shelf (osRate, static_cast<double> (safeFreq (2500.0f)), 0.0, 0.5, true)); // neutral until setDriveHfComp
         levelHfShelf.setCoeffs   (DBiquad::shelf (osRate, static_cast<double> (safeFreq (7900.0f)), 0.0, 0.45, true)); // neutral until setLevelComp
         levelLfShelf.setCoeffs   (DBiquad::peak  (osRate,   32.0, 0.0, 1.4)); // neutral until setLevelComp
+        presetLevelHmfPeak.setCoeffs (DBiquad::peak  (osRate, static_cast<double> (safeFreq (6300.0f)),  0.0, 1.0));
+        presetLevelHfShelf.setCoeffs (DBiquad::shelf (osRate, static_cast<double> (safeFreq (11000.0f)), 0.0, 0.7, true));
+        // The two lines above reinstalled NEUTRAL preset-EQ coeffs. Invalidate the rebuild
+        // cache so the next setPresetLevelEq() re-applies the active preset correction (at the
+        // new fs) even when the preset params are unchanged — otherwise its "hmfDb/hfDb changed"
+        // guard sees identical values against the stale cache and leaves the filters neutral,
+        // silently dropping the correction until a parameter finally changes.
+        presetLevelLastHmf = presetLevelLastHf = 999.0f;
+        // Same lifecycle for the program-keyed pair: prepare() rebuilds at the new fs but does
+        // NOT reinstall prog coeffs, so invalidate the rebuild cache too — otherwise the next
+        // setProgEq()'s "hmfDb/hfDb changed" guard sees unchanged trims against the stale cache
+        // and leaves progHmfPeak/progHfShelf on the OLD sample rate's coeffs.
+        progLastHmf = progLastHf = 999.0f;
         reproLfShelf.setCoeffs   (DBiquad::shelf (osRate,   80.0, 0.0, 0.5, false)); // 4-band repro EQ, neutral until setReproEq
         reproLmfPeak.setCoeffs   (DBiquad::peak  (osRate,  160.0, 0.0, 0.9));
         reproHmfPeak.setCoeffs   (DBiquad::peak  (osRate, static_cast<double> (safeFreq (5000.0f)), 0.0, 0.8));
         reproHfShelf.setCoeffs   (DBiquad::shelf (osRate, static_cast<double> (safeFreq (9000.0f)), 0.0, 0.5, true));
+        reproSubBellPeak.setCoeffs (DBiquad::peak (osRate, 31.0, 0.0, 2.5)); reproSubBellActive = false; // neutral until setReproEq
+        reproSubBellLast = 999.0f;   // invalidate rebuild cache (same fs-staleness fix as progLast above)
         slowModernPresencePeak.setCoeffs (DBiquad::peak (osRate,
             static_cast<double> (safeFreq (2700.0f)), 0.0, 1.6));
         transformerLfShelf.setCoeffs (DBiquad::shelf (osRate, 48.0, 0.0, 0.7, false)); // neutral until setTransformerOff
@@ -817,7 +832,11 @@ public:
         headBumpFilter.reset(); hfLossFilter1.reset(); hfLossFilter2.reset();
         gapLossFilter.reset(); biasFilter.reset(); dcBlocker.reset();
         headWidthFilter.reset(); driveHfShelf.reset(); levelHfShelf.reset(); levelLfShelf.reset();
+        presetLevelHmfPeak.reset(); presetLevelHfShelf.reset();
+        progHmfPeak.reset(); progHfShelf.reset();
+        progLfShelf.reset(); progLfLastDb = 999.0f; progLfConfigured = false;
         reproLfShelf.reset(); reproLmfPeak.reset(); reproHmfPeak.reset(); reproHfShelf.reset();
+        reproSubBellPeak.reset();
         slowModernPresencePeak.reset();
         transformerLfShelf.reset();
         emphLfPre.reset(); emphHfPre.reset(); emphHfPost.reset(); emphLfPost.reset();
@@ -892,17 +911,135 @@ public:
         levelLfShelf.setCoeffs (DBiquad::peak  (fs, lfFc, static_cast<double> (lfDb), lfQ));
     }
 
+    // Factory-preset correction for response changes above the -12 dBFS calibration
+    // anchor. Keep the filter coefficients fixed at the preset's full correction and
+    // crossfade dry/wet with levelFactor; modulating a cutting biquad's coefficients at
+    // block rate stores release energy and can brighten decays instead of attenuating them.
+    // A zero/zero preset bypasses both filters exactly, preserving the original path.
+    void setPresetLevelEq (float hmfDb, float hfDb, float hmfMix, float hfMix) noexcept
+    {
+        presetLevelHmfMix = std::clamp (hmfMix, 0.0f, 1.0f);
+        presetLevelHfMix = std::clamp (hfMix, 0.0f, 1.0f);
+        const bool configured = (hmfDb != 0.0f || hfDb != 0.0f);
+        if (! configured)
+        {
+            if (presetLevelEqConfigured)
+            {
+                presetLevelHmfPeak.reset();
+                presetLevelHfShelf.reset();
+                presetLevelLastHmf = presetLevelLastHf = 999.0f;
+            }
+            presetLevelEqConfigured = false;
+            return;
+        }
+        if (hmfDb != presetLevelLastHmf || hfDb != presetLevelLastHf)
+        {
+            const double fs = currentSampleRate > 0.0 ? currentSampleRate : 96000.0;
+            presetLevelHmfPeak.reset();
+            presetLevelHfShelf.reset();
+            presetLevelHmfPeak.setCoeffs (DBiquad::peak  (fs, 6300.0, static_cast<double> (hmfDb), 1.0));
+            presetLevelHfShelf.setCoeffs (DBiquad::shelf (fs, 11000.0, static_cast<double> (hfDb), 0.7, true));
+            presetLevelLastHmf = hmfDb;
+            presetLevelLastHf = hfDb;
+        }
+        presetLevelEqConfigured = true;
+    }
+
+    // Program-keyed above-anchor correction (Phase C wall-breaker). SAME fixed-coeff /
+    // level-crossfade idiom as setPresetLevelEq (identical 6.3 kHz peak + 11 kHz shelf
+    // geometry), but the mix is driven by the PROGRAM-BAND (500 Hz low-corner) envelope
+    // factor instead of the broadband one: a lone 1 kHz THD tone is LP-attenuated below the
+    // -12 anchor => progFactor 0 => mix 0 => the crossfade is EXACTLY dry => THD byte-identical
+    // BY CONSTRUCTION (the broadband trim ate the shaper-born harmonics; this cannot). A
+    // zero/zero preset skips both filters exactly (progEqConfigured false), preserving the path.
+    void setProgEq (float hmfDb, float hfDb, float hmfMix, float hfMix) noexcept
+    {
+        progHmfMix = std::clamp (hmfMix, 0.0f, 1.0f);
+        progHfMix = std::clamp (hfMix, 0.0f, 1.0f);
+        const bool configured = (hmfDb != 0.0f || hfDb != 0.0f);
+        if (! configured)
+        {
+            if (progEqConfigured)
+            {
+                progHmfPeak.reset();
+                progHfShelf.reset();
+                progLastHmf = progLastHf = 999.0f;
+            }
+            progEqConfigured = false;
+            return;
+        }
+        if (hmfDb != progLastHmf || hfDb != progLastHf)
+        {
+            const double fs = currentSampleRate > 0.0 ? currentSampleRate : 96000.0;
+            progHmfPeak.reset();
+            progHfShelf.reset();
+            progHmfPeak.setCoeffs (DBiquad::peak  (fs, 6300.0, static_cast<double> (hmfDb), 1.0));
+            progHfShelf.setCoeffs (DBiquad::shelf (fs, 11000.0, static_cast<double> (hfDb), 0.7, true));
+            progLastHmf = hmfDb;
+            progLastHf = hfDb;
+        }
+        progEqConfigured = true;
+    }
+
+    // Fixed deep-sub bloom shape (low-shelf); per-preset GAIN comes from progLfTrim (the reference
+    // bloom magnitude varies per preset, not cleanly per speed).
+    static constexpr double kProgLfFc = 33.0;   // low-shelf corner (Hz)
+    static constexpr double kProgLfQ  = 0.5;    // shelf Q
+
+    // Program-keyed deep-sub bloom band (EAR-GREEN campaign). The reference decks thicken the deep
+    // sub (25-50 Hz) on program hotter than the -12 anchor (a tape LF enhancement mine lacked =>
+    // hot presets read thin/bright; measured reference pink-minus-sweep @25 Hz ~= +5 dB @15 IPS,
+    // +3.6 @7.5 IPS, ~0 @30 IPS). SAME fixed-coeff / progFactor-crossfade idiom as setProgEq: a lone
+    // 1 kHz THD/alias tone and the -12 dBFS FR sweep read progFactor 0 => mix 0 => EXACTLY dry =>
+    // THD/FR/alias byte-identical BY CONSTRUCTION. lfDb 0 (30 IPS, Thru, all clean presets) => exact
+    // bypass. Gain is per-preset data (progLfTrim), fitted on program pink.
+    void setProgLf (float lfDb, float lfMix) noexcept
+    {
+        progLfMix = std::clamp (lfMix, 0.0f, 1.0f);
+        const bool configured = (lfDb != 0.0f);
+        if (! configured)
+        {
+            if (progLfConfigured)
+            {
+                progLfShelf.reset();
+                progLfLastDb = 999.0f;
+            }
+            progLfConfigured = false;
+            return;
+        }
+        if (lfDb != progLfLastDb)
+        {
+            const double fs = currentSampleRate > 0.0 ? currentSampleRate : 96000.0;
+            progLfShelf.reset();
+            progLfShelf.setCoeffs (DBiquad::shelf (fs, kProgLfFc, static_cast<double> (lfDb), kProgLfQ, false));
+            progLfLastDb = lfDb;
+        }
+        progLfConfigured = true;
+    }
+
     // Advanced repro-head EQ: a post-tape 4-band shaper (LF low-shelf 80 Hz, low-mid
     // peak 160 Hz, high-mid/presence peak 5 kHz, HF high-shelf 9 kHz) modelling the reference
     // decks' Repro EQ section. Per-preset trims that reproduce the factory presets'
     // baked repro EQ shape. 0 dB on all => neutral => reference unchanged. Block-rate.
-    void setReproEq (float lfDb, float lmfDb, float hmfDb, float hfDb) noexcept
+    void setReproEq (float lfDb, float lmfDb, float hmfDb, float hfDb, float subBellDb) noexcept
     {
         const double fs = currentSampleRate > 0.0 ? currentSampleRate : 96000.0;
         reproLfShelf.setCoeffs  (DBiquad::shelf (fs,   80.0, static_cast<double> (lfDb),  0.5, false));
         reproLmfPeak.setCoeffs  (DBiquad::peak  (fs,  160.0, static_cast<double> (lmfDb), 0.9));
         reproHmfPeak.setCoeffs  (DBiquad::peak  (fs, 5000.0, static_cast<double> (hmfDb), 0.8));
         reproHfShelf.setCoeffs  (DBiquad::shelf (fs, 9000.0, static_cast<double> (hfDb),  0.5, true));
+        // Per-preset repro sub-bell (31 Hz Q2.5): fills the American-30 head-bump's narrow LF dip
+        // for GP9 Drum Bus without lifting 50 Hz (a shelf would). EXACT bypass at 0 dB — see
+        // reproSubBellActive: skipping the process call keeps every non-GP9 preset byte-identical.
+        const bool subBellActive = (subBellDb != 0.0f);
+        if (subBellDb != reproSubBellLast)
+        {
+            reproSubBellPeak.reset();   // clear stale state across any change, incl. (de)activation transitions
+            if (subBellActive)
+                reproSubBellPeak.setCoeffs (DBiquad::peak (fs, 31.0, static_cast<double> (subBellDb), 2.5));
+            reproSubBellLast = subBellDb;
+        }
+        reproSubBellActive = subBellActive;
     }
 
     // Transformer Off (American only): bypassing the American output transformer EXTENDS
@@ -1086,6 +1223,39 @@ public:
             // reference/preset gate signals stay at 0 dB so their FR holds.
             signal = static_cast<float> (levelHfShelf.process (static_cast<double> (signal)));
             signal = static_cast<float> (levelLfShelf.process (static_cast<double> (signal)));
+            if (presetLevelEqConfigured)
+            {
+                const double hmfDry = static_cast<double> (signal);
+                const double hmfWet = presetLevelHmfPeak.process (hmfDry);
+                signal = static_cast<float> (hmfDry + static_cast<double> (presetLevelHmfMix) * (hmfWet - hmfDry));
+                const double hfDry = static_cast<double> (signal);
+                const double hfWet = presetLevelHfShelf.process (hfDry);
+                signal = static_cast<float> (hfDry + static_cast<double> (presetLevelHfMix) * (hfWet - hfDry));
+            }
+            // Program-keyed above-anchor pair (Phase C). Parallel to the preset-level pair
+            // above but crossfaded by the PROGRAM-BAND envelope factor (progHmfMix/progHfMix),
+            // so it engages on sustained sub-500 Hz program yet stays EXACTLY dry (mix 0) on a
+            // lone 1 kHz THD tone -> THD byte-identical. Same fixed-coeff idiom; a zero/zero
+            // preset skips it entirely (progEqConfigured false).
+            if (progEqConfigured)
+            {
+                const double phmfDry = static_cast<double> (signal);
+                const double phmfWet = progHmfPeak.process (phmfDry);
+                signal = static_cast<float> (phmfDry + static_cast<double> (progHmfMix) * (phmfWet - phmfDry));
+                const double phfDry = static_cast<double> (signal);
+                const double phfWet = progHfShelf.process (phfDry);
+                signal = static_cast<float> (phfDry + static_cast<double> (progHfMix) * (phfWet - phfDry));
+            }
+            // Program-level deep-sub bloom restore (EAR-GREEN): adds the reference's speed-dependent
+            // deep-sub thickening on program above the -12 anchor. Crossfaded by progLfMix (=progFactor)
+            // so it is EXACTLY dry on the -12 sweep / 1 kHz THD tone => byte-identical there; 30 IPS /
+            // Thru leave the gain 0 => progLfConfigured false => skipped entirely.
+            if (progLfConfigured)
+            {
+                const double plfDry = static_cast<double> (signal);
+                const double plfWet = progLfShelf.process (plfDry);
+                signal = static_cast<float> (plfDry + static_cast<double> (progLfMix) * (plfWet - plfDry));
+            }
 
             // Advanced repro-head EQ trims (neutral at 0 dB; reproduce the reference factory
             // presets' baked Repro HF/LF EQ so each preset's FR matches).
@@ -1093,6 +1263,10 @@ public:
             signal = static_cast<float> (reproLmfPeak.process (static_cast<double> (signal)));
             signal = static_cast<float> (reproHmfPeak.process (static_cast<double> (signal)));
             signal = static_cast<float> (reproHfShelf.process (static_cast<double> (signal)));
+            // Per-preset repro sub-bell (31 Hz Q2.5). Gated: skipped entirely at 0 dB so every
+            // preset that leaves it neutral (all but GP9 Drum Bus) renders byte-identical.
+            if (reproSubBellActive)
+                signal = static_cast<float> (reproSubBellPeak.process (static_cast<double> (signal)));
 
             // The American's 3.75 IPS / modern formulation has a narrow reproduce-head
             // presence resonance around 3 kHz before its steep 5 kHz shoulder. The
@@ -1195,7 +1369,30 @@ private:
     DBiquad driveHfShelf;                   // drive-linked HF restore (neutral at reference drive)
     DBiquad levelHfShelf;                   // signal-level HF restore (neutral at 0 dB; keyed on instantaneous flux)
     DBiquad levelLfShelf;                   // signal-level LF cut (neutral at 0 dB; keyed on instantaneous flux)
+    DBiquad presetLevelHmfPeak;             // per-preset above-anchor 6.3 kHz correction
+    DBiquad presetLevelHfShelf;             // per-preset above-anchor 11 kHz correction
+    bool presetLevelEqConfigured = false;   // exact bypass for presets with zero correction data
+    float presetLevelHmfMix = 0.0f;         // raw above-anchor factor (THD-sensitive band)
+    float presetLevelHfMix = 0.0f;          // expanded above-anchor factor (THD-safe band)
+    float presetLevelLastHmf = 999.0f, presetLevelLastHf = 999.0f;
+    // Program-keyed above-anchor pair (Phase C wall-breaker): same 6.3k/11k geometry as the
+    // preset-level pair, but crossfaded by the PROGRAM-BAND (500 Hz low-corner) envelope factor
+    // so it never engages on a lone 1 kHz THD tone (byte-identical THD by construction).
+    DBiquad progHmfPeak;                    // program-keyed 6.3 kHz peak
+    DBiquad progHfShelf;                    // program-keyed 11 kHz high-shelf
+    bool progEqConfigured = false;          // exact bypass for presets with zero prog trims
+    float progHmfMix = 0.0f, progHfMix = 0.0f;   // program-band factor mix (0 at/below the -12 anchor)
+    float progLastHmf = 999.0f, progLastHf = 999.0f;
+    DBiquad progLfShelf;                    // program-keyed deep-sub bloom (~33 Hz low-shelf)
+    bool progLfConfigured = false;          // exact bypass at 30 IPS / Thru (0 dB gain)
+    float progLfMix = 0.0f;                 // = progFactor mix (0 at/below the -12 anchor)
+    float progLfLastDb = 999.0f;
     DBiquad reproLfShelf, reproLmfPeak, reproHmfPeak, reproHfShelf; // advanced repro-head 4-band EQ (neutral at 0 dB)
+    DBiquad reproSubBellPeak;               // per-preset repro sub-bell (31 Hz Q2.5); fills a narrow head-bump LF dip
+    bool    reproSubBellActive = false;     // EXACT bypass at 0 dB: an always-on 0-dB peak biquad is NOT bit-identity
+                                            // (numerator==denominator cancels in exact math, not in float rounding), so
+                                            // skip the process call entirely when the band is 0 => byte-identical to no band.
+    float   reproSubBellLast = 0.0f;        // last-configured sub-bell dB; reset filter state on any change (incl. (de)activation)
     DBiquad slowModernPresencePeak;             // measured Classic 3.75 IPS / modern formulation presence resonance
     DBiquad transformerLfShelf;             // Transformer-Off LF restore (neutral at 0 dB = Transformer On)
     // Emphasis-rebalance G / 1-G pair wrapping ONLY the shaper (per-machine, always active).
@@ -1878,6 +2075,17 @@ public:
     void setReproLmf    (float db) noexcept { pReproLmf.store (db, std::memory_order_relaxed); }
     void setReproHmf    (float db) noexcept { pReproHmf.store (db, std::memory_order_relaxed); }
     void setReproHf     (float db) noexcept { pReproHf.store  (db, std::memory_order_relaxed); }
+    void setReproSubBell(float db) noexcept { pReproSubBell.store (db, std::memory_order_relaxed); } // per-preset 31 Hz Q2.5 sub-bell
+    void setLevelHmfTrim(float db) noexcept { pLevelHmfTrim.store (db, std::memory_order_relaxed); }
+    void setLevelHfTrim (float db) noexcept { pLevelHfTrim.store  (db, std::memory_order_relaxed); }
+    // Clamped to the declared param range: DuskSVF::setResonance only guards the LOW side
+    // (Q < 0.05), so an out-of-range value from a malformed state file or a host that does not
+    // fix values to the declared range would drive R2 -> 0 and leave an undamped resonator at
+    // the LP cutoff. This is the only param whose failure mode is self-oscillation.
+    void setLpQ         (float q)  noexcept { pLpQ.store (std::clamp (q, 0.5f, 2.5f), std::memory_order_relaxed); } // lowpass resonance (preset data)
+    void setProgHmfTrim (float db) noexcept { pProgHmfTrim.store (db, std::memory_order_relaxed); } // program-keyed above-anchor presence (Phase C)
+    void setProgHfTrim  (float db) noexcept { pProgHfTrim.store  (db, std::memory_order_relaxed); } // program-keyed above-anchor top-octave (Phase C)
+    void setProgLfTrim  (float db) noexcept { pProgLfTrim.store  (db, std::memory_order_relaxed); } // program-keyed deep-sub bloom (EAR-GREEN)
     void setBypass      (bool b)   noexcept { pBypass.store (b, std::memory_order_relaxed); }
 
     float getVuL() const noexcept { return vuL.load (std::memory_order_relaxed); }
@@ -1916,6 +2124,11 @@ private:
     std::atomic<float> pHighpassHz{20.0f}, pLowpassHz{20000.0f};
     std::atomic<float> pNoiseAmount{0.0f}, pWow{7.0f}, pFlutter{3.0f}, pOutputGainDb{0.0f};
     std::atomic<float> pReproLf{0.0f}, pReproLmf{0.0f}, pReproHmf{0.0f}, pReproHf{0.0f}; // advanced repro-head 4-band EQ (0 = neutral)
+    std::atomic<float> pReproSubBell{0.0f}; // per-preset repro sub-bell 31 Hz Q2.5 (0 = neutral, exact bypass)
+    std::atomic<float> pLevelHmfTrim{0.0f}, pLevelHfTrim{0.0f}; // hidden per-preset above-anchor HF curve
+    std::atomic<float> pProgHmfTrim{0.0f}, pProgHfTrim{0.0f};   // hidden program-band above-anchor HF trims (Phase C)
+    std::atomic<float> pProgLfTrim{0.0f};                        // hidden program-band deep-sub bloom (EAR-GREEN)
+    std::atomic<float> pLpQ{0.707f};        // lowpass SVF resonance (hidden preset data; 0.707 = the historic fixed Q)
     std::atomic<bool>  pAutoCal{true}, pNoiseEnabled{false}, pAutoComp{true}, pBypass{false};
     // American front-panel toggles — default On = the state the American tuning captured.
     std::atomic<bool>  pCrosstalk{true}, pWowFlutterOn{true}, pTransformer{true};
@@ -1948,6 +2161,14 @@ private:
     float m_levelEnv = 0.0f;         // persistent linear peak state (across blocks) — PRE gain
     float m_levelRelCoeff = 0.0f;    // per-sample release decay (set in prepare)
 
+    // Program-band (low-corner) envelope for the Phase C prog-trim pair: a 500 Hz 2-pole LP
+    // per channel feeds a peak follower (instant attack, shared 30 ms m_levelRelCoeff release)
+    // so a 1 kHz THD tone reads well below the -12 anchor (the LP attenuates 1 kHz ~-12 dB) =>
+    // progFactor 0 => byte-identical THD; sustained sub-500 Hz program still engages the trim.
+    DBiquad m_progLpL, m_progLpR;    // per-channel 500 Hz 2-pole LP (base rate; on the RAW pre-gain input)
+    float m_progEnv = 0.0f;          // persistent linear peak state (across blocks) — PRE gain, program band
+    float m_progFactorSm = 0.0f;     // persistent smoothed program-band factor (0..1); shares the level-comp coeffs
+
     // Level-comp factor smoother (block-rate, applied once per block): FAST attack so the
     // tone shifts ON a transient, slower release tracking the 30 ms detector. Prevents a
     // multi-dB shelf-gain step (biquad coeff discontinuity / zipper / click) when the factor
@@ -1963,7 +2184,7 @@ private:
     float m_driveDecaySm = 1.0f;     // persistent smoothed driveHfComp decay factor (~-0.75..1)
 
     // --- dirty tracking ---
-    float lastHpFreq = -1.0f, lastLpFreq = -1.0f;
+    float lastHpFreq = -1.0f, lastLpFreq = -1.0f, lastLpQ = -1.0f;
     int   lastFactor = -1;
 
     // --- scratch (allocated in prepare) ---

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
@@ -54,11 +54,12 @@ enum ParamId
     // stay bypassed on the 1 kHz THD tone => byte-identical THD. Both default 0 = neutral.
     kParamProgHmfTrim,     // -24..24 dB program-band presence correction (6.3 kHz peak)
     kParamProgHfTrim,      // -24..24 dB program-band top-octave correction (11 kHz shelf)
-    // Per-preset repro sub-bell (31 Hz Q2.5). A visible/automatable repro-EQ band like the other
-    // four; appended here (after the trims) so the earlier param IDs stay fixed. Neutral at 0 dB
+    // Per-preset repro sub-bell (31 Hz Q2.5). HIDDEN calibration data, like the trims above: it has
+    // no Advanced-panel control, and automating it would desync a preset from its fitted response.
+    // Appended here (after the trims) so the earlier param IDs stay fixed. Neutral at 0 dB
     // (exact bypass in the DSP) => byte-identical on every preset that leaves it 0. Only GP9 Drum
     // Bus carries a nonzero value (fills the American-30 head-bump's narrow LF dip at ~31 Hz).
-    kParamReproSubBell,    // -12..12 dB repro-head sub-bell (advanced)
+    kParamReproSubBell,    // -12..12 dB repro-head sub-bell
     // Hidden PROGRAM-BAND deep-sub bloom restore (EAR-GREEN). Keyed off the SAME 500 Hz program
     // envelope as the prog trims => byte-null on the -12 dBFS sweep / 1 kHz THD tone. Adds the
     // reference decks' deep-sub program thickening (a 33 Hz low-shelf); mine lacked it so hot 15/7.5

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
@@ -44,6 +44,27 @@ enum ParamId
     kParamReproLMF,        // -12..12 dB repro-head low-mid peak (advanced)
     kParamReproHMF,        // -12..12 dB repro-head high-mid/presence peak (advanced)
     kParamReproHF,         // -12..12 dB repro-head HF shelf  (advanced)
+    // Hidden factory-preset calibration data. Both gains are multiplied by the
+    // above-anchor level factor in the DSP, so 0 VU / -12 dBFS remains neutral.
+    kParamLevelHmfTrim,    // -24..24 dB full-factor presence correction
+    kParamLevelHfTrim,     // -24..24 dB full-factor top-octave correction
+    kParamLpQ,             // 0.5..2.5 lowpass resonance Q (cassette head-resonance peak at the LP cliff)
+    // Hidden program-band above-anchor trims (Phase C). Keyed off a 500 Hz low-corner program
+    // envelope (not the broadband detector), so they engage on sustained low-corner program yet
+    // stay bypassed on the 1 kHz THD tone => byte-identical THD. Both default 0 = neutral.
+    kParamProgHmfTrim,     // -24..24 dB program-band presence correction (6.3 kHz peak)
+    kParamProgHfTrim,      // -24..24 dB program-band top-octave correction (11 kHz shelf)
+    // Per-preset repro sub-bell (31 Hz Q2.5). A visible/automatable repro-EQ band like the other
+    // four; appended here (after the trims) so the earlier param IDs stay fixed. Neutral at 0 dB
+    // (exact bypass in the DSP) => byte-identical on every preset that leaves it 0. Only GP9 Drum
+    // Bus carries a nonzero value (fills the American-30 head-bump's narrow LF dip at ~31 Hz).
+    kParamReproSubBell,    // -12..12 dB repro-head sub-bell (advanced)
+    // Hidden PROGRAM-BAND deep-sub bloom restore (EAR-GREEN). Keyed off the SAME 500 Hz program
+    // envelope as the prog trims => byte-null on the -12 dBFS sweep / 1 kHz THD tone. Adds the
+    // reference decks' deep-sub program thickening (a 33 Hz low-shelf); mine lacked it so hot 15/7.5
+    // IPS presets read thin/bright. Default 0 = neutral. Appended after reproSubBell so its ID stays
+    // fixed (only the output-meter IDs below shift).
+    kParamProgLfTrim,      // -24..24 dB program-band deep-sub bloom (33 Hz low-shelf)
     // --- output-only (meters); kept as params for generic-UI fallback ---
     kParamVuL,             // output: L peak level for the VU meter
     kParamVuR,             // output: R peak level for the VU meter
@@ -111,6 +132,13 @@ static constexpr TmParam kTmParams[kParamCount] =
     { "reproLMF",     "Repro LMF",    'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
     { "reproHMF",     "Repro HMF",    'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
     { "reproHF",      "Repro HF",     'f', -12.f, 12.f,  0.f,  "dB", nullptr, 0 },
+    { "levelHmfTrim", "Level HMF Trim",'f',-24.f, 24.f,  0.f,  "dB", nullptr, 0 },
+    { "levelHfTrim",  "Level HF Trim", 'f',-24.f, 24.f,  0.f,  "dB", nullptr, 0 },
+    { "lpQ",          "Lowpass Q",    'f', 0.5f, 2.5f,   0.707f,"",  nullptr, 0 },
+    { "progHmfTrim",  "Prog HMF Trim",'f',-24.f, 24.f,  0.f,  "dB", nullptr, 0 },
+    { "progHfTrim",   "Prog HF Trim", 'f',-24.f, 24.f,  0.f,  "dB", nullptr, 0 },
+    { "reproSubBell", "Repro Sub Bell",'f',-12.f, 12.f,  0.f,  "dB", nullptr, 0 },
+    { "progLfTrim",   "Prog LF Trim", 'f',-24.f, 24.f,  0.f,  "dB", nullptr, 0 },
     { "vuL",          "VU L",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
     { "vuR",          "VU R",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
 };

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
@@ -62,8 +62,10 @@ enum ParamId
     kParamReproSubBell,    // -12..12 dB repro-head sub-bell
     // Hidden PROGRAM-BAND deep-sub bloom restore (EAR-GREEN). Keyed off the SAME 500 Hz program
     // envelope as the prog trims => byte-null on the -12 dBFS sweep / 1 kHz THD tone. Adds the
-    // reference decks' deep-sub program thickening (a 33 Hz low-shelf); mine lacked it so hot 15/7.5
-    // IPS presets read thin/bright. Default 0 = neutral. Appended after reproSubBell so its ID stays
+    // reference decks' deep-sub program thickening (a 33 Hz low-shelf); mine lacked it so hot presets
+    // read thin/bright. The gain is fitted per preset on program pink, NOT derived from tape speed —
+    // it is nonzero across every speed (see the progLfTrim notes in TapeMachinePresets.hpp for the
+    // full list). Default 0 = neutral. Appended after reproSubBell so its ID stays
     // fixed (only the output-meter IDs below shift).
     kParamProgLfTrim,      // -24..24 dB program-band deep-sub bloom (33 Hz low-shelf)
     // --- output-only (meters); kept as params for generic-UI fallback ---
@@ -143,3 +145,13 @@ static constexpr TmParam kTmParams[kParamCount] =
     { "vuL",          "VU L",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
     { "vuR",          "VU R",         'o', 0.f, 2.f,     0.f,  "",   nullptr, 0 },
 };
+
+// The table is POSITIONAL: kTmParams[i] must describe ParamId i. Declaring it [kParamCount]
+// already rejects a surplus row (compile error), but a MISSING row is silently zero-filled from
+// the end — that row would reach initParameter with a null symbol/name. These anchors pin the
+// last three entries so an insertion that forgets its table row fails to compile instead.
+static_assert(kTmParams[kParamCount - 1].id != nullptr, "kTmParams has a zero-filled row (missing entry)");
+static_assert(kTmParams[kParamVuL].kind == 'o' && kTmParams[kParamVuR].kind == 'o',
+              "kTmParams out of sync with ParamId: meters must be last and kind 'o'");
+static_assert(kTmParams[kParamBypass].kind == 'b',
+              "kTmParams out of sync with ParamId: bypass row moved");

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -80,6 +80,20 @@ protected:
             break;
         }
 
+        // Hidden factory-calibration data. These carry per-preset correction values fitted by the
+        // parity campaign, not user controls: exposing them lets a user desync a preset from its
+        // fit (and automating one blanks the preset-name display, since deriveFactoryPreset stops
+        // matching). reproSubBell belongs here too — it has no UI control on the Advanced panel,
+        // and only GP9 Drum Bus sets it nonzero.
+        // NOTE: DPF honours kParameterIsHidden in the LV2 exporter ONLY; the VST3 and CLAP
+        // backends never read the flag, so these still appear in those hosts' parameter lists.
+        // The assignment REPLACES kParameterIsAutomatable on purpose, which at least drops the
+        // automate flag there.
+        if (index == kParamLevelHmfTrim || index == kParamLevelHfTrim || index == kParamLpQ
+            || index == kParamProgHmfTrim || index == kParamProgHfTrim || index == kParamProgLfTrim
+            || index == kParamReproSubBell)
+            p.hints = kParameterIsHidden;
+
         p.name   = d.name;
         p.symbol = d.id;
         p.unit   = d.unit;
@@ -202,6 +216,13 @@ private:
         case kParamReproLMF:    dsp.setReproLmf(v);             break;
         case kParamReproHMF:    dsp.setReproHmf(v);             break;
         case kParamReproHF:     dsp.setReproHf(v);              break;
+        case kParamLevelHmfTrim:dsp.setLevelHmfTrim(v);         break;
+        case kParamLevelHfTrim: dsp.setLevelHfTrim(v);          break;
+        case kParamLpQ:         dsp.setLpQ(v);                  break;
+        case kParamProgHmfTrim: dsp.setProgHmfTrim(v);         break;
+        case kParamProgHfTrim:  dsp.setProgHfTrim(v);          break;
+        case kParamProgLfTrim:  dsp.setProgLfTrim(v);          break;
+        case kParamReproSubBell:dsp.setReproSubBell(v);         break;
         case kParamBypass:      dsp.setBypass(v > 0.5f);         break;
         }
     }

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
@@ -51,14 +51,33 @@ struct TmPreset
     float progHfTrim  = 0.0f; // hidden PROGRAM-BAND above-anchor top-octave trim (11 kHz; Phase C).
                     // Keyed off a 500 Hz low-corner program envelope (NOT the broadband detector),
                     // so they shape sustained-program HF yet stay bypassed on the 1 kHz THD tone =>
-                    // byte-identical THD. Only Drum Bus / Old Tape / Sunbaked carry nonzero values.
+                    // byte-identical THD. Both bands cut on presets that read bright and boost on
+                    // the ones that read dark; counts are stated so drift is easy to spot.
+                    // progHmfTrim nonzero on 7 of 20: Classic Rock Crisp -1, Modern Rock -2,
+                    //   Thick Saturation -8, Hip-Hop Punch -8, Old Tape -8, Drum Bus -14,
+                    //   Analog Warmth +8.
+                    // progHfTrim nonzero on 12 of 20: Bright & Sizzly -3, Nice 456 Master -5,
+                    //   Lush Film -5, Bass Bump -6, Classic Rock Crisp -6, Modern Rock -8,
+                    //   Thick Saturation -8, Drum Bus -14, Hip-Hop Punch -18, Old Tape -20,
+                    //   Vocal Presence +10, Analog Warmth +20.
+                    // Sunbaked Cassette carries NEITHER: its 78% over-bias + high cal put the
+                    // operating flux below the -12 anchor, so the above-anchor factor is 0 and
+                    // the mechanism cannot engage (see the in-table note on that row).
     float reproSubBell = 0.0f; // per-preset repro sub-bell (31 Hz Q2.5, dB). Fills the American-30
                     // head-bump's narrow LF dip WITHOUT lifting 50 Hz (a shelf would). Exact bypass
                     // at 0 in the DSP => byte-identical everywhere it is 0. Only GP9 Drum Bus is nonzero.
     float progLfTrim = 0.0f; // hidden PROGRAM-BAND deep-sub bloom restore (33 Hz low-shelf, dB; EAR-GREEN).
                     // Adds the reference decks' deep-sub program thickening (measured ref pink-minus-sweep
                     // ~+5 dB @25 Hz @15 IPS) that mine lacked. Keyed off the 500 Hz program envelope =>
-                    // neutral on the -12 dBFS sweep/THD tone (byte-identical). Nonzero on 15/7.5 IPS presets.
+                    // neutral on the -12 dBFS sweep/THD tone (byte-identical).
+                    // Nonzero on 13 of 20, and NOT speed-derived — it spans every speed, fitted
+                    // per preset on program pink: Nice 456 Master +5.0 (30 IPS), Lush Film +5.5,
+                    //   Classic Rock Crisp +7, Modern Rock +8, Fat 456 Master +9,
+                    //   Bright & Sizzly +15 (7.5 IPS), Hip-Hop Punch +15.5,
+                    //   Analog Warmth +15.5 (3.75 IPS), Bass Bump +16.5, Drum Bus +17.5,
+                    //   Big 456 Master +18, Thick Saturation +19, Old Tape +20.5 (7.5 IPS).
+                    // Zero on: Jazz Vision Master, Clean 900 Master, GP9 Drum Bus, Hi-Fi Shine,
+                    //   Jazz Warmth, Vocal Presence, Sunbaked Cassette.
 };
 
 // Preset field order:

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
@@ -38,48 +38,91 @@ struct TmPreset
                     // inverse (output = -input + outTrim); matches the reference preset's
                     // own non-unity output level. Post-tape LINEAR gain: shifts loudness only,
                     // transparent to THD/FR/aliasing. 0 = unity; every row sets it explicitly.
+    bool  crosstalk = false;  // American-only adjacent-track bleed toggle, matching the reference
+                    // preset's own Crosstalk switch. Omitted (=false) on Swiss presets (that deck
+                    // models zero crosstalk) and on American presets whose reference ships it Off;
+                    // set true only on American presets whose reference ships Crosstalk On.
+    float levelHmfTrim = 0.0f; // hidden above-anchor presence correction data (full-factor dB)
+    float levelHfTrim  = 0.0f; // hidden above-anchor top-octave correction data (full-factor dB)
+    float lpQ = 0.707f; // lowpass SVF resonance. 0.707 (default) = the historic fixed Butterworth Q;
+                    // lo-fi cassette-style presets raise it to model the reference's head-resonance
+                    // peak right before the LP cliff (a +/-/+ FR wiggle the 4-band repro EQ cannot make).
+    float progHmfTrim = 0.0f; // hidden PROGRAM-BAND above-anchor presence trim (6.3 kHz; Phase C).
+    float progHfTrim  = 0.0f; // hidden PROGRAM-BAND above-anchor top-octave trim (11 kHz; Phase C).
+                    // Keyed off a 500 Hz low-corner program envelope (NOT the broadband detector),
+                    // so they shape sustained-program HF yet stay bypassed on the 1 kHz THD tone =>
+                    // byte-identical THD. Only Drum Bus / Old Tape / Sunbaked carry nonzero values.
+    float reproSubBell = 0.0f; // per-preset repro sub-bell (31 Hz Q2.5, dB). Fills the American-30
+                    // head-bump's narrow LF dip WITHOUT lifting 50 Hz (a shelf would). Exact bypass
+                    // at 0 in the DSP => byte-identical everywhere it is 0. Only GP9 Drum Bus is nonzero.
+    float progLfTrim = 0.0f; // hidden PROGRAM-BAND deep-sub bloom restore (33 Hz low-shelf, dB; EAR-GREEN).
+                    // Adds the reference decks' deep-sub program thickening (measured ref pink-minus-sweep
+                    // ~+5 dB @25 Hz @15 IPS) that mine lacked. Keyed off the 500 Hz program envelope =>
+                    // neutral on the -12 dBFS sweep/THD tone (byte-identical). Nonzero on 15/7.5 IPS presets.
 };
 
 // Preset field order:
 //   name, category, machine, speed, type, eq, cal, path, head,
 //   inGain, autoCal, bias, hp, lp, wow, flutter, noise,
-//   reproLf, reproLmf, reproHmf, reproHf, outTrim
+//   reproLf, reproLmf, reproHmf, reproHf, outTrim, [crosstalk, levelHmfTrim, levelHfTrim, lpQ, progHmfTrim, progHfTrim, reproSubBell, progLfTrim]
+// The trailing fields default to false/0/0/0.707/0/0/0. Level trims are multiplied by the DSP's existing
+// above-anchor factor, hence are exactly neutral at the -12 dBFS calibration anchor. lpQ only
+// deviates from 0.707 on lo-fi presets that model the reference's LP-cliff head resonance. progHmf/HfTrim
+// are keyed off a 500 Hz PROGRAM-band envelope (Phase C), neutral on the -12 dBFS THD/sweep stimuli.
 static constexpr TmPreset kTmPresets[] =
 {
     // Input gain controls drive while the reproduce-EQ bands shape the calibrated
     // response. Higher calibration levels saturate more, and drive-linked HF
     // compensation keeps hot presets balanced.
     // ---- American: mixdown / mastering (2-bus glue) --------------------
-    { "Big 456 Master", "American Master", 1, 1, 0, 0, 0, 0, 1, 2.7f, true, 50.f, 20.f, 20000.f, 2.f, 1.f, 65.6f, 0.7f, 0.5f, -0.5f, 2.1f, 0.f },
-    { "Nice 456 Master", "American Master", 1, 2, 0, 0, 0, 0, 1, 2.6f, true, 50.f, 20.f, 20000.f, 1.f, 1.f, 62.1f, 1.1f, 0.4f, -3.f, 0.7f, 0.f },
-    { "Jazz Vision Master", "American Master", 1, 1, 0, 0, 0, 0, 1, -4.9f, true, 50.f, 20.f, 20000.f, 1.f, 1.f, 29.5f, -0.7f, 1.f, -1.1f, 6.9f, -0.3f },
+    { "Big 456 Master", "American Master", 1, 1, 0, 0, 0, 0, 1, 2.7f, true, 50.f, 20.f, 20000.f, 2.f, 1.f, 65.6f, 0.7f, 0.5f, -0.5f, 2.1f, 0.f, true, 0.0f, 0.0f, 0.707f, 0.0f, 0.0f, 0.0f, 18.0f },
+    { "Nice 456 Master", "American Master", 1, 2, 0, 0, 0, 0, 1, 2.6f, true, 50.f, 20.f, 20000.f, 1.f, 1.f, 62.1f, 1.1f, 0.4f, -3.f, 0.7f, 0.f, true, 0.0f, 0.0f, 0.707f, 0.0f, -5.0f, 0.0f, 5.0f },
+    { "Jazz Vision Master", "American Master", 1, 1, 0, 0, 0, 0, 1, -4.9f, true, 50.f, 20.f, 20000.f, 1.f, 1.f, 29.5f, -0.7f, 1.f, -1.1f, 6.9f, -0.3f, true },
     { "Clean 900 Master", "American Master", 1, 1, 2, 1, 2, 0, 1, -12.f, true, 50.f, 20.f, 20000.f, 1.f, 1.f, 0.f, -2.3f, -0.2f, 4.5f, 4.7f, 0.f },
 
     // ---- American: colour / character ----------------------------------
-    { "Fat 456 Master", "American Color", 1, 1, 0, 0, 0, 1, 1, 2.7f, true, 50.f, 45.f, 20000.f, 3.f, 2.f, 62.0f, 4.0f, 2.8f, 2.f, -0.3f, -0.5f },
-    { "GP9 Drum Bus", "American Color", 1, 2, 1, 0, 1, 0, 2, 6.8f, true, 50.f, 20.f, 20000.f, 3.f, 2.f, 44.9f, 2.5f, -0.6f, -3.6f, -0.1f, 1.4f },
-    { "Massive Bass", "American Color", 1, 1, 3, 0, 3, 0, 1, 7.8f, false, 72.f, 20.f, 20000.f, 3.f, 2.f, 96.7f, -0.7f, 0.4f, 0.6f, 1.6f, -1.0f },
-    { "Bright & Sizzly", "American Color", 1, 0, 1, 0, 0, 0, 0, -10.2f, false, 26.f, 20.f, 19000.f, 5.f, 3.f, 18.1f, -3.1f, 0.3f, -0.f, 0.8f, -0.8f },
+    { "Fat 456 Master", "American Color", 1, 1, 0, 0, 0, 1, 1, 2.7f, true, 50.f, 45.f, 20000.f, 3.f, 2.f, 62.0f, 4.0f, 2.8f, 2.f, -0.3f, -0.5f, true, 0.0f, 0.0f, 0.707f, 0.0f, 0.0f, 0.0f, 9.0f },
+    { "GP9 Drum Bus", "American Color", 1, 2, 1, 0, 1, 0, 2, 6.8f, true, 50.f, 20.f, 20000.f, 3.f, 2.f, 44.9f, 2.5f, -0.6f, -3.6f, -0.1f, 1.8f, false, 0.0f, -10.0f, 0.707f, 0.0f, 0.0f, 1.0f },
+    { "Bass Bump", "American Color", 1, 1, 3, 0, 3, 0, 1, 7.8f, false, 72.f, 20.f, 20000.f, 3.f, 2.f, 96.7f, -0.5f, 0.4f, 0.6f, 1.6f, -1.0f, false, 0.0f, 0.0f, 0.707f, 0.0f, -6.0f, 0.0f, 16.5f },
+    { "Bright & Sizzly", "American Color", 1, 0, 1, 0, 0, 0, 0, -10.2f, false, 26.f, 20.f, 19000.f, 5.f, 3.f, 18.1f, -3.1f, 0.3f, -0.f, 0.8f, -0.7f, false, 0.0f, -3.0f, 0.707f, 0.0f, -3.0f, 0.0f, 15.0f },
 
     // ---- Swiss: mix / tracking ----------------------------------------
-    { "Classic Rock Crisp", "Swiss Mix", 0, 1, 3, 0, 1, 0, 1, 0.0f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 2.6f, -0.3f, 0.2f, -0.9f, 0.5f, 0.4f },
-    { "Modern Rock", "Swiss Mix", 0, 1, 0, 0, 1, 0, 1, 5.0f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 4.0f, -0.2f, 0.2f, -1.f, 1.2f, 0.9f },
-    { "Drum Bus", "Swiss Mix", 0, 1, 1, 0, 1, 1, 1, 10.9f, false, 62.f, 20.f, 20000.f, 0.f, 0.f, 0.f, -1.7f, 0.4f, -0.4f, 7.4f, 1.5f },
+    { "Classic Rock Crisp", "Swiss Mix", 0, 1, 3, 0, 1, 0, 1, 0.0f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 2.6f, -0.3f, 0.2f, -0.9f, 0.5f, 0.4f, false, 0.0f, 0.0f, 0.707f, -1.0f, -6.0f, 0.0f, 7.0f },
+    { "Modern Rock", "Swiss Mix", 0, 1, 0, 0, 1, 0, 1, 5.0f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 4.0f, -0.2f, 0.2f, -1.f, 1.2f, 0.9f, false, 0.0f, 0.0f, 0.707f, -2.0f, -8.0f, 0.0f, 8.0f },
+    // progHmf/HfTrim -14/-14 (Phase C): mine is uniformly +6 dB too bright on sustained program
+    // (6.3-16 kHz); the program-band-keyed cut closes it (sustHF 6.12 -> 0.38) while THD stays
+    // byte-identical (the 1 kHz tone is below the prog envelope's -12 anchor). Phase B reproHf=8.7 kept.
+    // outTrim 1.5 -> 2.53: the HF cut removed ~1.46 dB broadband on loud program (pink loud-region
+    // dRMS), so the makeup restores loud-region loudness parity (Cat1 dRMS -1.03 -> 0.0). outTrim is
+    // a post-tape LINEAR gain (THD %/FR/alias invariant; it does scale the render level).
+    { "Drum Bus", "Swiss Mix", 0, 1, 1, 0, 1, 1, 1, 10.9f, false, 62.f, 20.f, 20000.f, 0.f, 0.f, 0.f, -1.7f, 0.4f, -0.4f, 8.7f, 2.53f, false, 0.0f, 0.0f, 0.707f, -14.0f, -14.0f, 0.0f, 17.5f },
     { "Hi-Fi Shine", "Swiss Mix", 0, 2, 1, 0, 1, 0, 1, 5.1f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 0.f, 0.6f, 0.3f, -0.8f, 5.5f, 0.3f },
-    { "Lush Film", "Swiss Mix", 0, 1, 2, 0, 0, 1, 1, 3.1f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 0.f, -1.7f, 0.5f, -0.8f, 1.f, 0.9f },
+    { "Lush Film", "Swiss Mix", 0, 1, 2, 0, 0, 1, 1, 3.1f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 0.f, -1.7f, 0.5f, -0.8f, 1.f, 0.9f, false, 0.0f, 0.0f, 0.707f, 0.0f, -5.0f, 0.0f, 5.5f },
     { "Jazz Warmth", "Swiss Mix", 0, 2, 2, 0, 0, 0, 1, -9.1f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 0.f, 0.6f, 0.4f, 0.2f, -0.6f, 0.f },
 
     // ---- Swiss: character / saturation --------------------------------
-    { "Thick Saturation", "Swiss Color", 0, 1, 1, 0, 3, 1, 1, 2.2f, false, 40.f, 20.f, 20000.f, 0.f, 0.f, 3.7f, -1.8f, 0.7f, 0.0f, 6.1f, -0.7f },
-    { "Hip-Hop Punch", "Swiss Color", 0, 1, 1, 0, 2, 1, 1, 6.8f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 6.3f, -0.1f, 0.5f, -0.6f, 7.8f, 0.f },
-    { "Vocal Presence", "Swiss Color", 0, 2, 2, 0, 3, 1, 1, 11.8f, false, 64.2f, 20.f, 20000.f, 0.f, 0.f, 0.f, 0.5f, 0.5f, -1.6f, 1.7f, 2.5f },
+    { "Thick Saturation", "Swiss Color", 0, 1, 1, 0, 3, 1, 1, 2.2f, false, 40.f, 20.f, 20000.f, 0.f, 0.f, 3.7f, -1.8f, 0.7f, 0.0f, 6.1f, 0.0f, false, 0.0f, -5.0f, 0.707f, -8.0f, -8.0f, 0.0f, 19.0f },
+    { "Hip-Hop Punch", "Swiss Color", 0, 1, 1, 0, 2, 1, 1, 6.8f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 6.3f, -0.1f, 0.5f, -0.6f, 7.8f, 0.f, false, 0.0f, -2.0f, 0.707f, -8.0f, -18.0f, 0.0f, 15.5f },
+    { "Vocal Presence", "Swiss Color", 0, 2, 2, 0, 3, 1, 1, 11.8f, false, 64.2f, 20.f, 20000.f, 0.f, 0.f, 0.f, 0.5f, 0.5f, -1.6f, 1.7f, 2.5f, false, 0.0f, -7.0f, 0.707f, 0.0f, 10.0f },
 
     // ---- Lo-Fi (both decks) -------------------------------------------------
-    { "Sunbaked Cassette", "Lo-Fi", 1, 3, 2, 0, 0, 0, 0, 10.9f, false, 78.f, 39.f, 10000.f, 18.f, 12.f, 88.7f, 2.2f, -4.1f, -4.9f, -4.4f, -4.0f },
-    { "Analog Warmth", "Lo-Fi", 1, 3, 3, 0, 3, 0, 0, -12.f, false, 37.3f, 30.f, 12000.f, 14.f, 10.f, 25.1f, 3.1f, -0.1f, -7.5f, 9.1f, -0.4f },
+    // Sunbaked gets NO prog trim (Phase C wall): its 78% over-bias + +3 cal put the operating flux
+    // ~8.8 dB BELOW the -12 anchor on -6 dBFS program, so the above-anchor-keyed prog factor (and
+    // the existing levelFactor) are exactly 0 for it — the mechanism cannot engage. Its residual
+    // sustHF (~3.4, mostly the 12.5/16 kHz LP-cliff bands past its 10.8 kHz lowpass) is a below-
+    // anchor/static-tone effect the above-anchor trim is the wrong tool for. Left byte-identical.
+    { "Sunbaked Cassette", "Lo-Fi", 1, 3, 2, 0, 0, 0, 0, 10.9f, false, 78.f, 34.f, 10800.f, 18.f, 12.f, 88.7f, 0.75f, -3.8f, -4.7f, -8.3f, -4.6f, true, 0.0f, 0.0f, 0.89f },
+    { "Analog Warmth", "Lo-Fi", 1, 3, 3, 0, 3, 0, 0, -12.f, false, 37.3f, 30.f, 12000.f, 14.f, 10.f, 25.1f, 3.1f, -0.1f, -7.5f, 9.1f, -0.4f, true, -2.0f, -14.0f, 0.707f, 8.0f, 20.0f, 0.0f, 15.5f },
     // Old Tape is Swiss (machine 0); the reference tracking deck has NO wow/flutter, so its
     // W&F is 0/0 by design (2026-07-12 authenticity decision) — loses the old 12/8 lo-fi wobble.
-    { "Old Tape", "Lo-Fi", 0, 0, 3, 0, 2, 1, 1, 2.5f, false, 42.f, 30.f, 12000.f, 0.f, 0.f, 24.5f, -6.2f, 1.2f, -2.4f, -10.9f, 0.9f },
+    // EAR-GREEN (2026-07-17c, re-based on PROGRAM/pink, not the synth sustain stimulus):
+    //   progLfTrim 20.5 restores the reference's deep-sub program bloom (ear_audit sub -3.5 -> +0.3).
+    //   progHmf/HfTrim -8/-20 CUT the top: on pink mine reads BRIGHT (air +3.9, tilt -5.2), the
+    //   program-band-keyed cut closes most of it (tilt -> -0.64). Byte-identical on the -12 tone
+    //   (progFactor 0). A prior Phase-C +14/+10 BOOST was fit to the sustain stimulus (no real HF ->
+    //   mis-read this LP@12k lo-fi preset as DARK) and was reverted; the residual bright tilt -0.64 +
+    //   bass3rd -9.1 are documented lo-fi / memoryless-shaper walls. outTrim 0.9 (boost makeup reverted).
+    { "Old Tape", "Lo-Fi", 0, 0, 3, 0, 2, 1, 1, 2.5f, false, 42.f, 30.f, 12000.f, 0.f, 0.f, 27.7f, -6.2f, 1.2f, -2.4f, -10.9f, 0.9f, false, 0.0f, 0.0f, 0.707f, -8.0f, -20.0f, 0.0f, 20.5f },
 };
 
 static constexpr int kNumTmPresets = (int)(sizeof(kTmPresets) / sizeof(kTmPresets[0]));
@@ -100,10 +143,10 @@ inline void tmApplyPreset(int idx, SetFn&& set)
     set(kParamCalibration,  (float)p.calibration);
     set(kParamSignalPath,   (float)p.signalPath);
     set(kParamHeadWidth,    (float)p.headWidth);
-    // American front-panel toggles: every factory preset was curated from the reference
-    // default state (Crosstalk/W&F/Transformer all On), which is also the state the
-    // American tuning captured — force On so preset recall always uses the fitted path.
-    set(kParamCrosstalk,    1.0f);
+    // American front-panel toggles. Crosstalk mirrors the reference preset's own switch
+    // (p.crosstalk); the Swiss deck models zero crosstalk so its presets leave it Off (moot).
+    // W&F/Transformer stay On (the state the American tuning captured).
+    set(kParamCrosstalk,    p.crosstalk ? 1.0f : 0.0f);
     set(kParamWowFlutterOn, 1.0f);
     set(kParamTransformer,  1.0f);
     set(kParamInputGain,    p.inputGain);
@@ -123,4 +166,11 @@ inline void tmApplyPreset(int idx, SetFn&& set)
     set(kParamReproLMF,     p.reproLmf);
     set(kParamReproHMF,     p.reproHmf);
     set(kParamReproHF,      p.reproHf);
+    set(kParamLevelHmfTrim, p.levelHmfTrim);
+    set(kParamLevelHfTrim,  p.levelHfTrim);
+    set(kParamLpQ,          p.lpQ);
+    set(kParamProgHmfTrim,  p.progHmfTrim);
+    set(kParamProgHfTrim,   p.progHfTrim);
+    set(kParamProgLfTrim,   p.progLfTrim);
+    set(kParamReproSubBell, p.reproSubBell);
 }

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -14,6 +14,7 @@
 #include "TapeMachinePresets.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiWidgets.hpp"
+#include "DuskSupportersOverlay.hpp"   // shared DPF Patreon "Special Thanks" overlay (click title)
 
 #include <cmath>
 #include <cstdio>
@@ -147,7 +148,12 @@ protected:
         // input — the manual dl-> draws (knobs, meters, text use explicit colours) are unaffected,
         // so the background still renders normally under the scrim's dim. drawAdvanced runs OUTSIDE
         // the disabled scope so the card, scrim and EQ knobs stay live.
-        if (showAdvanced) ImGui::BeginDisabled();
+        // A modal (Advanced panel OR the Patreon overlay) disables the background widgets so clicks
+        // land on the scrim, not a knob/combo underneath. Captured BEFORE drawHeader so the Begin/End
+        // stay balanced even when a title-click flips showSupporters on mid-frame (the overlay then
+        // draws below, and the header is disabled from the next frame).
+        const bool modalOpen = showAdvanced || showSupporters;
+        if (modalOpen) ImGui::BeginDisabled();
         drawHeader(dl);
         // The PEAK lamp is a digital-CLIP indicator: peakLevel(ch) reads the DSP's final-OUTPUT
         // sample-peak hold, and the lamp lights when the output crosses 0 dBFS (see drawVU),
@@ -159,8 +165,10 @@ protected:
         drawVU(dl, 412, 62, 732, 198, meterLevel(1), peakLevel(1), needleR, clipHoldR, clipEnabled, accent, "R");
         drawSelectors(dl);
         drawControls(dl);
-        if (showAdvanced) ImGui::EndDisabled();
+        if (modalOpen) ImGui::EndDisabled();
         if (showAdvanced) drawAdvanced(dl);
+        if (showSupporters)
+            duskdpf::drawSupportersOverlay(panel, dl, kDesignW, kDesignH, showSupporters, "TapeMachine 2", "");
 
         ImGui::End();
         ImGui::PopStyleVar(2);
@@ -497,6 +505,11 @@ private:
             dl->AddRect(P(193, 16), P(243, 34), IM_COL32(0, 0, 0, 90), 3.0f * s, 0, 1.0f * s);
             text(dl, 218, 20, 8.5f, IM_COL32(18, 18, 20, 255), badge, 0, true);
         }
+        // The title nameplate is a click target -> Patreon "Special Thanks" overlay (matches the
+        // JUCE plugins' click-title-to-see-supporters behaviour). Input-only; the visuals above stay.
+        ImGui::SetCursorScreenPos(P(30, 12));
+        if (ImGui::InvisibleButton("##titlecredits", ImVec2(217.0f * s, 28.0f * s)))
+            showSupporters = true;
 
         // preset browser, centred between the title and the (right-anchored) bypass:
         //   < [combo] >  INIT  SAVE          (all on the 18..38 band)
@@ -1234,6 +1247,7 @@ private:
     char    saveBuf[64] = {};
     bool    openSaveModal = false;
     bool    showAdvanced = false;   // hidden advanced (Repro EQ) panel toggle
+    bool    showSupporters = false; // Patreon "Special Thanks" overlay (click the title nameplate)
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachineUI)
 };

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -1245,7 +1245,6 @@ private:
     struct UserPreset { std::string name, path; float vals[kParamVuL]; };
     std::vector<UserPreset> userPresets;
     char    saveBuf[64] = {};
-    bool    openSaveModal = false;
     bool    showAdvanced = false;   // hidden advanced (Repro EQ) panel toggle
     bool    showSupporters = false; // Patreon "Special Thanks" overlay (click the title nameplate)
 

--- a/plugins/shared-dpf/ui/DuskSupportersOverlay.hpp
+++ b/plugins/shared-dpf/ui/DuskSupportersOverlay.hpp
@@ -1,0 +1,143 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
+// others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
+//
+// DuskSupportersOverlay.hpp — framework-free (DPF/Dear ImGui) Patreon "Special Thanks"
+// credits overlay. The non-JUCE counterpart of plugins/shared/SupportersOverlay.h, so
+// DPF ports show the same click-title-to-see-supporters panel as the JUCE plugins.
+//
+// Usage (call every frame, LAST, while `open` is true — it draws a scrim over the UI):
+//     if (showSupporters)
+//         duskdpf::drawSupportersOverlay(panel, dl, kDesignW, kDesignH,
+//                                        showSupporters, "TapeMachine 2", "1.0.1");
+// Open it from a title/logo hit-test:  if (titleClicked) showSupporters = true;
+// Reads the generated, JUCE-free duskdpf::patreonTiers() list. Reusable across all DPF UIs.
+
+#pragma once
+
+#include "DuskImGuiWidgets.hpp"   // duskdpf::DuskPanel (crisp text + P()/scale); requires imgui.h pre-included
+#include "PatreonBackersDpf.hpp"  // duskdpf::patreonTiers() — generated, framework-free
+
+#include <algorithm>   // std::min
+#include <cstdio>      // std::snprintf
+#include <cstring>     // std::strcmp
+
+namespace duskdpf
+{
+
+// Per-tier accent colour, matched to the JUCE SupportersOverlay palette (HUGS is DPF-only, warm).
+inline ImU32 supporterTierColor(const char* title) noexcept
+{
+    if (std::strcmp(title, "CHAMPIONS") == 0)       return IM_COL32(255, 215,   0, 255);  // gold
+    if (std::strcmp(title, "PATRONS") == 0)         return IM_COL32(  0, 170, 255, 255);  // blue
+    if (std::strcmp(title, "SUPPORTERS") == 0)      return IM_COL32(106, 196, 126, 255);  // green
+    if (std::strcmp(title, "HUGS") == 0)            return IM_COL32(224, 156, 112, 255);  // warm peach
+    if (std::strcmp(title, "PAST SUPPORTERS") == 0) return IM_COL32(140, 140, 140, 255);  // grey
+    return IM_COL32(200, 200, 204, 255);
+}
+
+// Full-canvas "Special Thanks" credits overlay. Immediate-mode: draws a dark scrim over the whole
+// plugin area, a centred panel with per-tier accented names (scrollable so a growing list never
+// overflows), and a footer. Clicking the scrim (anywhere outside the scrolling list) dismisses.
+// Coordinates are the plugin's DESIGN space (0..designW/H); the shared DuskPanel maps to screen.
+inline void drawSupportersOverlay(DuskPanel& panel, ImDrawList* dl,
+                                  float designW, float designH, bool& open,
+                                  const char* pluginName, const char* version = "")
+{
+    if (!open)
+        return;
+
+    const float s = panel.scale();
+
+    // --- scrim + click-to-dismiss (any click outside the scrolling name list) ---------------
+    dl->AddRectFilled(panel.P(0.0f, 0.0f), panel.P(designW, designH), IM_COL32(16, 16, 16, 242));
+    ImGui::SetCursorScreenPos(panel.P(0.0f, 0.0f));
+    ImGui::SetNextItemAllowOverlap();
+    if (ImGui::InvisibleButton("##supscrim", ImVec2(designW * s, designH * s)))
+        open = false;
+
+    // --- centred panel (design coords) ------------------------------------------------------
+    const float pw = std::min(384.0f, designW - 56.0f);
+    const float ph = std::min(452.0f, designH - 40.0f);
+    const float px = 0.5f * (designW - pw);
+    const float py = 0.5f * (designH - ph);
+
+    dl->AddRectFilled(panel.P(px, py), panel.P(px + pw, py + ph), IM_COL32(30, 30, 32, 255), 11.0f * s);
+    dl->AddRect      (panel.P(px, py), panel.P(px + pw, py + ph), IM_COL32(80, 80, 84, 255), 11.0f * s, 0, 1.6f * s);
+
+    // header
+    panel.text(dl, px + pw * 0.5f, py + 20.0f, 18.0f, IM_COL32(232, 232, 232, 255), "Special Thanks", 0, true);
+    panel.text(dl, px + pw * 0.5f, py + 46.0f, 9.5f,  IM_COL32(120, 120, 120, 255),
+               "To our supporters who make this plugin possible", 0);
+    dl->AddRectFilled(panel.P(px + 26.0f, py + 66.0f), panel.P(px + pw - 26.0f, py + 67.0f), IM_COL32(58, 58, 58, 255));
+
+    // --- scrolling tier/name list -----------------------------------------------------------
+    const float listTop = py + 76.0f;
+    const float footerH = 40.0f;
+    const float listH   = ph - (listTop - py) - footerH;
+
+    ImGui::SetCursorScreenPos(panel.P(px + 14.0f, listTop));
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(0, 0, 0, 0));
+    ImGui::BeginChild("##suplist", ImVec2((pw - 28.0f) * s, listH * s), false,
+                      ImGuiWindowFlags_None);   // native scrollbar appears only when the list overflows
+    {
+        ImDrawList* cdl = ImGui::GetWindowDrawList();
+        const float avail = ImGui::GetContentRegionAvail().x;
+
+        auto centred = [&](const char* txt, float px_sz, ImU32 col, float advance)
+        {
+            ImFont* f = panel.pickFont(px_sz * s);
+            const float fsz = px_sz * s;
+            const ImVec2 ts = f->CalcTextSizeA(fsz, FLT_MAX, 0.0f, txt);
+            const ImVec2 cur = ImGui::GetCursorScreenPos();
+            cdl->AddText(f, fsz, ImVec2(std::floor(cur.x + 0.5f * (avail - ts.x) + 0.5f),
+                                        std::floor(cur.y + 0.5f)), col, txt);
+            ImGui::Dummy(ImVec2(avail, advance * s));
+        };
+
+        bool first = true;
+        for (const BackerTier& tier : patreonTiers())
+        {
+            if (tier.names.empty())
+                continue;
+            const bool isPast = (std::strcmp(tier.title, "PAST SUPPORTERS") == 0);
+            if (!first)
+                ImGui::Dummy(ImVec2(avail, 12.0f * s));   // gap between tiers
+            first = false;
+
+            const ImU32 accent = supporterTierColor(tier.title);
+            centred(tier.title, 9.5f, accent, 17.0f);
+
+            // short accent line under the heading
+            const ImVec2 cur = ImGui::GetCursorScreenPos();
+            const float lineW = 26.0f * s;
+            cdl->AddRectFilled(ImVec2(cur.x + 0.5f * (avail - lineW), cur.y),
+                               ImVec2(cur.x + 0.5f * (avail + lineW), cur.y + 1.0f * s),
+                               (accent & 0x00ffffff) | 0x66000000);
+            ImGui::Dummy(ImVec2(avail, 8.0f * s));
+
+            const ImU32 nameCol = isPast ? IM_COL32(130, 130, 130, 255) : IM_COL32(206, 206, 206, 255);
+            for (const char* name : tier.names)
+                centred(name, isPast ? 11.0f : 12.0f, nameCol, 15.5f);
+        }
+    }
+    ImGui::EndChild();
+    ImGui::PopStyleColor();
+
+    // --- footer -----------------------------------------------------------------------------
+    dl->AddRectFilled(panel.P(px + 26.0f, py + ph - footerH), panel.P(px + pw - 26.0f, py + ph - footerH + 1.0f),
+                      IM_COL32(58, 58, 58, 255));
+    panel.text(dl, px + pw * 0.5f, py + ph - footerH + 8.0f, 10.0f, IM_COL32(96, 96, 96, 255),
+               "Click anywhere to close", 0);
+
+    char credit[128];
+    if (pluginName == nullptr || pluginName[0] == '\0')
+        std::snprintf(credit, sizeof(credit), "by Dusk Audio");
+    else if (version == nullptr || version[0] == '\0')
+        std::snprintf(credit, sizeof(credit), "%s by Dusk Audio", pluginName);
+    else
+        std::snprintf(credit, sizeof(credit), "%s v%s by Dusk Audio", pluginName, version);
+    panel.text(dl, px + pw * 0.5f, py + ph - footerH + 23.0f, 10.0f, IM_COL32(80, 80, 80, 255), credit, 0);
+}
+
+} // namespace duskdpf


### PR DESCRIPTION
Adds a 500 Hz program-band envelope detector alongside the existing broadband one, and keys three correction stages off it so they engage on sustained low-corner program while staying neutral at the -12 dBFS calibration anchor:

- prog HMF/HF trims (6.3 kHz peak + 11 kHz shelf)
- prog LF deep-sub bloom (33 Hz low-shelf)
- preset-level HMF/HF trims, keyed off the broadband factor

Also adds a per-preset repro sub-bell (31 Hz Q2.5) and a per-preset lowpass Q, so lo-fi presets can model the reference head-resonance peak at the LP cliff. Every new band bypasses exactly at 0 dB.

Crosstalk retuned to the reference: Swiss 0.0006 -> 0 (the reference models no L/R bleed), American 0.0027 -> 0.00224 (~-53 dB midpoint). Presets now honour their own Crosstalk switch instead of forcing it On.

Preset "Massive Bass" renamed "Bass Bump".

UI: clicking the title nameplate opens the Patreon supporters overlay, via a new shared DuskSupportersOverlay.hpp for DPF ports.

Review fixes:
- clamp setLpQ to the declared 0.5..2.5 range. DuskSVF::setResonance guards only the low side, so an out-of-range value could leave an undamped resonator at the LP cutoff.
- mark reproSubBell hidden: it has no UI control, and automating it desyncs a preset from its calibration fit.

Verified: all four DPF formats build clean; an offline A/B probe confirms the program-keyed stages contribute exactly zero at and below the -12 dBFS anchor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Special Thanks” (supporter credits) overlay with click-to-open/close behavior from the plugin title area.
  - Expanded factory preset calibration for more detailed program-band shaping, including Phase C envelope/corrections, added trim controls, and updated repro sub-bell response.

- **Bug Fixes**
  - Improved preset/sample-rate transition stability by ensuring advanced EQ/correction and LP behavior refresh correctly when settings change.
  - Presets now properly retain and honor their configured crosstalk setting.

- **Documentation**
  - Renamed the American preset “Massive Bass” to “Bass Bump” in the manual and plugin documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->