### PR TITLE
remove dead vca_mix and fix bus_mix ignored when stereo link active

### DIFF
--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -2774,12 +2774,13 @@ public:
         // Apply makeup gain
         float output = processed * juce::Decibels::decibelsToGain(makeupGain);
 
-        // Note: Mix/parallel compression is now handled globally at the end of processBlock
-        // for consistency across all compressor modes (mixAmount parameter kept for API compatibility)
-        (void)mixAmount;  // Suppress unused warning
-
-        // Final output limiting
-        return juce::jlimit(-Constants::OUTPUT_HARD_LIMIT, Constants::OUTPUT_HARD_LIMIT, output);
+        // Local Bus mix (parallel): blend the untransformed input against the
+        // full wet chain, then let the caller apply its native-rate compensation.
+        // Applied here as well as in processStereoLinked so bus_mix behaves
+        // identically with or without stereo link; the global "mix" still wraps
+        // this blend downstream via dryWetMixer.
+        const float wet = juce::jlimit(-Constants::OUTPUT_HARD_LIMIT, Constants::OUTPUT_HARD_LIMIT, output);
+        return wet * mixAmount + input * (1.0f - mixAmount);
     }
 
     // Stereo-linked bus processing — true British bus behaviour: the sidechain is
@@ -2793,7 +2794,9 @@ public:
     void processStereoLinked (float* dataL, float* dataR, int numSamples,
                               float threshold, float ratio,
                               int attackIndex, int releaseIndex,
-                              float makeupGain, float postGain, float stereoLinkAmount,
+                              float makeupGain, float postGain,
+                              const float* mixCurve, int mixCurveSize,
+                              float stereoLinkAmount,
                               const float* extScL, const float* extScR,
                               bool useExternalSidechain)
     {
@@ -2854,8 +2857,10 @@ public:
 
         for (int i = 0; i < numSamples; ++i)
         {
-            const float tL = inputTransformer.processSample (dataL[i], 0);
-            const float tR = inputTransformer.processSample (dataR[i], 1);
+            const float dryL = dataL[i];
+            const float dryR = dataR[i];
+            const float tL = inputTransformer.processSample (dryL, 0);
+            const float tR = inputTransformer.processSample (dryR, 1);
 
             // Per-channel RMS detection (external or HP-filtered feedback), each
             // blended toward the pair's max by the link amount.
@@ -2873,8 +2878,16 @@ public:
             dL.prevCompressed = cL;   // feedback taps
             dR.prevCompressed = cR;
 
-            dataL[i] = outStage (cL, 0, makeupGain) * postGain;
-            dataR[i] = outStage (cR, 1, makeupGain) * postGain;
+            const float wetL = outStage (cL, 0, makeupGain);
+            const float wetR = outStage (cR, 1, makeupGain);
+            const float mixAmount = mixCurve[static_cast<size_t>(
+                juce::jmin(i, mixCurveSize - 1))];
+
+            // Local Bus mix is inside the global Mix: blend the untransformed
+            // input against the complete compressed/output-stage signal, then
+            // apply the caller's native-rate compensation to the whole blend.
+            dataL[i] = (wetL * mixAmount + dryL * (1.0f - mixAmount)) * postGain;
+            dataR[i] = (wetR * mixAmount + dryR * (1.0f - mixAmount)) * postGain;
         }
     }
 
@@ -4796,9 +4809,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout UniversalCompressor::createP
         "studio_vca_output", "Output",
         juce::NormalisableRange<float>(-20.0f, 20.0f, 0.1f), 0.0f));
     // DEAD PARAMETER: nothing reads "studio_vca_mix" — Studio VCA uses the
-    // global "mix". Kept in the layout because removing a parameter breaks
-    // session/state compatibility; do not wire it up without also deciding how
-    // it stacks with the global Mix (see bus_mix/digital_mix, which multiply).
+    // global "mix". Keep it in the JUCE layout for saved-session compatibility;
+    // do not wire or remove it here. It is intentionally dropped by the DPF port
+    // in #130, where JUCE session compatibility no longer applies.
     layout.add(std::make_unique<juce::AudioParameterFloat>(
         "studio_vca_mix", "Mix",
         juce::NormalisableRange<float>(0.0f, 100.0f, 1.0f), 100.0f));  // Parallel compression
@@ -6542,15 +6555,13 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                     {
                         // True console stereo link (oversampled path): shared sidechain
                         // drives both VCAs. No compensationGain here (postGain=1).
-                        // KNOWN GAP: this path has no mix argument, so bus_mix is
-                        // silently ignored whenever stereo link is engaged (the
-                        // per-channel branch below honours it). Pre-existing; no
-                        // UI binds bus_mix, so exposure is automation-only.
                         busCompressor->processStereoLinked(
                             oversampledBlock.getChannelPointer(static_cast<size_t>(0)), oversampledBlock.getChannelPointer(static_cast<size_t>(1)), osNumSamples,
                             cachedParams[0], cachedParams[1],
                             static_cast<int>(cachedParams[2]), static_cast<int>(cachedParams[3]),
-                            cachedParams[4], 1.0f, stereoLinkAmount,
+                            cachedParams[4], 1.0f,
+                            modeMixCurve.data(), static_cast<int>(modeMixCurve.size()),
+                            stereoLinkAmount,
                             interpolatedSidechain.getReadPointer(0),
                             interpolatedSidechain.getReadPointer(juce::jmin(1, interpolatedSidechain.getNumChannels() - 1)),
                             hasExternalSidechain);
@@ -6690,7 +6701,9 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
                             buffer.getWritePointer(0), buffer.getWritePointer(1), numSamples,
                             cachedParams[0], cachedParams[1],
                             static_cast<int>(cachedParams[2]), static_cast<int>(cachedParams[3]),
-                            cachedParams[4], compensationGain, stereoLinkAmount,
+                            cachedParams[4], compensationGain,
+                            modeMixCurve.data(), static_cast<int>(modeMixCurve.size()),
+                            stereoLinkAmount,
                             linkedSidechain.getReadPointer(0), linkedSidechain.getReadPointer(1),
                             hasExternalSidechain);
                     }

--- a/plugins/multi-comp/tests/test_mix_ramp_click.cpp
+++ b/plugins/multi-comp/tests/test_mix_ramp_click.cpp
@@ -16,14 +16,20 @@
  * The measure is the peak |x[n] - x[n-1]| over the sweep, compared against the
  * same figure from a static render (no knob movement) of the same signal. Any
  * excess is the click.
+ *
+ * The Bus compressor also has an automation-only local mix. Its stereo-linked
+ * path once ignored that parameter entirely, so this gate additionally checks
+ * the local dry/full-wet endpoints and its 20 ms automation ramp.
  */
 
 #include <JuceHeader.h>
 #include "../UniversalCompressor.h"
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 namespace
@@ -56,6 +62,163 @@ struct SweepResult
     int   peakBlock = -1;
     float peakMix = -1.0f;    // Mix target in effect when the worst step happened
 };
+
+struct BusRender
+{
+    std::vector<float> inputL;
+    std::vector<float> inputR;
+    std::vector<float> outputL;
+    std::vector<float> outputR;
+};
+
+void configureBus(UniversalCompressor& plugin, bool oversampling, float stereoLink,
+                  float busMix, double sr, int block)
+{
+    plugin.setPlayConfigDetails(2, 2, sr, block);
+    plugin.setInternalOversamplingEnabled(oversampling);
+    plugin.prepareToPlay(sr, block);
+
+    setParam(plugin, "mode", static_cast<float>(static_cast<int>(CompressorMode::Bus)));
+    setParam(plugin, "auto_makeup", 0.0f);
+    setParam(plugin, "mix", 100.0f);
+    setParam(plugin, "noise_enable", 0.0f);
+    setParam(plugin, "stereo_link_mode", 0.0f);
+    setParam(plugin, "stereo_link", stereoLink);
+    setParam(plugin, "bus_threshold", -24.0f);
+    setParam(plugin, "bus_ratio", 2.0f);
+    setParam(plugin, "bus_attack", 0.0f);
+    setParam(plugin, "bus_release", 0.0f);
+    setParam(plugin, "bus_makeup", 6.0f);
+    setParam(plugin, "bus_mix", busMix);
+}
+
+BusRender renderBus(float stereoLink, float busMix, bool oversampling,
+                    double sr, int block, int numBlocks,
+                    float targetBusMix = -1.0f, int changeBlock = -1)
+{
+    UniversalCompressor plugin;
+    configureBus(plugin, oversampling, stereoLink, busMix, sr, block);
+
+    juce::MidiBuffer midi;
+    juce::AudioBuffer<float> buf(2, block);
+    juce::Random rng(0x129B05);
+
+    BusRender result;
+    const auto total = static_cast<size_t>(block) * static_cast<size_t>(numBlocks);
+    result.inputL.reserve(total);
+    result.inputR.reserve(total);
+    result.outputL.reserve(total);
+    result.outputR.reserve(total);
+
+    for (int b = 0; b < numBlocks; ++b)
+    {
+        if (b == changeBlock && targetBusMix >= 0.0f)
+            setParam(plugin, "bus_mix", targetBusMix);
+
+        for (int i = 0; i < block; ++i)
+        {
+            // Keep both channels identical so the link itself cannot introduce
+            // an unrelated image shift into the endpoint/control comparisons.
+            const float s = 0.55f * (rng.nextFloat() * 2.0f - 1.0f);
+            buf.setSample(0, i, s);
+            buf.setSample(1, i, s);
+            result.inputL.push_back(s);
+            result.inputR.push_back(s);
+        }
+
+        plugin.processBlock(buf, midi);
+        const float* outL = buf.getReadPointer(0);
+        const float* outR = buf.getReadPointer(1);
+        for (int i = 0; i < block; ++i)
+        {
+            result.outputL.push_back(outL[i]);
+            result.outputR.push_back(outR[i]);
+        }
+    }
+
+    return result;
+}
+
+float maxAbsDiffFrom(const std::vector<float>& a, const std::vector<float>& b, size_t start)
+{
+    if (a.size() != b.size() || start > a.size())
+        return std::numeric_limits<float>::infinity();
+
+    float peak = 0.0f;
+    for (size_t i = start; i < a.size(); ++i)
+        peak = juce::jmax(peak, std::abs(a[i] - b[i]));
+    return peak;
+}
+
+bool byteEqualFrom(const std::vector<float>& a, const std::vector<float>& b, size_t start)
+{
+    return a.size() == b.size() && start <= a.size()
+        && std::memcmp(a.data() + start, b.data() + start,
+                       (a.size() - start) * sizeof(float)) == 0;
+}
+
+/** Renders the automation-only Bus mix while stereo link is engaged. */
+SweepResult renderLinkedBusMixSweep(bool oversampling, bool moveMix,
+                                    double sr, int block, int numBlocks)
+{
+    UniversalCompressor plugin;
+    configureBus(plugin, oversampling, 100.0f, 100.0f, sr, block);
+
+    juce::MidiBuffer midi;
+    juce::AudioBuffer<float> buf(2, block);
+    const double phaseInc = 2.0 * juce::MathConstants<double>::pi * 220.0 / sr;
+    double phase = 0.0;
+
+    SweepResult result;
+    float previous = 0.0f;
+    bool havePrevious = false;
+    float currentMix = 100.0f;
+    constexpr int warmupBlocks = 48;
+
+    for (int b = 0; b < numBlocks; ++b)
+    {
+        if (moveMix && b >= warmupBlocks)
+        {
+            const float t = static_cast<float>(b - warmupBlocks)
+                          / static_cast<float>(std::max(1, numBlocks - warmupBlocks - 1));
+            const float triangle = t < 0.5f ? (1.0f - 2.0f * t) : (2.0f * t - 1.0f);
+            currentMix = juce::jlimit(0.0f, 100.0f, triangle * 100.0f);
+            setParam(plugin, "bus_mix", currentMix);
+        }
+
+        for (int i = 0; i < block; ++i)
+        {
+            const float s = static_cast<float>(0.35 * std::sin(phase));
+            phase += phaseInc;
+            buf.setSample(0, i, s);
+            buf.setSample(1, i, s);
+        }
+
+        plugin.processBlock(buf, midi);
+
+        if (b >= warmupBlocks)
+        {
+            const float* out = buf.getReadPointer(0);
+            for (int i = 0; i < block; ++i)
+            {
+                if (havePrevious)
+                {
+                    const float delta = std::abs(out[i] - previous);
+                    if (delta > result.peakDelta)
+                    {
+                        result.peakDelta = delta;
+                        result.peakBlock = b;
+                        result.peakMix = currentMix;
+                    }
+                }
+                previous = out[i];
+                havePrevious = true;
+            }
+        }
+    }
+
+    return result;
+}
 
 /** Renders a sine while stepping Mix once per block; returns peak sample delta. */
 SweepResult renderSweep(const Scenario& scenario, bool moveKnob, double sr, int block, int numBlocks)
@@ -266,6 +429,74 @@ int main()
         std::cout << (ok ? "  ok   " : "  FAIL ")
                   << std::setw(20) << std::left << scenario.name << std::right
                   << "  lag " << lag << " samples\n";
+    }
+
+    std::cout << "\n  Bus local mix under stereo link:\n";
+
+    // At native rate the Bus-local dry endpoint must return the exact samples
+    // presented to the Bus core. This is deliberately a byte comparison.
+    const auto busDry = renderBus(100.0f, 0.0f, false, sr, block, 64);
+    constexpr size_t dryCompareStart = static_cast<size_t>(8 * block);
+    const bool dryL = byteEqualFrom(busDry.inputL, busDry.outputL, dryCompareStart);
+    const bool dryR = byteEqualFrom(busDry.inputR, busDry.outputR, dryCompareStart);
+    const float dryMaxError = juce::jmax(
+        maxAbsDiffFrom(busDry.inputL, busDry.outputL, dryCompareStart),
+        maxAbsDiffFrom(busDry.inputR, busDry.outputR, dryCompareStart));
+    constexpr float dryTolerance = 1.0e-7f;
+    const bool dryOk = (dryL && dryR) || dryMaxError <= dryTolerance;
+    if (! dryOk)
+        ++failures;
+    std::cout << (dryOk ? "  ok   " : "  FAIL ")
+              << std::setw(28) << std::left << "0% local mix = dry (native)" << std::right
+              << "  byte-equal L/R: " << (dryL ? "yes" : "no") << "/" << (dryR ? "yes" : "no")
+              << "  max error " << std::scientific << std::setprecision(3) << dryMaxError
+              << " (tol " << dryTolerance << ")" << std::fixed << std::setprecision(6) << "\n";
+
+    // A local-dry render must keep running the complete wet chain: the detector
+    // feedback and output-stage state stay pre-blend. Once its 20 ms ramp reaches
+    // 100%, it must therefore byte-null against a control held full-wet throughout.
+    for (const bool oversampling : { false, true })
+    {
+        constexpr int changeBlock = 16;
+        constexpr int compareBlock = 24;  // 8 blocks later: safely past the 20 ms ramp
+        const auto control = renderBus(100.0f, 100.0f, oversampling, sr, block, 96);
+        const auto linked  = renderBus(100.0f,   0.0f, oversampling, sr, block, 96,
+                                      100.0f, changeBlock);
+        const size_t compareSample = static_cast<size_t>(compareBlock) * static_cast<size_t>(block);
+        const float diff = juce::jmax(maxAbsDiffFrom(control.outputL, linked.outputL, compareSample),
+                                      maxAbsDiffFrom(control.outputR, linked.outputR, compareSample));
+        const bool ok = diff == 0.0f;
+        if (! ok)
+            ++failures;
+        std::cout << (ok ? "  ok   " : "  FAIL ")
+                  << std::setw(28) << std::left
+                  << (oversampling ? "100% local mix (oversampled)" : "100% local mix (native)")
+                  << std::right << "  post-ramp control delta " << diff
+                  << " (byte-null)\n";
+    }
+
+    constexpr float busMixMaxRatio = 1.4f;
+    for (const bool oversampling : { false, true })
+    {
+        const SweepResult staticRun = renderLinkedBusMixSweep(oversampling, false, sr, block, numBlocks);
+        const SweepResult sweepRun  = renderLinkedBusMixSweep(oversampling, true,  sr, block, numBlocks);
+        const float ratio = staticRun.peakDelta > 1.0e-9f
+                          ? sweepRun.peakDelta / staticRun.peakDelta : 0.0f;
+        const bool ok = ratio <= busMixMaxRatio;
+        if (! ok)
+            ++failures;
+        std::cout << (ok ? "  ok   " : "  FAIL ")
+                  << std::setw(28) << std::left
+                  << (oversampling ? "local mix sweep (oversampled)" : "local mix sweep (native)")
+                  << std::right << "  static " << staticRun.peakDelta
+                  << "  sweep " << sweepRun.peakDelta
+                  << "  ratio " << std::setprecision(2) << ratio
+                  << std::setprecision(6);
+        if (! ok)
+            std::cout << " (worst block " << sweepRun.peakBlock
+                      << ", bus_mix " << std::setprecision(1) << sweepRun.peakMix << "%)"
+                      << std::setprecision(6);
+        std::cout << "\n";
     }
 
     if (g_paramError)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Bus compressor mix handling in stereo-linked processing.
  * Bus mix changes now apply consistently in both oversampled and standard processing.
  * Improved dry/wet transitions to prevent audible clicks during mix automation.
  * Removed the unused Studio VCA mix control while preserving existing global mix settings.

* **Tests**
  * Added coverage for dry, wet, stereo-linked, oversampled, and automated Bus mix behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->