### PR TITLE
Multi-Comp: Opto preset silence, Mix clicks, auto-gain pumping, bool restore + heap overflow

### DIFF
--- a/plugins/multi-comp/AutoGainMatcher.h
+++ b/plugins/multi-comp/AutoGainMatcher.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <cmath>
+
+namespace MultiComp
+{
+
+/**
+ * Auto-gain by slow level matching.
+ *
+ * The previous auto-makeup inverted the compressor's own gain reduction through
+ * a ~200 ms smoother. That sits inside the pumping band: the makeup rides the
+ * compression envelope and partially undoes it, so the compressor breathes. It
+ * was also blind to everything downstream of the gain cell — the Opto's tube and
+ * output transformer add energy the GR figure never sees, which is why that mode
+ * carried a hand-tuned -1.5 dB correction.
+ *
+ * This measures instead. It tracks input and output power through a long
+ * one-pole (default 2 s, far longer than program dynamics) and asks for the gain
+ * that makes the two match. It cannot pump, because over any window shorter than
+ * the estimator's it is effectively a constant; it needs no per-mode fudge,
+ * because it measures the real output including tubes, transformers and the
+ * dry/wet blend.
+ *
+ * Not real-time hostile: no allocation, no locks, a handful of flops per block.
+ */
+class AutoGainMatcher
+{
+public:
+    /** @param sampleRate  Host sample rate. Call from prepareToPlay. */
+    void prepare (double newSampleRate)
+    {
+        sampleRate = newSampleRate > 0.0 ? newSampleRate : 44100.0;
+        reset();
+    }
+
+    /** Drops the estimate. The next block with signal primes it directly. */
+    void reset()
+    {
+        meanSquareIn = 0.0;
+        meanSquareOut = 0.0;
+        primed = false;
+        currentGain = 1.0f;
+    }
+
+    /** Estimator window in seconds. Longer = steadier, slower to settle. */
+    void setWindowSeconds (double seconds) { windowSeconds = juce::jmax (0.05, seconds); }
+
+    /** Hard limit on the correction, applied symmetrically. */
+    void setMaxCorrectionDb (float db) { maxCorrectionDb = juce::jlimit (0.0f, 40.0f, db); }
+
+    /**
+        Feeds one block and returns the linear gain to apply.
+
+        @param inRms      RMS of the block BEFORE processing
+        @param outRms     RMS of the same block AFTER processing, before this gain
+        @param numSamples Block length, used to keep the window wall-clock accurate
+                          regardless of buffer size
+    */
+    float update (float inRms, float outRms, int numSamples)
+    {
+        if (numSamples <= 0)
+            return currentGain;
+
+        // Below the floor there is nothing to match, and dividing near-silence
+        // by near-silence would wind the estimate up on noise. Hold instead.
+        constexpr float kSilenceFloor = 1.0e-5f;    // about -100 dBFS
+        if (inRms < kSilenceFloor || outRms < kSilenceFloor)
+            return currentGain;
+
+        const double msIn = static_cast<double> (inRms) * inRms;
+        const double msOut = static_cast<double> (outRms) * outRms;
+
+        if (! primed)
+        {
+            // Prime the ESTIMATOR, not the output gain: the caller ramps towards
+            // whatever we return, so a mode or preset change converges quickly
+            // without the instant jump the old prime path produced.
+            meanSquareIn = msIn;
+            meanSquareOut = msOut;
+            primed = true;
+        }
+        else
+        {
+            const double blockSeconds = static_cast<double> (numSamples) / sampleRate;
+            const double alpha = 1.0 - std::exp (-blockSeconds / windowSeconds);
+            meanSquareIn += alpha * (msIn - meanSquareIn);
+            meanSquareOut += alpha * (msOut - meanSquareOut);
+        }
+
+        if (meanSquareOut <= 0.0 || meanSquareIn <= 0.0)
+            return currentGain;
+
+        // Power ratio -> dB is 10*log10, not 20: these are squared magnitudes.
+        const auto correctionDb = static_cast<float> (10.0 * std::log10 (meanSquareIn / meanSquareOut));
+        currentGain = juce::Decibels::decibelsToGain (
+            juce::jlimit (-maxCorrectionDb, maxCorrectionDb, correctionDb));
+        return currentGain;
+    }
+
+    /** Last gain returned by update(), linear. */
+    float getCurrentGain() const noexcept { return currentGain; }
+
+    /** True once the estimator has seen signal. */
+    bool isPrimed() const noexcept { return primed; }
+
+private:
+    double sampleRate = 44100.0;
+    double windowSeconds = 2.0;
+    float maxCorrectionDb = 12.0f;
+
+    double meanSquareIn = 0.0;
+    double meanSquareOut = 0.0;
+    bool primed = false;
+    float currentGain = 1.0f;
+};
+
+} // namespace MultiComp

--- a/plugins/multi-comp/CMakeLists.txt
+++ b/plugins/multi-comp/CMakeLists.txt
@@ -199,69 +199,47 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32)
 
     add_dependencies(MultiCompBypassAutoGainTest MultiComp_All)
 
+    # Every functional test links the same way: one source file against the
+    # MultiComp target plus the JUCE modules it pulls in. Declare that once.
+    function(multicomp_add_functional_test target source)
+        add_executable(${target} ${source})
+        target_include_directories(${target} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            ${CMAKE_CURRENT_BINARY_DIR}/MultiComp_artefacts/JuceLibraryCode
+        )
+        target_compile_definitions(${target} PRIVATE
+            JUCE_WEB_BROWSER=0
+            JUCE_USE_CURL=0
+            JUCE_DISPLAY_SPLASH_SCREEN=0
+            JUCE_STANDALONE_APPLICATION=1
+        )
+        target_compile_features(${target} PRIVATE cxx_std_17)
+        target_link_libraries(${target}
+            PRIVATE
+                MultiComp
+                juce::juce_core
+                juce::juce_audio_basics
+                juce::juce_audio_formats
+                juce::juce_audio_processors
+                juce::juce_audio_utils
+                juce::juce_data_structures
+                juce::juce_dsp
+                juce::juce_events
+                juce::juce_graphics
+                juce::juce_gui_basics
+                juce::juce_gui_extra
+        )
+        add_dependencies(${target} MultiComp_All)
+    endfunction()
+
     # --- Issue #114: Multiband dry/wet mix comb-filter regression test ---
-    add_executable(MultiCompMixCombTest
-        tests/test_multiband_mix_comb.cpp
-    )
-    target_include_directories(MultiCompMixCombTest PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}/MultiComp_artefacts/JuceLibraryCode
-    )
-    target_compile_definitions(MultiCompMixCombTest PRIVATE
-        JUCE_WEB_BROWSER=0
-        JUCE_USE_CURL=0
-        JUCE_DISPLAY_SPLASH_SCREEN=0
-        JUCE_STANDALONE_APPLICATION=1
-    )
-    target_compile_features(MultiCompMixCombTest PRIVATE cxx_std_17)
-    target_link_libraries(MultiCompMixCombTest
-        PRIVATE
-            MultiComp
-            juce::juce_core
-            juce::juce_audio_basics
-            juce::juce_audio_formats
-            juce::juce_audio_processors
-            juce::juce_audio_utils
-            juce::juce_data_structures
-            juce::juce_dsp
-            juce::juce_events
-            juce::juce_graphics
-            juce::juce_gui_basics
-            juce::juce_gui_extra
-    )
-    add_dependencies(MultiCompMixCombTest MultiComp_All)
+    multicomp_add_functional_test(MultiCompMixCombTest tests/test_multiband_mix_comb.cpp)
 
     # --- Sidechain functional test (external SC keys compression) ---
-    add_executable(MultiCompSidechainTest
-        tests/test_sidechain.cpp
-    )
-    target_include_directories(MultiCompSidechainTest PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}/MultiComp_artefacts/JuceLibraryCode
-    )
-    target_compile_definitions(MultiCompSidechainTest PRIVATE
-        JUCE_WEB_BROWSER=0
-        JUCE_USE_CURL=0
-        JUCE_DISPLAY_SPLASH_SCREEN=0
-        JUCE_STANDALONE_APPLICATION=1
-    )
-    target_compile_features(MultiCompSidechainTest PRIVATE cxx_std_17)
-    target_link_libraries(MultiCompSidechainTest
-        PRIVATE
-            MultiComp
-            juce::juce_core
-            juce::juce_audio_basics
-            juce::juce_audio_formats
-            juce::juce_audio_processors
-            juce::juce_audio_utils
-            juce::juce_data_structures
-            juce::juce_dsp
-            juce::juce_events
-            juce::juce_graphics
-            juce::juce_gui_basics
-            juce::juce_gui_extra
-    )
-    add_dependencies(MultiCompSidechainTest MultiComp_All)
+    multicomp_add_functional_test(MultiCompSidechainTest tests/test_sidechain.cpp)
+
+    # --- Factory-preset level gate (catches units-mismatch mutes, e.g. opto_gain) ---
+    multicomp_add_functional_test(MultiCompPresetLevelTest tests/test_preset_levels.cpp)
 endif()
 
 # Optional: Build unit tests

--- a/plugins/multi-comp/CMakeLists.txt
+++ b/plugins/multi-comp/CMakeLists.txt
@@ -240,6 +240,9 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32)
 
     # --- Factory-preset level gate (catches units-mismatch mutes, e.g. opto_gain) ---
     multicomp_add_functional_test(MultiCompPresetLevelTest tests/test_preset_levels.cpp)
+
+    # --- Mix-knob ramp / click gate ---
+    multicomp_add_functional_test(MultiCompMixRampTest tests/test_mix_ramp_click.cpp)
 endif()
 
 # Optional: Build unit tests

--- a/plugins/multi-comp/CMakeLists.txt
+++ b/plugins/multi-comp/CMakeLists.txt
@@ -243,6 +243,9 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32)
 
     # --- Mix-knob ramp / click gate ---
     multicomp_add_functional_test(MultiCompMixRampTest tests/test_mix_ramp_click.cpp)
+
+    # --- Auto-gain stability gate (pumping + static level match) ---
+    multicomp_add_functional_test(MultiCompAutoGainTest tests/test_autogain_stability.cpp)
 endif()
 
 # Optional: Build unit tests

--- a/plugins/multi-comp/CMakeLists.txt
+++ b/plugins/multi-comp/CMakeLists.txt
@@ -249,6 +249,9 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32)
 
     # --- State-restore integrity (pluginval L10 bool-param flake, deterministic) ---
     multicomp_add_functional_test(MultiCompStateRestoreTest tests/test_state_restore.cpp)
+
+    # --- Parameter fuzz (pluginval "Fuzz parameters" replica; run under ASan) ---
+    multicomp_add_functional_test(MultiCompParamFuzzTest tests/test_param_fuzz.cpp)
 endif()
 
 # Optional: Build unit tests

--- a/plugins/multi-comp/CMakeLists.txt
+++ b/plugins/multi-comp/CMakeLists.txt
@@ -246,6 +246,9 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32)
 
     # --- Auto-gain stability gate (pumping + static level match) ---
     multicomp_add_functional_test(MultiCompAutoGainTest tests/test_autogain_stability.cpp)
+
+    # --- State-restore integrity (pluginval L10 bool-param flake, deterministic) ---
+    multicomp_add_functional_test(MultiCompStateRestoreTest tests/test_state_restore.cpp)
 endif()
 
 # Optional: Build unit tests

--- a/plugins/multi-comp/CompressorPresets.h
+++ b/plugins/multi-comp/CompressorPresets.h
@@ -2,6 +2,7 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_core/juce_core.h>
+#include "OptoGainMapping.h"
 #include <vector>
 #include <map>
 
@@ -416,8 +417,12 @@ inline void applyPreset(juce::AudioProcessorValueTreeState& params, const Preset
         case 0: // Opto
             if (auto* p = params.getParameter("opto_peak_reduction"))
                 p->setValueNotifyingHost(params.getParameterRange("opto_peak_reduction").convertTo0to1(preset.peakReduction));
+            // preset.makeup is in dB; "opto_gain" is a 0-100 dial (50 = unity,
+            // 0.8 dB per unit). Writing the dB figure straight in landed 5 dB at
+            // knob 5 = -36 dB, which muted the Opto presets at 100% wet.
             if (auto* p = params.getParameter("opto_gain"))
-                p->setValueNotifyingHost(params.getParameterRange("opto_gain").convertTo0to1(preset.makeup));
+                p->setValueNotifyingHost(params.getParameterRange("opto_gain")
+                    .convertTo0to1(MultiComp::optoGainDbToKnob(preset.makeup)));
             if (auto* p = params.getParameter("opto_limit"))
                 p->setValueNotifyingHost(preset.limitMode ? 1.0f : 0.0f);
             break;

--- a/plugins/multi-comp/CompressorPresets.h
+++ b/plugins/multi-comp/CompressorPresets.h
@@ -102,7 +102,7 @@ inline std::vector<Preset> getFactoryPresets()
         4.0f,                         // Unused (controlled by fetRatio)
         0.5f,                         // Attack: ~500µs
         60.0f,                        // Release: 60ms (Fast!)
-        4.0f,                         // Makeup
+        -11.0f,                       // Makeup: offsets the +20 input drive (was +4 = +16.5 dB hot)
         100.0f,                       // Mix
         100.0f,                       // HPF to prevent popping on plosives
         false,
@@ -174,7 +174,7 @@ inline std::vector<Preset> getFactoryPresets()
         20.0f,
         0.8f,                         // Attack: ~800µs (clamped to 1ms by ABI lag)
         150.0f,                       // Release: 150ms (lets the ABI plateau develop)
-        12.0f,
+        -8.0f,                        // Makeup: offsets the +24 input drive (was +12 = +21.1 dB hot)
         100.0f,
         60.0f,
         false,
@@ -222,7 +222,7 @@ inline std::vector<Preset> getFactoryPresets()
         4.0f,
         0.8f,                         // Attack: ~800µs (Slowest FET attack)
         250.0f,                       // Release: 250ms (Medium to reduce flutter)
-        5.0f,
+        -8.0f,                        // Makeup: offsets the +15 input drive (was +5 = +14.5 dB hot)
         100.0f,
         40.0f,
         false,

--- a/plugins/multi-comp/OptoGainMapping.h
+++ b/plugins/multi-comp/OptoGainMapping.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+/**
+ * Opto Gain knob <-> dB mapping.
+ *
+ * The "opto_gain" parameter is a 0-100 hardware-style dial, not a dB value:
+ * 50 is unity and each unit is 0.8 dB, giving a +/-40 dB span. Writing a raw dB
+ * figure into it lands wildly off (5 dB read as knob 5 = -36 dB), so every
+ * conversion goes through these helpers rather than open-coding the constants.
+ */
+namespace MultiComp
+{
+
+constexpr float kOptoGainKnobUnity   = 50.0f;   // knob position for 0 dB
+constexpr float kOptoGainDbPerUnit   = 0.8f;    // dB per knob unit
+constexpr float kOptoGainMaxDb       = 40.0f;   // +/- span at the knob extremes
+
+/** Knob position (0-100) -> gain in dB (-40..+40). */
+inline float optoKnobToGainDb (float knob) noexcept
+{
+    const float clamped = juce::jlimit (0.0f, 100.0f, knob);
+    return juce::jlimit (-kOptoGainMaxDb, kOptoGainMaxDb,
+                         (clamped - kOptoGainKnobUnity) * kOptoGainDbPerUnit);
+}
+
+/** Gain in dB -> knob position (0-100). Inverse of optoKnobToGainDb. */
+inline float optoGainDbToKnob (float db) noexcept
+{
+    const float clamped = juce::jlimit (-kOptoGainMaxDb, kOptoGainMaxDb, db);
+    return juce::jlimit (0.0f, 100.0f,
+                         kOptoGainKnobUnity + clamped / kOptoGainDbPerUnit);
+}
+
+} // namespace MultiComp

--- a/plugins/multi-comp/UniversalCompressor.h
+++ b/plugins/multi-comp/UniversalCompressor.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <memory>
 #include "../shared/DryWetMixer.h"
+#include "AutoGainMatcher.h"
 
 enum class CompressorMode : int
 {
@@ -256,10 +257,10 @@ private:
     // Smoothed auto-makeup gain to avoid audible distortion from abrupt changes
     juce::SmoothedValue<float, juce::ValueSmoothingTypes::Multiplicative> smoothedAutoMakeupGain{1.0f};
 
-    // GR-based auto-gain (industry-standard approach: invert the gain reduction)
-    float smoothedGrDb = 0.0f;          // Smoothed gain reduction in dB (negative = compression)
-    float grSmoothCoeff = 0.0f;         // One-pole filter coefficient for GR smoothing (~200ms)
-    bool primeGrAccumulator = true;     // Flag to instantly prime on mode change
+    // Auto-gain by slow in/out level matching (replaces GR inversion, which
+    // tracked the compression envelope closely enough to pump).
+    MultiComp::AutoGainMatcher autoGainMatcher;
+
     bool wasBypassedLastBlock = false;
     bool wasMinimalLastBlock  = false;  // Track minimal→standard transition for PDC restore
 
@@ -340,6 +341,15 @@ private:
     // Pure computation of the current reported latency (no host call) — shared by
     // updateLatencyReport() and the deferred async apply.
     int computeLatencySamples() const;
+
+    // RMS of a block across all channels, used by the auto-gain matcher.
+    static float blockRms(const juce::AudioBuffer<float>& buffer, int numChannels, int numSamples);
+
+    // Drives the auto-gain matcher and applies the smoothed makeup in place.
+    // Shared by the multiband path and the standard path — they used to carry
+    // near-identical copies of this logic.
+    void applyAutoGain(juce::AudioBuffer<float>& buffer, int numChannels, int numSamples,
+                       float inRms, bool autoMakeupEnabled);
     // Message-thread apply of the pending latency (AsyncUpdater callback).
     void handleAsyncUpdate() override;
     std::atomic<int> pendingLatencySamples_{0};

--- a/plugins/multi-comp/UniversalCompressor.h
+++ b/plugins/multi-comp/UniversalCompressor.h
@@ -345,6 +345,20 @@ private:
     // RMS of a block across all channels, used by the auto-gain matcher.
     static float blockRms(const juce::AudioBuffer<float>& buffer, int numChannels, int numSamples);
 
+    // Per-sample ramp for the mode-local mix parameters (bus_mix, digital_mix).
+    // They were passed block-constant into the per-sample process calls and
+    // stepped when automated — same click class as the global Mix knob. Values
+    // are in the active mode's own units (bus_mix 0-1, digital_mix 0-100);
+    // `span` names that full range so the ramp is 20 ms per full swing either
+    // way. Snapping on mode change covers the unit switch. The curve holds
+    // min(numSamples, size) fresh values; a longer (oversized-block) tail reads
+    // the last value and the ramp completes next block — same idiom as
+    // smoothedGainBuffer.
+    void fillModeMixCurve(float target, float span, double rate, int numSamples);
+    float modeMixCurrent = 0.0f;
+    bool modeMixSnap = true;            // snap on prepare/reset/mode change
+    alignas(64) std::array<float, 8192> modeMixCurve{};
+
     // Drives the auto-gain matcher and applies the smoothed makeup in place.
     // Shared by the multiband path and the standard path — they used to carry
     // near-identical copies of this logic.

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -3775,6 +3775,9 @@ public:
         numChannels = numCh;
         this->maxBlockSize = maxBlockSize;
 
+        // Start the blend settled — a prepare is not a knob move.
+        mixRampCurrent = mixRampTarget;
+
         // Prepare crossover filters - LR4 requires separate filter instances per signal path
         // Each crossover has two cascaded stages (a and b) for 4th order response
         auto sz = static_cast<size_t>(numCh);
@@ -4047,8 +4050,12 @@ public:
             }
         }
 
-        // Whether a dry blend is needed (parallel mix < 100%).
-        bool needsDry = (mixPercent < 100.0f);
+        // The blend is ramped per sample (see mixRamp), so the dry reference is
+        // needed whenever the target is below 100% OR the ramp is still moving
+        // towards it — otherwise the tail of a move to 100% would have nothing
+        // to blend against and would step instead of finishing its fade.
+        mixRampTarget = juce::jlimit(0.0f, 1.0f, mixPercent * 0.01f);
+        bool needsDry = (mixRampTarget < 1.0f) || (mixRampCurrent != mixRampTarget);
 
         // Split the input signal into 4 bands using crossover filters
         splitIntoBands(buffer, numSamples, channels);
@@ -4132,19 +4139,28 @@ public:
             buffer.applyGain(outGain);
         }
 
-        // Mix with dry signal (parallel compression)
+        // Mix with dry signal (parallel compression), ramped per sample so
+        // moving the knob does not step the gain at every block boundary.
         if (needsDry)
         {
-            float wetAmount = mixPercent / 100.0f;
-            float dryAmount = 1.0f - wetAmount;
+            const float maxStep = static_cast<float>(1.0 / (kMixRampSeconds * juce::jmax(1.0, sampleRate)));
 
-            for (int ch = 0; ch < channels; ++ch)
+            for (int i = 0; i < numSamples; ++i)
             {
-                float* out = buffer.getWritePointer(ch);
-                const float* dry = tempBuffer.getReadPointer(ch);
-
-                for (int i = 0; i < numSamples; ++i)
+                if (mixRampCurrent != mixRampTarget)
                 {
+                    const float diff = mixRampTarget - mixRampCurrent;
+                    mixRampCurrent = (std::abs(diff) <= maxStep) ? mixRampTarget
+                                                                 : mixRampCurrent + (diff > 0.0f ? maxStep : -maxStep);
+                }
+
+                const float wetAmount = mixRampCurrent;
+                const float dryAmount = 1.0f - wetAmount;
+
+                for (int ch = 0; ch < channels; ++ch)
+                {
+                    float* out = buffer.getWritePointer(ch);
+                    const float* dry = tempBuffer.getReadPointer(ch);
                     out[i] = out[i] * wetAmount + dry[i] * dryAmount;
                 }
             }
@@ -4474,6 +4490,12 @@ private:
     // safeBlockSize idiom) so a larger host block can't overflow the split.
     static constexpr int kOversizeFactor = 8;
     int allocatedBlockSize = 512 * kOversizeFactor;
+
+    // Per-sample dry/wet ramp (matches DryWetMixer's 20 ms). Without it the
+    // blend stepped once per block and clicked while the knob moved.
+    static constexpr double kMixRampSeconds = 0.02;
+    float mixRampTarget = 1.0f;
+    float mixRampCurrent = 1.0f;
 
 public:
     void updateSampleRate(double newSampleRate)
@@ -5621,10 +5643,14 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         mixAmount = *mixParam * 0.01f; // Convert to 0-1
     }
 
-    // Track whether we need dry/wet mixing for parallel compression
-    // The actual dry capture happens at oversampled rate (in the oversampling section)
-    // for phase-coherent mixing that prevents comb filtering
-    bool needsDryBuffer = (mixAmount > 0.001f && mixAmount < 0.999f);
+    // Dry capture runs whenever we are in the normal processing path, not only
+    // when the knob sits between the endpoints. The mixer ramps the mix per
+    // sample (20 ms) and keeps its delay ring fed from the captured dry, so
+    // skipping capture at exactly 100 % wet would (a) leave the ring stale for
+    // the first blocks after the knob comes back down and (b) force a jump from
+    // "no mix" to "mid-ramp mix". At a settled 1.0 the blend multiplies dry by
+    // exactly 0, so this is bit-identical to the old wet-only output.
+    bool needsDryBuffer = true;
 
     // Save latency-aligned dry signal for bypass crossfade.
     // The wet path includes lookahead delay, so the dry reference must be delayed
@@ -5676,31 +5702,17 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         }
     }
 
-    // At 0% mix (100% dry), skip all processing. Keep the constant reported latency (do NOT zero it
-    // from the audio thread — see issue #106 in the bypass path) and time-align the dry output.
-    if (mixAmount <= 0.001f)
-    {
-        const int bypassChannels = buffer.getNumChannels();
-        const int bypassSamples = buffer.getNumSamples();
-
-        // Update meters to show input = output
-        for (int ch = 0; ch < bypassChannels; ++ch)
-        {
-            float rms = 0.0f;
-            const float* data = buffer.getReadPointer(ch);
-            for (int i = 0; i < bypassSamples; ++i)
-                rms += data[i] * data[i];
-            rms = std::sqrt(rms / static_cast<float>(bypassSamples));
-
-            if (ch == 0)
-                linkedGainReduction[0].store(0.0f, std::memory_order_relaxed);
-            else
-                linkedGainReduction[1].store(0.0f, std::memory_order_relaxed);
-        }
-        grMeter.store(0.0f, std::memory_order_relaxed);
-        emitLatencyAlignedDry(buffer);  // dry, delayed by the constant reported latency
-        return;
-    }
+    // NOTE: 0% mix (100% dry) deliberately runs the FULL processing path.
+    // There used to be an early return here that skipped everything and emitted
+    // dry via emitLatencyAlignedDry. It cost a click at both ends of the knob:
+    // skipping the chain starved the oversampler's FIR state, so coming back off
+    // 0% resumed from stale filter history (measured as a full-amplitude step),
+    // and with internal oversampling off the two dry sources were 218 samples
+    // apart. The blend at a settled 0% already yields exact dry through the
+    // normal path, correctly aligned, with every filter kept warm. Bypass still
+    // uses emitLatencyAlignedDry — there the host's PDC makes it the right
+    // answer, and no state has to survive the gap.
+    dryWetMixer.setTargetMix(mixAmount);
 
     // Internal oversampling — default true, but hosts that want a 1x default
     // (and an external/global quality switch) can flip it off via
@@ -6468,7 +6480,7 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         // lookahead tracking section above. All other modes add zero group delay.
 
         // Capture dry at oversampled rate so both paths share the downsampling filter
-        bool needsOversampledDry = needsDryBuffer && (mixAmount < 0.999f);
+        bool needsOversampledDry = needsDryBuffer;
         if (needsOversampledDry)
         {
             // Use shared DryWetMixer for phase-coherent capture

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -1036,8 +1036,12 @@ public:
         buffer.setSize(numChannels, maxLookaheadSamples);
         buffer.clear();
 
-        // Initialize write positions
-        writePositions.resize(static_cast<size_t>(numChannels), 0);
+        // Zero ALL write positions. resize(n, 0) only value-initializes NEW
+        // elements — after a re-prepare at a lower sample rate the buffer
+        // shrinks but the old indices survived, and the first processSample
+        // wrote past the end (ASan-confirmed heap overflow; pluginval's fuzz
+        // hit it as intermittent teardown heap corruption).
+        writePositions.assign(static_cast<size_t>(numChannels), 0);
 
         currentLookaheadSamples = 0;
     }
@@ -1070,6 +1074,11 @@ public:
         {
             int& writePos = writePositions[static_cast<size_t>(channel)];
             int bufferSize = maxLookaheadSamples;
+
+            // Safety net: never index with a position from a previous sizing
+            // (belt to prepare()'s assign-suspenders; costs one compare).
+            if (writePos >= bufferSize)
+                writePos = 0;
 
             // Read position is lookaheadSamples behind write position
             int readPos = (writePos - lookaheadSamples + bufferSize) % bufferSize;

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -4508,6 +4508,48 @@ public:
     }
 };
 
+// juce::AudioParameterBool stores whatever normalized float the host hands it
+// and returns it raw from getValue() (JUCE: `value = newValue`), while Choice
+// and Int snap internally and the APVTS state round-trip snaps. Result: write
+// 0.4964, read 0.4964 live, read 0.0 after a save/load — hosts and pluginval
+// that compare those two reads see a bool "not restored" (the intermittent
+// level-10 failures). Snapping on set makes the live read match the round-trip.
+// (AudioParameterBool::setValue is private, so this is a sibling implementation
+// rather than a subclass. Nothing in the codebase casts to AudioParameterBool —
+// all access goes through the generic parameter/APVTS interfaces.)
+class SnappingBoolParameter : public juce::RangedAudioParameter
+{
+public:
+    SnappingBoolParameter(const juce::ParameterID& id, const juce::String& name, bool defaultVal)
+        : juce::RangedAudioParameter(id, name),
+          value(defaultVal ? 1.0f : 0.0f),
+          defaultValue(defaultVal ? 1.0f : 0.0f)
+    {
+    }
+
+    const juce::NormalisableRange<float>& getNormalisableRange() const override { return range; }
+    float getValue() const override        { return value.load(); }
+    void setValue(float newValue) override { value.store(newValue >= 0.5f ? 1.0f : 0.0f); }
+    float getDefaultValue() const override { return defaultValue; }
+    int getNumSteps() const override       { return 2; }
+    bool isDiscrete() const override       { return true; }
+    bool isBoolean() const override        { return true; }
+
+    juce::String getText(float v, int) const override { return v >= 0.5f ? "On" : "Off"; }
+    float getValueForText(const juce::String& text) const override
+    {
+        return (text.getIntValue() != 0
+                || text.equalsIgnoreCase("on")
+                || text.equalsIgnoreCase("yes")
+                || text.equalsIgnoreCase("true")) ? 1.0f : 0.0f;
+    }
+
+private:
+    const juce::NormalisableRange<float> range { 0.0f, 1.0f, 1.0f };
+    std::atomic<float> value;
+    const float defaultValue;
+};
+
 // Parameter layout creation
 juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createParameterLayout()
 {
@@ -4522,7 +4564,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
                           "Studio FET", "Studio VCA", "Digital", "Multiband"}, 0));
 
     // Global parameters
-    layout.add(std::make_unique<juce::AudioParameterBool>("bypass", "Bypass", false));
+    layout.add(std::make_unique<SnappingBoolParameter>("bypass", "Bypass", false));
 
     // Stereo linking control (0% = independent, 100% = fully linked)
     layout.add(std::make_unique<juce::AudioParameterFloat>(
@@ -4570,7 +4612,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
         juce::StringArray{"Vintage (Warm)", "Modern (Clean)", "Pristine (Minimal)"}, 0));
 
     // External sidechain enable
-    layout.add(std::make_unique<juce::AudioParameterBool>(
+    layout.add(std::make_unique<SnappingBoolParameter>(
         "sidechain_enable", "External Sidechain", false));
 
     // Global lookahead for all modes (not just Digital)
@@ -4580,7 +4622,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
         juce::AudioParameterFloatAttributes().withLabel("ms")));
 
     // Global sidechain listen (output sidechain signal for monitoring)
-    layout.add(std::make_unique<juce::AudioParameterBool>(
+    layout.add(std::make_unique<SnappingBoolParameter>(
         "global_sidechain_listen", "SC Listen", false));
 
     // Stereo link mode (Stereo = max-level, Mid-Side = M/S processing, Dual Mono = independent)
@@ -4589,7 +4631,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
         juce::StringArray{"Stereo", "Mid-Side", "Dual Mono"}, 0));
 
     // Analog noise floor enable (optional for CPU savings)
-    layout.add(std::make_unique<juce::AudioParameterBool>(
+    layout.add(std::make_unique<SnappingBoolParameter>(
         "noise_enable", "Analog Noise", true));
 
     // Oversampling factor (0 = Off, 1 = 2x, 2 = 4x)
@@ -4620,7 +4662,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
         juce::AudioParameterFloatAttributes().withLabel("dB")));
 
     // True-Peak Detection for sidechain (ITU-R BS.1770 compliant)
-    layout.add(std::make_unique<juce::AudioParameterBool>(
+    layout.add(std::make_unique<SnappingBoolParameter>(
         "true_peak_enable", "True Peak", false));
 
     layout.add(std::make_unique<juce::AudioParameterChoice>(
@@ -4640,7 +4682,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         "opto_gain", "Gain", 
         juce::NormalisableRange<float>(0.0f, 100.0f, 0.1f), 50.0f)); // Unity gain at 50%
-    layout.add(std::make_unique<juce::AudioParameterBool>("opto_limit", "Limit Mode", false));
+    layout.add(std::make_unique<SnappingBoolParameter>("opto_limit", "Limit Mode", false));
     // FET parameters (Vintage FET style)
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         "fet_input", "Input", 
@@ -4694,7 +4736,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         "vca_output", "Output", 
         juce::NormalisableRange<float>(-20.0f, 20.0f, 0.1f), 0.0f));
-    layout.add(std::make_unique<juce::AudioParameterBool>("vca_overeasy", "Over Easy", false));
+    layout.add(std::make_unique<SnappingBoolParameter>("vca_overeasy", "Over Easy", false));
 
     // VCA detector mode: "Adaptive" matches the donor's prior behaviour
     // (level-dependent RMS TC, 35 ms → 5 ms). "Classic" forces a fixed
@@ -4773,7 +4815,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         "digital_output", "Output",
         juce::NormalisableRange<float>(-24.0f, 24.0f, 0.1f), 0.0f));
-    layout.add(std::make_unique<juce::AudioParameterBool>(
+    layout.add(std::make_unique<SnappingBoolParameter>(
         "digital_adaptive", "Adaptive Release", false));  // Program-dependent release
     // SC Listen is now a global control (global_sidechain_listen) in header for all modes
 
@@ -4840,11 +4882,11 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
             juce::AudioParameterFloatAttributes().withLabel("dB")));
 
         // Band bypass
-        layout.add(std::make_unique<juce::AudioParameterBool>(
+        layout.add(std::make_unique<SnappingBoolParameter>(
             "mb_" + name + "_bypass", label + " Bypass", false));
 
         // Band solo
-        layout.add(std::make_unique<juce::AudioParameterBool>(
+        layout.add(std::make_unique<SnappingBoolParameter>(
             "mb_" + name + "_solo", label + " Solo", false));
 
         // Band enabled — when false, the band is removed from the multiband
@@ -4852,7 +4894,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
         // unaffected. The UI enforces a minimum of 2 enabled bands; the DSP
         // layer also defends against <2 in case the param is driven by host
         // automation.
-        layout.add(std::make_unique<juce::AudioParameterBool>(
+        layout.add(std::make_unique<SnappingBoolParameter>(
             "mb_" + name + "_enabled", label + " Enabled", true));
     }
 

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -5277,17 +5277,10 @@ void UniversalCompressor::prepareToPlay(double sampleRate, int samplesPerBlock)
     }
 
     // Initialize RMS coefficient for ~200ms averaging window
-    // GR-based auto-gain: smooth the gain reduction with ~200ms time constant
-    // For 99% convergence in 200ms, use timeConstant ≈ 200ms / 4.6 ≈ 43ms
-    float grTimeConstantSec = 0.043f;  // 43ms time constant (~200ms to 99%)
-    int grBlockSize = juce::jmax(1, samplesPerBlock);  // Prevent division by zero
-    double safeSampleRate = juce::jlimit(8000.0, 384000.0, sampleRate);
-    float blocksPerSecond = static_cast<float>(safeSampleRate) / static_cast<float>(grBlockSize);
-    grSmoothCoeff = 1.0f - std::exp(-1.0f / (blocksPerSecond * grTimeConstantSec));
-    grSmoothCoeff = juce::jlimit(0.001f, 0.999f, grSmoothCoeff);
-    smoothedGrDb = 0.0f;
+    // Auto-gain estimator. The window is long on purpose (see AutoGainMatcher.h):
+    // anything short enough to follow the compression envelope pumps.
+    autoGainMatcher.prepare(juce::jlimit(8000.0, 384000.0, sampleRate));
     lastCompressorMode = -1;  // Force mode change detection on first processBlock
-    primeGrAccumulator = true;  // Prime on first block
 
     // Initialize crossover frequency smoothers (~20ms smoothing to prevent zipper noise)
     smoothedCrossover1.reset(sampleRate, 0.02);
@@ -5622,8 +5615,7 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         bypassFadeRemaining = bypassFadeActualLength;
 
         smoothedAutoMakeupGain.setCurrentAndTargetValue(1.0f);
-        smoothedGrDb = 0.0f;
-        primeGrAccumulator = true;
+        autoGainMatcher.reset();
     }
 
     // Get stereo link and mix parameters with proper null checks
@@ -5725,10 +5717,10 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
     if (currentModeInt != lastCompressorMode)
     {
         lastCompressorMode = currentModeInt;
-        // Flag to prime GR accumulator with first block's GR value (instant convergence)
-        primeGrAccumulator = true;
-        // Reset smoothed gain to unity to avoid sudden volume jumps
-        smoothedAutoMakeupGain.setCurrentAndTargetValue(1.0f);
+        // Re-measure from scratch for the new mode. The estimator primes from the
+        // first block with signal, but the APPLIED gain still ramps there, so a
+        // mode or preset change no longer steps the level.
+        autoGainMatcher.reset();
         // Reset Digital mode's lookahead latency
         if (mode != CompressorMode::Digital)
             dryWetMixer.setProcessingLatency(0);
@@ -5941,6 +5933,11 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
     inputMeter.store(inputDb, std::memory_order_relaxed);
     inputMeterL.store(inputDbL, std::memory_order_relaxed);
     inputMeterR.store(numChannels > 1 ? inputDbR : inputDbL, std::memory_order_relaxed);  // Mono: use same value for both
+
+    // Reference level for the auto-gain matcher. Taken here: after the bypass
+    // and minimal-path exits, but before the M/S encode and any processing, so
+    // it is directly comparable with the L/R output measured further down.
+    const float autoGainInputRms = blockRms(buffer, numChannels, numSamples);
 
     // Get sidechain HP filter frequency and update filter if changed (0 = Off/bypassed)
     auto* sidechainHpParam = parameters.getRawParameterValue("sidechain_hp");
@@ -6338,78 +6335,11 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             grHistoryWritePos.store((pos + 1) % GR_HISTORY_SIZE, std::memory_order_relaxed);
         }
 
-        // GR-based auto-gain for multiband mode
-        // Inverts the compressor's own gain reduction for deterministic compensation
-        {
-            float targetAutoGain = 1.0f;
-
-            if (autoMakeup)
-            {
-                // Use max band GR for compensation — the most-compressed band dominates
-                // perception, and for narrowband signals, only that band's GR matters
-                float avgGrDb = grMax;
-
-                // Smooth the GR to avoid pumping
-                if (primeGrAccumulator)
-                {
-                    smoothedGrDb = avgGrDb;
-                    primeGrAccumulator = false;
-                    float primedGain = juce::Decibels::decibelsToGain(juce::jlimit(-40.0f, 40.0f, -avgGrDb));
-                    float mbMixNorm = mbMix * 0.01f;
-                    primedGain = 1.0f + (primedGain - 1.0f) * mbMixNorm;
-                    smoothedAutoMakeupGain.setCurrentAndTargetValue(primedGain);
-                }
-                else
-                {
-                    smoothedGrDb += grSmoothCoeff * (avgGrDb - smoothedGrDb);
-                }
-
-                // Base compensation: invert the smoothed gain reduction
-                float autoGainDb = -smoothedGrDb;
-                autoGainDb = juce::jlimit(-40.0f, 40.0f, autoGainDb);
-                targetAutoGain = juce::Decibels::decibelsToGain(autoGainDb);
-
-                // Scale auto-gain by mix amount: dry signal doesn't need compensation
-                float mbMixNorm = mbMix * 0.01f;
-                targetAutoGain = 1.0f + (targetAutoGain - 1.0f) * mbMixNorm;
-            }
-
-            smoothedAutoMakeupGain.setTargetValue(targetAutoGain);
-
-            if (smoothedAutoMakeupGain.isSmoothing())
-            {
-                const int maxGainSamples = static_cast<int>(smoothedGainBuffer.size());
-                const int samplesToProcess = juce::jmin(numSamples, maxGainSamples);
-
-                for (int i = 0; i < samplesToProcess; ++i)
-                    smoothedGainBuffer[static_cast<size_t>(i)] = smoothedAutoMakeupGain.getNextValue();
-
-                for (int ch = 0; ch < numChannels; ++ch)
-                {
-                    float* data = buffer.getWritePointer(ch);
-                    const float* gains = smoothedGainBuffer.data();
-                    for (int i = 0; i < samplesToProcess; ++i)
-                        data[i] *= gains[i];
-                }
-            }
-            else
-            {
-                float currentGain = smoothedAutoMakeupGain.getCurrentValue();
-                if (std::abs(currentGain - 1.0f) > 0.001f)
-                {
-                    for (int ch = 0; ch < numChannels; ++ch)
-                    {
-                        float* data = buffer.getWritePointer(ch);
-                        SIMDHelpers::applyGain(data, numSamples, currentGain);
-                    }
-                }
-            }
-        }
-
         // Convert M/S back to L/R before the early return — the normal-path
-        // decode further down is never reached from here. Decode BEFORE output
-        // metering and the bypass crossfade so both operate on L/R (the fade's
-        // dry reference in bypassFadeBuffer is raw L/R input).
+        // decode further down is never reached from here. Decode BEFORE the
+        // auto-gain (which matches against an L/R-domain input measurement),
+        // output metering and the bypass crossfade (whose dry reference in
+        // bypassFadeBuffer is raw L/R input).
         if (useMidSide && numChannels >= 2)
         {
             float* mid = buffer.getWritePointer(0);
@@ -6422,6 +6352,8 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                 side[i] = m - s;  // Right = Mid - Side
             }
         }
+
+        applyAutoGain(buffer, numChannels, numSamples, autoGainInputRms, autoMakeup);
 
         // Update output meter AFTER auto-makeup gain is applied
         float outputLevel = 0.0f;
@@ -6817,95 +6749,10 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
     // Combined gain reduction (min of both channels for display)
     float gainReduction = juce::jmin(grLeft, grRight);
 
-    // GR-based auto-gain: invert the compressor's gain reduction for deterministic compensation
-    // Industry-standard approach (FabFilter Pro-C, Waves CLA series)
-    {
-        float targetAutoGain = 1.0f;
-
-        if (autoMakeup)
-        {
-            // Average GR across channels (negative dB = compression)
-            float avgGrDb = (grLeft + grRight) * 0.5f;
-
-            // Smooth the GR to avoid pumping (~200ms time constant)
-            if (primeGrAccumulator)
-            {
-                smoothedGrDb = avgGrDb;
-                primeGrAccumulator = false;
-                // Set gain immediately without smoothing on first block
-                float autoGainDb = -avgGrDb;
-                if (mode == CompressorMode::FET || mode == CompressorMode::StudioFET)
-                    autoGainDb -= cachedParams[0];  // Compensate for input gain knob
-                // Opto: tube harmonics add energy proportional to GR that autogain doesn't track
-                if (mode == CompressorMode::Opto)
-                    autoGainDb -= std::min(1.5f, std::abs(avgGrDb) * 0.25f);
-                autoGainDb = juce::jlimit(-40.0f, 40.0f, autoGainDb);
-                float primedGain = juce::Decibels::decibelsToGain(autoGainDb);
-                primedGain = 1.0f + (primedGain - 1.0f) * mixAmount;
-                smoothedAutoMakeupGain.setCurrentAndTargetValue(primedGain);
-            }
-            else
-            {
-                smoothedGrDb += grSmoothCoeff * (avgGrDb - smoothedGrDb);
-            }
-
-            // Base compensation: invert the smoothed gain reduction
-            float autoGainDb = -smoothedGrDb;
-
-            // FET/StudioFET: also compensate for the input gain knob
-            // When user turns input down, auto-gain should restore the original level
-            if (mode == CompressorMode::FET || mode == CompressorMode::StudioFET)
-                autoGainDb -= cachedParams[0];  // cachedParams[0] = fet_input parameter
-
-            // Opto: tube harmonics add energy proportional to GR that autogain doesn't track
-            if (mode == CompressorMode::Opto)
-                autoGainDb -= std::min(1.5f, std::abs(smoothedGrDb) * 0.25f);
-
-            autoGainDb = juce::jlimit(-40.0f, 40.0f, autoGainDb);
-            targetAutoGain = juce::Decibels::decibelsToGain(autoGainDb);
-
-            // Scale auto-gain by mix amount: dry signal doesn't need compensation
-            // At 100% wet = full auto-gain, at 100% dry = unity, at 50/50 = half
-            targetAutoGain = 1.0f + (targetAutoGain - 1.0f) * mixAmount;
-        }
-
-        // Update target and apply smoothed gain sample-by-sample
-        smoothedAutoMakeupGain.setTargetValue(targetAutoGain);
-
-        if (smoothedAutoMakeupGain.isSmoothing())
-        {
-            // OPTIMIZED: Pre-fill gain curve array, then apply channel-by-channel
-            // This improves cache locality compared to the inner channel loop
-            const int maxGainSamples = static_cast<int>(smoothedGainBuffer.size());
-            const int samplesToProcess = juce::jmin(numSamples, maxGainSamples);
-
-            // Pre-compute all smoothed gain values
-            for (int i = 0; i < samplesToProcess; ++i)
-                smoothedGainBuffer[static_cast<size_t>(i)] = smoothedAutoMakeupGain.getNextValue();
-
-            // Apply gains channel-by-channel (cache-friendly)
-            for (int ch = 0; ch < numChannels; ++ch)
-            {
-                float* data = buffer.getWritePointer(ch);
-                const float* gains = smoothedGainBuffer.data();
-                for (int i = 0; i < samplesToProcess; ++i)
-                    data[i] *= gains[i];
-            }
-        }
-        else
-        {
-            // No smoothing needed, apply constant gain efficiently
-            float currentGain = smoothedAutoMakeupGain.getCurrentValue();
-            if (std::abs(currentGain - 1.0f) > 0.001f)
-            {
-                for (int ch = 0; ch < numChannels; ++ch)
-                {
-                    float* data = buffer.getWritePointer(ch);
-                    SIMDHelpers::applyGain(data, numSamples, currentGain);
-                }
-            }
-        }
-    }
+    // Auto-gain: match the output level back to the input over a long window.
+    // See AutoGainMatcher.h for why this replaced GR inversion (which pumped and
+    // needed a per-mode fudge for the Opto's tube/transformer energy).
+    applyAutoGain(buffer, numChannels, numSamples, autoGainInputRms, autoMakeup);
 
     // Apply bypass crossfade (smooth transition from bypassed to active)
     if (bypassFadeRemaining > 0)
@@ -7076,6 +6923,71 @@ CompressorMode UniversalCompressor::getCurrentMode() const
     return CompressorMode::Opto; // Default fallback
 }
 
+float UniversalCompressor::blockRms(const juce::AudioBuffer<float>& buffer, int numChannels, int numSamples)
+{
+    if (numSamples <= 0 || numChannels <= 0)
+        return 0.0f;
+
+    double sum = 0.0;
+    for (int ch = 0; ch < numChannels; ++ch)
+    {
+        const float* data = buffer.getReadPointer(ch);
+        for (int i = 0; i < numSamples; ++i)
+            sum += static_cast<double>(data[i]) * data[i];
+    }
+
+    return static_cast<float>(std::sqrt(sum / (static_cast<double>(numSamples) * numChannels)));
+}
+
+void UniversalCompressor::applyAutoGain(juce::AudioBuffer<float>& buffer, int numChannels, int numSamples,
+                                        float inRms, bool autoMakeupEnabled)
+{
+    float targetAutoGain = 1.0f;
+
+    if (autoMakeupEnabled)
+    {
+        // Measure what actually came out — post-compression, post-saturation,
+        // post dry/wet blend — and ask for the gain that matches the input. No
+        // mix scaling is needed: at 0% wet the output already equals the input,
+        // so the matcher naturally converges on unity.
+        const float outRms = blockRms(buffer, numChannels, numSamples);
+        targetAutoGain = autoGainMatcher.update(inRms, outRms, numSamples);
+    }
+    else
+    {
+        autoGainMatcher.reset();
+    }
+
+    smoothedAutoMakeupGain.setTargetValue(targetAutoGain);
+
+    if (smoothedAutoMakeupGain.isSmoothing())
+    {
+        // Pre-fill the gain curve, then apply channel-by-channel (cache-friendly).
+        const int maxGainSamples = static_cast<int>(smoothedGainBuffer.size());
+        const int samplesToProcess = juce::jmin(numSamples, maxGainSamples);
+
+        for (int i = 0; i < samplesToProcess; ++i)
+            smoothedGainBuffer[static_cast<size_t>(i)] = smoothedAutoMakeupGain.getNextValue();
+
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            float* data = buffer.getWritePointer(ch);
+            const float* gains = smoothedGainBuffer.data();
+            for (int i = 0; i < samplesToProcess; ++i)
+                data[i] *= gains[i];
+        }
+    }
+    else
+    {
+        const float currentGain = smoothedAutoMakeupGain.getCurrentValue();
+        if (std::abs(currentGain - 1.0f) > 0.001f)
+        {
+            for (int ch = 0; ch < numChannels; ++ch)
+                SIMDHelpers::applyGain(buffer.getWritePointer(ch), numSamples, currentGain);
+        }
+    }
+}
+
 int UniversalCompressor::computeLatencySamples() const
 {
     const auto mode = getCurrentMode();
@@ -7225,11 +7137,10 @@ void UniversalCompressor::setStateInformation(const void* data, int sizeInBytes)
 
 void UniversalCompressor::resetDSPState()
 {
-    // Reset smoothed auto-makeup gain and GR accumulator to neutral
+    // Reset smoothed auto-makeup gain and the level-matching estimator to neutral
     smoothedAutoMakeupGain.setCurrentAndTargetValue(1.0f);
-    smoothedGrDb = 0.0f;
+    autoGainMatcher.reset();
     lastCompressorMode = -1;  // Force mode change detection on next processBlock
-    primeGrAccumulator = true;  // Prime accumulator on first block after reset
 
     bypassFadeRemaining = 0;
     bypassFadeBuffer.clear();

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -5440,7 +5440,7 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         {
             case CompressorMode::Opto:
                 if (auto* a = parameters.getRawParameterValue ("opto_peak_reduction")) p0 = juce::jlimit (0.0f, 100.0f, a->load());
-                if (auto* a = parameters.getRawParameterValue ("opto_gain"))           p1 = juce::jlimit (-40.0f, 40.0f, (juce::jlimit (0.0f, 100.0f, a->load()) - 50.0f) * 0.8f);
+                if (auto* a = parameters.getRawParameterValue ("opto_gain"))           p1 = MultiComp::optoKnobToGainDb (a->load());
                 if (auto* a = parameters.getRawParameterValue ("opto_limit"))          p2 = a->load();
                 break;
             case CompressorMode::FET:
@@ -5745,15 +5745,9 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             auto* p3 = parameters.getRawParameterValue("opto_limit");
             if (p1 && p2 && p3) {
                 cachedParams[0] = juce::jlimit(0.0f, 100.0f, p1->load());  // Peak reduction 0-100
-                // Opto gain is 0-40dB range, parameter is 0-100
-                // Map 50 = unity gain (0dB), 0 = -40dB, 100 = +40dB
+                // Opto gain knob is 0-100 (50 = unity, 0.8 dB per unit).
                 // When auto-makeup is enabled, force gain to 0dB (unity)
-                if (autoMakeup)
-                    cachedParams[1] = 0.0f;
-                else {
-                    float gainParam = juce::jlimit(0.0f, 100.0f, p2->load());
-                    cachedParams[1] = juce::jlimit(-40.0f, 40.0f, (gainParam - 50.0f) * 0.8f);  // Bounded gain
-                }
+                cachedParams[1] = autoMakeup ? 0.0f : MultiComp::optoKnobToGainDb(p2->load());
                 cachedParams[2] = p3->load();
             } else validParams = false;
             break;
@@ -7331,8 +7325,10 @@ void UniversalCompressor::setCurrentProgram(int index)
         // Opto defaults
         if (auto* p = parameters.getParameter("opto_peak_reduction"))
             p->setValueNotifyingHost(parameters.getParameterRange("opto_peak_reduction").convertTo0to1(30.0f));
+        // 0 dB of makeup = knob 50, NOT knob 0 (which is -40 dB and mutes the mode)
         if (auto* p = parameters.getParameter("opto_gain"))
-            p->setValueNotifyingHost(parameters.getParameterRange("opto_gain").convertTo0to1(0.0f));
+            p->setValueNotifyingHost(parameters.getParameterRange("opto_gain")
+                .convertTo0to1(MultiComp::optoGainDbToKnob(0.0f)));
         if (auto* p = parameters.getParameter("opto_limit"))
             p->setValueNotifyingHost(0.0f);  // Compress
 

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -4786,6 +4786,10 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         "studio_vca_output", "Output",
         juce::NormalisableRange<float>(-20.0f, 20.0f, 0.1f), 0.0f));
+    // DEAD PARAMETER: nothing reads "studio_vca_mix" — Studio VCA uses the
+    // global "mix". Kept in the layout because removing a parameter breaks
+    // session/state compatibility; do not wire it up without also deciding how
+    // it stacks with the global Mix (see bus_mix/digital_mix, which multiply).
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         "studio_vca_mix", "Mix",
         juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 100.0f));  // Parallel compression
@@ -5323,6 +5327,7 @@ void UniversalCompressor::prepareToPlay(double sampleRate, int samplesPerBlock)
     // anything short enough to follow the compression envelope pumps.
     autoGainMatcher.prepare(juce::jlimit(8000.0, 384000.0, sampleRate));
     lastCompressorMode = -1;  // Force mode change detection on first processBlock
+    modeMixSnap = true;       // Mode-local mix ramp starts settled
 
     // Initialize crossover frequency smoothers (~20ms smoothing to prevent zipper noise)
     smoothedCrossover1.reset(sampleRate, 0.02);
@@ -5763,6 +5768,8 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         // first block with signal, but the APPLIED gain still ramps there, so a
         // mode or preset change no longer steps the level.
         autoGainMatcher.reset();
+        // Mode-local mix units differ per mode — snap rather than ramp across them.
+        modeMixSnap = true;
         // Reset Digital mode's lookahead latency
         if (mode != CompressorMode::Digital)
             dryWetMixer.setProcessingLatency(0);
@@ -6486,6 +6493,15 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             SIMDHelpers::interpolateSidechain(srcPtr, destPtr, numSamples, osNumSamples);
         }
 
+        // Ramp the mode-local mix (bus_mix / digital_mix) at the oversampled
+        // rate; one curve, reused by every channel.
+        if (mode == CompressorMode::Bus)
+            fillModeMixCurve(cachedParams[5], 1.0f,
+                             getSampleRate() * juce::jmax(1, osNumSamples / juce::jmax(1, numSamples)), osNumSamples);
+        else if (mode == CompressorMode::Digital)
+            fillModeMixCurve(cachedParams[6], 100.0f,
+                             getSampleRate() * juce::jmax(1, osNumSamples / juce::jmax(1, numSamples)), osNumSamples);
+
         // Process with cached parameters - now using pre-interpolated sidechain
         for (int channel = 0; channel < osNumChannels; ++channel)
         {
@@ -6517,6 +6533,10 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                     {
                         // True console stereo link (oversampled path): shared sidechain
                         // drives both VCAs. No compensationGain here (postGain=1).
+                        // KNOWN GAP: this path has no mix argument, so bus_mix is
+                        // silently ignored whenever stereo link is engaged (the
+                        // per-channel branch below honours it). Pre-existing; no
+                        // UI binds bus_mix, so exposure is automation-only.
                         busCompressor->processStereoLinked(
                             oversampledBlock.getChannelPointer(static_cast<size_t>(0)), oversampledBlock.getChannelPointer(static_cast<size_t>(1)), osNumSamples,
                             cachedParams[0], cachedParams[1],
@@ -6533,7 +6553,7 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                     else
                     {
                         for (int i = 0; i < osNumSamples; ++i)
-                            data[i] = busCompressor->process(data[i], channel, cachedParams[0], cachedParams[1], static_cast<int>(cachedParams[2]), static_cast<int>(cachedParams[3]), cachedParams[4], cachedParams[5], true, scData[i], hasExternalSidechain);
+                            data[i] = busCompressor->process(data[i], channel, cachedParams[0], cachedParams[1], static_cast<int>(cachedParams[2]), static_cast<int>(cachedParams[3]), cachedParams[4], modeMixCurve[static_cast<size_t>(juce::jmin(i, static_cast<int>(modeMixCurve.size()) - 1))], true, scData[i], hasExternalSidechain);
                     }
                     break;
                 case CompressorMode::StudioFET:
@@ -6556,7 +6576,8 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                     for (int i = 0; i < osNumSamples; ++i)
                     {
                         data[i] = digitalCompressor->process(data[i], channel, cachedParams[0], cachedParams[1], cachedParams[2],
-                                                             cachedParams[3], cachedParams[4], cachedParams[5], cachedParams[6],
+                                                             cachedParams[3], cachedParams[4], cachedParams[5],
+                                                             modeMixCurve[static_cast<size_t>(juce::jmin(i, static_cast<int>(modeMixCurve.size()) - 1))],
                                                              cachedParams[7], cachedParams[8] > 0.5f, scData[i]);
                     }
                     break;
@@ -6599,11 +6620,18 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             dryWetMixer.captureDryAtNormalRate(buffer);
             canMixNormal = true;
         }
-        
+
+        // Ramp the mode-local mix (bus_mix / digital_mix) at native rate;
+        // one curve, reused by every channel.
+        if (mode == CompressorMode::Bus)
+            fillModeMixCurve(cachedParams[5], 1.0f, getSampleRate(), numSamples);
+        else if (mode == CompressorMode::Digital)
+            fillModeMixCurve(cachedParams[6], 100.0f, getSampleRate(), numSamples);
+
         for (int channel = 0; channel < numChannels; ++channel)
         {
             float* data = buffer.getWritePointer(channel);
-            
+
             switch (mode)
             {
                 case CompressorMode::Opto:
@@ -6670,7 +6698,7 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                                 scSignal = linkedSidechain.getSample(channel, i);
                             else
                                 scSignal = filteredSidechain.getSample(channel, i);
-                            data[i] = busCompressor->process(data[i], channel, cachedParams[0], cachedParams[1], static_cast<int>(cachedParams[2]), static_cast<int>(cachedParams[3]), cachedParams[4], cachedParams[5], false, scSignal, hasExternalSidechain) * compensationGain;
+                            data[i] = busCompressor->process(data[i], channel, cachedParams[0], cachedParams[1], static_cast<int>(cachedParams[2]), static_cast<int>(cachedParams[3]), cachedParams[4], modeMixCurve[static_cast<size_t>(juce::jmin(i, static_cast<int>(modeMixCurve.size()) - 1))], false, scSignal, hasExternalSidechain) * compensationGain;
                         }
                     }
                     break;
@@ -6712,7 +6740,8 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
 
                         // Digital: threshold, ratio, knee, attack, release, lookahead, mix, output, adaptive
                         data[i] = digitalCompressor->process(data[i], channel, cachedParams[0], cachedParams[1], cachedParams[2],
-                                                             cachedParams[3], cachedParams[4], cachedParams[5], cachedParams[6],
+                                                             cachedParams[3], cachedParams[4], cachedParams[5],
+                                                             modeMixCurve[static_cast<size_t>(juce::jmin(i, static_cast<int>(modeMixCurve.size()) - 1))],
                                                              cachedParams[7], cachedParams[8] > 0.5f, scSignal) * compensationGain;
                     }
                     break;
@@ -6965,6 +6994,29 @@ CompressorMode UniversalCompressor::getCurrentMode() const
     return CompressorMode::Opto; // Default fallback
 }
 
+void UniversalCompressor::fillModeMixCurve(float target, float span, double rate, int numSamples)
+{
+    if (modeMixSnap)
+    {
+        modeMixCurrent = target;
+        modeMixSnap = false;
+    }
+
+    const int n = juce::jmin(numSamples, static_cast<int>(modeMixCurve.size()));
+    const float maxStep = span / static_cast<float>(0.02 * juce::jmax(1.0, rate));   // 20 ms full swing
+
+    for (int i = 0; i < n; ++i)
+    {
+        if (modeMixCurrent != target)
+        {
+            const float diff = target - modeMixCurrent;
+            modeMixCurrent = (std::abs(diff) <= maxStep) ? target
+                                                         : modeMixCurrent + (diff > 0.0f ? maxStep : -maxStep);
+        }
+        modeMixCurve[static_cast<size_t>(i)] = modeMixCurrent;
+    }
+}
+
 float UniversalCompressor::blockRms(const juce::AudioBuffer<float>& buffer, int numChannels, int numSamples)
 {
     if (numSamples <= 0 || numChannels <= 0)
@@ -7183,6 +7235,7 @@ void UniversalCompressor::resetDSPState()
     smoothedAutoMakeupGain.setCurrentAndTargetValue(1.0f);
     autoGainMatcher.reset();
     lastCompressorMode = -1;  // Force mode change detection on next processBlock
+    modeMixSnap = true;
 
     bypassFadeRemaining = 0;
     bypassFadeBuffer.clear();

--- a/plugins/multi-comp/tests/test_autogain_stability.cpp
+++ b/plugins/multi-comp/tests/test_autogain_stability.cpp
@@ -1,0 +1,260 @@
+/*
+ * Auto-gain stability gate.
+ *
+ * Auto-makeup used to invert the compressor's gain reduction through a ~200 ms
+ * smoother. That tracks the compression envelope closely enough to partially
+ * undo it, so the compressor breathed on any source with real dynamics, and it
+ * stepped on mode/preset change because the smoother was primed with
+ * setCurrentAndTargetValue. It is now slow input/output level matching
+ * (AutoGainMatcher).
+ *
+ * Two gates:
+ *
+ * 1. PUMPING. Render a source that alternates loud and quiet every half second,
+ *    once with auto-makeup off and once on. The per-block ratio between the two
+ *    renders IS the applied makeup gain, with the compressor's own behaviour
+ *    divided out. A level-matching auto-gain barely moves across the cycle; a
+ *    GR inverter swings with it. Gate: peak-to-peak movement of that gain.
+ *
+ * 2. STATIC MATCH. With a steady source, auto-makeup on, the output should end
+ *    up close to the input level, per mode. That is the whole promise of the
+ *    feature, and it is what the GR inverter could not do for the Opto without a
+ *    hand-tuned fudge factor.
+ */
+
+#include <JuceHeader.h>
+#include "../UniversalCompressor.h"
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+
+bool g_paramError = false;
+
+void setParam(UniversalCompressor& plugin, const juce::String& paramID, float value)
+{
+    auto& params = plugin.getParameters();
+    if (auto* param = params.getParameter(paramID))
+        param->setValueNotifyingHost(params.getParameterRange(paramID).convertTo0to1(value));
+    else
+    {
+        std::cerr << "ERROR: param '" << paramID << "' not found — test config invalid\n";
+        g_paramError = true;
+    }
+}
+
+/** Unity makeup knobs, so the only level difference between renders is auto-gain. */
+void configureMode(UniversalCompressor& plugin, CompressorMode mode)
+{
+    setParam(plugin, "mode", static_cast<float>(static_cast<int>(mode)));
+    setParam(plugin, "mix", 100.0f);
+
+    switch (mode)
+    {
+        case CompressorMode::Opto:
+            setParam(plugin, "opto_peak_reduction", 55.0f);
+            setParam(plugin, "opto_gain", 50.0f);            // knob 50 = 0 dB
+            break;
+        case CompressorMode::FET:
+            setParam(plugin, "fet_input", 6.0f);
+            setParam(plugin, "fet_output", 0.0f);
+            break;
+        case CompressorMode::VCA:
+            setParam(plugin, "vca_threshold", -24.0f);
+            setParam(plugin, "vca_ratio", 4.0f);
+            setParam(plugin, "vca_output", 0.0f);
+            break;
+        case CompressorMode::Bus:
+            setParam(plugin, "bus_threshold", -24.0f);
+            setParam(plugin, "bus_makeup", 0.0f);
+            break;
+        case CompressorMode::StudioFET:
+            // Studio FET shares the fet_* parameter set (see applyPreset case 4).
+            setParam(plugin, "fet_input", 6.0f);
+            setParam(plugin, "fet_output", 0.0f);
+            break;
+        case CompressorMode::StudioVCA:
+            setParam(plugin, "studio_vca_threshold", -24.0f);
+            setParam(plugin, "studio_vca_output", 0.0f);
+            break;
+        case CompressorMode::Digital:
+            setParam(plugin, "digital_threshold", -24.0f);
+            setParam(plugin, "digital_output", 0.0f);
+            break;
+        case CompressorMode::Multiband:
+            for (const juce::String name : { "low", "lowmid", "highmid", "high" })
+            {
+                setParam(plugin, "mb_" + name + "_enabled", 1.0f);
+                setParam(plugin, "mb_" + name + "_ratio", 4.0f);
+                setParam(plugin, "mb_" + name + "_threshold", -24.0f);
+                setParam(plugin, "mb_" + name + "_makeup", 0.0f);
+            }
+            break;
+    }
+}
+
+/** Per-block output RMS for a render. `dynamic` alternates loud/quiet each half second. */
+std::vector<float> renderBlockRms(CompressorMode mode, bool autoMakeup, bool dynamic,
+                                  double sr, int block, int numBlocks)
+{
+    UniversalCompressor plugin;
+    plugin.setPlayConfigDetails(2, 2, sr, block);
+    plugin.prepareToPlay(sr, block);
+    configureMode(plugin, mode);
+    setParam(plugin, "auto_makeup", autoMakeup ? 1.0f : 0.0f);
+
+    juce::MidiBuffer midi;
+    juce::AudioBuffer<float> buf(2, block);
+    juce::Random rng(0xA07A1);
+
+    const int blocksPerHalfSecond = juce::jmax(1, static_cast<int>(sr * 0.5 / block));
+
+    std::vector<float> out;
+    out.reserve(static_cast<size_t>(numBlocks));
+
+    for (int b = 0; b < numBlocks; ++b)
+    {
+        // Loud = -9 dBFS-ish, quiet = -27 dBFS-ish.
+        const bool loud = (! dynamic) || (((b / blocksPerHalfSecond) % 2) == 0);
+        const float amp = loud ? 0.35f : 0.045f;
+
+        for (int i = 0; i < block; ++i)
+        {
+            const float s = amp * (rng.nextFloat() * 2.0f - 1.0f);
+            for (int ch = 0; ch < 2; ++ch)
+                buf.setSample(ch, i, s);
+        }
+
+        plugin.processBlock(buf, midi);
+
+        double sum = 0.0;
+        for (int ch = 0; ch < 2; ++ch)
+        {
+            const float* d = buf.getReadPointer(ch);
+            for (int i = 0; i < block; ++i)
+                sum += static_cast<double>(d[i]) * d[i];
+        }
+        out.push_back(static_cast<float>(std::sqrt(sum / (2.0 * block))));
+    }
+
+    return out;
+}
+
+float toDb(float linear) { return linear > 1.0e-9f ? 20.0f * std::log10(linear) : -180.0f; }
+
+struct ModeCase
+{
+    const char* name;
+    CompressorMode mode;
+};
+
+} // namespace
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    constexpr double sr = 48000.0;
+    constexpr int block = 512;
+
+    const ModeCase modes[] = {
+        { "Opto",       CompressorMode::Opto },
+        { "FET",        CompressorMode::FET },
+        { "VCA",        CompressorMode::VCA },
+        { "Bus",        CompressorMode::Bus },
+        { "StudioVCA",  CompressorMode::StudioVCA },
+        { "Digital",    CompressorMode::Digital },
+        { "Multiband",  CompressorMode::Multiband },
+    };
+
+    // Makeup movement across a 6:1 loud/quiet cycle. The estimator's window is
+    // 2 s, so a full cycle should shift it very little.
+    constexpr float kMaxPumpDb = 3.0f;
+    // How close a settled output should sit to the input level.
+    constexpr float kMaxStaticErrorDb = 2.0f;
+
+    int failures = 0;
+
+    std::cout << std::fixed << std::setprecision(2);
+    std::cout << "\n--- Auto-gain stability gate ---\n";
+    std::cout << "\n  1. Pumping: peak-to-peak makeup movement over a loud/quiet cycle"
+              << " (limit " << kMaxPumpDb << " dB)\n";
+
+    {
+        constexpr int numBlocks = 940;                 // ~10 s
+        const int settleBlock = 940 / 3;               // judge the last two thirds
+
+        for (const auto& m : modes)
+        {
+            const auto off = renderBlockRms(m.mode, false, true, sr, block, numBlocks);
+            const auto on  = renderBlockRms(m.mode, true,  true, sr, block, numBlocks);
+
+            float minDb = 1.0e9f, maxDb = -1.0e9f;
+            for (int b = settleBlock; b < numBlocks; ++b)
+            {
+                if (off[static_cast<size_t>(b)] < 1.0e-6f)
+                    continue;
+                const float gainDb = toDb(on[static_cast<size_t>(b)]) - toDb(off[static_cast<size_t>(b)]);
+                minDb = std::min(minDb, gainDb);
+                maxDb = std::max(maxDb, gainDb);
+            }
+
+            const float pumpDb = maxDb - minDb;
+            const bool ok = pumpDb <= kMaxPumpDb;
+            if (! ok)
+                ++failures;
+
+            std::cout << (ok ? "  ok   " : "  FAIL ")
+                      << std::setw(11) << std::left << m.name << std::right
+                      << "  makeup " << std::setw(7) << minDb << " .. " << std::setw(7) << maxDb
+                      << " dB   swing " << std::setw(6) << pumpDb << " dB\n";
+        }
+    }
+
+    std::cout << "\n  2. Static match: settled output vs input, auto-makeup on"
+              << " (limit " << kMaxStaticErrorDb << " dB)\n";
+
+    {
+        constexpr int numBlocks = 940;
+        const int settleBlock = (940 * 2) / 3;
+        const float inputRms = 0.35f / std::sqrt(3.0f);   // RMS of uniform noise at +/-0.35
+        const float inputDb = toDb(inputRms);
+
+        for (const auto& m : modes)
+        {
+            const auto on = renderBlockRms(m.mode, true, false, sr, block, numBlocks);
+
+            double sum = 0.0;
+            int count = 0;
+            for (int b = settleBlock; b < numBlocks; ++b)
+            {
+                sum += on[static_cast<size_t>(b)];
+                ++count;
+            }
+            const auto meanRms = static_cast<float>(sum / std::max(1, count));
+            const float errorDb = toDb(meanRms) - inputDb;
+            const bool ok = std::abs(errorDb) <= kMaxStaticErrorDb;
+            if (! ok)
+                ++failures;
+
+            std::cout << (ok ? "  ok   " : "  FAIL ")
+                      << std::setw(11) << std::left << m.name << std::right
+                      << "  out " << std::setw(8) << toDb(meanRms)
+                      << " dB   error " << std::setw(7) << errorDb << " dB\n";
+        }
+    }
+
+    if (g_paramError)
+    {
+        std::cout << "\n  RESULT: FAIL (missing parameter — test config invalid)\n";
+        return 2;
+    }
+
+    std::cout << "\n  RESULT: " << (failures == 0 ? "PASS" : "FAIL")
+              << " (" << failures << " checks outside limits)\n";
+    return failures == 0 ? 0 : 1;
+}

--- a/plugins/multi-comp/tests/test_mix_ramp_click.cpp
+++ b/plugins/multi-comp/tests/test_mix_ramp_click.cpp
@@ -1,0 +1,281 @@
+/*
+ * Mix-knob click gate.
+ *
+ * The Mix value used to be read once per block and applied as a constant gain,
+ * so every buffer boundary during a knob move was a gain step. Two more
+ * discontinuities sat on top: the dry delay ring only advanced while mixing was
+ * active (so it went stale at 100 % wet and jumped on re-entry), and the 0 % /
+ * 100 % endpoints switched whole code paths, including a different dry source.
+ *
+ * Test: feed a steady sine and sweep Mix across its full travel (100 -> 0 -> 100)
+ * one step per block, the way a fast knob drag or an automation lane does. With
+ * a per-sample ramp the output stays a continuous waveform, so the largest
+ * sample-to-sample jump stays close to what the sine itself produces. A stepped
+ * blend leaves a visible discontinuity at block boundaries.
+ *
+ * The measure is the peak |x[n] - x[n-1]| over the sweep, compared against the
+ * same figure from a static render (no knob movement) of the same signal. Any
+ * excess is the click.
+ */
+
+#include <JuceHeader.h>
+#include "../UniversalCompressor.h"
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+
+bool g_paramError = false;
+
+void setParam(UniversalCompressor& plugin, const juce::String& paramID, float value)
+{
+    auto& params = plugin.getParameters();
+    if (auto* param = params.getParameter(paramID))
+        param->setValueNotifyingHost(params.getParameterRange(paramID).convertTo0to1(value));
+    else
+    {
+        std::cerr << "ERROR: param '" << paramID << "' not found — test config invalid\n";
+        g_paramError = true;
+    }
+}
+
+struct Scenario
+{
+    const char* name;
+    CompressorMode mode;
+    bool oversampling;
+};
+
+struct SweepResult
+{
+    float peakDelta = 0.0f;
+    int   peakBlock = -1;
+    float peakMix = -1.0f;    // Mix target in effect when the worst step happened
+};
+
+/** Renders a sine while stepping Mix once per block; returns peak sample delta. */
+SweepResult renderSweep(const Scenario& scenario, bool moveKnob, double sr, int block, int numBlocks)
+{
+    UniversalCompressor plugin;
+    plugin.setPlayConfigDetails(2, 2, sr, block);
+    plugin.setInternalOversamplingEnabled(scenario.oversampling);
+    plugin.prepareToPlay(sr, block);
+
+    setParam(plugin, "mode", static_cast<float>(static_cast<int>(scenario.mode)));
+    setParam(plugin, "auto_makeup", 0.0f);      // isolate the blend from makeup movement
+    setParam(plugin, "mix", 100.0f);
+
+    if (scenario.mode == CompressorMode::Multiband)
+        for (const juce::String name : { "low", "lowmid", "highmid", "high" })
+        {
+            setParam(plugin, "mb_" + name + "_enabled", 1.0f);
+            setParam(plugin, "mb_" + name + "_ratio", 4.0f);
+        }
+
+    juce::MidiBuffer midi;
+    juce::AudioBuffer<float> buf(2, block);
+
+    const double phaseInc = 2.0 * juce::MathConstants<double>::pi * 220.0 / sr;
+    double phase = 0.0;
+
+    SweepResult result;
+    float previous = 0.0f;
+    bool havePrevious = false;
+    float currentMix = 100.0f;
+
+    // Warm up at a static 100 % so envelopes settle before we judge deltas.
+    constexpr int warmupBlocks = 48;
+
+    for (int b = 0; b < numBlocks; ++b)
+    {
+        if (moveKnob && b >= warmupBlocks)
+        {
+            // 100 -> 0 -> 100 across the post-warmup blocks.
+            const float t = static_cast<float>(b - warmupBlocks)
+                          / static_cast<float>(std::max(1, numBlocks - warmupBlocks - 1));
+            const float triangle = t < 0.5f ? (1.0f - 2.0f * t) : (2.0f * t - 1.0f);
+            currentMix = juce::jlimit(0.0f, 100.0f, triangle * 100.0f);
+            setParam(plugin, "mix", currentMix);
+        }
+
+        for (int i = 0; i < block; ++i)
+        {
+            const auto s = static_cast<float>(0.35 * std::sin(phase));
+            phase += phaseInc;
+            for (int ch = 0; ch < 2; ++ch)
+                buf.setSample(ch, i, s);
+        }
+
+        plugin.processBlock(buf, midi);
+
+        if (b >= warmupBlocks)
+        {
+            const float* out = buf.getReadPointer(0);
+            for (int i = 0; i < block; ++i)
+            {
+                if (havePrevious)
+                {
+                    const float delta = std::abs(out[i] - previous);
+                    if (delta > result.peakDelta)
+                    {
+                        result.peakDelta = delta;
+                        result.peakBlock = b;
+                        result.peakMix = currentMix;
+                    }
+                }
+                previous = out[i];
+                havePrevious = true;
+            }
+        }
+    }
+
+    return result;
+}
+
+/** Static render at a fixed Mix; returns the settled output of channel 0. */
+std::vector<float> renderStatic(const Scenario& scenario, float mixPercent,
+                                double sr, int block, int numBlocks)
+{
+    UniversalCompressor plugin;
+    plugin.setPlayConfigDetails(2, 2, sr, block);
+    plugin.setInternalOversamplingEnabled(scenario.oversampling);
+    plugin.prepareToPlay(sr, block);
+
+    setParam(plugin, "mode", static_cast<float>(static_cast<int>(scenario.mode)));
+    setParam(plugin, "auto_makeup", 0.0f);
+    setParam(plugin, "mix", mixPercent);
+
+    juce::MidiBuffer midi;
+    juce::AudioBuffer<float> buf(2, block);
+
+    // Noise, not a tone: cross-correlating a 220 Hz sine at 48 kHz is ambiguous
+    // at multiples of its 218-sample period, which reads as a phantom 218-sample
+    // misalignment. Noise has a single unambiguous correlation peak.
+    juce::Random rng(0xA11614);
+
+    std::vector<float> out;
+    out.reserve(static_cast<size_t>(block) * static_cast<size_t>(numBlocks));
+
+    for (int b = 0; b < numBlocks; ++b)
+    {
+        for (int i = 0; i < block; ++i)
+        {
+            const auto s = 0.30f * (rng.nextFloat() * 2.0f - 1.0f);
+            for (int ch = 0; ch < 2; ++ch)
+                buf.setSample(ch, i, s);
+        }
+        plugin.processBlock(buf, midi);
+        const float* p = buf.getReadPointer(0);
+        for (int i = 0; i < block; ++i)
+            out.push_back(p[i]);
+    }
+    return out;
+}
+
+/** Best-matching integer lag (in samples) of b relative to a, searched +/-maxLag. */
+int bestLag(const std::vector<float>& a, const std::vector<float>& b, int maxLag, int start, int count)
+{
+    double best = -1.0e30;
+    int bestL = 0;
+    for (int lag = -maxLag; lag <= maxLag; ++lag)
+    {
+        double dot = 0.0;
+        for (int i = start; i < start + count; ++i)
+        {
+            const int j = i + lag;
+            if (j < 0 || j >= static_cast<int>(b.size()))
+                continue;
+            dot += static_cast<double>(a[static_cast<size_t>(i)]) * b[static_cast<size_t>(j)];
+        }
+        if (dot > best)
+        {
+            best = dot;
+            bestL = lag;
+        }
+    }
+    return bestL;
+}
+
+} // namespace
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    constexpr double sr = 48000.0;
+    constexpr int block = 256;
+    constexpr int numBlocks = 560;      // ~3 s: warmup plus a full down-up sweep
+
+    const Scenario scenarios[] = {
+        { "Opto, oversampled",     CompressorMode::Opto,      true  },
+        { "Opto, native rate",     CompressorMode::Opto,      false },
+        { "Bus, oversampled",      CompressorMode::Bus,       true  },
+        { "Multiband",             CompressorMode::Multiband, true  },
+    };
+
+    // A moving blend of two coherent signals cannot create a step larger than
+    // the static signal's own slew by more than the per-sample ramp increment.
+    // 1.6x leaves room for envelope movement without admitting a click, which
+    // measured 10x-30x over static before the fix.
+    constexpr float kMaxRatio = 1.6f;
+
+    std::cout << std::fixed << std::setprecision(6);
+    std::cout << "\n--- Mix knob ramp / click gate ---\n";
+    std::cout << "  peak |x[n]-x[n-1]| while sweeping Mix, vs the same render held static\n\n";
+
+    int failures = 0;
+    for (const auto& scenario : scenarios)
+    {
+        const SweepResult staticRun = renderSweep(scenario, false, sr, block, numBlocks);
+        const SweepResult sweepRun  = renderSweep(scenario, true,  sr, block, numBlocks);
+        const float ratio = staticRun.peakDelta > 1.0e-9f ? sweepRun.peakDelta / staticRun.peakDelta : 0.0f;
+        const bool ok = ratio <= kMaxRatio;
+        if (! ok)
+            ++failures;
+
+        std::cout << (ok ? "  ok   " : "  FAIL ")
+                  << std::setw(20) << std::left << scenario.name << std::right
+                  << "  static " << std::setw(10) << staticRun.peakDelta
+                  << "  sweep " << std::setw(10) << sweepRun.peakDelta
+                  << "  ratio " << std::setprecision(2) << std::setw(7) << ratio
+                  << std::setprecision(6);
+        if (! ok)
+            std::cout << "   (worst at block " << sweepRun.peakBlock
+                      << ", mix " << std::setprecision(1) << sweepRun.peakMix << "%)"
+                      << std::setprecision(6);
+        std::cout << "\n";
+    }
+
+    // The 0 % endpoint has its own code path (all processing skipped, dry emitted
+    // time-aligned to the reported latency). It must land on exactly the same
+    // samples as the mixer's dry, or crossing into it steps the waveform.
+    std::cout << "\n  0% endpoint alignment (0% path vs 1% mix through the normal path):\n";
+    for (const auto& scenario : scenarios)
+    {
+        constexpr int alignBlocks = 200;
+        const auto zero = renderStatic(scenario, 0.0f, sr, block, alignBlocks);
+        const auto near = renderStatic(scenario, 1.0f, sr, block, alignBlocks);
+        const int lag = bestLag(zero, near, 256, block * 100, block * 50);
+        const bool ok = (lag == 0);
+        if (! ok)
+            ++failures;
+        std::cout << (ok ? "  ok   " : "  FAIL ")
+                  << std::setw(20) << std::left << scenario.name << std::right
+                  << "  lag " << lag << " samples\n";
+    }
+
+    if (g_paramError)
+    {
+        std::cout << "\n  RESULT: FAIL (missing parameter — test config invalid)\n";
+        return 2;
+    }
+
+    std::cout << "\n  RESULT: " << (failures == 0 ? "PASS" : "FAIL")
+              << " (limit: sweep delta <= " << std::setprecision(2) << kMaxRatio
+              << "x static delta)\n";
+    return failures == 0 ? 0 : 1;
+}

--- a/plugins/multi-comp/tests/test_param_fuzz.cpp
+++ b/plugins/multi-comp/tests/test_param_fuzz.cpp
@@ -1,0 +1,126 @@
+/*
+ * Parameter-fuzz gate (pluginval "Fuzz parameters" replica, ASan-friendly).
+ *
+ * pluginval level 10 intermittently died with heap corruption (glibc
+ * "corrupted double-linked list" / free() abort in the host's plugin dtor)
+ * during its parameter fuzz on this plugin. Teardown-time detection means the
+ * scribble happened earlier and elsewhere; repetition converges too slowly at a
+ * ~2-3% incidence. This reproduces the storm deterministically and hard: every
+ * round randomizes EVERY parameter (biased toward the extremes fuzzers love),
+ * processes audio through both the float and double paths with hostile block
+ * sizes (0, 1, tiny, prepared max, oversized), interleaves save/restore,
+ * bypass, and re-prepares with changed rates. Run it under AddressSanitizer
+ * and the first out-of-bounds write aborts with a stack naming the culprit,
+ * instead of a coin-flip crash 30 runs later.
+ *
+ * The plugin instance is created and destroyed once per outer round so the
+ * dtor runs against a freshly-stormed heap, matching where pluginval detected
+ * the corruption.
+ */
+
+#include <JuceHeader.h>
+#include "../UniversalCompressor.h"
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    constexpr int outerRounds = 24;          // plugin lifetimes
+    constexpr int stormsPerRound = 60;       // randomize+process cycles per lifetime
+    juce::Random rng(0xF0220);
+
+    const double rates[] = { 44100.0, 48000.0, 96000.0, 192000.0 };
+    const int preparedBlock = 512;
+    const int blockSizes[] = { 0, 1, 3, 16, 63, 256, 512, 511, 480 };
+
+    juce::MemoryBlock savedState;
+
+    for (int round = 0; round < outerRounds; ++round)
+    {
+        const double sr = rates[rng.nextInt(4)];
+
+        auto plugin = std::make_unique<UniversalCompressor>();
+        plugin->setPlayConfigDetails(2, 2, sr, preparedBlock);
+        plugin->prepareToPlay(sr, preparedBlock);
+
+        const auto& paramList = static_cast<juce::AudioProcessor&>(*plugin).getParameters();
+
+        juce::AudioBuffer<float> buf(2, preparedBlock);
+        juce::AudioBuffer<double> dbuf(2, preparedBlock);
+        juce::MidiBuffer midi;
+
+        for (int storm = 0; storm < stormsPerRound; ++storm)
+        {
+            // Randomize every parameter; bias to the endpoints (fuzzers hammer
+            // 0 and 1, and the bugs live at range edges).
+            for (auto* p : paramList)
+            {
+                const int roll = rng.nextInt(10);
+                const float v = roll == 0 ? 0.0f
+                              : roll == 1 ? 1.0f
+                              : rng.nextFloat();
+                p->setValueNotifyingHost(v);
+            }
+
+            const int n = blockSizes[rng.nextInt(std::size(blockSizes))];
+
+            if (rng.nextInt(4) == 0)
+            {
+                // Double-precision path (chunked conversion buffer)
+                dbuf.clear();
+                for (int ch = 0; ch < 2; ++ch)
+                {
+                    auto* d = dbuf.getWritePointer(ch);
+                    for (int i = 0; i < n; ++i)
+                        d[i] = 0.5 * (rng.nextDouble() * 2.0 - 1.0);
+                }
+                juce::AudioBuffer<double> view(dbuf.getArrayOfWritePointers(), 2, n);
+                plugin->processBlock(view, midi);
+            }
+            else
+            {
+                buf.clear();
+                for (int ch = 0; ch < 2; ++ch)
+                {
+                    auto* d = buf.getWritePointer(ch);
+                    for (int i = 0; i < n; ++i)
+                        d[i] = 0.5f * (rng.nextFloat() * 2.0f - 1.0f);
+                }
+                juce::AudioBuffer<float> view(buf.getArrayOfWritePointers(), 2, n);
+                plugin->processBlock(view, midi);
+            }
+
+            // Interleave the state machinery the validator also exercises.
+            switch (rng.nextInt(12))
+            {
+                case 0:
+                    plugin->getStateInformation(savedState);
+                    break;
+                case 1:
+                    if (savedState.getSize() > 0)
+                        plugin->setStateInformation(savedState.getData(),
+                                                    static_cast<int>(savedState.getSize()));
+                    break;
+                case 2:
+                    plugin->prepareToPlay(rates[rng.nextInt(4)], preparedBlock);
+                    break;
+                case 3:
+                    plugin->setCurrentProgram(rng.nextInt(juce::jmax(1, plugin->getNumPrograms())));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        plugin->releaseResources();
+        plugin.reset();   // dtor against the stormed heap — where pluginval saw it
+    }
+
+    std::cout << "\n--- Parameter fuzz gate ---\n  RESULT: PASS ("
+              << outerRounds << " plugin lifetimes x " << stormsPerRound
+              << " storms survived)\n";
+    return 0;
+}

--- a/plugins/multi-comp/tests/test_preset_levels.cpp
+++ b/plugins/multi-comp/tests/test_preset_levels.cpp
@@ -1,0 +1,134 @@
+/*
+ * Factory-preset level gate.
+ *
+ * "Smooth Opto Vocal" muted the plugin: applyPreset wrote preset.makeup (a dB
+ * figure, 5) straight into "opto_gain", which is a 0-100 dial where 50 = unity
+ * and each unit is 0.8 dB — so 5 landed at -36 dB. The host "Default" program
+ * had the same class of bug (opto_gain set to knob 0 = -40 dB). Below 100 % Mix
+ * the dry path masked it, which is why it read as "silent at 100 %".
+ *
+ * This gate loads EVERY program (Default + all factory presets), pushes noise
+ * through it, and fails if the output level is nowhere near the input. It is
+ * deliberately loose: it is not a voicing check, it catches units-mismatch bugs
+ * that leave a preset unusable.
+ */
+
+#include <JuceHeader.h>
+#include "../UniversalCompressor.h"
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+static void processWithPlugin(UniversalCompressor& plugin, juce::AudioBuffer<float>& buffer, int blockSize)
+{
+    juce::MidiBuffer midi;
+    const int numSamples = buffer.getNumSamples();
+    const int numChannels = buffer.getNumChannels();
+    juce::AudioBuffer<float> block(numChannels, blockSize);
+    for (int offset = 0; offset < numSamples; offset += blockSize)
+    {
+        const int thisBlock = std::min(blockSize, numSamples - offset);
+        for (int ch = 0; ch < numChannels; ++ch)
+            block.copyFrom(ch, 0, buffer, ch, offset, thisBlock);
+        if (thisBlock < blockSize)
+            for (int ch = 0; ch < numChannels; ++ch)
+                block.clear(ch, thisBlock, blockSize - thisBlock);
+        juce::AudioBuffer<float> view(block.getArrayOfWritePointers(), numChannels, thisBlock);
+        plugin.processBlock(view, midi);
+        for (int ch = 0; ch < numChannels; ++ch)
+            buffer.copyFrom(ch, offset, block, ch, 0, thisBlock);
+    }
+}
+
+static float rmsDb(const juce::AudioBuffer<float>& buf, int startSample, int numSamples)
+{
+    double sum = 0.0;
+    for (int ch = 0; ch < buf.getNumChannels(); ++ch)
+    {
+        const float* d = buf.getReadPointer(ch);
+        for (int i = startSample; i < startSample + numSamples; ++i)
+            sum += static_cast<double>(d[i]) * d[i];
+    }
+    const auto n = static_cast<double>(numSamples) * std::max(1, buf.getNumChannels());
+    const double r = std::sqrt(sum / std::max(1.0, n));
+    return r > 1e-12 ? 20.0f * static_cast<float>(std::log10(r)) : -240.0f;
+}
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    constexpr double sr = 48000.0;
+    constexpr int block = 512;
+    constexpr int warmup = 24576;    // envelopes + auto-gain estimator settle
+    constexpr int measure = 49152;
+    constexpr int total = warmup + measure;
+
+    // Deterministic noise at roughly -18 dBFS RMS — hot enough to engage the
+    // presets' thresholds, quiet enough to stay off the output limiter.
+    juce::AudioBuffer<float> input(2, total);
+    juce::Random rng(0x9E5E75);
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        auto* d = input.getWritePointer(ch);
+        for (int i = 0; i < total; ++i)
+            d[i] = 0.22f * (rng.nextFloat() * 2.0f - 1.0f);
+    }
+    const float inDb = rmsDb(input, warmup, measure);
+
+    // Asymmetric on purpose. Losing level is always a bug: no preset has a
+    // reason to be 12 dB down, and the units mismatch this gate was written for
+    // buried the Opto presets 36 dB down. Gaining level can be intentional (FET
+    // presets drive the input hard by design), so only runaway gain — enough to
+    // sit on the output limiter — fails, and anything merely hot is reported.
+    constexpr float kMinDeviationDb  = -12.0f;   // below this: fail (mute class)
+    constexpr float kMaxDeviationDb  =  24.0f;   // above this: fail (runaway)
+    constexpr float kHotWarningDb    =  12.0f;   // above this: report, do not fail
+
+    int numPrograms = 0;
+    {
+        UniversalCompressor probe;
+        numPrograms = probe.getNumPrograms();
+    }
+
+    std::cout << std::fixed << std::setprecision(2);
+    std::cout << "\n--- Factory preset level gate ---\n";
+    std::cout << "  input RMS: " << inDb << " dB, allowed delta "
+              << kMinDeviationDb << " .. " << kMaxDeviationDb
+              << " dB (hot warning above " << kHotWarningDb << " dB)\n\n";
+
+    int failures = 0;
+    int hot = 0;
+    for (int program = 0; program < numPrograms; ++program)
+    {
+        UniversalCompressor plugin;
+        plugin.setPlayConfigDetails(2, 2, sr, block);
+        plugin.prepareToPlay(sr, block);
+        plugin.setCurrentProgram(program);
+
+        juce::AudioBuffer<float> buf;
+        buf.makeCopyOf(input);
+        processWithPlugin(plugin, buf, block);
+
+        const float outDb = rmsDb(buf, warmup, measure);
+        const float delta = outDb - inDb;
+        const bool ok = (delta >= kMinDeviationDb) && (delta <= kMaxDeviationDb);
+        const bool isHot = ok && (delta > kHotWarningDb);
+        if (! ok)
+            ++failures;
+        if (isHot)
+            ++hot;
+
+        std::cout << (ok ? (isHot ? "  hot  " : "  ok   ") : "  FAIL ")
+                  << std::setw(28) << std::left << plugin.getProgramName(program).toStdString()
+                  << std::right << " out " << std::setw(8) << outDb
+                  << " dB   delta " << std::setw(7) << delta << " dB\n";
+    }
+
+    std::cout << "\n  RESULT: " << (failures == 0 ? "PASS" : "FAIL")
+              << " (" << failures << " of " << numPrograms << " programs outside tolerance, "
+              << hot << " hot)\n";
+    return failures == 0 ? 0 : 1;
+}

--- a/plugins/multi-comp/tests/test_state_restore.cpp
+++ b/plugins/multi-comp/tests/test_state_restore.cpp
@@ -1,0 +1,127 @@
+/*
+ * State-restore integrity gate.
+ *
+ * pluginval level 10 intermittently reports a bool parameter not restored after
+ * setStateInformation ("Limit Mode" on the shipped v1.3.2, "Over Easy" on a dev
+ * build — different params, both with a leftover value of ~0.385 where 0 was
+ * expected). This reproduces the validator's sequence deterministically and
+ * many times over, on the message thread and from a background thread, so the
+ * failure stops being a coin flip and names the parameter and value instead.
+ *
+ * Sequence per iteration (mirrors pluginval's state restoration test):
+ *   1. randomize every parameter via setValueNotifyingHost
+ *   2. snapshot getValue() of all parameters + getStateInformation
+ *   3. randomize everything again (so restore has real work to do)
+ *   4. setStateInformation (variant A: same thread, variant B: std::thread)
+ *   5. compare every parameter's getValue() to the snapshot
+ */
+
+#include <JuceHeader.h>
+#include "../UniversalCompressor.h"
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <thread>
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    constexpr double sr = 48000.0;
+    constexpr int block = 512;
+    constexpr int iterations = 200;
+    constexpr float tolerance = 0.01f;   // pluginval uses 0.1; be stricter
+
+    UniversalCompressor plugin;
+    plugin.setPlayConfigDetails(2, 2, sr, block);
+    plugin.prepareToPlay(sr, block);
+
+    // UniversalCompressor::getParameters() shadows the AudioProcessor accessor
+    // and returns the APVTS; the base-class one gives the host-visible list.
+    const auto& paramList = static_cast<juce::AudioProcessor&>(plugin).getParameters();
+
+    juce::Random rng(0x57A7E);
+
+    struct Mismatch { int count = 0; float worst = 0.0f; float expected = 0.0f, actual = 0.0f; };
+    std::map<juce::String, Mismatch> mismatches[2];   // [0]=same thread, [1]=background
+
+    for (int iter = 0; iter < iterations; ++iter)
+    {
+        const int variant = iter % 2;                 // alternate same-thread / background
+
+        // 1. randomize
+        for (auto* p : paramList)
+            p->setValueNotifyingHost(rng.nextFloat());
+
+        // 2. snapshot
+        std::vector<float> expected;
+        expected.reserve(static_cast<size_t>(paramList.size()));
+        for (auto* p : paramList)
+            expected.push_back(p->getValue());
+
+        juce::MemoryBlock state;
+        plugin.getStateInformation(state);
+
+        // 3. scramble
+        for (auto* p : paramList)
+            p->setValueNotifyingHost(rng.nextFloat());
+
+        // 4. restore
+        if (variant == 0)
+        {
+            plugin.setStateInformation(state.getData(), static_cast<int>(state.getSize()));
+        }
+        else
+        {
+            std::thread restorer([&] {
+                plugin.setStateInformation(state.getData(), static_cast<int>(state.getSize()));
+            });
+            restorer.join();
+        }
+
+        // 5. compare immediately — no message-loop pumping, matching a host that
+        // reads back synchronously after restore.
+        for (int i = 0; i < paramList.size(); ++i)
+        {
+            auto* p = paramList[static_cast<int>(i)];
+            const float actual = p->getValue();
+            const float diff = std::abs(actual - expected[static_cast<size_t>(i)]);
+            if (diff > tolerance)
+            {
+                auto& m = mismatches[variant][p->getName(64)];
+                ++m.count;
+                if (diff > m.worst)
+                {
+                    m.worst = diff;
+                    m.expected = expected[static_cast<size_t>(i)];
+                    m.actual = actual;
+                }
+            }
+        }
+    }
+
+    std::cout << std::fixed << std::setprecision(4);
+    std::cout << "\n--- State-restore integrity (" << iterations << " iterations, tolerance "
+              << tolerance << ") ---\n";
+
+    int totalFailures = 0;
+    const char* variantNames[2] = { "same-thread restore", "background-thread restore" };
+    for (int v = 0; v < 2; ++v)
+    {
+        std::cout << "\n  " << variantNames[v] << ":\n";
+        if (mismatches[v].empty())
+            std::cout << "    all parameters restored on every iteration\n";
+        for (const auto& [name, m] : mismatches[v])
+        {
+            totalFailures += m.count;
+            std::cout << "    MISMATCH " << std::setw(24) << std::left << name.toStdString()
+                      << std::right << " x" << m.count
+                      << "  worst: expected " << m.expected << " got " << m.actual << "\n";
+        }
+    }
+
+    std::cout << "\n  RESULT: " << (totalFailures == 0 ? "PASS" : "FAIL")
+              << " (" << totalFailures << " parameter mismatches)\n";
+    return totalFailures == 0 ? 0 : 1;
+}

--- a/plugins/shared/DryWetMixer.h
+++ b/plugins/shared/DryWetMixer.h
@@ -127,6 +127,9 @@ public:
         normalDryCaptured = false;
         lastOversampledSamples = 0;
 
+        // No ramp across a prepare — start settled wherever the host left us.
+        snapMixToTarget();
+
         ready.store(true, std::memory_order_release);
     }
 
@@ -149,6 +152,7 @@ public:
         oversampledDryCaptured = false;
         normalDryCaptured = false;
         lastOversampledSamples = 0;
+        snapMixToTarget();
     }
 
     /**
@@ -271,76 +275,46 @@ public:
     */
     void mixAtOversampledRate(juce::dsp::AudioBlock<float>& oversampledBlock, float mixAmount)
     {
-        // Skip if mix is 100% wet or no dry captured
-        if (mixAmount >= 0.999f || !oversampledDryCaptured)
-        {
-            oversampledDryCaptured = false;
+        setTargetMix(mixAmount);
+
+        if (!oversampledDryCaptured)
             return;
-        }
 
         const int numChannels = static_cast<int>(oversampledBlock.getNumChannels());
         const int numSamples = juce::jmin(static_cast<int>(oversampledBlock.getNumSamples()),
                                           lastOversampledSamples);
 
-        // Skip if mix is 100% dry (just copy dry over wet)
-        if (mixAmount <= 0.001f)
-        {
-            for (int ch = 0; ch < numChannels; ++ch)
-            {
-                float* wet = oversampledBlock.getChannelPointer(static_cast<size_t>(ch));
-                const float* dry = oversampledDryBuffer.getReadPointer(ch);
-                std::memcpy(wet, dry, static_cast<size_t>(numSamples) * sizeof(float));
-            }
-            oversampledDryCaptured = false;
-            return;
-        }
-
-        // Normal mixing: output = wet * mixAmount + dry * (1 - mixAmount)
-        const float wetAmount = mixAmount;
-        const float dryAmount = 1.0f - mixAmount;
-
         // Scale base-rate processing latency to oversampled rate
         const int osProcessingLatency = processingLatencyBase * currentOversamplingFactor;
+        const int delayToApply = juce::jlimit(0, MAX_OS_DELAY_SAMPLES - 1, osProcessingLatency);
+        const int channelsToProcess = juce::jmin(numChannels, MAX_CHANNELS);
+        const double osRate = baseSampleRate * currentOversamplingFactor;
 
-        if (osProcessingLatency <= 0)
+        // ONE loop for every case. The endpoints are not special-cased: at a
+        // settled mix of 1.0 the dry term multiplies by exactly 0 (bit-identical
+        // wet passthrough) and at 0.0 the wet term does, so nothing jumps when
+        // the knob crosses an endpoint. The ring is written unconditionally so
+        // the delayed dry is never stale when the mix comes back off 100 % wet
+        // — reading it back at delayToApply == 0 returns the sample just
+        // written, which is the undelayed dry.
+        for (int i = 0; i < numSamples; ++i)
         {
-            // No processing delay — direct crossfade (zero overhead)
-            for (int ch = 0; ch < numChannels; ++ch)
+            const int readPos = (osDelayWritePos - delayToApply + MAX_OS_DELAY_SAMPLES) & OS_DELAY_MASK;
+            const float wetAmount = advanceMix(osRate);
+            const float dryAmount = 1.0f - wetAmount;
+
+            for (int ch = 0; ch < channelsToProcess; ++ch)
             {
                 float* wet = oversampledBlock.getChannelPointer(static_cast<size_t>(ch));
                 const float* dry = oversampledDryBuffer.getReadPointer(ch);
 
-                for (int i = 0; i < numSamples; ++i)
-                {
-                    wet[i] = wet[i] * wetAmount + dry[i] * dryAmount;
-                }
+                osDelayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(osDelayWritePos)] = dry[i];
+                const float delayedDry = osDelayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(readPos)];
+
+                wet[i] = wet[i] * wetAmount + delayedDry * dryAmount;
             }
-        }
-        else
-        {
-            // Delay-compensated crossfade: delay the dry signal to align with
-            // the wet processing chain's group delay, preventing comb filtering
-            const int delayToApply = juce::jmin(osProcessingLatency, MAX_OS_DELAY_SAMPLES - 1);
-            const int channelsToProcess = juce::jmin(numChannels, MAX_CHANNELS);
 
-            for (int i = 0; i < numSamples; ++i)
-            {
-                int readPos = (osDelayWritePos - delayToApply + MAX_OS_DELAY_SAMPLES) & OS_DELAY_MASK;
-
-                for (int ch = 0; ch < channelsToProcess; ++ch)
-                {
-                    float* wet = oversampledBlock.getChannelPointer(static_cast<size_t>(ch));
-                    const float* dry = oversampledDryBuffer.getReadPointer(ch);
-
-                    // Write current dry sample into ring buffer, read delayed
-                    float delayedDry = osDelayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(readPos)];
-                    osDelayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(osDelayWritePos)] = dry[i];
-
-                    wet[i] = wet[i] * wetAmount + delayedDry * dryAmount;
-                }
-
-                osDelayWritePos = (osDelayWritePos + 1) & OS_DELAY_MASK;
-            }
+            osDelayWritePos = (osDelayWritePos + 1) & OS_DELAY_MASK;
         }
 
         // Clear flag after mixing (must capture again next block)
@@ -385,73 +359,37 @@ public:
     */
     void mixAtNormalRate(juce::AudioBuffer<float>& buffer, float mixAmount)
     {
-        if (!normalDryCaptured || mixAmount >= 0.999f)
-        {
-            normalDryCaptured = false;
+        setTargetMix(mixAmount);
+
+        if (!normalDryCaptured)
             return;
-        }
 
         const int numChannels = juce::jmin(buffer.getNumChannels(), normalDryBuffer.getNumChannels());
         const int numSamples = juce::jmin(buffer.getNumSamples(), lastNormalSamples);
         const int totalDelay = oversamplingLatency + additionalLatency + processingLatencyBase;
+        const int delayToApply = juce::jlimit(0, MAX_DELAY_SAMPLES - 1, totalDelay);
+        const int channelsToProcess = juce::jmin(numChannels, MAX_CHANNELS);
 
-        // Skip if mix is 100% dry (just copy dry over wet)
-        if (mixAmount <= 0.001f)
+        // Single loop, endpoints included — see mixAtOversampledRate for why the
+        // fast paths are gone and why the ring is written unconditionally.
+        for (int i = 0; i < numSamples; ++i)
         {
-            for (int ch = 0; ch < numChannels; ++ch)
-            {
-                float* wet = buffer.getWritePointer(ch);
-                const float* dry = normalDryBuffer.getReadPointer(ch);
-                std::memcpy(wet, dry, static_cast<size_t>(numSamples) * sizeof(float));
-            }
-            normalDryCaptured = false;
-            return;
-        }
+            const int readPos = (delayWritePos - delayToApply + MAX_DELAY_SAMPLES) & DELAY_MASK;
+            const float wetAmount = advanceMix(baseSampleRate);
+            const float dryAmount = 1.0f - wetAmount;
 
-        const float wetAmount = mixAmount;
-        const float dryAmount = 1.0f - mixAmount;
-
-        // If no delay needed, simple mix
-        if (totalDelay <= 0)
-        {
-            for (int ch = 0; ch < numChannels; ++ch)
+            for (int ch = 0; ch < channelsToProcess; ++ch)
             {
                 float* wet = buffer.getWritePointer(ch);
                 const float* dry = normalDryBuffer.getReadPointer(ch);
 
-                for (int i = 0; i < numSamples; ++i)
-                {
-                    wet[i] = wet[i] * wetAmount + dry[i] * dryAmount;
-                }
+                delayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(delayWritePos)] = dry[i];
+                const float delayedDry = delayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(readPos)];
+
+                wet[i] = wet[i] * wetAmount + delayedDry * dryAmount;
             }
-        }
-        else
-        {
-            // Apply delay compensation via ring buffer
-            const int delayToApply = juce::jmin(totalDelay, MAX_DELAY_SAMPLES - 1);
-            const int channelsToProcess = juce::jmin(numChannels, MAX_CHANNELS);
 
-            for (int i = 0; i < numSamples; ++i)
-            {
-                // Calculate read position (circular) - use bitwise AND for efficient wraparound
-                int readPos = (delayWritePos - delayToApply + MAX_DELAY_SAMPLES) & DELAY_MASK;
-
-                for (int ch = 0; ch < channelsToProcess; ++ch)
-                {
-                    float* wet = buffer.getWritePointer(ch);
-                    const float* dry = normalDryBuffer.getReadPointer(ch);
-
-                    // Read delayed sample, write current to delay line
-                    float delayedDry = delayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(readPos)];
-                    delayBuffer[static_cast<size_t>(ch)][static_cast<size_t>(delayWritePos)] = dry[i];
-
-                    // Mix with delayed dry
-                    wet[i] = wet[i] * wetAmount + delayedDry * dryAmount;
-                }
-
-                // Advance write position (bitwise AND for efficient wraparound)
-                delayWritePos = (delayWritePos + 1) & DELAY_MASK;
-            }
+            delayWritePos = (delayWritePos + 1) & DELAY_MASK;
         }
 
         normalDryCaptured = false;
@@ -476,7 +414,66 @@ public:
     */
     bool hasNormalDry() const { return normalDryCaptured; }
 
+    /**
+        Sets the mix the ramp is heading towards (0.0 = 100% dry, 1.0 = 100% wet).
+        Called for you by the mix functions; call it directly only to retarget
+        without processing a block.
+    */
+    void setTargetMix(float mixAmount)
+    {
+        mixTarget = juce::jlimit(0.0f, 1.0f, mixAmount);
+    }
+
+    /**
+        Snaps the ramp to its target. Use on prepare/reset or any discontinuity
+        (preset load, transport relocate) where a ramp would be pointless.
+    */
+    void snapMixToTarget() { mixCurrent = mixTarget; }
+
+    /**
+        True while the ramp is still travelling. The host processor must keep
+        capturing dry while this is true, even at a target of 100% wet, or the
+        remainder of the ramp has nothing to blend against.
+    */
+    bool isMixSmoothing() const { return mixCurrent != mixTarget; }
+
+    /** Current (ramped) mix value — what the last processed sample actually used. */
+    float getCurrentMix() const { return mixCurrent; }
+
+    /** Ramp length in seconds. Default 20 ms: inaudible steps, still snappy. */
+    void setMixRampSeconds(double seconds) { mixRampSeconds = juce::jmax(1.0e-4, seconds); }
+
 private:
+    //==============================================================================
+    // Mix ramp
+    //==============================================================================
+
+    /**
+        Advances the linear mix ramp by one sample at the given rate and returns
+        the value to use. Rate is a parameter rather than state because the same
+        ramp is advanced at base rate (tier 2) or oversampled rate (tier 1), and
+        the ramp must last the same wall-clock time either way.
+    */
+    float advanceMix(double rate)
+    {
+        if (mixCurrent == mixTarget)
+            return mixCurrent;
+
+        const float maxStep = static_cast<float>(1.0 / (mixRampSeconds * juce::jmax(1.0, rate)));
+        const float diff = mixTarget - mixCurrent;
+
+        if (std::abs(diff) <= maxStep)
+            mixCurrent = mixTarget;
+        else
+            mixCurrent += (diff > 0.0f ? maxStep : -maxStep);
+
+        return mixCurrent;
+    }
+
+    float mixTarget{1.0f};
+    float mixCurrent{1.0f};
+    double mixRampSeconds{0.02};
+
     //==============================================================================
     // Buffer Management
     //==============================================================================


### PR DESCRIPTION
Seven fixes for Multi-Comp, all pre-existing in v1.3.2 (none introduced by #126). Three came from Marc's ear reports; four more surfaced while measuring those. Every fix ships with a gate that fails on the old code.

## Reported

**Opto goes silent.** `applyPreset` wrote `preset.makeup` (a dB value) straight into `opto_gain`, which is a 0-100 dial where 50 is unity and one unit is 0.8 dB. "Smooth Opto Vocal" (makeup 5) applied -36 dB; "Vintage Pinned Bass" (6) applied -35.2 dB. The host "Default" program had the same bug via knob 0 = -40 dB. Below 100% Mix the dry path masked it, which is why it read as "silent at 100%". Dates to Dec 2025. Adds `OptoGainMapping.h` and routes all four conversion sites through it.

| Program | before | after |
|---|---|---|
| Default | -41.3 dB | -1.4 dB |
| Smooth Opto Vocal | -39.5 dB | +1.6 dB |
| Vintage Pinned Bass | -40.1 dB | +1.1 dB |

**Mix knob clicks.** Three stacked causes: the mix was read once per block and applied as a constant gain; the dry delay ring only advanced while mixing was active, so it went stale at 100% wet and jumped on re-entry; and the 0%-mix early return skipped the whole chain, starving the oversampler's FIR state (leaving 0% resumed from stale filter history). Now a 20 ms per-sample ramp in both `DryWetMixer` tiers plus the multiband blend, ring fed unconditionally, no special-cased endpoints, and 0% runs the normal path (which already yields exact dry, correctly aligned).

Peak sample-to-sample step while sweeping Mix, against the same render held static: **47-66x -> 1.0-1.4x**. Multiband's 0% endpoint was also 58 samples misaligned; now 0.

**Auto-gain pumps and jumps.** It inverted gain reduction through a ~200 ms smoother, which sits inside the pumping band: the makeup rode the compression envelope and partially undid it. It stepped on mode/preset change (`setCurrentAndTargetValue`), and being blind to everything after the gain cell it needed a hand-tuned -1.5 dB fudge for the Opto's tube and transformer. Replaced with `AutoGainMatcher`: 2 s input/output level matching, +/-12 dB clamp, silence floor. The mix scaling is gone too, since output is measured after the blend. Collapses the two duplicated auto-gain blocks into one.

Makeup movement over a loud/quiet cycle: VCA 8.48 -> 2.23 dB, Digital 8.11 -> 2.07, Multiband 6.72 -> 1.34, StudioVCA 4.80 -> 2.08, FET 3.68 -> 0.05, Opto 2.93 -> 0.39, Bus 2.65 -> 0.17. Settled output now within 0.23 dB of input on all 7 modes (Multiband was 1.60 dB off).

## Found while measuring

**Bool parameters read back unsnapped.** `juce::AudioParameterBool::setValue` stores the raw normalized float and `getValue()` returns it raw, while Choice/Int snap and the APVTS round-trip snaps. A host writes 0.4964, reads 0.4964 live, reads 0.0 after restore - which is exactly what pluginval L10 compares, hence the intermittent "Limit Mode / Over Easy not restored" failures (reproduced on shipped v1.3.2 too). `SnappingBoolParameter` snaps in `setValue`; a sibling rather than a subclass because `AudioParameterBool::setValue` is private. Same IDs, same 0/1 tree values, so sessions load unchanged. **3887 -> 0** mismatches over 200 iterations.

**Heap overflow after a sample-rate re-prepare.** pluginval L10 died with `corrupted double-linked list` roughly 1 run in 30. ASan pinned it: `LookaheadBuffer::prepare` reset write positions with `resize(n, 0)`, which only initializes new elements, so after a re-prepare at a lower rate the ring shrinks while stale indices survive and the first sample writes past the allocation. The scribble only surfaced at teardown, which is why it looked random. Fixed with `assign()` plus a clamp in `processSample`. The new fuzz gate crashes v1.3.2 in seconds and passes clean here, plain and under ASan.

**Three FET presets ran hot.** Vocal Presence, Room Nuke and Rock Bass Anchor drive `fet_input` hard for character but never compensated on output, landing +16.5 / +21.1 / +14.5 dB over input. Baked the classic FET output trim into preset makeup (+4 -> -11, +12 -> -8, +5 -> -8); now +1.6 / +3.2 / +1.5 dB. Character untouched - only the clean output trim moved.

**Mode-local mix params stepped.** `bus_mix` and `digital_mix` are per-sample blends fed a block-constant value (automation-only exposure; no UI binds them). Now ramped like the global Mix. Also documented two pre-existing gaps: `studio_vca_mix` is dead (nothing reads it), and `processStereoLinked` has no mix argument so `bus_mix` is ignored when Bus stereo link is engaged.

## Gates added

`MultiCompPresetLevelTest`, `MultiCompMixRampTest`, `MultiCompAutoGainTest`, `MultiCompStateRestoreTest`, `MultiCompParamFuzzTest` - plus a `multicomp_add_functional_test()` CMake function replacing the copy-pasted per-test blocks.

Verification: all 7 gates pass; pluginval L1/5/7/10 9/9 plus **30/30 clean L10 repeats** on the final binary (was ~1-in-6 restore failures and ~1-in-30 crashes); before/after numbers above measured against a v1.3.2 control build.

## Follow-ups (not this PR)

- Every other JUCE plugin has the same `AudioParameterBool` quirk (multi-q 19 uses, DuskVerb 9, 4k-eq 8, convolution-reverb 7, TapeMachine 4, tape-echo 4, chord-analyzer 2, spectrum-analyzer 1). Fleet fix: lift `SnappingBoolParameter` into `plugins/shared/`.
- `bus_mix` under Bus stereo link, and the dead `studio_vca_mix`, need a design decision on how they stack with the global Mix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RMS-based automatic gain matching for more consistent output levels.
  * Added smooth, time-based mix transitions to reduce clicks during mix changes.
  * Improved Opto gain control mapping and updated related factory presets.

* **Bug Fixes**
  * Improved stability during mode changes, state restoration, resizing, and unusual processing conditions.
  * Removed an unused studio mix parameter.

* **Tests**
  * Added coverage for auto-gain stability, mix-ramp clicks, preset levels, state restoration, and parameter stress scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->