### PR TITLE
Fix Multi-Q pass filter icons (#121)

### DIFF
--- a/plugins/multi-q/EQGraphicDisplay.cpp
+++ b/plugins/multi-q/EQGraphicDisplay.cpp
@@ -1009,26 +1009,23 @@ void EQGraphicDisplay::drawBandControlPoint(juce::Graphics& g, int bandIndex)
     {
         case BandType::HighPass:
         {
-            // HPF icon: slope rising to the right (/¯)
+            // Keep pass-filter icons as bare slopes so they cannot be mistaken
+            // for the shelf icons, which deliberately have horizontal tails.
             juce::Path hpfPath;
             float cx = point.x, cy = point.y;
-            hpfPath.startNewSubPath(cx - iconSize * 0.6f, cy + iconSize * 0.4f);
-            hpfPath.lineTo(cx - iconSize * 0.1f, cy + iconSize * 0.4f);
-            hpfPath.lineTo(cx + iconSize * 0.3f, cy - iconSize * 0.4f);
-            hpfPath.lineTo(cx + iconSize * 0.6f, cy - iconSize * 0.4f);
+            hpfPath.startNewSubPath(cx - iconSize * 0.4f, cy + iconSize * 0.4f);
+            hpfPath.lineTo(cx + iconSize * 0.4f, cy - iconSize * 0.4f);
             g.strokePath(hpfPath, juce::PathStrokeType(strokeWidth, juce::PathStrokeType::curved,
                                                         juce::PathStrokeType::rounded));
             break;
         }
         case BandType::LowPass:
         {
-            // LPF icon: slope falling to the right (¯\)
+            // Bare falling slope; shelf icons retain their horizontal tails.
             juce::Path lpfPath;
             float cx = point.x, cy = point.y;
-            lpfPath.startNewSubPath(cx - iconSize * 0.6f, cy - iconSize * 0.4f);
-            lpfPath.lineTo(cx - iconSize * 0.3f, cy - iconSize * 0.4f);
-            lpfPath.lineTo(cx + iconSize * 0.1f, cy + iconSize * 0.4f);
-            lpfPath.lineTo(cx + iconSize * 0.6f, cy + iconSize * 0.4f);
+            lpfPath.startNewSubPath(cx - iconSize * 0.4f, cy - iconSize * 0.4f);
+            lpfPath.lineTo(cx + iconSize * 0.4f, cy + iconSize * 0.4f);
             g.strokePath(lpfPath, juce::PathStrokeType(strokeWidth, juce::PathStrokeType::curved,
                                                         juce::PathStrokeType::rounded));
             break;

--- a/plugins/multi-q/dpf-plugin/MultiQUI.cpp
+++ b/plugins/multi-q/dpf-plugin/MultiQUI.cpp
@@ -891,11 +891,12 @@ private:
     }
 
     // Shape-glyph drawn INSIDE a control node (JUCE drawBandControlPoint :1008-1101).
-    // Primitives only — no unicode: HPF "/¯", LPF "¯\", low/high shelf steps, notch
+    // Primitives only — no unicode: HPF "/", LPF "\", low/high shelf steps, notch
     // "V", bandpass "^", else the band number. cx/cy are the (design-space) node
     // centre, iconR the glyph half-extent, w the stroke width, col the ink colour.
-    // Coordinate offsets are copied verbatim from the JUCE Path builders (y grows
-    // down in both frameworks, so +y is below centre).
+    // The pass filters intentionally omit horizontal tails so they remain distinct
+    // from shelves. Coordinate offsets match the JUCE Path builders (y grows down
+    // in both frameworks, so +y is below centre).
     void digNodeGlyph(ImDrawList* dl, int b, float cx, float cy,
                       float iconR, float w, ImU32 col) const
     {
@@ -918,8 +919,8 @@ private:
         ImVec2 v[5]; int n = 0;
         switch (g)
         {
-            case 1: v[0]=pt(-0.6f,0.4f); v[1]=pt(-0.1f,0.4f); v[2]=pt(0.3f,-0.4f); v[3]=pt(0.6f,-0.4f); n=4; break; // HPF /¯
-            case 2: v[0]=pt(-0.6f,-0.4f);v[1]=pt(-0.3f,-0.4f);v[2]=pt(0.1f,0.4f);  v[3]=pt(0.6f,0.4f);  n=4; break; // LPF ¯\
+            case 1: v[0]=pt(-0.4f,0.4f); v[1]=pt(0.4f,-0.4f); n=2; break; // HPF /
+            case 2: v[0]=pt(-0.4f,-0.4f);v[1]=pt(0.4f,0.4f);  n=2; break; // LPF falling slope
             case 3: v[0]=pt(-0.6f,0.3f); v[1]=pt(-0.15f,0.3f);v[2]=pt(0.15f,-0.3f);v[3]=pt(0.6f,-0.3f); n=4; break; // low shelf
             case 4: v[0]=pt(-0.6f,-0.3f);v[1]=pt(-0.15f,-0.3f);v[2]=pt(0.15f,0.3f);v[3]=pt(0.6f,0.3f);  n=4; break; // high shelf
             case 5: v[0]=pt(-0.6f,-0.3f);v[1]=pt(-0.15f,-0.3f);v[2]=pt(0.f,0.5f);  v[3]=pt(0.15f,-0.3f);v[4]=pt(0.6f,-0.3f); n=5; break; // notch V


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated high-pass and low-pass filter icons with simpler diagonal shapes.
  * Improved visual distinction between pass-filter and shelf-filter controls.
  * Applied the updated glyph styling consistently across EQ controls and digital EQ displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->