### PR TITLE
TapeMachine 2: fix preset-switch gain-link pop (dB-domain gain smoothing)

### DIFF
--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -144,13 +144,14 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     smFlutter.prepare (baseSampleRate, kParamTau);
     smNoise.prepare   (baseSampleRate, kParamTau);
 
-    // Initial (snap) values matching PluginProcessor::prepareToPlay.
+    // Initial (snap) values matching PluginProcessor::prepareToPlay. inGain/outGain
+    // hold dB (converted per sample in processBlock — see the smoothing note there).
     const float inGainDb = pInputGainDb.load (std::memory_order_relaxed);
-    inGain.snap  (dbToGain (inGainDb));
+    inGain.snap  (inGainDb);
     {
         outGain.snap (pAutoComp.load (std::memory_order_relaxed)
-                          ? dbToGain (-inGainDb + pOutputGainDb.load (std::memory_order_relaxed))  // gain link = inverse + Output trim
-                          : dbToGain (pOutputGainDb.load (std::memory_order_relaxed)));
+                          ? -inGainDb + pOutputGainDb.load (std::memory_order_relaxed)  // gain link = inverse + Output trim
+                          : pOutputGainDb.load (std::memory_order_relaxed));
     }
     const float initSat = std::clamp (((inGainDb + 12.0f) / 24.0f) * 100.0f, 0.0f, 100.0f);
     smSat.snap     (initSat);
@@ -434,9 +435,8 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     const bool transformerOn = pTransformer.load (std::memory_order_relaxed);
 
     const float inputGainDb = pInputGainDb.load (std::memory_order_relaxed);
-    const float targetInputGain = dbToGain (inputGainDb);
 
-    float targetOutputGain;
+    float targetOutputGainDb;
     if (pAutoComp.load (std::memory_order_relaxed))
     {
         // Gain link ("LINK"): output = -input + Output-knob trim. The inverse of the
@@ -446,15 +446,24 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         // makeup trim on top of the inverse (default 0 -> pure inverse -> byte-identical
         // unity). Factory presets use it to carry the reference preset's own non-unity output
         // level (a post-tape LINEAR gain: shifts loudness but not THD/FR/aliasing).
-        targetOutputGain = dbToGain (-inputGainDb + pOutputGainDb.load (std::memory_order_relaxed));
+        targetOutputGainDb = -inputGainDb + pOutputGainDb.load (std::memory_order_relaxed);
     }
     else
     {
-        targetOutputGain = dbToGain (pOutputGainDb.load (std::memory_order_relaxed));
+        targetOutputGainDb = pOutputGainDb.load (std::memory_order_relaxed);
     }
 
-    inGain.setTarget (targetInputGain);
-    outGain.setTarget (targetOutputGain);
+    // inGain/outGain smooth in the dB DOMAIN (dbToGain applied per sample in the ramp
+    // loops below), NOT linear gain. With the gain link engaged the two one-poles share
+    // the same tau, so their dB trajectories cancel term-for-term and the in*out product
+    // tracks the Output trim exactly through the whole transition. Linear-domain smoothing
+    // of g and 1/g does NOT cancel: the product bulges to 1 + (r-1)^2/(4r) mid-ramp
+    // (r = gain-change ratio) — a 23.8 dB preset-switch input step transiently boosted
+    // the OUTPUT by ~+13 dB (audible pop over 0 dBFS on every large preset change).
+    // Static renders are bit-identical: after snap/convergence the smoother repeats the
+    // same dB value and dbToGain of it reproduces the identical linear gain per sample.
+    inGain.setTarget (inputGainDb);
+    outGain.setTarget (targetOutputGainDb);
 
     const float saturationAmount = std::clamp (((inputGainDb + 12.0f) / 24.0f) * 100.0f, 0.0f, 100.0f);
     smSat.setTarget     (saturationAmount);
@@ -750,7 +759,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     const int osN = nSamples * factor;
 
     for (int n = 0; n < nSamples; ++n)
-        inGainArr[static_cast<size_t> (n)] = inGain.next();
+        inGainArr[static_cast<size_t> (n)] = dbToGain (inGain.next());   // dB-domain ramp (see smoothing note above)
 
     for (int i = 0; i < osN; ++i)
     {
@@ -770,7 +779,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         wowFlutArr[si]   = combined * 0.01f;
         noiseArr[si]     = nv * 100.0f;
         sharedModArr[si] = sm;
-        outGainArr[si]   = outGain.next();
+        outGainArr[si]   = dbToGain (outGain.next());   // dB-domain ramp (see smoothing note above)
     }
 
     // --- per-channel oversampled processing ----------------------------------

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2146,8 +2146,12 @@ private:
     DuskSVF hpL, hpR, lpL, lpR;
 
     // --- smoothers ---
-    SmoothedValue inGain;                   // base-rate ramp (shared by L/R)
-    SmoothedValue outGain;                  // OS-rate ramp (shared by L/R)
+    // inGain/outGain hold dB, not linear gain (dbToGain applied per ramp sample): with
+    // the gain link on, dB-domain one-poles cancel exactly so in*out tracks the Output
+    // trim through a transition. Linear-domain smoothing of g and 1/g bulged the product
+    // by up to ~+13 dB on a large preset-switch gain step (pop over 0 dBFS).
+    SmoothedValue inGain;                   // base-rate ramp, dB (shared by L/R)
+    SmoothedValue outGain;                  // OS-rate ramp, dB (shared by L/R)
     SmoothedValue smSat, smWow, smFlutter, smNoise, smBias;
 
     bool bypassLowpass = true;


### PR DESCRIPTION
## Problem

Clicking preset prev/next while audio plays often produced pops with output peaks above 0 dBFS.

## Root cause

`inGain`/`outGain` were smoothed as **linear** gain through matching exponential one-poles. With the gain link engaged (output target = `-input + trim`), linearly interpolating `g` and `1/g` never multiplies to unity mid-ramp: the product bulges to `1 + (r-1)^2/(4r)` (r = gain-change ratio), peaking ~4.6 ms after the step. A preset switch is a single large input-gain step, so every big preset change transiently boosted the output — up to +13.6 dB measured for the worst adjacent-preset pair (Sunbaked Cassette → Analog Warmth, 22.9 dB input delta).

## Fix

Smooth both gains in the **dB domain** (`dbToGain` applied per ramp sample). The two dB one-poles share the same tau, so their trajectories cancel term-for-term and the in×out product tracks the Output trim monotonically through every transition — no overshoot possible.

## Measurements (200 Hz @ -12 dBFS, link on, worst-case preset-like gain step)

|  | Before | After |
|---|---|---|
| Peak in 100 ms window after switch | **+0.83 dBFS** | -11.74 dBFS |
| Bulge over steady level | +13.57 dB | +0.99 dB |

Remaining +0.99 dB is tape-saturation release during the drive ramp plus the preset's own +4.2 dB trim step — physical, not gain math.

## Parity safety

2 s static render (input +2.7 dB, link on, American 15 IPS) before vs after: **byte-identical** (`cmp` on raw float dumps). After snap/convergence the smoother repeats the same dB value and `dbToGain` of it reproduces the identical linear gain per sample, so all A800 parity gates are unaffected.

## Validation

- DPF build clean; AU/VST3/CLAP/LV2 install verified locally.
- Standalone harness compiling the framework-free core directly (measurements above).
- pluginval not available locally; `run_plugin_tests.sh` has no TapeMachine 2 entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gain smoothing in the Tape Machine effect to prevent unwanted level changes during gain-link transitions.
  * Preserved consistent input and output levels when adjusting gain-related controls.
* **Documentation**
  * Added clarification around gain smoothing behavior for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->