### PR TITLE
Duskverb/stereo image

### DIFF
--- a/plugins/DuskVerb/src/dsp/DenseHallReverb.h
+++ b/plugins/DuskVerb/src/dsp/DenseHallReverb.h
@@ -57,6 +57,13 @@ public:
         // at a new SR reallocates; keeps update() allocation-free (audio-thread).
         spinL_.alloc ((int)(0.0061f*sr_), (int)(0.0002f*sr_));
         spinR_.alloc ((int)(0.0049f*sr_), (int)(0.0002f*sr_));
+        // Stereo-image bias only: per-provenance twins of the two spin allpasses
+        // (identical length/excursion, so the two halves re-sum to the unbiased
+        // tap). Unused — and never processed — while the bias is off.
+        spinLa_.alloc ((int)(0.0061f*sr_), (int)(0.0002f*sr_));
+        spinLb_.alloc ((int)(0.0061f*sr_), (int)(0.0002f*sr_));
+        spinRa_.alloc ((int)(0.0049f*sr_), (int)(0.0002f*sr_));
+        spinRb_.alloc ((int)(0.0049f*sr_), (int)(0.0002f*sr_));
         rebuild();   // sets line_[i].len at the current size (no allocation)
 
         // Smooth modulation LFOs (sine), detuned per side; spin LFO slower.
@@ -87,6 +94,7 @@ public:
         susLimMidDet_.clear(); susLimLowDet_.clear(); susLimKey_.clear();
         susLimMidRed_ = susLimLowRed_ = susLimMidAcc_ = susLimLowAcc_ = 0.0f;
         spinL_.clear(); spinR_.clear();
+        spinLa_.clear(); spinLb_.clear(); spinRa_.clear(); spinRb_.clear();
         tcL_.reset(); tcR_.reset();
         for (auto& d : dc_) d.reset();   // process() always runs the input DC blockers — clear their history too, else state leaks across instances/sessions
     }
@@ -155,6 +163,64 @@ public:
     }
     void setCrossoverFreq (float hz)     { lowX_  = std::clamp (hz, 40.0f, 2000.0f);   if (lowX_ > highX_) highX_ = lowX_; if (prepared_) update(); }  // bass↔mid split (keeps lowX_<=highX_)
     void setHighCrossoverFreq (float hz) { highX_ = std::clamp (hz, 800.0f, 14000.0f); if (highX_ < lowX_) lowX_ = highX_; if (prepared_) update(); }  // mid↔high split (keeps lowX_<=highX_)
+    // STEREO IMAGE BIAS (issue #123). A hard-panned source comes out of this tank
+    // dead centre (measured tail ILD −0.21 dB) while the reference halls hold a
+    // +1.3..+4.3 dB lean toward the source side. Root cause is in the output taps,
+    // not the tank: after the Hadamard butterfly the two taps collapse EXACTLY to
+    //   oL = g·(p1 + p5),   oR = g·(p2 − p6)
+    // (p = pre-Hadamard line values; verified by pushing basis vectors through
+    // hadamard8). Lines 0-3 are L-fed and 4-7 R-fed, so each output carries one
+    // L-fed and one R-fed line at EQUAL weight — the lean is cancelled by
+    // construction. This setter reweights the taps by provenance.
+    //
+    // The reweighting is a ROTATION inside the side domain, not a per-line gain:
+    //   D  = ½[(L-fed half) − (R-fed half)]        (the provenance difference)
+    //   S' = cos·S + sin·D                          (S = ½(oL − oR), M = ½(oL + oR))
+    // Properties that make it safe on centred material:
+    //   • M is untouched ⇒ L+R is preserved to float rounding, so mono-compatible
+    //     content keeps its tone, decay and level exactly (rule 2 of the brief).
+    //   • E(D) == E(S) for equal line energies ⇒ the rotation is constant-power:
+    //     no width change and no level change either, just a reshuffle of which
+    //     decorrelated tank nodes carry the side.
+    //   • The lean rides entirely on ⟨M,D⟩ = ¼(E_Lfed − E_Rfed), which is ZERO for
+    //     a centred source and positive for a left-panned one — so this can never
+    //     act as a fixed panner.
+    // Signs are untouched (they are the output decorrelation); only magnitudes
+    // move. The feedback matrix is not involved, so decay/T60 are unchanged.
+    // amount 0 = off = the pre-feature instruction stream (see process()).
+    //
+    // MEASURED CEILING — READ BEFORE TUNING THIS. amount=1 is the FULL rotation
+    // (sin=1: the side is entirely the provenance difference) and it buys only
+    // −0.21 → +0.76 dB of tail ILD on algo 14, well short of the +2.5..+4 dB the
+    // reference halls show. That is a property of the tank, not of this formula:
+    // ILD ∝ (E_Lfed − E_Rfed), and the Hadamard-8 scatter is FULL mixing, so line
+    // provenance is destroyed within one loop pass (~60-90 ms) while 77% of the
+    // tail energy arrives at or after that point. Measured per-window on a
+    // left-panned burst at amount=1: 0.05-0.15 s (77% of energy) only +0.43 dB.
+    // The brief's alternative per-line constant-power weighting was built and
+    // measured at ITS maximum lean (pure same-side taps) — +0.79 dB, the same
+    // ceiling, while destroying the centred-input null (L+R only −10.7 dB vs
+    // −89.5 dB here). Raising the lean further needs asymmetry in the FEEDBACK
+    // path (out of scope: it moves decay/T60) or a >1 gain on D, which breaks
+    // constant-power — reaching +2.5 dB that way needs ~2.8x, i.e. ~9 dB of extra
+    // side energy on centred material. Do not chase it from here.
+    void setStereoImageBias (float amount)
+    {
+        stereoBias_ = std::clamp (amount, 0.0f, 1.0f);
+        const bool wasActive = stereoBiasActive_;
+        stereoBiasActive_ = stereoBias_ > 0.0f;
+        // amount 1 = kBiasMaxSin = the full rotation, i.e. everything this mechanism
+        // has (+0.76 dB tail ILD). See the measured-ceiling note above.
+        biasSin_ = stereoBias_ * kBiasMaxSin;
+        biasCos_ = std::sqrt (std::max (0.0f, 1.0f - biasSin_ * biasSin_));
+        // Twins are cold until the bias runs; clear on the off→on edge so a toggle
+        // can never splice a stale tail back in.
+        if (stereoBiasActive_ && ! wasActive)
+        {
+            spinLa_.clear(); spinLb_.clear(); spinRa_.clear(); spinRb_.clear();
+        }
+    }
+
     void setModDepth (float d)       { modDepth_ = std::clamp (d, 0.0f, 1.0f); }       // scales allpass/delay excursion
     void setModRate (float hz)       { modRate_=std::clamp(hz,0.05f,3.0f); lfo1_.setRate(modRate_); lfo2_.setRate(modRate_*1.19f); }
     void setFreeze (bool f)          { frozen_ = f; if (prepared_) update(); }
@@ -239,6 +305,45 @@ public:
             const float sp = spin_.next() * (0.05f + 0.95f * modDepth_);
             oL = spinL_.process (oL, sp);
             oR = spinR_.process (oR, -sp);
+
+            // STEREO IMAGE BIAS (setStereoImageBias) — issue #123. Appended, never
+            // interleaved: every statement above is byte-for-byte the pre-feature
+            // code so the disabled build keeps its exact instruction stream (this
+            // target is -O3 -ffast-math; an earlier version that merely SPLIT the
+            // two lines above into if/else branches moved the disabled output by
+            // −67 dB). Off ⇒ this block is not entered and nothing above it changed.
+            if (stereoBiasActive_)
+            {
+                // Recover the four lines the taps resolve to. The butterfly is its
+                // own inverse up to 1/8, and x[] still holds g·(H·p), so
+                //   g·p_j = ⅛ Σ_k H[j][k]·x[k]
+                // gives them back exactly — no capture before the butterfly, which
+                // would have perturbed the loop above. By construction
+                // gp1 + gp5 == the left tap and gp2 − gp6 == the right tap.
+                const float gp1 = 0.125f * (x[0] - x[1] + x[2] - x[3] + x[4] - x[5] + x[6] - x[7]);   // L-fed
+                const float gp2 = 0.125f * (x[0] + x[1] - x[2] - x[3] + x[4] + x[5] - x[6] - x[7]);   // L-fed
+                const float gp5 = 0.125f * (x[0] - x[1] + x[2] - x[3] - x[4] + x[5] - x[6] + x[7]);   // R-fed
+                const float gp6 = 0.125f * (x[0] + x[1] - x[2] - x[3] - x[4] - x[5] + x[6] + x[7]);   // R-fed
+
+                // Each half gets its own copy of that channel's spin allpass (same
+                // length, gain and mod), so by linearity the halves re-sum to the
+                // unbiased tap — the spin stays inside the bias, which is what lets
+                // the mid come out untouched.
+                const float aL = spinLa_.process ( gp1,  sp);   // L-fed → left tap
+                const float bL = spinLb_.process ( gp5,  sp);   // R-fed → left tap
+                const float aR = spinRa_.process ( gp2, -sp);   // L-fed → right tap
+                const float bR = spinRb_.process (-gp6, -sp);   // R-fed → right tap
+
+                // Side-domain rotation: M is untouched (so L+R survives), and the
+                // lean rides on ⟨M,D⟩ = ¼(E_Lfed − E_Rfed) — zero for a centred
+                // source, positive for a left-panned one.
+                const float mid   = 0.5f * ((aL + bL) + (aR + bR));
+                const float side  = 0.5f * ((aL + bL) - (aR + bR));
+                const float dProv = 0.5f * ((aL + aR) - (bL + bR));   // L-fed minus R-fed
+                const float sideB = biasCos_ * side + biasSin_ * dProv;
+                oL = mid + sideB;
+                oR = mid - sideB;
+            }
 
             // FORK B — Jot tonal correction (decouple per-band T60 from LEVEL).
             // Output GEQ (post-tank, non-recursive → no codegen bit-null risk).
@@ -569,4 +674,17 @@ private:
     OctaveBandDamping::Coeffs tcCoeffs_;
     bool  tcActive_         = false;
     bool  tonalCorrEnabled_ = false;
+
+    // Stereo image bias (setStereoImageBias) — issue #123.
+    // KEEP THESE LAST. This target builds -O3 -ffast-math, and inserting members
+    // higher up shifts the offsets of every array the per-sample loop touches;
+    // that alone re-rolls the vectoriser's alignment decisions and moved the
+    // bias-OFF output by ~1e-5 (−67 dB) on Bright Hall. Appending leaves every
+    // pre-existing offset untouched, which is what makes bias off byte-identical.
+    // spinL2_/spinR2_ carry the R-fed and L-fed halves of the two output taps and
+    // only ever run on the biased path.
+    static constexpr float kBiasMaxSin = 1.0f;   // side-domain rotation at amount = 1
+    SpinComb spinLa_, spinLb_, spinRa_, spinRb_;
+    float stereoBias_ = 0.0f, biasCos_ = 1.0f, biasSin_ = 0.0f;
+    bool  stereoBiasActive_ = false;
 };

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -683,8 +683,10 @@ void DuskVerbEngine::setPostSteer (float amount)
     // Issue #123 (agent 8) — engine-agnostic post-tank source-side ILD steer on the
     // FINAL wet. 0 = off = bit-identical. No preset calls this yet; enablement waits
     // on the ear pass. Precompute psK_ so the hot loop only reads members.
-    psAmount_        = std::clamp (amount, 0.0f, 1.0f);
-    postSteerActive_ = psAmount_ > 1.0e-6f;
+    // amount ∈ [-1,+1]: negative leans AWAY from the source side (de-steers presets whose
+    // engine already over-leans vs the anchor). psK_ tracks the sign.
+    psAmount_        = std::clamp (amount, -1.0f, 1.0f);
+    postSteerActive_ = std::abs (psAmount_) > 1.0e-6f;
     psK_             = kPostSteerKMax * psAmount_;
 }
 
@@ -696,8 +698,8 @@ void DuskVerbEngine::applyPostSteerOverride()
     // setPostSteer is never called ⇒ postSteerActive_ stays false ⇒ bit-identical default.
     if (const char* ov = std::getenv ("DUSKVERB_POSTSTEER"))
     {
-        const float amount = std::clamp (static_cast<float> (std::atof (ov)), 0.0f, 1.0f);
-        if (amount > 0.0f)
+        const float amount = std::clamp (static_cast<float> (std::atof (ov)), -1.0f, 1.0f);
+        if (std::abs (amount) > 0.0f)
             setPostSteer (amount);
     }
 }

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -650,6 +650,14 @@ void DuskVerbEngine::setPmbBand (int b, float t60s, float level, float direct, f
     pmb_.setBand (b, t60s, level, direct, width);
 }
 
+void DuskVerbEngine::setPmbStereoImageBias (float amount)
+{
+    // Issue #123 — route the ParallelMultiband band taps' side onto the line that
+    // actually carries the input side. 0 = off = bit-identical. No preset calls
+    // this yet; enablement waits on the ear pass.
+    pmb_.setStereoImageBias (amount);
+}
+
 void DuskVerbEngine::setDenseHallOctaveDecayRef (float seconds)
 {
     denseHall_.setOctaveDecayRef (seconds);
@@ -679,7 +687,10 @@ void DuskVerbEngine::applyStereoImageBiasOverride()
     {
         const float amount = std::clamp (static_cast<float> (std::atof (ov)), 0.0f, 1.0f);
         if (amount > 0.0f)
+        {
             denseHall_.setStereoImageBias (amount);
+            pmb_.setStereoImageBias (amount);
+        }
     }
 }
 

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 
@@ -46,7 +47,6 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     diffuseER_.prepare (sampleRate, maxBlockSize);
     denseHall_.prepare (sampleRate, maxBlockSize);
     pmb_.prepare (sampleRate, maxBlockSize);
-    applyStereoImageBiasOverride();   // issue #123 calibration hook; no-op without the env var
     buildupDiffuser_.prepare (sampleRate, maxBlockSize);
     buildupBufL_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
     buildupBufR_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
@@ -611,6 +611,11 @@ void DuskVerbEngine::setQuadStereoMod (float rateHz, float depth)
     quad_.setStereoMod (rateHz, depth);
 }
 
+void DuskVerbEngine::setQuadStereoInput (float amount)
+{
+    quad_.setStereoInput (amount);
+}
+
 void DuskVerbEngine::setTankHFSustain (float db, float cornerHz)
 {
     // Per-pass HF-sustain compensation (top-octave cliff fix) — Dattorro + DenseHall
@@ -685,11 +690,16 @@ void DuskVerbEngine::applyStereoImageBiasOverride()
     // env ⇒ nothing is called at all ⇒ the engines keep their bit-identical default.
     if (const char* ov = std::getenv ("DUSKVERB_STEREOBIAS"))
     {
-        const float amount = std::clamp (static_cast<float> (std::atof (ov)), 0.0f, 1.0f);
-        if (amount > 0.0f)
+        const float raw = static_cast<float> (std::atof (ov));
+        if (raw > 0.0f)
         {
+            // Tier-2 output-tap levers clamp to 0..1 here; the tank injection
+            // levers (measured walls, env-only, no preset) take the raw value
+            // and clamp to their own 0..4 range internally.
+            const float amount = std::clamp (raw, 0.0f, 1.0f);
             denseHall_.setStereoImageBias (amount);
             pmb_.setStereoImageBias (amount);
+            quad_.setStereoInput (raw);
         }
     }
 }

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 
 namespace
@@ -45,6 +46,7 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     diffuseER_.prepare (sampleRate, maxBlockSize);
     denseHall_.prepare (sampleRate, maxBlockSize);
     pmb_.prepare (sampleRate, maxBlockSize);
+    applyStereoImageBiasOverride();   // issue #123 calibration hook; no-op without the env var
     buildupDiffuser_.prepare (sampleRate, maxBlockSize);
     buildupBufL_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
     buildupBufR_.assign (static_cast<size_t> (maxBlockSize), 0.0f);
@@ -657,6 +659,28 @@ void DuskVerbEngine::setDenseHallTonalCorrection (bool enabled)
 {
     // FORK B — DenseHall Jot output tonal-correction (decouple T60 from level).
     denseHall_.setTonalCorrection (enabled);
+}
+
+void DuskVerbEngine::setDenseHallStereoImageBias (float amount)
+{
+    // Issue #123 — restore the source-side energy lean a hard-panned input loses in
+    // the DenseHall output taps. 0 = off = bit-identical. No preset calls this yet;
+    // enablement waits on the ear pass.
+    denseHall_.setStereoImageBias (amount);
+}
+
+void DuskVerbEngine::applyStereoImageBiasOverride()
+{
+    // Calibration hook (issue #123), same pattern as DUSKVERB_VELVET / DUSKVERB_REVERSE:
+    // lets the render harness measure the ILD table without wiring the feature into
+    // any preset path. Message thread only (prepare), read once per prepare, absent
+    // env ⇒ nothing is called at all ⇒ the engines keep their bit-identical default.
+    if (const char* ov = std::getenv ("DUSKVERB_STEREOBIAS"))
+    {
+        const float amount = std::clamp (static_cast<float> (std::atof (ov)), 0.0f, 1.0f);
+        if (amount > 0.0f)
+            denseHall_.setStereoImageBias (amount);
+    }
 }
 
 void DuskVerbEngine::setReflectionTap (float ms, float gain, float lpFc)

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.cpp
@@ -161,6 +161,16 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     xtalkLpL_     = 0.0f;
     xtalkLpR_     = 0.0f;
 
+    // Post-tank stereo image steer (issue #123, agent 8): dry-balance follower +
+    // applied-gain smoother one-pole coeffs. exp(-1/(tau·sr)): larger tau →
+    // coeff nearer 1 → slower. State resets to unity gain / zero envelope. These
+    // writes touch ONLY the new members, so the disabled path is unaffected.
+    psAtkCoeff_  = std::exp (-1.0f / (0.080f * static_cast<float> (sampleRate)));   // 80 ms attack (softens the L<->R balance flip in the alternating-source case)
+    psRelCoeff_  = std::exp (-1.0f / (0.350f * static_cast<float> (sampleRate)));   // 350 ms release (tail "remembers" the source side, then centers)
+    psGainCoeff_ = std::exp (-1.0f / (0.020f * static_cast<float> (sampleRate)));   // 20 ms applied-gain smoother: click-free (a bounded one-pole, no zipper) yet fast enough that a single hard-pan reaches full tilt inside the measured tail window (preserves the ILD table)
+    psEnvL_ = psEnvR_ = 0.0f;
+    psGainL_ = psGainR_ = 1.0f;
+
     // Per-band Width tilt — one-pole LP coeffs at the 300 Hz / 5 kHz crossovers.
     wbLp1Coeff_ = std::exp (-kTwoPi *  300.0f / static_cast<float> (sampleRate));
     wbLp2Coeff_ = std::exp (-kTwoPi * 5000.0f / static_cast<float> (sampleRate));
@@ -181,6 +191,11 @@ void DuskVerbEngine::prepare (double sampleRate, int maxBlockSize)
     // Force-apply algorithm 0 on first prepare (don't bypass via early-return).
     currentAlgorithm_ = -1;
     setAlgorithm (0);
+
+    // #123 post-tank steer env hook (DUSKVERB_POSTSTEER; offline measurement
+    // harness only). Must run AFTER the steer state reset above; the per-engine
+    // DUSKVERB_STEREOBIAS hook runs earlier in prepare. Unset → bit-null.
+    applyPostSteerOverride();
 }
 
 void DuskVerbEngine::clearAllBuffers()
@@ -661,6 +676,30 @@ void DuskVerbEngine::setPmbStereoImageBias (float amount)
     // actually carries the input side. 0 = off = bit-identical. No preset calls
     // this yet; enablement waits on the ear pass.
     pmb_.setStereoImageBias (amount);
+}
+
+void DuskVerbEngine::setPostSteer (float amount)
+{
+    // Issue #123 (agent 8) — engine-agnostic post-tank source-side ILD steer on the
+    // FINAL wet. 0 = off = bit-identical. No preset calls this yet; enablement waits
+    // on the ear pass. Precompute psK_ so the hot loop only reads members.
+    psAmount_        = std::clamp (amount, 0.0f, 1.0f);
+    postSteerActive_ = psAmount_ > 1.0e-6f;
+    psK_             = kPostSteerKMax * psAmount_;
+}
+
+void DuskVerbEngine::applyPostSteerOverride()
+{
+    // Calibration hook (issue #123), same pattern as DUSKVERB_VELVET / DUSKVERB_REVERSE:
+    // lets the render harness measure the ILD table without wiring the feature into any
+    // preset path. Message thread only (called from prepare()), read once; absent env ⇒
+    // setPostSteer is never called ⇒ postSteerActive_ stays false ⇒ bit-identical default.
+    if (const char* ov = std::getenv ("DUSKVERB_POSTSTEER"))
+    {
+        const float amount = std::clamp (static_cast<float> (std::atof (ov)), 0.0f, 1.0f);
+        if (amount > 0.0f)
+            setPostSteer (amount);
+    }
 }
 
 void DuskVerbEngine::setDenseHallOctaveDecayRef (float seconds)
@@ -2241,6 +2280,41 @@ void DuskVerbEngine::process (float* left, float* right, int numSamples)
         // by construction).
         wetL = perBandEDT_.processL (wetL);
         wetR = perBandEDT_.processR (wetR);
+
+        // ---- Post-tank stereo image steer (issue #123, agent 8) ----
+        // Constant-power L/R gain tilt on the FINAL wet, keyed off the CLEAN dry input
+        // still held in left[i]/right[i] here (the engine writes wet back only at the
+        // end of this loop; the pre-delay read and sus-limiter mutate their OWN buffers,
+        // never left/right — verified). Applied HERE, downstream of every engine and
+        // BEFORE the Mono Maker / width M/S stage, so the imposed ILD is then shaped by
+        // width exactly like any other stereo content. Engine-agnostic: works even on
+        // the mono-in tanks (Dattorro) where output-tap surgery cannot lean the image.
+        //
+        // Detector: per-sample amplitude-envelope followers on |dryL|,|dryR| (attack/
+        // release one-poles), balance b=(EL-ER)/(EL+ER+eps) clamped [-1,1]. Steer:
+        // gl=sqrt(1+k·b), gr=sqrt(1-k·b) (constant-power), k=kPostSteerKMax·amount,
+        // smoothed by a one-pole gain smoother (anti-zipper — the Vocal Hall AttackRamp
+        // distortion bug was an unsmoothed audio-rate gain; not repeated here). Time
+        // constants (attack/release/gain-smooth) live in prepare().
+        //
+        // postSteerActive_ false → this block is skipped → the left[i]/right[i] final
+        // write below is byte-identical to legacy (bit-null). Centered input →
+        // EL==ER exactly → b==0 → gl==gr==sqrt(1.0f)==1.0f → wet × 1.0f → byte-identical
+        // even with the feature ON (a stronger guarantee than the < -100 dB target).
+        if (postSteerActive_)
+        {
+            const float axl = std::fabs (left[i]);
+            const float axr = std::fabs (right[i]);
+            psEnvL_ = axl + ((axl > psEnvL_) ? psAtkCoeff_ : psRelCoeff_) * (psEnvL_ - axl);
+            psEnvR_ = axr + ((axr > psEnvR_) ? psAtkCoeff_ : psRelCoeff_) * (psEnvR_ - axr);
+            const float b   = std::clamp ((psEnvL_ - psEnvR_) / (psEnvL_ + psEnvR_ + 1.0e-9f), -1.0f, 1.0f);
+            const float glT = std::sqrt (std::max (0.0f, 1.0f + psK_ * b));
+            const float grT = std::sqrt (std::max (0.0f, 1.0f - psK_ * b));
+            psGainL_ = glT + psGainCoeff_ * (psGainL_ - glT);
+            psGainR_ = grT + psGainCoeff_ * (psGainR_ - grT);
+            wetL *= psGainL_;
+            wetR *= psGainR_;
+        }
 
         // Mono Maker — sums L+R below the cutoff to mono before width
         // processing. 1st-order matched-phase complementary split: HP = input

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -347,6 +347,10 @@ public:
                                float atkMs, float relFastMs, float relSlowMs);
     void setPmbBand (int b, float t60s, float level, float direct, float width);   // ParallelMultiband (algo 15) per-band config; no-op elsewhere
     void setPmbStereoImageBias (float amount);   // #123 source-side energy lean; 0 = off = bit-identical
+    // #123 (agent 8) — engine-agnostic post-tank source-side ILD steer applied to
+    // the FINAL wet, keyed off the clean dry-input balance, BEFORE the Mono Maker /
+    // width stage. amount 0 = off = bit-identical. No preset calls it yet.
+    void setPostSteer (float amount);
     void setDenseHallOctaveDecayRef (float seconds);
     void setDenseHallTonalCorrection (bool enabled);   // fork B: decouple T60 from level
     void setDenseHallStereoImageBias (float amount);   // #123 source-side energy lean; 0 = off = bit-identical
@@ -852,7 +856,32 @@ private:
 
     void updateLoCutCoeffs (float hz);
     void updateHiCutCoeffs (float hz);
+    void applyStereoImageBiasOverride();   // #123 DUSKVERB_STEREOBIAS calibration hook (prepare, message thread)
     void recomputeTankFeedCoeffs();   // tank-feed shelf coeffs from stored Fc at sampleRate_
     void recomputeTankOnsetSamples(); // tank-onset sample count from tankOnsetMs_ at sampleRate_
     void designMatchEQ();             // (re)design match-EQ coeffs from matchCorr_ at sampleRate_
+    void applyPostSteerOverride();    // #123 DUSKVERB_POSTSTEER calibration hook (prepare, message thread)
+
+    // ---- Post-tank stereo image steer (issue #123, agent 8) — declared LAST ----
+    // Engine-agnostic source-side energy lean on the FINAL wet, keyed off the clean
+    // dry-input L/R balance, downstream of every engine and BEFORE the Mono Maker /
+    // width M/S stage. Restores the +2..+4 dB tail ILD a hard-panned input loses in
+    // the tanks — the mechanism the per-engine output-tap reweighting could not
+    // reach (DenseHall ceilinged at +0.76 dB, PMB +0.20 dB).
+    //
+    // Declared LAST so existing member offsets are unchanged and the disabled path's
+    // codegen stays byte-identical (Lessons #2). postSteerActive_ false → the whole
+    // per-sample block is skipped → bit-null. Centered input → psEnvL_==psEnvR_ →
+    // b==0 exactly → gl==gr==sqrt(1)==1.0f → wet × 1.0f → byte-identical even ON.
+    static constexpr float kPostSteerKMax = 0.34f;  // amount=1 tilt strength: pure-tilt ILD 10log10((1+k)/(1-k))=+3.05dB, lands algo14 L +2.8 / algo0 L +3.7 (both inside the +2.5..+4 target)
+    float psAmount_        = 0.0f;   // 0..1 from setPostSteer(); 0 = off
+    bool  postSteerActive_ = false;  // psAmount_ > 0
+    float psK_             = 0.0f;   // kPostSteerKMax * psAmount_ (precomputed)
+    float psAtkCoeff_      = 0.0f;   // dry-balance follower attack one-pole (tau set in prepare)
+    float psRelCoeff_      = 0.0f;   // dry-balance follower release one-pole (tau set in prepare)
+    float psGainCoeff_     = 0.0f;   // applied-gain smoother one-pole, anti-zipper (tau set in prepare)
+    float psEnvL_          = 0.0f;   // dry-L amplitude envelope
+    float psEnvR_          = 0.0f;   // dry-R amplitude envelope
+    float psGainL_         = 1.0f;   // smoothed applied L gain (starts at unity)
+    float psGainR_         = 1.0f;   // smoothed applied R gain
 };

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -873,10 +873,13 @@ private:
     // codegen stays byte-identical (Lessons #2). postSteerActive_ false → the whole
     // per-sample block is skipped → bit-null. Centered input → psEnvL_==psEnvR_ →
     // b==0 exactly → gl==gr==sqrt(1)==1.0f → wet × 1.0f → byte-identical even ON.
-    static constexpr float kPostSteerKMax = 0.34f;  // amount=1 tilt strength: pure-tilt ILD 10log10((1+k)/(1-k))=+3.05dB, lands algo14 L +2.8 / algo0 L +3.7 (both inside the +2.5..+4 target)
-    float psAmount_        = 0.0f;   // 0..1 from setPostSteer(); 0 = off
-    bool  postSteerActive_ = false;  // psAmount_ > 0
-    float psK_             = 0.0f;   // kPostSteerKMax * psAmount_ (precomputed)
+    // raised 2026-07-20 to reach the Cathedral anchor's +11.9 dB lean (k=0.875); at full
+    // k the opposite channel drops ~-10 dB — per-preset amounts are calibrated, presets
+    // never receive raw 1.0 blindly.
+    static constexpr float kPostSteerKMax = 0.9f;
+    float psAmount_        = 0.0f;   // -1..+1 from setPostSteer(); 0 = off (negative = lean away from source side)
+    bool  postSteerActive_ = false;  // |psAmount_| > 0
+    float psK_             = 0.0f;   // kPostSteerKMax * psAmount_ (precomputed; may be negative)
     float psAtkCoeff_      = 0.0f;   // dry-balance follower attack one-pole (tau set in prepare)
     float psRelCoeff_      = 0.0f;   // dry-balance follower release one-pole (tau set in prepare)
     float psGainCoeff_     = 0.0f;   // applied-gain smoother one-pole, anti-zipper (tau set in prepare)

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -346,6 +346,7 @@ public:
     void setPmbBand (int b, float t60s, float level, float direct, float width);   // ParallelMultiband (algo 15) per-band config; no-op elsewhere
     void setDenseHallOctaveDecayRef (float seconds);
     void setDenseHallTonalCorrection (bool enabled);   // fork B: decouple T60 from level
+    void setDenseHallStereoImageBias (float amount);   // #123 source-side energy lean; 0 = off = bit-identical
     // FORK A: discrete early-reflection tap (the "duh-duh"). ms ~90-110, gain 0=off.
     void setReflectionTap (float ms, float gain, float lpFc = 11000.0f);  // lpFc: tap rolloff (11k=sharp tick, ~5-6k=fuller/softer)
     void setEarlyTapBank  (const float* timesMs, const float* gains, int count, float lpFc = 9000.0f);  // up to 8 discrete ER taps at anchor-measured times; count 0 = off/bit-null
@@ -849,6 +850,7 @@ private:
     void updateLoCutCoeffs (float hz);
     void updateHiCutCoeffs (float hz);
     void recomputeTankFeedCoeffs();   // tank-feed shelf coeffs from stored Fc at sampleRate_
+    void applyStereoImageBiasOverride();   // #123 DUSKVERB_STEREOBIAS calibration hook (prepare, message thread)
     void recomputeTankOnsetSamples(); // tank-onset sample count from tankOnsetMs_ at sampleRate_
     void designMatchEQ();             // (re)design match-EQ coeffs from matchCorr_ at sampleRate_
 };

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -329,6 +329,8 @@ public:
                                   float atkMs, float relFastMs, float relSlowMs);
     // QuadTank wet-output stereo chorus/ensemble (79VC "phasey" character); depth 0 = bit-null.
     void setQuadStereoMod (float rateHz, float depth);
+    // QuadTank stereo-input injection (issue #123); amount 0 = OFF/default = bit-null.
+    void setQuadStereoInput (float amount);
     // Per-pass HF-sustain compensation shelf (top-octave cliff / "muffle" fix) —
     // Dattorro + DenseHall; 0 dB = bit-null.
     void setTankHFSustain (float db, float cornerHz);
@@ -851,7 +853,6 @@ private:
     void updateLoCutCoeffs (float hz);
     void updateHiCutCoeffs (float hz);
     void recomputeTankFeedCoeffs();   // tank-feed shelf coeffs from stored Fc at sampleRate_
-    void applyStereoImageBiasOverride();   // #123 DUSKVERB_STEREOBIAS calibration hook (prepare, message thread)
     void recomputeTankOnsetSamples(); // tank-onset sample count from tankOnsetMs_ at sampleRate_
     void designMatchEQ();             // (re)design match-EQ coeffs from matchCorr_ at sampleRate_
 };

--- a/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
+++ b/plugins/DuskVerb/src/dsp/DuskVerbEngine.h
@@ -344,6 +344,7 @@ public:
     void setSustainLimiterLow (float loHz, float hiHz, float threshDb, float maxCutDb,
                                float atkMs, float relFastMs, float relSlowMs);
     void setPmbBand (int b, float t60s, float level, float direct, float width);   // ParallelMultiband (algo 15) per-band config; no-op elsewhere
+    void setPmbStereoImageBias (float amount);   // #123 source-side energy lean; 0 = off = bit-identical
     void setDenseHallOctaveDecayRef (float seconds);
     void setDenseHallTonalCorrection (bool enabled);   // fork B: decouple T60 from level
     void setDenseHallStereoImageBias (float amount);   // #123 source-side energy lean; 0 = off = bit-identical

--- a/plugins/DuskVerb/src/dsp/ParallelMultibandTank.h
+++ b/plugins/DuskVerb/src/dsp/ParallelMultibandTank.h
@@ -196,6 +196,9 @@ public:
         }
         for (int b = 0; b < kBands; ++b) susLimDet_[b].clear();
         susLimKey_.clear();
+        for (int b = 0; b < kBands; ++b)
+            for (int f = 0; f < 8; ++f)
+                biasZ_[b][f][0] = biasZ_[b][f][1] = 0.0f;   // stereo-image-bias side filter (unused while off)
     }
 
     // ── Per-band config ─────────────────────────────────────────────────────
@@ -239,6 +242,73 @@ public:
                 smearLfo_[b][l].setDepth (smearDepthSamples_);
                 smearLfo_[b][l].setRate  (smearRateHz_ * (0.85f + 0.02f * static_cast<float> (b * kLines + l)));
             }
+    }
+
+    // STEREO IMAGE BIAS (issue #123). A hard-panned source leaves this tank dead
+    // centre (measured tail ILD −0.31 dB) where the reference halls hold a
+    // +1.3..+4.3 dB lean toward the source side. The cause is visible in the tap
+    // algebra: the two band taps reduce EXACTLY to
+    //   bl = ½(p2 + p5),   br = ½(p5 − p2)
+    // (p = pre-Hadamard line values; verified against the tap expressions below),
+    // so the band's output MID is line 5 and its output SIDE is line 2. Now look
+    // at what the injection pattern (x0+=L, x1−=L, x2+=R, x3−=R) puts on each line
+    // after the butterfly: lines 1 and 5 receive the input MID (L+R), lines 3 and 7
+    // receive the input SIDE (L−R), and lines 0, 2, 4, 6 receive NOTHING directly.
+    // The output mid is therefore correctly fed by a mid-carrying line, but the
+    // output side is fed by line 2 — a line with no direct injection at all. The
+    // engine's side content is pure feedback scramble, unrelated to the input
+    // image, which is why the lean is zero (and why this engine reads as
+    // centre-collapsed).
+    //
+    // This setter rotates the output side off line 2 and onto line 3, the line that
+    // actually carries the input side:
+    //   S' = cos·(½p2) + sin·(½p3)
+    // Only the side moves, so the mid — and therefore L+R — is preserved exactly
+    // through the direct-add, width and level stages downstream, and a CENTRED
+    // source puts nothing on line 3 at all (L−R = 0), leaving it pure feedback
+    // scramble like line 2: same level, same width, no fixed panner. Magnitudes
+    // only — the injection sign alternation is untouched and the feedback path is
+    // not involved, so per-band T60/level/direct are unchanged. amount 0 = off =
+    // bit-identical (the block is appended, never interleaved).
+    //
+    // WHAT THIS DOES AND DOES NOT BUY — MEASURED, READ BEFORE TUNING. It does NOT
+    // deliver the target lean: full rotation moves tail ILD only −0.31 → +0.20 dB
+    // on algo 15. The reason is that an energy lean needs ⟨M,S⟩ ≠ 0, and here M is
+    // ½p5 while S is a DIFFERENT delay line; the same burst reaches lines 5 and 3
+    // at different delays (the line lengths are mutually prime by design), so the
+    // two are temporally decorrelated and their inner product integrates to ~0 over
+    // the tail. Re-weighting output taps can only create a lean when the mid and
+    // the side share content, and a decorrelating tank guarantees they do not.
+    // (Contrast DenseHall, where the mid IS the sum of an L-fed and an R-fed
+    // aggregate, so the same rotation yields a genuine energy difference.)
+    // What it DOES buy is that the output side finally tracks the input image: the
+    // panned-vs-centred side/mid delta flips from −0.88 dB (a panned source made
+    // LESS side energy than a centred one — the centre-collapse signature) to
+    // +0.33 dB. That is the defect this fixes; the ILD is a separate wall.
+    //
+    // THE LEAN IS AVAILABLE, BUT NOT FROM HERE. Tapping L from the L-injected lines
+    // (0,1) and R from the R-injected lines (2,3) — i.e. bl = ½(p0−p1),
+    // br = ½(p2−p3) — was built and measured: +3.73 dB left-pan, −3.97 dB
+    // right-pan, mirror error 0.24 dB, squarely inside the target window. It is not
+    // shipped because it REPLACES the output taps rather than reweighting them: the
+    // mid changes completely (L+R null +1.5 dB, level +0.73 dB), which breaks the
+    // centred-input rule and re-voices both shipping PMB presets (Vocal Hall,
+    // Medium Drum Room) that were tuned hard on the current taps. Taking it needs
+    // an ear pass plus a re-tune of those two, which is a deliberate call, not a
+    // side effect of enabling a bias. Do not "fix" the number here without it.
+    void setStereoImageBias (float amount)
+    {
+        stereoBias_ = std::clamp (amount, 0.0f, 1.0f);
+        const bool wasActive = stereoBiasActive_;
+        stereoBiasActive_ = stereoBias_ > 0.0f;
+        biasSin_ = stereoBias_ * kBiasMaxSin;
+        biasCos_ = std::sqrt (std::max (0.0f, 1.0f - biasSin_ * biasSin_));
+        // The side-line filter chain is cold until the bias runs; clear it on the
+        // off→on edge so a toggle can't splice a stale tail back in.
+        if (stereoBiasActive_ && ! wasActive)
+            for (int b = 0; b < kBands; ++b)
+                for (int f = 0; f < 8; ++f)
+                    biasZ_[b][f][0] = biasZ_[b][f][1] = 0.0f;
     }
 
     // ── In-loop sustained-energy limiter (SustainBandLimiter.h) ────────────
@@ -339,6 +409,29 @@ public:
                 // confined to the band's own range (leak-rings-long defect).
                 float bl = bandFilter (b, 0, 0.35355339f * (x[0] - x[3] + x[5] - x[6]));
                 float br = bandFilter (b, 1, 0.35355339f * (x[2] - x[1] + x[7] - x[4]));
+                // Stereo image bias (setStereoImageBias) — issue #123. Appended
+                // rather than folded into the two taps above: this target builds
+                // -O3 -ffast-math, so touching the statements of the hot loop moves
+                // the disabled output too (same lesson as the gb-local variant
+                // noted above, and as the DenseHall port of this feature). Off ⇒
+                // never entered, and nothing above it changed ⇒ bit-identical.
+                if (stereoBiasActive_)
+                {
+                    // ½p3 recovered by inverse Hadamard (the butterfly is its own
+                    // inverse up to the 1/sqrt8 it already applied), then run
+                    // through the band's own confinement filter with private state
+                    // so it lands inside the band exactly like the taps do.
+                    const float dRaw = 0.17677670f * (x[0] - x[1] - x[2] + x[3]
+                                                    + x[4] - x[5] - x[6] + x[7]);
+                    const float dF = biasBandFilter (b, dRaw);
+                    // bandFilter is linear with per-channel state, so the filtered
+                    // mid and side come straight out of the two taps above.
+                    const float midF  = 0.5f * (bl + br);
+                    const float sideF = 0.5f * (bl - br);
+                    const float sNew  = biasCos_ * sideF + biasSin_ * dF;
+                    bl = midF + sNew;
+                    br = midF - sNew;
+                }
                 // feed-forward direct (EDT/front-load, outside the loop —
                 // unfiltered: it is already band-split and must stay
                 // phase-tight for EDT shaping)
@@ -537,4 +630,29 @@ private:
     DspUtils::MultiSineLFO smearLfo_[kBands][kLines];   // per-LINE mode-smear wander (anti-boing, fully decorrelated)
     float smearDepthSamples_ = 0.0f, smearRateHz_ = 0.08f;
     bool  smearActive_ = false;
+
+    // Stereo image bias (setStereoImageBias) — issue #123. A private copy of the
+    // band confinement filter for the side-carrying line; deliberately NOT a
+    // reuse of bandFilter with a state pointer, since editing that function would
+    // recompile the disabled path's hot loop and move its output under
+    // -ffast-math. KEEP THESE MEMBERS LAST for the same reason: inserting them
+    // higher up shifts the offsets of every array the loop touches, which alone
+    // re-rolls the vectoriser and breaks the bias-off byte match.
+    float biasBandFilter (int b, float v)
+    {
+        for (int f = 0; f < outNb_[b]; ++f)
+        {
+            const BQ& c = outBq_[b][f];
+            float* z = biasZ_[b][f];
+            const float x = v;
+            v = c.b0 * x + z[0];
+            z[0] = c.b1 * x - c.a1 * v + z[1];
+            z[1] = c.b2 * x - c.a2 * v;
+        }
+        return v;
+    }
+    static constexpr float kBiasMaxSin = 1.0f;   // side-domain rotation at amount = 1
+    float biasZ_[kBands][8][2] = {};
+    float stereoBias_ = 0.0f, biasCos_ = 1.0f, biasSin_ = 0.0f;
+    bool  stereoBiasActive_ = false;
 };

--- a/plugins/DuskVerb/src/dsp/QuadTank.cpp
+++ b/plugins/DuskVerb/src/dsp/QuadTank.cpp
@@ -187,6 +187,12 @@ void QuadTank::process (const float* inputL, const float* inputR,
         if (frozen_)
             input = 0.0f;
 
+        // Stereo-input side term (issue #123). Zero (and branch-free-equivalent)
+        // when the feature is off or frozen, so the legacy mono path is unchanged.
+        const float side = (stereoInputActive_ && ! frozen_)
+                         ? (inputL[i] - inputR[i]) * 0.5f
+                         : 0.0f;
+
         // Phase 2: advance master sine ONCE per sample (not per tank).
         if (useCoherent)
             coherentLfo_.advance();
@@ -222,6 +228,10 @@ void QuadTank::process (const float* inputL, const float* inputR,
             const float otherCrossFeed = kCrossFeedFwd  * cf[prev]
                                        + kCrossFeedBack * cf[next];
             float tankIn = input + otherCrossFeed;
+            // Stereo-input injection appended AFTER the untouched legacy tankIn (see
+            // header). Skipped entirely when inactive => byte-identical to legacy.
+            if (stereoInputActive_)
+                tankIn += stereoInjectCoeff_[t] * side;
 
             // --- Modulated allpass (decay diffusion 1) ---
             // Phase 2: in CoherentLoop mode, read from master sine at this
@@ -404,6 +414,44 @@ void QuadTank::setMidMultiply (float mult)
 void QuadTank::setSaturation (float amount)
 {
     saturationAmount_ = std::clamp (amount, 0.0f, 1.0f);
+}
+
+void QuadTank::setStereoInput (float amount)
+{
+    // See header. amount 0 => inactive => bit-null (default; no preset enables it).
+    //
+    // DEAD LEVER — TWO INDEPENDENT WALLS (issue #123, measured 2026-07-20). The task
+    // was to feed mono + amount*side into two tanks and mono - amount*side into the
+    // other two, choosing the pairing by which tanks' taps dominate outL vs outR.
+    //
+    // WALL 1 (weak): a tap-ownership sweep (all 3 pairings + sign flip, algo 3,
+    // hard-L/R burst) showed ownership is effectively SYMMETRIC — every output channel
+    // taps 12 signed taps from all 4 tanks at equal power, AND the lossless
+    // bidirectional cross-feed (kCrossFeedFwd 0.733 + kCrossFeedBack 0.267, ρ=1)
+    // homogenizes the injected side across all 4 tanks within ~one loop pass. Tail ILD
+    // SATURATES at ~+0.23 dB even at amount=4 (L-pan ILD: a1 -0.16, a2 +0.13, a3 +0.21,
+    // a4 +0.23) — far short of the +2 dB target.
+    //
+    // WALL 2 (incorrect): this injection keys on (inputL - inputR) at the QuadTank
+    // input, which is DOWNSTREAM of the engine's tank input diffuser (DuskVerbEngine
+    // step 3, a Schroeder cascade with different L/R delays). That diffuser
+    // decorrelates even a centred/mono source into distinct L/R, so the "side" here is
+    // contaminated by diffuser decorrelation rather than being pure source side. With
+    // the feature ON a CENTRED burst changes by only -10.8 dB vs OFF (rule 2 requires
+    // <-100 dB) — it breaks the mono/centred-null guarantee. The output-tap
+    // constant-power fallback is likewise invalid: the legacy mono sum (input =
+    // (L+R)*0.5) discards source provenance inside the tank (baseline L-pan and R-pan
+    // ILD are identical -0.67 dB), so a static output bias would lean centred input too.
+    //
+    // Parked default-OFF (bit-null when off; NO preset enables it). Kept as a documented
+    // negative result + reproducible env lever (DUSKVERB_STEREOBIAS); the {1,2}|{0,3}
+    // sign pattern below is the best (correct-sign) pairing measured. A real fix needs
+    // BOTH a source-side signal captured PRE-diffuser and a cross-feed decoupling.
+    const float a = std::clamp (amount, 0.0f, 4.0f);
+    static constexpr float kSideSign[kNumTanks] = { -1.0f, +1.0f, +1.0f, -1.0f };  // {1,2}|{0,3}
+    for (int t = 0; t < kNumTanks; ++t)
+        stereoInjectCoeff_[t] = a * kSideSign[t];
+    stereoInputActive_ = a > 1.0e-6f;
 }
 
 void QuadTank::setTrebleMultiply (float mult)

--- a/plugins/DuskVerb/src/dsp/QuadTank.h
+++ b/plugins/DuskVerb/src/dsp/QuadTank.h
@@ -62,6 +62,13 @@ public:
     // it, and raw tank modDepth smears T60/ripple instead). depth 0 = bypass/bit-null.
     void setStereoMod (float rateHz, float depth);
 
+    // Stereo-input injection (issue #123). amount 0 = OFF/default = legacy mono sum
+    // (bit-null). Feeds mono + amount*side into two tanks and mono - amount*side into
+    // the other two, so a hard-panned source keeps a tail energy lean toward its side
+    // instead of collapsing to centre. Freeze zeros the side term. See setStereoInput
+    // in the .cpp for the pairing rationale and measured ILD ceiling.
+    void setStereoInput (float amount);
+
 private:
     // StereoMod — verbatim port of ShimmerEngine::StereoMod (see there for design notes).
     struct StereoMod
@@ -380,4 +387,12 @@ public:
 private:
 
     float readOutputTap (const OutputTap& tap) const;
+
+    // --- Stereo-input injection state (issue #123). Declared LAST so the disabled
+    // path compiles to the identical instruction stream for the legacy tankIn
+    // computation (see the -ffast-math bit-null trap in the stereo-image brief).
+    // stereoInputActive_ false (default) => the injection block is skipped and the
+    // side term is a compile-time-visible 0 => byte-identical to legacy.
+    bool  stereoInputActive_ = false;
+    float stereoInjectCoeff_[kNumTanks] = { 0.0f, 0.0f, 0.0f, 0.0f };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stereo image controls for shaping the width and left/right balance of DuskVerb’s reverb character.
  * Added stereo-input injection to distribute spatial energy across the reverb tanks.
  * Added post-tank stereo steering with smoothly evolving channel balance for more natural movement.
  * Controls remain transparent when disabled, preserving the existing sound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->