### PR TITLE
TapeMachine 2: fix invalid LV2 TTL from inch-mark head-width labels

### DIFF
--- a/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineParams.hpp
@@ -85,7 +85,12 @@ namespace tmparams
     static constexpr const char* kCalibration[] = { "+3dB", "+6dB", "+7.5dB", "+9dB" };
     static constexpr const char* kOffOn[]       = { "Off", "On" };
     static constexpr const char* kOversampling[]= { "1x", "2x", "4x" };
-    static constexpr const char* kHeadWidth[]   = { "1/4\"", "1/2\"", "1\"" };   // American head stack
+    // Inch marks use U+2033 DOUBLE PRIME, not an ASCII quote: DPF's LV2 TTL
+    // writer wraps any label containing an ASCII '"' in Turtle long-quotes, and a
+    // label ENDING in '"' produces """1/4"""" — four quotes — which is an invalid
+    // Turtle string (Ardour: "no ports"; Reaper: "invalid character in quote").
+    // The prime renders identically as the inch mark and dodges the writer bug.
+    static constexpr const char* kHeadWidth[]   = { "1/4″", "1/2″", "1″" };   // American head stack
 
     template <int N> static constexpr int count(const char* const (&)[N]) { return N; }
 }


### PR DESCRIPTION
TapeMachine 2's LV2 build produces an invalid `tape_machine_2.ttl`, so strict hosts reject the plugin:

- **Ardour** (serd): `Ignoring invalid LV2 plugin (missing name, no ports)`
- **Reaper**: `tape_machine_2.ttl: turtle parse error @ line 388: invalid character in quote`

Both are the same malformed file - Ardour just fails the whole parse so it reports no ports. Affects every released TM2 (1.0.0-1.0.3).

## Cause

The Head Width choice labels were `1/4"` / `1/2"` / `1"`, each ending in an ASCII double quote. DPF's LV2 TTL writer wraps any label containing a `"` in Turtle long-quotes (`"""..."""`), so a label ending in `"` emits `"""1/4""""` - four consecutive quotes - which is not a valid Turtle string. That is line 388, exactly where Reaper points.

## Fix

Use U+2033 DOUBLE PRIME (`″`) instead of the ASCII quote in `kHeadWidth`. It renders identically as the inch mark, is valid UTF-8 in Turtle, and does not trip DPF's `contains('"')` long-quote path, so the label emits as a plain `"1/4″"`. Head Width is stored as an int index, so no state, preset or UI code depends on the label text.

## Verified

- Regenerated `tape_machine_2.ttl`: labels now `rdfs:label "1/4″"`, **zero** `""""` sequences, parses clean under raptor and rdflib.
- All three formats (VST3 / CLAP / LV2) build.
- Confirmed the currently-shipped TTL is the one that broke (`"""1/4""""` at line 388 col 37).

The underlying DPF writer bug (no escaping for a label ending in `"`) is upstream; dodged here rather than patched because CI clones a pinned DPF. Rule going forward: no ASCII `"` in DPF choice labels - use `″` for inches. Other DPF plugins were grep-clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated head-width labels to use the correct inch mark symbol, improving display consistency and avoiding malformed text in exported data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->