### PR TITLE
134 tm2   updates

### DIFF
--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -218,6 +218,7 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     m_driveDecaySm  = 1.0f;   // neutral (no below-anchor decay until the signal drops below -12)
     vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     inPeakStateL = inPeakStateR = 0.0f;
+    inputPeakUsesRawInput = false;
     outPeakStateL = outPeakStateR = 0.0f;
     vuL.store (0.0f, std::memory_order_relaxed);
     vuR.store (0.0f, std::memory_order_relaxed);
@@ -256,6 +257,7 @@ void TapeMachineDSP::reset()
     m_driveDecaySm  = 1.0f;
     vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     inPeakStateL = inPeakStateR = 0.0f;
+    inputPeakUsesRawInput = false;
     outPeakStateL = outPeakStateR = 0.0f;
     vuL.store (0.0f, std::memory_order_relaxed);
     vuR.store (0.0f, std::memory_order_relaxed);
@@ -334,15 +336,28 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     if (reqFactor != currentFactor)
         applyFactor (reqFactor);
 
+    const bool hardBypass = pBypass.load (std::memory_order_relaxed);
+    const auto signalPath = static_cast<TapeCore::SignalPath> (
+        clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3));
+    const bool useRawInputPeak = hardBypass || signalPath == TapeCore::Thru;
+
+    // Normal processing meters post-input-gain; bypass and Thru meter raw input.
+    // A held value cannot cross between those reference nodes without changing meaning.
+    if (useRawInputPeak != inputPeakUsesRawInput)
+    {
+        inPeakStateL = inPeakStateR = 0.0f;
+        inputPeakUsesRawInput = useRawInputPeak;
+    }
+
     // --- bypass: pure passthrough + sample-peak refresh -----------------------
-    if (pBypass.load (std::memory_order_relaxed))
+    if (hardBypass)
     {
         for (int ch = 0; ch < nCh; ++ch)
             if (inputs[ch] != outputs[ch])
                 for (int n = 0; n < nSamples; ++n) outputs[ch][n] = inputs[ch][n];
 
-        // Input and output are identical while bypassed, but retain their independent
-        // peak states so peaks from before the transition continue to decay naturally.
+        // Input and output are identical while bypassed, but retain independent states:
+        // raw input starts from the rebased value while the output diagnostic keeps decaying.
         float pL = inPeakStateL, pR = inPeakStateR;
         float pkOL = outPeakStateL, pkOR = outPeakStateR;
         for (int n = 0; n < nSamples; ++n)
@@ -369,8 +384,6 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // Input VU is metered POST-input-trim / PRE-saturation, inside the processing
     // loops below (see item B): it reflects record/tape-drive level, not the raw
     // incoming signal. Same 0 VU reference + ANSI mean-abs ballistics as the output VU.
-
-    const auto signalPath = static_cast<TapeCore::SignalPath> (clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3));
 
     // --- Thru: passthrough + VU (input == output) ----------------------------
     if (signalPath == TapeCore::Thru)

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -334,22 +334,32 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     if (reqFactor != currentFactor)
         applyFactor (reqFactor);
 
-    // --- bypass: pure passthrough (matches JUCE early return, no meter update)-
+    // --- bypass: pure passthrough + sample-peak refresh -----------------------
     if (pBypass.load (std::memory_order_relaxed))
     {
         for (int ch = 0; ch < nCh; ++ch)
             if (inputs[ch] != outputs[ch])
                 for (int n = 0; n < nSamples; ++n) outputs[ch][n] = inputs[ch][n];
 
-        // Keep the output PEAK lamp honest even while bypassed: capture any real
-        // output clip and let a stale peak decay instead of latching the UI lamp.
+        // Input and output are identical while bypassed, but retain their independent
+        // peak states so peaks from before the transition continue to decay naturally.
+        float pL = inPeakStateL, pR = inPeakStateR;
         float pkOL = outPeakStateL, pkOR = outPeakStateR;
         for (int n = 0; n < nSamples; ++n)
         {
-            const float aL = std::abs (outputs[0][n]);
+            const float aL = std::abs (inputs[0][n]);
+            pL = aL > pL ? aL : pL * peakDecayCoeff;
             pkOL = aL > pkOL ? aL : pkOL * peakDecayCoeff;
-            if (nCh >= 2) { const float aR = std::abs (outputs[1][n]); pkOR = aR > pkOR ? aR : pkOR * peakDecayCoeff; }
+            if (nCh >= 2)
+            {
+                const float aR = std::abs (inputs[1][n]);
+                pR = aR > pR ? aR : pR * peakDecayCoeff;
+                pkOR = aR > pkOR ? aR : pkOR * peakDecayCoeff;
+            }
         }
+        inPeakStateL = pL; inPeakStateR = (nCh >= 2) ? pR : pL;
+        inPeakL.store (inPeakStateL, std::memory_order_relaxed);
+        inPeakR.store (inPeakStateR, std::memory_order_relaxed);
         outPeakStateL = pkOL; outPeakStateR = (nCh >= 2) ? pkOR : pkOL;
         outPeakL.store (outPeakStateL, std::memory_order_relaxed);
         outPeakR.store (outPeakStateR, std::memory_order_relaxed);
@@ -835,7 +845,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         }
     }
 
-    // input VU + input true-peak store (post-trim / pre-sat record level)
+    // input VU + input sample-peak store (post-trim / pre-sat record level)
     inVuStateL = inSL; inVuStateR = (nCh >= 2) ? inSR : inSL;
     inVuL.store (inVuStateL, std::memory_order_relaxed);
     inVuR.store (inVuStateR, std::memory_order_relaxed);
@@ -863,11 +873,10 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         }
     }
 
-    // --- VU meter (output; ANSI mean-abs one-pole, ~300 ms to 99%) + output true-peak ----
-    // The PEAK lamp is a genuine digital-clip (output over 0 dBFS) indicator: it reads the
-    // final-output sample-peak taken HERE (post-tape / post-output-gain / post-crosstalk — the
-    // exact buffer the host receives), instant attack with the ~300 ms peakDecayCoeff release.
-    // Tape soft-saturates, so moderate record drive never trips it — only a true output over does.
+    // --- VU meter (output; ANSI mean-abs one-pole, ~300 ms to 99%) + output sample peak ----
+    // Retain the final-output sample peak as a diagnostic even though the UI PEAK lamp now
+    // follows the input record node. This is post-tape / post-output-gain / post-crosstalk,
+    // with instant attack and the ~300 ms peakDecayCoeff release.
     float sL = vuStateL, sR = vuStateR;
     float pkOL = outPeakStateL, pkOR = outPeakStateR;
     for (int n = 0; n < nSamples; ++n)

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -939,8 +939,8 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // output gain. Input gain is applied at base rate before upsampling.
     float inSL = inVuStateL, inSR = inVuStateR;   // input VU: mean-abs of the post-trim record level
     // Input sample peak hold (instant attack, ~300 ms release) at the SAME record node the
-    // input VU meters — post-input-gain, PRE-tape. Feeds only the UI PEAK lamp (a record-
-    // level over indicator), kept separate from the mean-abs VU integrator.
+    // input VU meters — post-input-gain, PRE-tape. Retained as a diagnostic separate from
+    // the mean-abs VU integrator.
     float pkL = inPeakStateL, pkR = inPeakStateR;
     {
         int osIdx = 0;
@@ -948,7 +948,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         {
             const float x = inputs[0][n] * inGainArr[static_cast<size_t> (n)];
             const float axL = std::abs (x); inSL += (axL - inSL) * vuBallisticAlpha;
-            pkL = axL > pkL ? axL : pkL * peakDecayCoeff;   // input sample peak for the PEAK lamp
+            pkL = axL > pkL ? axL : pkL * peakDecayCoeff;
             outputs[0][n] = osL.processSample (x, [&] (float s) noexcept
             {
                 const size_t si = static_cast<size_t> (osIdx);
@@ -971,7 +971,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         {
             const float x = inputs[1][n] * inGainArr[static_cast<size_t> (n)];
             const float axR = std::abs (x); inSR += (axR - inSR) * vuBallisticAlpha;
-            pkR = axR > pkR ? axR : pkR * peakDecayCoeff;   // input sample peak for the PEAK lamp
+            pkR = axR > pkR ? axR : pkR * peakDecayCoeff;
             outputs[1][n] = osR.processSample (x, [&] (float s) noexcept
             {
                 const size_t si = static_cast<size_t> (osIdx);
@@ -1102,9 +1102,9 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     }
 
     // --- VU meter (output; ANSI mean-abs one-pole, ~300 ms to 99%) + output sample peak ----
-    // Retain the final-output sample peak as a diagnostic even though the UI PEAK lamp now
-    // follows the input record node. This is post-tape / post-output-gain / post-crosstalk,
-    // with instant attack and the ~300 ms peakDecayCoeff release.
+    // Retain the final-output sample peak as a diagnostic. This is post-tape /
+    // post-output-gain / post-crosstalk, with instant attack and the ~300 ms
+    // peakDecayCoeff release.
     float sL = vuStateL, sR = vuStateR;
     float pkOL = outPeakStateL, pkOR = outPeakStateR;
     for (int n = 0; n < nSamples; ++n)

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -17,6 +17,9 @@ namespace duskaudio
 static constexpr float kGainTau  = 0.0067f; // ~20 ms settle (juce::dsp::Gain 20 ms ramp)
 static constexpr float kSatTau   = 0.05f;   // ~150 ms settle (smoothedSaturation 150 ms)
 static constexpr float kParamTau = 0.0067f; // ~20 ms settle (wow / flutter / noise 20 ms)
+static constexpr float kLinkedMatchTau = 0.05f; // ~150 ms settle for linked peak makeup
+static constexpr float kLinkedGuardSec = 0.25f; // prevent preset-transition overshoot
+static constexpr float kLinkedSlewReleaseSec = 0.05f;
 
 //==============================================================================
 // Signal-level FR compensation (Phase B). The tape core's FR drifts with record
@@ -138,6 +141,7 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     // is advanced at the oversampled rate so it is configured there.
     inGain.prepare  (baseSampleRate, kGainTau);
     outGain.prepare (currentOsRate,  kGainTau);
+    linkedMakeupDb.prepare (baseSampleRate, kLinkedMatchTau);
     smSat.prepare     (baseSampleRate, kSatTau);
     smBias.prepare    (baseSampleRate, kSatTau);
     smWow.prepare     (baseSampleRate, kParamTau);
@@ -148,6 +152,12 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     // hold dB (converted per sample in processBlock — see the smoothing note there).
     const float inGainDb = pInputGainDb.load (std::memory_order_relaxed);
     inGain.snap  (inGainDb);
+    lastLinkedInputGainDb = pAutoComp.load (std::memory_order_relaxed) ? inGainDb : 1000.0f;
+    linkedMakeupDb.snap (0.0f);
+    linkedGuardSamples = 0;
+    lastLinkedOutputL = lastLinkedOutputR = 0.0f;
+    lastLinkedInputL = lastLinkedInputR = 0.0f;
+    linkedTopologyKey = UINT32_MAX;
     {
         outGain.snap (pAutoComp.load (std::memory_order_relaxed)
                           ? -inGainDb  // gain link = exact inverse; stored Output is unlinked-only
@@ -176,6 +186,7 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
 
     // Scratch buffers (allocated here; never on the audio thread).
     inGainArr.assign  (static_cast<size_t> (maxBlock), 0.0f);
+    linkedSlewLimitArr.assign (static_cast<size_t> (maxBlock), 1.0f);
     const size_t osCap = static_cast<size_t> (maxBlock) * 4u;
     satArr.assign       (osCap, 0.0f);
     biasArr.assign      (osCap, 0.0f);
@@ -258,6 +269,12 @@ void TapeMachineDSP::reset()
     vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     inPeakStateL = inPeakStateR = 0.0f;
     inputPeakUsesRawInput = false;
+    lastLinkedInputGainDb = 1000.0f;
+    linkedMakeupDb.snap (0.0f);
+    linkedGuardSamples = 0;
+    lastLinkedOutputL = lastLinkedOutputR = 0.0f;
+    lastLinkedInputL = lastLinkedInputR = 0.0f;
+    linkedTopologyKey = UINT32_MAX;
     outPeakStateL = outPeakStateR = 0.0f;
     vuL.store (0.0f, std::memory_order_relaxed);
     vuR.store (0.0f, std::memory_order_relaxed);
@@ -337,9 +354,20 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         applyFactor (reqFactor);
 
     const bool hardBypass = pBypass.load (std::memory_order_relaxed);
+    const bool gainLinked = pAutoComp.load (std::memory_order_relaxed);
     const auto signalPath = static_cast<TapeCore::SignalPath> (
         clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3));
     const bool useRawInputPeak = hardBypass || signalPath == TapeCore::Thru;
+    const uint32_t topologyKey =
+        static_cast<uint32_t> (clampI (pMachine.load (std::memory_order_relaxed), 0, 1))
+        | (static_cast<uint32_t> (clampI (pSpeed.load (std::memory_order_relaxed), 0, 3)) << 1u)
+        | (static_cast<uint32_t> (clampI (pType.load (std::memory_order_relaxed), 0, 3)) << 3u)
+        | (static_cast<uint32_t> (signalPath) << 5u)
+        | (static_cast<uint32_t> (clampI (pEqStandard.load (std::memory_order_relaxed), 0, 1)) << 7u)
+        | (static_cast<uint32_t> (clampI (pCalibration.load (std::memory_order_relaxed), 0, 3)) << 8u)
+        | (static_cast<uint32_t> (clampI (pHeadWidth.load (std::memory_order_relaxed), 0, 2)) << 10u);
+    bool linkedTransition = gainLinked && topologyKey != linkedTopologyKey;
+    linkedTopologyKey = gainLinked ? topologyKey : UINT32_MAX;
 
     // Normal processing meters post-input-gain; bypass and Thru meter raw input.
     // A held value cannot cross between those reference nodes without changing meaning.
@@ -352,6 +380,10 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // --- bypass: pure passthrough + sample-peak refresh -----------------------
     if (hardBypass)
     {
+        linkedMakeupDb.snap (0.0f);
+        linkedGuardSamples = 0;
+        lastLinkedInputGainDb = 1000.0f;
+        linkedTopologyKey = UINT32_MAX;
         for (int ch = 0; ch < nCh; ++ch)
             if (inputs[ch] != outputs[ch])
                 for (int n = 0; n < nSamples; ++n) outputs[ch][n] = inputs[ch][n];
@@ -378,6 +410,10 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         outPeakStateL = pkOL; outPeakStateR = (nCh >= 2) ? pkOR : pkOL;
         outPeakL.store (outPeakStateL, std::memory_order_relaxed);
         outPeakR.store (outPeakStateR, std::memory_order_relaxed);
+        lastLinkedOutputL = outputs[0][nSamples - 1];
+        lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
+        lastLinkedInputL = inputs[0][nSamples - 1];
+        lastLinkedInputR = inputs[nCh >= 2 ? 1 : 0][nSamples - 1];
         return;
     }
 
@@ -388,6 +424,10 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // --- Thru: passthrough + VU (input == output) ----------------------------
     if (signalPath == TapeCore::Thru)
     {
+        linkedMakeupDb.snap (0.0f);
+        linkedGuardSamples = 0;
+        lastLinkedInputGainDb = 1000.0f;
+        linkedTopologyKey = UINT32_MAX;
         for (int ch = 0; ch < nCh; ++ch)
             if (inputs[ch] != outputs[ch])
                 for (int n = 0; n < nSamples; ++n) outputs[ch][n] = inputs[ch][n];
@@ -415,7 +455,35 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         inVuStateL = vuStateL; inVuStateR = vuStateR;   // Thru: input == output
         inVuL.store (inVuStateL, std::memory_order_relaxed);
         inVuR.store (inVuStateR, std::memory_order_relaxed);
+        lastLinkedOutputL = outputs[0][nSamples - 1];
+        lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
+        lastLinkedInputL = inputs[0][nSamples - 1];
+        lastLinkedInputR = inputs[nCh >= 2 ? 1 : 0][nSamples - 1];
         return;
+    }
+
+    // Capture the host-facing input peak before an in-place buffer can be overwritten.
+    // Gain Link uses this as the unity target for its post-tape peak makeup.
+    float linkedInputBlockPeak = 0.0f;
+    if (gainLinked)
+    {
+        float prevL = lastLinkedInputL;
+        float prevR = lastLinkedInputR;
+        for (int ch = 0; ch < nCh; ++ch)
+            for (int n = 0; n < nSamples; ++n)
+                linkedInputBlockPeak = std::max (linkedInputBlockPeak, std::abs (inputs[ch][n]));
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float curL = inputs[0][n];
+            const float curR = inputs[nCh >= 2 ? 1 : 0][n];
+            const float inputDelta = std::max (std::abs (curL - prevL), std::abs (curR - prevR));
+            linkedSlewLimitArr[static_cast<size_t> (n)] =
+                std::max (1.0e-4f, inputDelta);
+            prevL = curL;
+            prevR = curR;
+        }
+        lastLinkedInputL = prevL;
+        lastLinkedInputR = prevR;
     }
 
     // --- tone SVF coefficient refresh (dirty) --------------------------------
@@ -460,12 +528,12 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     const float inputGainDb = pInputGainDb.load (std::memory_order_relaxed);
 
     float targetOutputGainDb;
-    if (pAutoComp.load (std::memory_order_relaxed))
+    if (gainLinked)
     {
-        // Gain link ("LINK"): output is the exact inverse of input. The stored Output
-        // parameter is deliberately ignored here so changing presets cannot introduce a
-        // hidden makeup-trim step while the two visible gain controls remain opposed.
-        // Unity/cal-neutrality are handled inside the tape core.
+        // The linked linear output stage is the exact inverse of input. The stored Output
+        // parameter is deliberately ignored so presets cannot introduce a hidden trim step.
+        // The post-tape matcher below then restores host-facing peak unity after nonlinear
+        // compression and topology changes.
         targetOutputGainDb = -inputGainDb;
     }
     else
@@ -480,10 +548,19 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // of g and 1/g does NOT cancel: the product bulges to 1 + (r-1)^2/(4r) mid-ramp
     // (r = gain-change ratio) — a 23.8 dB preset-switch input step transiently boosted
     // the OUTPUT by ~+13 dB (audible pop over 0 dBFS on every large preset change).
-    // Static renders are bit-identical: after snap/convergence the smoother repeats the
-    // same dB value and dbToGain of it reproduces the identical linear gain per sample.
+    // The paired ramps therefore cannot create their own gain bulge; the post-tape linked
+    // matcher below handles level changes produced by the nonlinear/model stages.
+    const bool largeLinkedGainStep =
+        gainLinked && std::abs (inputGainDb - lastLinkedInputGainDb) > 0.5f;
+    linkedTransition = linkedTransition || largeLinkedGainStep;
+    if (linkedTransition)
+    {
+        linkedMakeupDb.snap (0.0f);
+        linkedGuardSamples = static_cast<int> (baseSampleRate * kLinkedGuardSec);
+    }
     inGain.setTarget (inputGainDb);
     outGain.setTarget (targetOutputGainDb);
+    lastLinkedInputGainDb = gainLinked ? inputGainDb : 1000.0f;
 
     const float saturationAmount = std::clamp (((inputGainDb + 12.0f) / 24.0f) * 100.0f, 0.0f, 100.0f);
     smSat.setTarget     (saturationAmount);
@@ -881,6 +958,76 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             outputs[0][n] += tempR * crosstalkAmount;
             outputs[1][n] += tempL * crosstalkAmount;
         }
+    }
+
+    // Gain Link is a host-level unity contract, not only a linear input/output-knob
+    // inverse. Measure the processed block before makeup and restore its peak to the raw
+    // input peak. During steady processing makeup moves smoothly; during the short preset
+    // guard it follows each block immediately so stale filter or nonlinear state cannot
+    // create an overshoot above the incoming peak.
+    const bool linkedGuardActive = linkedGuardSamples > 0;
+    if (gainLinked && linkedInputBlockPeak > 1.0e-6f)
+    {
+        float linkedOutputBlockPeak = 0.0f;
+        for (int ch = 0; ch < nCh; ++ch)
+            for (int n = 0; n < nSamples; ++n)
+                linkedOutputBlockPeak = std::max (linkedOutputBlockPeak, std::abs (outputs[ch][n]));
+
+        if (linkedOutputBlockPeak > 1.0e-9f)
+        {
+            const float targetDb = std::clamp (
+                20.0f * std::log10 (linkedInputBlockPeak / linkedOutputBlockPeak),
+                -36.0f, 12.0f);
+            if (linkedGuardActive)
+                linkedMakeupDb.snap (targetDb);
+            else
+                linkedMakeupDb.setTarget (targetDb);
+
+            for (int n = 0; n < nSamples; ++n)
+            {
+                const float makeup = dbToGain (linkedMakeupDb.next());
+                outputs[0][n] *= makeup;
+                if (nCh >= 2) outputs[1][n] *= makeup;
+            }
+        }
+    }
+    else if (! gainLinked)
+    {
+        linkedMakeupDb.snap (0.0f);
+        linkedGuardSamples = 0;
+    }
+
+    // A topology change can also alter filter phase. During the short level guard, limit
+    // output slew to the source signal's own per-sample slew so the coefficient change
+    // cannot turn into a click. This does not run during steady processing.
+    if (linkedGuardActive)
+    {
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const int releaseSamples =
+                std::max (1, static_cast<int> (baseSampleRate * kLinkedSlewReleaseSec));
+            const float release = linkedGuardSamples < releaseSamples
+                ? 1.0f - static_cast<float> (linkedGuardSamples)
+                         / static_cast<float> (releaseSamples)
+                : 0.0f;
+            const float slewScale = 1.25f + release * 14.75f;
+            const float limit = linkedSlewLimitArr[static_cast<size_t> (n)] * slewScale;
+            outputs[0][n] = std::clamp (outputs[0][n],
+                                        lastLinkedOutputL - limit, lastLinkedOutputL + limit);
+            lastLinkedOutputL = outputs[0][n];
+            if (nCh >= 2)
+            {
+                outputs[1][n] = std::clamp (outputs[1][n],
+                                            lastLinkedOutputR - limit, lastLinkedOutputR + limit);
+                lastLinkedOutputR = outputs[1][n];
+            }
+            linkedGuardSamples = std::max (0, linkedGuardSamples - 1);
+        }
+    }
+    else
+    {
+        lastLinkedOutputL = outputs[0][nSamples - 1];
+        lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
     }
 
     // --- VU meter (output; ANSI mean-abs one-pole, ~300 ms to 99%) + output sample peak ----

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -25,6 +25,8 @@ static constexpr float kLinkedSlewStartScale = 4.0f;
 static constexpr float kLinkedSlewTightScale = 1.5f;
 static constexpr float kLinkedSlewCeilingDb = -12.0f;
 static constexpr float kLinkedDirectGuardDb = 3.0f; // catch abrupt jumps, not normal UI gestures
+static constexpr float kLinkedGuardSnapFloor = 1.0e-3f; // -60 dBFS: below this a block peak is
+                                                        // noise/tail, not a usable match reference
 
 //==============================================================================
 // Signal-level FR compensation (Phase B). The tape core's FR drifts with record
@@ -365,6 +367,14 @@ void TapeMachineDSP::applyFactor (int newFactor)
 
     osL.setFactor (newFactor); osR.setFactor (newFactor);
     osL.reset();               osR.reset();
+
+    // NOTE: linkedInputDelayL/R are NOT resized here. They are sized in prepare() from
+    // activeLatencySamples(), which is factor-dependent, so a live factor change would
+    // leave the gain-link reference misaligned against the output. Harmless today because
+    // factorFromChoice() is hardwired to 2 and this function therefore never runs after
+    // prepare(). If per-factor oversampling is ever re-enabled, pre-size both buffers for
+    // the MAX factor in prepare() and track the active length in a member — do not assign
+    // here (audio thread).
 
     // No reallocation: wow/flutter buffers are pre-sized for the max factor.
     coreL.prepare (currentOsRate, newFactor, maxOsRate);
@@ -1058,9 +1068,21 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             const float targetDb = std::clamp (
                 20.0f * std::log10 (matchInputPeak / matchOutputPeak),
                 -36.0f, 12.0f);
+            // The guard's first block hard-snaps so a preset change cannot overshoot before
+            // the smoother catches up. Only do that when BOTH block peaks are audible: the
+            // guard compares per-block maxima, so a transition landing in a quiet passage
+            // would otherwise derive its ratio from noise/tail samples and snap straight to
+            // the +/-clamp. Below the floor, fall through to setTarget and disarm — the
+            // guard tau is ~0.5 ms, so it converges within a millisecond anyway, and a
+            // still-armed snap would fire mid-signal later in the window as a hard step.
             if (linkedGuardActive && linkedGuardFirstBlock)
             {
-                linkedMakeupDb.snap (targetDb);
+                if (matchInputPeak > kLinkedGuardSnapFloor
+                    && matchOutputPeak > kLinkedGuardSnapFloor)
+                    linkedMakeupDb.snap (targetDb);
+                else
+                    linkedMakeupDb.setTarget (targetDb);
+
                 linkedGuardFirstBlock = false;
             }
             else

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -296,6 +296,11 @@ void TapeMachineDSP::reset()
     const bool gainLinked = pAutoComp.load (std::memory_order_relaxed);
     lastLinkedInputGainDb = gainLinked
         ? pInputGainDb.load (std::memory_order_relaxed) : 1000.0f;
+    // Re-prepare with the steady-state tau, matching the bypass/Thru/unlinked branches. A
+    // reset landing mid-guard would otherwise clear linkedGuardSamples while the smoother
+    // still held the fast guard coefficient, and the "guard ended" re-prepare in
+    // processBlock only runs when a guard counts down to zero — never after this.
+    linkedMakeupDb.prepare (baseSampleRate, kLinkedMatchTau);
     linkedMakeupDb.snap (0.0f);
     linkedGuardSamples = 0;
     linkedGuardFirstBlock = false;
@@ -489,12 +494,31 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             const float aL = std::abs (inputs[0][n]);
             pL = aL > pL ? aL : pL * peakDecayCoeff;
             pkOL = aL > pkOL ? aL : pkOL * peakDecayCoeff;
+            // Keep the slew history moving with the passthrough. Leaving bypass invalidates
+            // the topology key above, so the first processed block arms a guard whose ceiling
+            // is derived from this history — and the fixed floor is only -12 dB/sample, below
+            // the per-sample delta of loud HF content. Freezing the history for the length of
+            // the bypass would let a quiet pre-bypass passage impose that floor on whatever
+            // plays after, clamping legitimate transients for the guard's 250 ms.
+            const float deltaL = std::abs (outputs[0][n] - lastLinkedOutputL);
+            linkedRecentOutputSlewL =
+                std::max (deltaL, linkedRecentOutputSlewL * linkedOutputSlewDecay);
+            lastLinkedOutputL = outputs[0][n];
             if (nCh >= 2)
             {
                 const float aR = std::abs (inputs[1][n]);
                 pR = aR > pR ? aR : pR * peakDecayCoeff;
                 pkOR = aR > pkOR ? aR : pkOR * peakDecayCoeff;
+                const float deltaR = std::abs (outputs[1][n] - lastLinkedOutputR);
+                linkedRecentOutputSlewR =
+                    std::max (deltaR, linkedRecentOutputSlewR * linkedOutputSlewDecay);
+                lastLinkedOutputR = outputs[1][n];
             }
+        }
+        if (nCh < 2)
+        {
+            lastLinkedOutputR = lastLinkedOutputL;
+            linkedRecentOutputSlewR = linkedRecentOutputSlewL;
         }
         inPeakStateL = pL; inPeakStateR = (nCh >= 2) ? pR : pL;
         inPeakL.store (inPeakStateL, std::memory_order_relaxed);
@@ -502,8 +526,6 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         outPeakStateL = pkOL; outPeakStateR = (nCh >= 2) ? pkOR : pkOL;
         outPeakL.store (outPeakStateL, std::memory_order_relaxed);
         outPeakR.store (outPeakStateR, std::memory_order_relaxed);
-        lastLinkedOutputL = outputs[0][nSamples - 1];
-        lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
         return;
     }
 
@@ -536,7 +558,29 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             sL += (aL - sL) * vuBallisticAlpha;
             pL = aL > pL ? aL : pL * peakDecayCoeff;
             pkOL = aL > pkOL ? aL : pkOL * peakDecayCoeff;
-            if (nCh >= 2) { const float aR = std::abs (inputs[1][n]); sR += (aR - sR) * vuBallisticAlpha; pR = aR > pR ? aR : pR * peakDecayCoeff; pkOR = aR > pkOR ? aR : pkOR * peakDecayCoeff; }
+            // Same reason as the bypass branch: this path invalidates the topology key, so
+            // leaving Thru arms a guard whose slew ceiling comes from this history. Track the
+            // passthrough rather than freezing a pre-Thru value.
+            const float deltaL = std::abs (outputs[0][n] - lastLinkedOutputL);
+            linkedRecentOutputSlewL =
+                std::max (deltaL, linkedRecentOutputSlewL * linkedOutputSlewDecay);
+            lastLinkedOutputL = outputs[0][n];
+            if (nCh >= 2)
+            {
+                const float aR = std::abs (inputs[1][n]);
+                sR += (aR - sR) * vuBallisticAlpha;
+                pR = aR > pR ? aR : pR * peakDecayCoeff;
+                pkOR = aR > pkOR ? aR : pkOR * peakDecayCoeff;
+                const float deltaR = std::abs (outputs[1][n] - lastLinkedOutputR);
+                linkedRecentOutputSlewR =
+                    std::max (deltaR, linkedRecentOutputSlewR * linkedOutputSlewDecay);
+                lastLinkedOutputR = outputs[1][n];
+            }
+        }
+        if (nCh < 2)
+        {
+            lastLinkedOutputR = lastLinkedOutputL;
+            linkedRecentOutputSlewR = linkedRecentOutputSlewL;
         }
         vuStateL = sL; vuStateR = (nCh >= 2) ? sR : sL;
         inPeakStateL = pL; inPeakStateR = (nCh >= 2) ? pR : pL;
@@ -550,8 +594,6 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         inVuStateL = vuStateL; inVuStateR = vuStateR;   // Thru: input == output
         inVuL.store (inVuStateL, std::memory_order_relaxed);
         inVuR.store (inVuStateR, std::memory_order_relaxed);
-        lastLinkedOutputL = outputs[0][nSamples - 1];
-        lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
         return;
     }
 
@@ -1043,7 +1085,12 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // latency-aligned raw-input peak. During steady processing makeup moves smoothly;
     // during the short preset guard it starts from the first measured block, then follows
     // subsequent block targets with a fast smoother to avoid hard gain steps.
-    const bool linkedGuardActive = linkedGuardSamples > 0;
+    // Must include the LIVE link state, not just the counter. The unlinked branch below
+    // zeroes linkedGuardSamples, but this snapshot is taken first — so a guard armed while
+    // linked would otherwise still gate the slew limiter for one block after Gain Link is
+    // switched off, clamping output the unlinked path never asked to limit. Inside the
+    // gainLinked branch the added term is a no-op, so peak-selection there is unchanged.
+    const bool linkedGuardActive = gainLinked && linkedGuardSamples > 0;
     if (gainLinked)
     {
         float linkedOutputPeak = linkedOutputMatchPeak;
@@ -1072,22 +1119,22 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             // the smoother catches up. Only do that when BOTH block peaks are audible: the
             // guard compares per-block maxima, so a transition landing in a quiet passage
             // would otherwise derive its ratio from noise/tail samples and snap straight to
-            // the +/-clamp. Below the floor, fall through to setTarget and disarm — the
-            // guard tau is ~0.5 ms, so it converges within a millisecond anyway, and a
-            // still-armed snap would fire mid-signal later in the window as a hard step.
-            if (linkedGuardActive && linkedGuardFirstBlock)
-            {
-                if (matchInputPeak > kLinkedGuardSnapFloor
-                    && matchOutputPeak > kLinkedGuardSnapFloor)
-                    linkedMakeupDb.snap (targetDb);
-                else
-                    linkedMakeupDb.setTarget (targetDb);
-
-                linkedGuardFirstBlock = false;
-            }
+            // the +/-clamp. Below the floor, ramp instead — the guard tau is ~0.5 ms, so it
+            // converges within a millisecond anyway.
+            if (linkedGuardActive && linkedGuardFirstBlock
+                && matchInputPeak > kLinkedGuardSnapFloor
+                && matchOutputPeak > kLinkedGuardSnapFloor)
+                linkedMakeupDb.snap (targetDb);
             else
                 linkedMakeupDb.setTarget (targetDb);
         }
+
+        // Disarm after the guard's FIRST block whether or not it yielded a usable target.
+        // A silent first block skips the audibility gate above entirely, and leaving the
+        // snap armed would fire it on a later block once signal returns — a hard gain step
+        // mid-transition, the exact artifact the snap exists to prevent.
+        if (linkedGuardActive)
+            linkedGuardFirstBlock = false;
 
         // Keep the current makeup active even when the aligned input is silent. The active
         // path can still be emitting its delayed tail or tape noise in that block; bypassing

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -158,7 +158,9 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     linkedGuardSamples = 0;
     lastLinkedOutputL = lastLinkedOutputR = 0.0f;
     lastLinkedInputL = lastLinkedInputR = 0.0f;
-    linkedTopologyKey = UINT32_MAX;
+    linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
+    linkedTopologyKey = pAutoComp.load (std::memory_order_relaxed)
+        ? currentLinkedTopologyKey() : UINT32_MAX;
     lastLinkedBatchRevision = pLinkedBatchRevision.load (std::memory_order_relaxed);
     {
         outGain.snap (pAutoComp.load (std::memory_order_relaxed)
@@ -188,6 +190,11 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
 
     // Scratch buffers (allocated here; never on the audio thread).
     inGainArr.assign  (static_cast<size_t> (maxBlock), 0.0f);
+    const size_t linkedDelaySize =
+        static_cast<size_t> (std::max (0, activeLatencySamples()));
+    linkedInputDelayL.assign (linkedDelaySize, 0.0f);
+    linkedInputDelayR.assign (linkedDelaySize, 0.0f);
+    linkedInputDelayIndex = 0;
     linkedSlewLimitArr.assign (static_cast<size_t> (maxBlock), 1.0f);
     const size_t osCap = static_cast<size_t> (maxBlock) * 4u;
     satArr.assign       (osCap, 0.0f);
@@ -208,6 +215,11 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     }
     // Clip-lamp peak hold: instant attack, 300 ms release (unchanged ballistic).
     peakDecayCoeff = std::exp (-1.0f / (0.3f * static_cast<float> (baseSampleRate)));
+    // Gain-link matching uses a 50 ms shared peak envelope. The same release on the latency-
+    // aligned input and output makes its ratio stable across host block sizes without turning
+    // isolated block maxima into a block-rate gain modulator.
+    linkedMatchPeakDecay =
+        std::exp (-1.0f / (0.050f * static_cast<float> (baseSampleRate)));
 
     // Signal-level envelope detector: instant attack, ~30 ms release (base rate).
     // Fast enough to track drum transients (the level-keyed EQ must shift tone on the
@@ -271,12 +283,18 @@ void TapeMachineDSP::reset()
     vuStateL = vuStateR = inVuStateL = inVuStateR = 0.0f;
     inPeakStateL = inPeakStateR = 0.0f;
     inputPeakUsesRawInput = false;
-    lastLinkedInputGainDb = 1000.0f;
+    const bool gainLinked = pAutoComp.load (std::memory_order_relaxed);
+    lastLinkedInputGainDb = gainLinked
+        ? pInputGainDb.load (std::memory_order_relaxed) : 1000.0f;
     linkedMakeupDb.snap (0.0f);
     linkedGuardSamples = 0;
     lastLinkedOutputL = lastLinkedOutputR = 0.0f;
     lastLinkedInputL = lastLinkedInputR = 0.0f;
-    linkedTopologyKey = UINT32_MAX;
+    linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
+    std::fill (linkedInputDelayL.begin(), linkedInputDelayL.end(), 0.0f);
+    std::fill (linkedInputDelayR.begin(), linkedInputDelayR.end(), 0.0f);
+    linkedInputDelayIndex = 0;
+    linkedTopologyKey = gainLinked ? currentLinkedTopologyKey() : UINT32_MAX;
     lastLinkedBatchRevision = pLinkedBatchRevision.load (std::memory_order_relaxed);
     outPeakStateL = outPeakStateR = 0.0f;
     vuL.store (0.0f, std::memory_order_relaxed);
@@ -290,6 +308,18 @@ void TapeMachineDSP::reset()
 }
 
 //==============================================================================
+int TapeMachineDSP::activeLatencySamples() const noexcept
+{
+    // osL::latency() = global up/down FIR round trip (base-rate samples). Add the two
+    // LocalAAStage nonlinearity oversamplers (soft-limit + shaper) that run INSIDE the
+    // core at the OS rate: each contributes LocalAAStage::latency() surrounding-rate
+    // samples, so 2*that / factor in base-rate samples. Both always run (shaper no longer
+    // gated), so the reported latency is constant — no drive-dependent PDC drift.
+    const float localAaBase = 2.0f * duskaudio::LocalAAStage::latency()
+                            / static_cast<float> (currentFactor > 0 ? currentFactor : 1);
+    return static_cast<int> (std::lround (osL.latency() + localAaBase));
+}
+
 int TapeMachineDSP::latencySamples() const noexcept
 {
     // Bypass is a true zero-delay passthrough (processBlock copies input->output with no
@@ -302,14 +332,18 @@ int TapeMachineDSP::latencySamples() const noexcept
     if (pBypass.load (std::memory_order_relaxed))
         return 0;
 
-    // osL::latency() = global up/down FIR round trip (base-rate samples). Add the two
-    // LocalAAStage nonlinearity oversamplers (soft-limit + shaper) that run INSIDE the
-    // core at the OS rate: each contributes LocalAAStage::latency() surrounding-rate
-    // samples, so 2*that / factor in base-rate samples. Both always run (shaper no longer
-    // gated), so the reported latency is constant — no drive-dependent PDC drift.
-    const float localAaBase = 2.0f * duskaudio::LocalAAStage::latency()
-                            / static_cast<float> (currentFactor > 0 ? currentFactor : 1);
-    return static_cast<int> (std::lround (osL.latency() + localAaBase));
+    return activeLatencySamples();
+}
+
+uint32_t TapeMachineDSP::currentLinkedTopologyKey() const noexcept
+{
+    return static_cast<uint32_t> (clampI (pMachine.load (std::memory_order_relaxed), 0, 1))
+        | (static_cast<uint32_t> (clampI (pSpeed.load (std::memory_order_relaxed), 0, 3)) << 1u)
+        | (static_cast<uint32_t> (clampI (pType.load (std::memory_order_relaxed), 0, 3)) << 3u)
+        | (static_cast<uint32_t> (clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3)) << 5u)
+        | (static_cast<uint32_t> (clampI (pEqStandard.load (std::memory_order_relaxed), 0, 1)) << 7u)
+        | (static_cast<uint32_t> (clampI (pCalibration.load (std::memory_order_relaxed), 0, 3)) << 8u)
+        | (static_cast<uint32_t> (clampI (pHeadWidth.load (std::memory_order_relaxed), 0, 2)) << 10u);
 }
 
 //==============================================================================
@@ -364,14 +398,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     const uint32_t linkedBatchRevision = pLinkedBatchRevision.load (std::memory_order_relaxed);
     const bool linkedBatchStarted = linkedBatchRevision != lastLinkedBatchRevision;
     lastLinkedBatchRevision = linkedBatchRevision;
-    const uint32_t topologyKey =
-        static_cast<uint32_t> (clampI (pMachine.load (std::memory_order_relaxed), 0, 1))
-        | (static_cast<uint32_t> (clampI (pSpeed.load (std::memory_order_relaxed), 0, 3)) << 1u)
-        | (static_cast<uint32_t> (clampI (pType.load (std::memory_order_relaxed), 0, 3)) << 3u)
-        | (static_cast<uint32_t> (signalPath) << 5u)
-        | (static_cast<uint32_t> (clampI (pEqStandard.load (std::memory_order_relaxed), 0, 1)) << 7u)
-        | (static_cast<uint32_t> (clampI (pCalibration.load (std::memory_order_relaxed), 0, 3)) << 8u)
-        | (static_cast<uint32_t> (clampI (pHeadWidth.load (std::memory_order_relaxed), 0, 2)) << 10u);
+    const uint32_t topologyKey = currentLinkedTopologyKey();
     bool linkedTransition = gainLinked && topologyKey != linkedTopologyKey;
     linkedTopologyKey = gainLinked ? topologyKey : UINT32_MAX;
 
@@ -383,11 +410,54 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         inputPeakUsesRawInput = useRawInputPeak;
     }
 
+    // Delay the raw input reference by the active path's reported latency so its peak and
+    // slew are compared with the samples that actually produced this output block. Keep
+    // advancing it in bypass/Thru and while unlinked so the history is ready on transitions.
+    float linkedInputPeak = linkedInputMatchPeak;
+    float linkedInputBlockPeak = 0.0f;
+    {
+        const size_t delaySize = linkedInputDelayL.size();
+        size_t delayIndex = linkedInputDelayIndex;
+        float prevL = lastLinkedInputL;
+        float prevR = lastLinkedInputR;
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float curL = inputs[0][n];
+            const float curR = inputs[nCh >= 2 ? 1 : 0][n];
+            float alignedL = curL;
+            float alignedR = curR;
+            if (delaySize > 0)
+            {
+                alignedL = linkedInputDelayL[delayIndex];
+                alignedR = linkedInputDelayR[delayIndex];
+                linkedInputDelayL[delayIndex] = curL;
+                linkedInputDelayR[delayIndex] = curR;
+                if (++delayIndex == delaySize)
+                    delayIndex = 0;
+            }
+            const float alignedAbs =
+                std::max (std::abs (alignedL), std::abs (alignedR));
+            linkedInputBlockPeak = std::max (linkedInputBlockPeak, alignedAbs);
+            linkedInputPeak = alignedAbs > linkedInputPeak
+                ? alignedAbs : linkedInputPeak * linkedMatchPeakDecay;
+            const float inputDelta =
+                std::max (std::abs (alignedL - prevL), std::abs (alignedR - prevR));
+            linkedSlewLimitArr[static_cast<size_t> (n)] = std::max (1.0e-4f, inputDelta);
+            prevL = alignedL;
+            prevR = alignedR;
+        }
+        linkedInputDelayIndex = delayIndex;
+        lastLinkedInputL = prevL;
+        lastLinkedInputR = prevR;
+        linkedInputMatchPeak = linkedInputPeak;
+    }
+
     // --- bypass: pure passthrough + sample-peak refresh -----------------------
     if (hardBypass)
     {
         linkedMakeupDb.snap (0.0f);
         linkedGuardSamples = 0;
+        linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
         lastLinkedInputGainDb = 1000.0f;
         linkedTopologyKey = UINT32_MAX;
         for (int ch = 0; ch < nCh; ++ch)
@@ -418,8 +488,6 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         outPeakR.store (outPeakStateR, std::memory_order_relaxed);
         lastLinkedOutputL = outputs[0][nSamples - 1];
         lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
-        lastLinkedInputL = inputs[0][nSamples - 1];
-        lastLinkedInputR = inputs[nCh >= 2 ? 1 : 0][nSamples - 1];
         return;
     }
 
@@ -432,6 +500,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     {
         linkedMakeupDb.snap (0.0f);
         linkedGuardSamples = 0;
+        linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
         lastLinkedInputGainDb = 1000.0f;
         linkedTopologyKey = UINT32_MAX;
         for (int ch = 0; ch < nCh; ++ch)
@@ -463,33 +532,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
         inVuR.store (inVuStateR, std::memory_order_relaxed);
         lastLinkedOutputL = outputs[0][nSamples - 1];
         lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
-        lastLinkedInputL = inputs[0][nSamples - 1];
-        lastLinkedInputR = inputs[nCh >= 2 ? 1 : 0][nSamples - 1];
         return;
-    }
-
-    // Capture the host-facing input peak before an in-place buffer can be overwritten.
-    // Gain Link uses this as the unity target for its post-tape peak makeup.
-    float linkedInputBlockPeak = 0.0f;
-    if (gainLinked)
-    {
-        float prevL = lastLinkedInputL;
-        float prevR = lastLinkedInputR;
-        for (int ch = 0; ch < nCh; ++ch)
-            for (int n = 0; n < nSamples; ++n)
-                linkedInputBlockPeak = std::max (linkedInputBlockPeak, std::abs (inputs[ch][n]));
-        for (int n = 0; n < nSamples; ++n)
-        {
-            const float curL = inputs[0][n];
-            const float curR = inputs[nCh >= 2 ? 1 : 0][n];
-            const float inputDelta = std::max (std::abs (curL - prevL), std::abs (curR - prevR));
-            linkedSlewLimitArr[static_cast<size_t> (n)] =
-                std::max (1.0e-4f, inputDelta);
-            prevL = curL;
-            prevR = curR;
-        }
-        lastLinkedInputL = prevL;
-        lastLinkedInputR = prevR;
     }
 
     // --- tone SVF coefficient refresh (dirty) --------------------------------
@@ -973,40 +1016,56 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     }
 
     // Gain Link is a host-level unity contract, not only a linear input/output-knob
-    // inverse. Measure the processed block before makeup and restore its peak to the raw
-    // input peak. During steady processing makeup moves smoothly; during the short preset
-    // guard it follows each block immediately so stale filter or nonlinear state cannot
-    // create an overshoot above the incoming peak.
+    // inverse. Measure the processed block before makeup and restore its peak to the
+    // latency-aligned raw-input peak. During steady processing makeup moves smoothly;
+    // during the short preset guard it follows each block immediately so stale filter or
+    // nonlinear state cannot create an overshoot above the incoming peak.
     const bool linkedGuardActive = linkedGuardSamples > 0;
-    if (gainLinked && linkedInputBlockPeak > 1.0e-6f)
+    if (gainLinked)
     {
+        float linkedOutputPeak = linkedOutputMatchPeak;
         float linkedOutputBlockPeak = 0.0f;
-        for (int ch = 0; ch < nCh; ++ch)
-            for (int n = 0; n < nSamples; ++n)
-                linkedOutputBlockPeak = std::max (linkedOutputBlockPeak, std::abs (outputs[ch][n]));
+        for (int n = 0; n < nSamples; ++n)
+        {
+            float outputAbs = std::abs (outputs[0][n]);
+            if (nCh >= 2)
+                outputAbs = std::max (outputAbs, std::abs (outputs[1][n]));
+            linkedOutputBlockPeak = std::max (linkedOutputBlockPeak, outputAbs);
+            linkedOutputPeak = outputAbs > linkedOutputPeak
+                ? outputAbs : linkedOutputPeak * linkedMatchPeakDecay;
+        }
+        linkedOutputMatchPeak = linkedOutputPeak;
 
-        if (linkedOutputBlockPeak > 1.0e-9f)
+        const float matchInputPeak =
+            linkedGuardActive ? linkedInputBlockPeak : linkedInputPeak;
+        const float matchOutputPeak =
+            linkedGuardActive ? linkedOutputBlockPeak : linkedOutputPeak;
+        if (matchInputPeak > 1.0e-6f && matchOutputPeak > 1.0e-9f)
         {
             const float targetDb = std::clamp (
-                20.0f * std::log10 (linkedInputBlockPeak / linkedOutputBlockPeak),
+                20.0f * std::log10 (matchInputPeak / matchOutputPeak),
                 -36.0f, 12.0f);
             if (linkedGuardActive)
                 linkedMakeupDb.snap (targetDb);
             else
                 linkedMakeupDb.setTarget (targetDb);
+        }
 
-            for (int n = 0; n < nSamples; ++n)
-            {
-                const float makeup = dbToGain (linkedMakeupDb.next());
-                outputs[0][n] *= makeup;
-                if (nCh >= 2) outputs[1][n] *= makeup;
-            }
+        // Keep the current makeup active even when the aligned input is silent. The active
+        // path can still be emitting its delayed tail or tape noise in that block; bypassing
+        // this multiply there would create a block-boundary gain step.
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float makeup = dbToGain (linkedMakeupDb.next());
+            outputs[0][n] *= makeup;
+            if (nCh >= 2) outputs[1][n] *= makeup;
         }
     }
-    else if (! gainLinked)
+    else
     {
         linkedMakeupDb.snap (0.0f);
         linkedGuardSamples = 0;
+        linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
     }
 
     // A topology change can also alter filter phase. During the short level guard, limit

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -18,8 +18,12 @@ static constexpr float kGainTau  = 0.0067f; // ~20 ms settle (juce::dsp::Gain 20
 static constexpr float kSatTau   = 0.05f;   // ~150 ms settle (smoothedSaturation 150 ms)
 static constexpr float kParamTau = 0.0067f; // ~20 ms settle (wow / flutter / noise 20 ms)
 static constexpr float kLinkedMatchTau = 0.05f; // ~150 ms settle for linked peak makeup
+static constexpr float kLinkedGuardMatchTau = 0.0005f; // fast, continuous guard correction
 static constexpr float kLinkedGuardSec = 0.25f; // prevent preset-transition overshoot
 static constexpr float kLinkedSlewReleaseSec = 0.05f;
+static constexpr float kLinkedSlewStartScale = 4.0f;
+static constexpr float kLinkedSlewTightScale = 1.5f;
+static constexpr float kLinkedSlewCeilingDb = -12.0f;
 static constexpr float kLinkedDirectGuardDb = 3.0f; // catch abrupt jumps, not normal UI gestures
 
 //==============================================================================
@@ -156,8 +160,11 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     lastLinkedInputGainDb = pAutoComp.load (std::memory_order_relaxed) ? inGainDb : 1000.0f;
     linkedMakeupDb.snap (0.0f);
     linkedGuardSamples = 0;
+    linkedGuardFirstBlock = false;
+    linkedGuardDiscontinuity = false;
+    linkedGuardSlewScale = kLinkedSlewStartScale;
     lastLinkedOutputL = lastLinkedOutputR = 0.0f;
-    lastLinkedInputL = lastLinkedInputR = 0.0f;
+    linkedRecentOutputSlewL = linkedRecentOutputSlewR = 0.0f;
     linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
     linkedTopologyKey = pAutoComp.load (std::memory_order_relaxed)
         ? currentLinkedTopologyKey() : UINT32_MAX;
@@ -195,7 +202,6 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     linkedInputDelayL.assign (linkedDelaySize, 0.0f);
     linkedInputDelayR.assign (linkedDelaySize, 0.0f);
     linkedInputDelayIndex = 0;
-    linkedSlewLimitArr.assign (static_cast<size_t> (maxBlock), 1.0f);
     const size_t osCap = static_cast<size_t> (maxBlock) * 4u;
     satArr.assign       (osCap, 0.0f);
     biasArr.assign      (osCap, 0.0f);
@@ -220,6 +226,8 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     // isolated block maxima into a block-rate gain modulator.
     linkedMatchPeakDecay =
         std::exp (-1.0f / (0.050f * static_cast<float> (baseSampleRate)));
+    linkedOutputSlewDecay =
+        std::exp (-1.0f / (0.020f * static_cast<float> (baseSampleRate)));
 
     // Signal-level envelope detector: instant attack, ~30 ms release (base rate).
     // Fast enough to track drum transients (the level-keyed EQ must shift tone on the
@@ -288,8 +296,11 @@ void TapeMachineDSP::reset()
         ? pInputGainDb.load (std::memory_order_relaxed) : 1000.0f;
     linkedMakeupDb.snap (0.0f);
     linkedGuardSamples = 0;
+    linkedGuardFirstBlock = false;
+    linkedGuardDiscontinuity = false;
+    linkedGuardSlewScale = kLinkedSlewStartScale;
     lastLinkedOutputL = lastLinkedOutputR = 0.0f;
-    lastLinkedInputL = lastLinkedInputR = 0.0f;
+    linkedRecentOutputSlewL = linkedRecentOutputSlewR = 0.0f;
     linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
     std::fill (linkedInputDelayL.begin(), linkedInputDelayL.end(), 0.0f);
     std::fill (linkedInputDelayR.begin(), linkedInputDelayR.end(), 0.0f);
@@ -418,8 +429,6 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     {
         const size_t delaySize = linkedInputDelayL.size();
         size_t delayIndex = linkedInputDelayIndex;
-        float prevL = lastLinkedInputL;
-        float prevR = lastLinkedInputR;
         for (int n = 0; n < nSamples; ++n)
         {
             const float curL = inputs[0][n];
@@ -440,23 +449,20 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             linkedInputBlockPeak = std::max (linkedInputBlockPeak, alignedAbs);
             linkedInputPeak = alignedAbs > linkedInputPeak
                 ? alignedAbs : linkedInputPeak * linkedMatchPeakDecay;
-            const float inputDelta =
-                std::max (std::abs (alignedL - prevL), std::abs (alignedR - prevR));
-            linkedSlewLimitArr[static_cast<size_t> (n)] = std::max (1.0e-4f, inputDelta);
-            prevL = alignedL;
-            prevR = alignedR;
         }
         linkedInputDelayIndex = delayIndex;
-        lastLinkedInputL = prevL;
-        lastLinkedInputR = prevR;
         linkedInputMatchPeak = linkedInputPeak;
     }
 
     // --- bypass: pure passthrough + sample-peak refresh -----------------------
     if (hardBypass)
     {
+        linkedMakeupDb.prepare (baseSampleRate, kLinkedMatchTau);
         linkedMakeupDb.snap (0.0f);
         linkedGuardSamples = 0;
+        linkedGuardFirstBlock = false;
+        linkedGuardDiscontinuity = false;
+        linkedGuardSlewScale = kLinkedSlewStartScale;
         linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
         lastLinkedInputGainDb = 1000.0f;
         linkedTopologyKey = UINT32_MAX;
@@ -498,8 +504,12 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // --- Thru: passthrough + VU (input == output) ----------------------------
     if (signalPath == TapeCore::Thru)
     {
+        linkedMakeupDb.prepare (baseSampleRate, kLinkedMatchTau);
         linkedMakeupDb.snap (0.0f);
         linkedGuardSamples = 0;
+        linkedGuardFirstBlock = false;
+        linkedGuardDiscontinuity = false;
+        linkedGuardSlewScale = kLinkedSlewStartScale;
         linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
         lastLinkedInputGainDb = 1000.0f;
         linkedTopologyKey = UINT32_MAX;
@@ -610,8 +620,11 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     linkedTransition = linkedTransition || guardedLinkedGainStep;
     if (linkedTransition)
     {
-        linkedMakeupDb.snap (0.0f);
+        linkedMakeupDb.prepare (baseSampleRate, kLinkedGuardMatchTau);
         linkedGuardSamples = static_cast<int> (baseSampleRate * kLinkedGuardSec);
+        linkedGuardFirstBlock = true;
+        linkedGuardDiscontinuity = false;
+        linkedGuardSlewScale = kLinkedSlewStartScale;
     }
     inGain.setTarget (inputGainDb);
     outGain.setTarget (targetOutputGainDb);
@@ -1018,8 +1031,8 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // Gain Link is a host-level unity contract, not only a linear input/output-knob
     // inverse. Measure the processed block before makeup and restore its peak to the
     // latency-aligned raw-input peak. During steady processing makeup moves smoothly;
-    // during the short preset guard it follows each block immediately so stale filter or
-    // nonlinear state cannot create an overshoot above the incoming peak.
+    // during the short preset guard it starts from the first measured block, then follows
+    // subsequent block targets with a fast smoother to avoid hard gain steps.
     const bool linkedGuardActive = linkedGuardSamples > 0;
     if (gainLinked)
     {
@@ -1045,8 +1058,11 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
             const float targetDb = std::clamp (
                 20.0f * std::log10 (matchInputPeak / matchOutputPeak),
                 -36.0f, 12.0f);
-            if (linkedGuardActive)
+            if (linkedGuardActive && linkedGuardFirstBlock)
+            {
                 linkedMakeupDb.snap (targetDb);
+                linkedGuardFirstBlock = false;
+            }
             else
                 linkedMakeupDb.setTarget (targetDb);
         }
@@ -1063,42 +1079,98 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     }
     else
     {
+        linkedMakeupDb.prepare (baseSampleRate, kLinkedMatchTau);
         linkedMakeupDb.snap (0.0f);
         linkedGuardSamples = 0;
+        linkedGuardFirstBlock = false;
+        linkedGuardDiscontinuity = false;
+        linkedGuardSlewScale = kLinkedSlewStartScale;
         linkedInputMatchPeak = linkedOutputMatchPeak = 0.0f;
     }
 
-    // A topology change can also alter filter phase. During the short level guard, limit
-    // output slew to the source signal's own per-sample slew so the coefficient change
-    // cannot turn into a click. This does not run during steady processing.
+    // A topology change can also alter filter phase. During the short level guard, keep a
+    // permissive ceiling based on recent processed-output slew. Tighten it only after a
+    // sample actually exceeds that history-aware ceiling, so legitimate transients pass.
     if (linkedGuardActive)
     {
+        const int releaseSamples =
+            std::max (1, static_cast<int> (baseSampleRate * kLinkedSlewReleaseSec));
+        const float slewScaleStep =
+            (kLinkedSlewStartScale - kLinkedSlewTightScale)
+            / static_cast<float> (releaseSamples);
+        const float fixedSlewCeiling = dbToGain (kLinkedSlewCeilingDb);
         for (int n = 0; n < nSamples; ++n)
         {
-            const int releaseSamples =
-                std::max (1, static_cast<int> (baseSampleRate * kLinkedSlewReleaseSec));
-            const float release = linkedGuardSamples < releaseSamples
-                ? 1.0f - static_cast<float> (linkedGuardSamples)
-                         / static_cast<float> (releaseSamples)
-                : 0.0f;
-            const float slewScale = 1.25f + release * 14.75f;
-            const float limit = linkedSlewLimitArr[static_cast<size_t> (n)] * slewScale;
-            outputs[0][n] = std::clamp (outputs[0][n],
-                                        lastLinkedOutputL - limit, lastLinkedOutputL + limit);
+            if (linkedGuardDiscontinuity)
+                linkedGuardSlewScale =
+                    std::max (kLinkedSlewTightScale, linkedGuardSlewScale - slewScaleStep);
+
+            const float rawDeltaL = std::abs (outputs[0][n] - lastLinkedOutputL);
+            const float limitL = std::max (
+                fixedSlewCeiling, linkedRecentOutputSlewL * linkedGuardSlewScale);
+            if (rawDeltaL > limitL)
+            {
+                linkedGuardDiscontinuity = true;
+                outputs[0][n] = std::clamp (
+                    outputs[0][n], lastLinkedOutputL - limitL, lastLinkedOutputL + limitL);
+                linkedRecentOutputSlewL *= linkedOutputSlewDecay;
+            }
+            else
+            {
+                linkedRecentOutputSlewL = std::max (
+                    rawDeltaL, linkedRecentOutputSlewL * linkedOutputSlewDecay);
+            }
             lastLinkedOutputL = outputs[0][n];
+
             if (nCh >= 2)
             {
-                outputs[1][n] = std::clamp (outputs[1][n],
-                                            lastLinkedOutputR - limit, lastLinkedOutputR + limit);
+                const float rawDeltaR = std::abs (outputs[1][n] - lastLinkedOutputR);
+                const float limitR = std::max (
+                    fixedSlewCeiling, linkedRecentOutputSlewR * linkedGuardSlewScale);
+                if (rawDeltaR > limitR)
+                {
+                    linkedGuardDiscontinuity = true;
+                    outputs[1][n] = std::clamp (
+                        outputs[1][n], lastLinkedOutputR - limitR, lastLinkedOutputR + limitR);
+                    linkedRecentOutputSlewR *= linkedOutputSlewDecay;
+                }
+                else
+                {
+                    linkedRecentOutputSlewR = std::max (
+                        rawDeltaR, linkedRecentOutputSlewR * linkedOutputSlewDecay);
+                }
                 lastLinkedOutputR = outputs[1][n];
             }
             linkedGuardSamples = std::max (0, linkedGuardSamples - 1);
         }
+
+        if (linkedGuardSamples == 0)
+        {
+            linkedMakeupDb.prepare (baseSampleRate, kLinkedMatchTau);
+            linkedGuardFirstBlock = false;
+        }
     }
     else
     {
-        lastLinkedOutputL = outputs[0][nSamples - 1];
-        lastLinkedOutputR = outputs[nCh >= 2 ? 1 : 0][nSamples - 1];
+        for (int n = 0; n < nSamples; ++n)
+        {
+            const float deltaL = std::abs (outputs[0][n] - lastLinkedOutputL);
+            linkedRecentOutputSlewL = std::max (
+                deltaL, linkedRecentOutputSlewL * linkedOutputSlewDecay);
+            lastLinkedOutputL = outputs[0][n];
+            if (nCh >= 2)
+            {
+                const float deltaR = std::abs (outputs[1][n] - lastLinkedOutputR);
+                linkedRecentOutputSlewR = std::max (
+                    deltaR, linkedRecentOutputSlewR * linkedOutputSlewDecay);
+                lastLinkedOutputR = outputs[1][n];
+            }
+        }
+        if (nCh < 2)
+        {
+            lastLinkedOutputR = lastLinkedOutputL;
+            linkedRecentOutputSlewR = linkedRecentOutputSlewL;
+        }
     }
 
     // --- VU meter (output; ANSI mean-abs one-pole, ~300 ms to 99%) + output sample peak ----

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -350,6 +350,14 @@ int TapeMachineDSP::latencySamples() const noexcept
     if (pBypass.load (std::memory_order_relaxed))
         return 0;
 
+    // Thru is the same true zero-delay passthrough: its branch in processBlock copies
+    // input->output and returns before the oversampler ever runs. Reporting the active-path
+    // latency here made the host compensate for a delay that is not present, placing a
+    // Thru'd track ~32+ samples EARLY against the rest of the mix.
+    if (static_cast<TapeCore::SignalPath> (
+            clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3)) == TapeCore::Thru)
+        return 0;
+
     return activeLatencySamples();
 }
 

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -20,6 +20,7 @@ static constexpr float kParamTau = 0.0067f; // ~20 ms settle (wow / flutter / no
 static constexpr float kLinkedMatchTau = 0.05f; // ~150 ms settle for linked peak makeup
 static constexpr float kLinkedGuardSec = 0.25f; // prevent preset-transition overshoot
 static constexpr float kLinkedSlewReleaseSec = 0.05f;
+static constexpr float kLinkedDirectGuardDb = 3.0f; // catch abrupt jumps, not normal UI gestures
 
 //==============================================================================
 // Signal-level FR compensation (Phase B). The tape core's FR drifts with record
@@ -158,6 +159,7 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     lastLinkedOutputL = lastLinkedOutputR = 0.0f;
     lastLinkedInputL = lastLinkedInputR = 0.0f;
     linkedTopologyKey = UINT32_MAX;
+    lastLinkedBatchRevision = pLinkedBatchRevision.load (std::memory_order_relaxed);
     {
         outGain.snap (pAutoComp.load (std::memory_order_relaxed)
                           ? -inGainDb  // gain link = exact inverse; stored Output is unlinked-only
@@ -275,6 +277,7 @@ void TapeMachineDSP::reset()
     lastLinkedOutputL = lastLinkedOutputR = 0.0f;
     lastLinkedInputL = lastLinkedInputR = 0.0f;
     linkedTopologyKey = UINT32_MAX;
+    lastLinkedBatchRevision = pLinkedBatchRevision.load (std::memory_order_relaxed);
     outPeakStateL = outPeakStateR = 0.0f;
     vuL.store (0.0f, std::memory_order_relaxed);
     vuR.store (0.0f, std::memory_order_relaxed);
@@ -358,6 +361,9 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     const auto signalPath = static_cast<TapeCore::SignalPath> (
         clampI (pSignalPath.load (std::memory_order_relaxed), 0, 3));
     const bool useRawInputPeak = hardBypass || signalPath == TapeCore::Thru;
+    const uint32_t linkedBatchRevision = pLinkedBatchRevision.load (std::memory_order_relaxed);
+    const bool linkedBatchStarted = linkedBatchRevision != lastLinkedBatchRevision;
+    lastLinkedBatchRevision = linkedBatchRevision;
     const uint32_t topologyKey =
         static_cast<uint32_t> (clampI (pMachine.load (std::memory_order_relaxed), 0, 1))
         | (static_cast<uint32_t> (clampI (pSpeed.load (std::memory_order_relaxed), 0, 3)) << 1u)
@@ -550,9 +556,15 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // the OUTPUT by ~+13 dB (audible pop over 0 dBFS on every large preset change).
     // The paired ramps therefore cannot create their own gain bulge; the post-tape linked
     // matcher below handles level changes produced by the nonlinear/model stages.
-    const bool largeLinkedGainStep =
-        gainLinked && std::abs (inputGainDb - lastLinkedInputGainDb) > 0.5f;
-    linkedTransition = linkedTransition || largeLinkedGainStep;
+    // A preset batch or an abrupt >3 dB Input Gain jump arms the hard guard. Normal
+    // sub-3 dB UI gesture updates keep the paired dB smoothers and the normal makeup
+    // smoother, avoiding repeated hard snaps and transition-only slew limiting.
+    const float linkedGainDeltaDb = std::abs (inputGainDb - lastLinkedInputGainDb);
+    const bool guardedLinkedGainStep =
+        gainLinked
+        && (linkedGainDeltaDb > kLinkedDirectGuardDb
+            || (linkedBatchStarted && linkedGainDeltaDb > 0.5f));
+    linkedTransition = linkedTransition || guardedLinkedGainStep;
     if (linkedTransition)
     {
         linkedMakeupDb.snap (0.0f);

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -150,7 +150,7 @@ void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
     inGain.snap  (inGainDb);
     {
         outGain.snap (pAutoComp.load (std::memory_order_relaxed)
-                          ? -inGainDb + pOutputGainDb.load (std::memory_order_relaxed)  // gain link = inverse + Output trim
+                          ? -inGainDb  // gain link = exact inverse; stored Output is unlinked-only
                           : pOutputGainDb.load (std::memory_order_relaxed));
     }
     const float initSat = std::clamp (((inGainDb + 12.0f) / 24.0f) * 100.0f, 0.0f, 100.0f);
@@ -462,14 +462,11 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     float targetOutputGainDb;
     if (pAutoComp.load (std::memory_order_relaxed))
     {
-        // Gain link ("LINK"): output = -input + Output-knob trim. The inverse of the
-        // input drive locks the two knobs (drive the tape harder without the level
-        // rising); unity/cal-neutrality are handled inside the tape core
-        // (m_machineMakeupGain + cal restore). The Output knob remains a small ADDITIVE
-        // makeup trim on top of the inverse (default 0 -> pure inverse -> byte-identical
-        // unity). Factory presets use it to carry the reference preset's own non-unity output
-        // level (a post-tape LINEAR gain: shifts loudness but not THD/FR/aliasing).
-        targetOutputGainDb = -inputGainDb + pOutputGainDb.load (std::memory_order_relaxed);
+        // Gain link ("LINK"): output is the exact inverse of input. The stored Output
+        // parameter is deliberately ignored here so changing presets cannot introduce a
+        // hidden makeup-trim step while the two visible gain controls remain opposed.
+        // Unity/cal-neutrality are handled inside the tape core.
+        targetOutputGainDb = -inputGainDb;
     }
     else
     {
@@ -479,7 +476,7 @@ void TapeMachineDSP::processBlock (const float* const* inputs, float* const* out
     // inGain/outGain smooth in the dB DOMAIN (dbToGain applied per sample in the ramp
     // loops below), NOT linear gain. With the gain link engaged the two one-poles share
     // the same tau, so their dB trajectories cancel term-for-term and the in*out product
-    // tracks the Output trim exactly through the whole transition. Linear-domain smoothing
+    // remains at unity through the whole transition. Linear-domain smoothing
     // of g and 1/g does NOT cancel: the product bulges to 1 + (r-1)^2/(4r) mid-ramp
     // (r = gain-change ratio) — a 23.8 dB preset-switch input step transiently boosted
     // the OUTPUT by ~+13 dB (audible pop over 0 dBFS on every large preset change).

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2121,6 +2121,8 @@ private:
     // latencySamples(), so the tuned 2x core always runs regardless of the stored choice.
     static int factorFromChoice (int /*storedChoice*/) noexcept { return 2; }
 
+    int activeLatencySamples() const noexcept;
+    uint32_t currentLinkedTopologyKey() const noexcept;
     void applyFactor (int newFactor);   // reconfigure internal DSP for an OS-factor change
 
     // --- parameters (atomics) ---
@@ -2166,6 +2168,10 @@ private:
     int linkedGuardSamples = 0;
     float lastLinkedOutputL = 0.0f, lastLinkedOutputR = 0.0f;
     float lastLinkedInputL = 0.0f, lastLinkedInputR = 0.0f;
+    float linkedInputMatchPeak = 0.0f, linkedOutputMatchPeak = 0.0f;
+    float linkedMatchPeakDecay = 0.0f;
+    std::vector<float> linkedInputDelayL, linkedInputDelayR;
+    size_t linkedInputDelayIndex = 0;
     std::vector<float> linkedSlewLimitArr;
     uint32_t linkedTopologyKey = UINT32_MAX;
     uint32_t lastLinkedBatchRevision = 0u;

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2046,7 +2046,14 @@ public:
     void processBlock (const float* const* inputs, float* const* outputs, int nCh, int nSamples) noexcept;
     int  latencySamples() const noexcept;
 
-    void setTapeMachine (int idx)  noexcept { pMachine.store (clampI (idx, 0, 1), std::memory_order_relaxed); }
+    void setTapeMachine (int idx)  noexcept
+    {
+        pMachine.store (clampI (idx, 0, 1), std::memory_order_relaxed);
+        // Factory and user preset application writes Machine first, even when its value is
+        // unchanged. Keep that signal separate from a lone Input Gain gesture so a preset
+        // recall can arm the large-gain transition guard without classifying knob motion.
+        pLinkedBatchRevision.fetch_add (1u, std::memory_order_relaxed);
+    }
     void setTapeSpeed   (int idx)  noexcept { pSpeed.store (clampI (idx, 0, 3), std::memory_order_relaxed); }
     void setTapeType    (int idx)  noexcept { pType.store (clampI (idx, 0, 3), std::memory_order_relaxed); }
     void setSignalPath  (int idx)  noexcept { pSignalPath.store (clampI (idx, 0, 3), std::memory_order_relaxed); }
@@ -2128,6 +2135,7 @@ private:
     std::atomic<float> pProgHmfTrim{0.0f}, pProgHfTrim{0.0f};   // hidden program-band above-anchor HF trims (Phase C)
     std::atomic<float> pProgLfTrim{0.0f};                        // hidden program-band deep-sub bloom (EAR-GREEN)
     std::atomic<float> pLpQ{0.707f};        // lowpass SVF resonance (hidden preset data; 0.707 = the historic fixed Q)
+    std::atomic<uint32_t> pLinkedBatchRevision{0u};
     std::atomic<bool>  pAutoCal{true}, pNoiseEnabled{false}, pAutoComp{true}, pBypass{false};
     // American front-panel toggles — default On = the state the American tuning captured.
     std::atomic<bool>  pCrosstalk{true}, pWowFlutterOn{true}, pTransformer{true};
@@ -2160,6 +2168,7 @@ private:
     float lastLinkedInputL = 0.0f, lastLinkedInputR = 0.0f;
     std::vector<float> linkedSlewLimitArr;
     uint32_t linkedTopologyKey = UINT32_MAX;
+    uint32_t lastLinkedBatchRevision = 0u;
     SmoothedValue smSat, smWow, smFlutter, smNoise, smBias;
 
     bool bypassLowpass = true;

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2102,12 +2102,11 @@ public:
     // INPUT (record-node) sample-peak hold (instant attack, ~300 ms release), taken post-
     // input-gain / PRE-tape during normal processing and from the raw passthrough input while
     // bypassed or operating in Thru mode.
-    // Feeds ONLY the UI PEAK lamp; kept separate from the mean-abs VU integrator.
+    // Retained for diagnostic metering; kept separate from the mean-abs VU integrator.
     float getInPeakL() const noexcept { return inPeakL.load (std::memory_order_relaxed); }
     float getInPeakR() const noexcept { return inPeakR.load (std::memory_order_relaxed); }
     // OUTPUT (final post-everything) sample-peak hold (instant attack, ~300 ms release),
-    // taken on the buffer the host receives. Retained for diagnostic metering only; the UI
-    // PEAK lamp uses the input record-node accessors above.
+    // taken on the buffer the host receives. Retained for diagnostic metering only.
     float getOutPeakL() const noexcept { return outPeakL.load (std::memory_order_relaxed); }
     float getOutPeakR() const noexcept { return outPeakR.load (std::memory_order_relaxed); }
 
@@ -2223,7 +2222,7 @@ private:
     float vuStateL = 0.0f, vuStateR = 0.0f;
     float inVuStateL = 0.0f, inVuStateR = 0.0f;
     float vuBallisticAlpha = 0.0f;   // one-pole integrator coeff for ANSI VU ballistics (~300 ms to 99%)
-    // separate INPUT-node sample-peak hold for the PEAK lamp (instant attack, 300 ms release)
+    // separate INPUT-node diagnostic sample-peak hold (instant attack, 300 ms release)
     std::atomic<float> inPeakL{0.0f}, inPeakR{0.0f};
     float inPeakStateL = 0.0f, inPeakStateR = 0.0f;
     bool inputPeakUsesRawInput = false;  // audio-thread-only metering-node transition state

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2202,6 +2202,7 @@ private:
     // separate INPUT-node sample-peak hold for the PEAK lamp (instant attack, 300 ms release)
     std::atomic<float> inPeakL{0.0f}, inPeakR{0.0f};
     float inPeakStateL = 0.0f, inPeakStateR = 0.0f;
+    bool inputPeakUsesRawInput = false;  // audio-thread-only metering-node transition state
     std::atomic<float> outPeakL{0.0f}, outPeakR{0.0f};  // final-output sample-peak hold (diagnostic)
     float outPeakStateL = 0.0f, outPeakStateR = 0.0f;
     float peakDecayCoeff = 0.0f;

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2147,8 +2147,8 @@ private:
 
     // --- smoothers ---
     // inGain/outGain hold dB, not linear gain (dbToGain applied per ramp sample): with
-    // the gain link on, dB-domain one-poles cancel exactly so in*out tracks the Output
-    // trim through a transition. Linear-domain smoothing of g and 1/g bulged the product
+    // the gain link on, dB-domain one-poles cancel exactly so in*out stays at unity
+    // through a transition. Linear-domain smoothing of g and 1/g bulged the product
     // by up to ~+13 dB on a large preset-switch gain step (pop over 0 dBFS).
     SmoothedValue inGain;                   // base-rate ramp, dB (shared by L/R)
     SmoothedValue outGain;                  // OS-rate ramp, dB (shared by L/R)

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2093,7 +2093,8 @@ public:
     float getInVuL() const noexcept { return inVuL.load (std::memory_order_relaxed); }
     float getInVuR() const noexcept { return inVuR.load (std::memory_order_relaxed); }
     // INPUT (record-node) sample-peak hold (instant attack, ~300 ms release), taken post-
-    // input-gain / PRE-tape while processing and from the passthrough input while bypassed.
+    // input-gain / PRE-tape during normal processing and from the raw passthrough input while
+    // bypassed or operating in Thru mode.
     // Feeds ONLY the UI PEAK lamp; kept separate from the mean-abs VU integrator.
     float getInPeakL() const noexcept { return inPeakL.load (std::memory_order_relaxed); }
     float getInPeakR() const noexcept { return inPeakR.load (std::memory_order_relaxed); }

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2092,15 +2092,14 @@ public:
     // Pre-processing input peak (for a UI In/Out meter switch). Metering only.
     float getInVuL() const noexcept { return inVuL.load (std::memory_order_relaxed); }
     float getInVuR() const noexcept { return inVuR.load (std::memory_order_relaxed); }
-    // INPUT (record-node) true-peak hold (instant attack, ~300 ms release), taken post-
-    // input-gain / PRE-tape — feeds ONLY the UI PEAK lamp, kept separate from the mean-abs
-    // VU integrator. Metering only.
+    // INPUT (record-node) sample-peak hold (instant attack, ~300 ms release), taken post-
+    // input-gain / PRE-tape while processing and from the passthrough input while bypassed.
+    // Feeds ONLY the UI PEAK lamp; kept separate from the mean-abs VU integrator.
     float getInPeakL() const noexcept { return inPeakL.load (std::memory_order_relaxed); }
     float getInPeakR() const noexcept { return inPeakR.load (std::memory_order_relaxed); }
-    // OUTPUT (final post-everything) true sample-peak hold (instant attack, ~300 ms release),
-    // taken on the buffer the host receives — feeds the UI PEAK lamp as a genuine digital-clip
-    // (output over 0 dBFS) indicator. Tape saturates softly, so moderate drive does NOT trip it.
-    // Metering only.
+    // OUTPUT (final post-everything) sample-peak hold (instant attack, ~300 ms release),
+    // taken on the buffer the host receives. Retained for diagnostic metering only; the UI
+    // PEAK lamp uses the input record-node accessors above.
     float getOutPeakL() const noexcept { return outPeakL.load (std::memory_order_relaxed); }
     float getOutPeakR() const noexcept { return outPeakR.load (std::memory_order_relaxed); }
 
@@ -2200,10 +2199,10 @@ private:
     float vuStateL = 0.0f, vuStateR = 0.0f;
     float inVuStateL = 0.0f, inVuStateR = 0.0f;
     float vuBallisticAlpha = 0.0f;   // one-pole integrator coeff for ANSI VU ballistics (~300 ms to 99%)
-    // separate INPUT-node true-peak hold for the PEAK lamp (instant attack, 300 ms release)
+    // separate INPUT-node sample-peak hold for the PEAK lamp (instant attack, 300 ms release)
     std::atomic<float> inPeakL{0.0f}, inPeakR{0.0f};
     float inPeakStateL = 0.0f, inPeakStateR = 0.0f;
-    std::atomic<float> outPeakL{0.0f}, outPeakR{0.0f};  // final-output sample-peak hold (PEAK lamp = digital clip)
+    std::atomic<float> outPeakL{0.0f}, outPeakR{0.0f};  // final-output sample-peak hold (diagnostic)
     float outPeakStateL = 0.0f, outPeakStateR = 0.0f;
     float peakDecayCoeff = 0.0f;
 };

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2149,9 +2149,17 @@ private:
     // inGain/outGain hold dB, not linear gain (dbToGain applied per ramp sample): with
     // the gain link on, dB-domain one-poles cancel exactly so in*out stays at unity
     // through a transition. Linear-domain smoothing of g and 1/g bulged the product
-    // by up to ~+13 dB on a large preset-switch gain step (pop over 0 dBFS).
+    // by up to ~+13 dB on a large preset-switch gain step. linkedMakeupDb then restores
+    // host-facing peak unity across nonlinear and topology-dependent level changes.
     SmoothedValue inGain;                   // base-rate ramp, dB (shared by L/R)
     SmoothedValue outGain;                  // OS-rate ramp, dB (shared by L/R)
+    float lastLinkedInputGainDb = 1000.0f;
+    SmoothedValue linkedMakeupDb;            // post-tape linked peak matching, dB
+    int linkedGuardSamples = 0;
+    float lastLinkedOutputL = 0.0f, lastLinkedOutputR = 0.0f;
+    float lastLinkedInputL = 0.0f, lastLinkedInputR = 0.0f;
+    std::vector<float> linkedSlewLimitArr;
+    uint32_t linkedTopologyKey = UINT32_MAX;
     SmoothedValue smSat, smWow, smFlutter, smNoise, smBias;
 
     bool bypassLowpass = true;

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -2165,13 +2165,16 @@ private:
     float lastLinkedInputGainDb = 1000.0f;
     SmoothedValue linkedMakeupDb;            // post-tape linked peak matching, dB
     int linkedGuardSamples = 0;
+    bool linkedGuardFirstBlock = false;
+    bool linkedGuardDiscontinuity = false;
+    float linkedGuardSlewScale = 4.0f;
     float lastLinkedOutputL = 0.0f, lastLinkedOutputR = 0.0f;
-    float lastLinkedInputL = 0.0f, lastLinkedInputR = 0.0f;
+    float linkedRecentOutputSlewL = 0.0f, linkedRecentOutputSlewR = 0.0f;
+    float linkedOutputSlewDecay = 0.0f;
     float linkedInputMatchPeak = 0.0f, linkedOutputMatchPeak = 0.0f;
     float linkedMatchPeakDecay = 0.0f;
     std::vector<float> linkedInputDelayL, linkedInputDelayR;
     size_t linkedInputDelayIndex = 0;
-    std::vector<float> linkedSlewLimitArr;
     uint32_t linkedTopologyKey = UINT32_MAX;
     uint32_t lastLinkedBatchRevision = 0u;
     SmoothedValue smSat, smWow, smFlutter, smNoise, smBias;

--- a/plugins/TapeMachine/dpf-plugin/CMakeLists.txt
+++ b/plugins/TapeMachine/dpf-plugin/CMakeLists.txt
@@ -34,9 +34,12 @@ target_include_directories(tape_machine_2 PUBLIC
     ${DUSK_DPF_INCLUDE_DIRS})
 
 # Single source of truth for the plugin version: the project() VERSION above is
-# plumbed into getVersion() via these macros (see TapeMachinePlugin.cpp). Bumped
-# by the /release-plugin skill (slug tapemachine-2).
-target_compile_definitions(tape_machine_2 PRIVATE
+# plumbed into getVersion() and the UI version display via these macros (see
+# TapeMachineVersion.hpp). Bumped by the /release-plugin skill (slug
+# tapemachine-2). PUBLIC because DPF compiles the UI in a separate
+# tape_machine_2-ui target that links this one and must see the same values —
+# PRIVATE would leave the UI on the header's stale fallback.
+target_compile_definitions(tape_machine_2 PUBLIC
     TM2_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
     TM2_VERSION_MINOR=${PROJECT_VERSION_MINOR}
     TM2_VERSION_PATCH=${PROJECT_VERSION_PATCH})

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
@@ -18,8 +18,8 @@ DUSK_ACCESS_DECL(float, tapeMachineGetVuR);
 DUSK_ACCESS_DECL(float, tapeMachineGetInVuL);
 DUSK_ACCESS_DECL(float, tapeMachineGetInVuR);
 // INPUT sample-peak hold per channel — post-gain/pre-tape during normal processing,
-// raw passthrough input while bypassed or in Thru mode. Feeds the PEAK lamp; null
-// in split LV2 UI.
+// raw passthrough input while bypassed or in Thru mode. Retained as a direct-access
+// diagnostic; null in split LV2 UI.
 DUSK_ACCESS_DECL(float, tapeMachineGetInPeakL);
 DUSK_ACCESS_DECL(float, tapeMachineGetInPeakR);
 // OUTPUT (final, post-everything) sample-peak hold per channel. Retained as a

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
@@ -17,11 +17,11 @@ DUSK_ACCESS_DECL(float, tapeMachineGetVuR);
 // Pre-processing input peak per channel (for the UI's In/Out meter switch).
 DUSK_ACCESS_DECL(float, tapeMachineGetInVuL);
 DUSK_ACCESS_DECL(float, tapeMachineGetInVuR);
-// INPUT (post-gain, pre-tape) true-peak hold per channel — feeds only the PEAK lamp.
+// INPUT (post-gain, pre-tape) sample-peak hold per channel — feeds the PEAK lamp.
 // Null in split LV2 UI.
 DUSK_ACCESS_DECL(float, tapeMachineGetInPeakL);
 DUSK_ACCESS_DECL(float, tapeMachineGetInPeakR);
-// OUTPUT (final, post-everything) true sample-peak hold per channel — feeds the PEAK lamp
-// as a genuine digital-clip (output over 0 dBFS) indicator. Null in split LV2 UI.
+// OUTPUT (final, post-everything) sample-peak hold per channel. Retained as a
+// direct-access diagnostic for the output node. Null in split LV2 UI.
 DUSK_ACCESS_DECL(float, tapeMachineGetOutPeakL);
 DUSK_ACCESS_DECL(float, tapeMachineGetOutPeakR);

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineAccess.hpp
@@ -17,8 +17,9 @@ DUSK_ACCESS_DECL(float, tapeMachineGetVuR);
 // Pre-processing input peak per channel (for the UI's In/Out meter switch).
 DUSK_ACCESS_DECL(float, tapeMachineGetInVuL);
 DUSK_ACCESS_DECL(float, tapeMachineGetInVuR);
-// INPUT (post-gain, pre-tape) sample-peak hold per channel — feeds the PEAK lamp.
-// Null in split LV2 UI.
+// INPUT sample-peak hold per channel — post-gain/pre-tape during normal processing,
+// raw passthrough input while bypassed or in Thru mode. Feeds the PEAK lamp; null
+// in split LV2 UI.
 DUSK_ACCESS_DECL(float, tapeMachineGetInPeakL);
 DUSK_ACCESS_DECL(float, tapeMachineGetInPeakR);
 // OUTPUT (final, post-everything) sample-peak hold per channel. Retained as a

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -8,6 +8,7 @@
 #include "TapeMachineAccess.hpp"
 #include "TapeMachineParams.hpp"
 #include "TapeMachinePresets.hpp"
+#include "TapeMachineVersion.hpp"
 #include "TapeMachineDSP.hpp"
 
 #include <atomic>
@@ -42,13 +43,7 @@ protected:
     const char* getMaker() const override    { return "Dusk Audio"; }
     const char* getHomePage() const override { return "https://dusk-audio.github.io/"; }
     const char* getLicense() const override  { return "GPL-3.0-or-later"; }
-    // Version comes from the CMake project() VERSION via compile definitions
-    // (single source of truth). Fallback keeps non-CMake builds compiling.
-#ifndef TM2_VERSION_MAJOR
- #define TM2_VERSION_MAJOR 2
- #define TM2_VERSION_MINOR 0
- #define TM2_VERSION_PATCH 0
-#endif
+    // Version comes from the CMake project() VERSION via TapeMachineVersion.hpp.
     uint32_t    getVersion() const override  { return d_version(TM2_VERSION_MAJOR, TM2_VERSION_MINOR, TM2_VERSION_PATCH); }
     int64_t     getUniqueId() const override { return d_cconst('D', 's', 'T', 'M'); } // matches DISTRHO_PLUGIN_UNIQUE_ID (DsTM)
 

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePresets.hpp
@@ -8,10 +8,9 @@
 //
 // Gain link (Auto Compensation) is ON for every preset: driving the tape via Input
 // adds saturation while the output holds unity (-12 dBFS in -> -12 dBFS out), which
-// is how the reference operates at its calibrated -12 dBFS internal level. Each preset then
-// carries a small per-preset Output makeup trim (outTrim, applied on top of the link)
-// that matches the loudness of the reference preset it was curated from — the reference
-// presets dial their own record/repro levels, so their net output is not always unity.
+// is how the calibrated -12 dBFS internal level operates. Each preset also stores an
+// Output trim for unlinked operation; Gain Link deliberately ignores it so preset
+// changes cannot alter the linked gain-stage level.
 
 #pragma once
 
@@ -34,10 +33,9 @@ struct TmPreset
     float highpassFreq, lowpassFreq;
     float wow, flutter, noiseAmount;
     float reproLf, reproLmf, reproHmf, reproHf;  // advanced repro-head 4-band EQ (dB); 0 = neutral (rows may omit -> 0)
-    float outTrim;  // per-preset OUTPUT makeup trim (dB) applied on top of the gain-link
-                    // inverse (output = -input + outTrim); matches the reference preset's
-                    // own non-unity output level. Post-tape LINEAR gain: shifts loudness only,
-                    // transparent to THD/FR/aliasing. 0 = unity; every row sets it explicitly.
+    float outTrim;  // per-preset OUTPUT makeup trim (dB), used only with Gain Link off.
+                    // Post-tape LINEAR gain: shifts loudness only, transparent to
+                    // THD/FR/aliasing. 0 = unity; every row sets it explicitly.
     bool  crosstalk = false;  // American-only adjacent-track bleed toggle, matching the reference
                     // preset's own Crosstalk switch. Omitted (=false) on Swiss presets (that deck
                     // models zero crosstalk) and on American presets whose reference ships it Off;
@@ -112,8 +110,8 @@ static constexpr TmPreset kTmPresets[] =
     // (6.3-16 kHz); the program-band-keyed cut closes it (sustHF 6.12 -> 0.38) while THD stays
     // byte-identical (the 1 kHz tone is below the prog envelope's -12 anchor). Phase B reproHf=8.7 kept.
     // outTrim 1.5 -> 2.53: the HF cut removed ~1.46 dB broadband on loud program (pink loud-region
-    // dRMS), so the makeup restores loud-region loudness parity (Cat1 dRMS -1.03 -> 0.0). outTrim is
-    // a post-tape LINEAR gain (THD %/FR/alias invariant; it does scale the render level).
+    // dRMS), so this unlinked makeup restores loud-region loudness parity (Cat1 dRMS -1.03 -> 0.0).
+    // outTrim is a post-tape LINEAR gain (THD %/FR/alias invariant; it scales unlinked output).
     { "Drum Bus", "Swiss Mix", 0, 1, 1, 0, 1, 1, 1, 10.9f, false, 62.f, 20.f, 20000.f, 0.f, 0.f, 0.f, -1.7f, 0.4f, -0.4f, 8.7f, 2.53f, false, 0.0f, 0.0f, 0.707f, -14.0f, -14.0f, 0.0f, 17.5f },
     { "Hi-Fi Shine", "Swiss Mix", 0, 2, 1, 0, 1, 0, 1, 5.1f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 0.f, 0.6f, 0.3f, -0.8f, 5.5f, 0.3f },
     { "Lush Film", "Swiss Mix", 0, 1, 2, 0, 0, 1, 1, 3.1f, true, 50.f, 20.f, 20000.f, 0.f, 0.f, 0.f, -1.7f, 0.5f, -0.8f, 1.f, 0.9f, false, 0.0f, 0.0f, 0.707f, 0.0f, -5.0f, 0.0f, 5.5f },
@@ -148,8 +146,9 @@ static constexpr int kNumTmPresets = (int)(sizeof(kTmPresets) / sizeof(kTmPreset
 
 // Apply a preset by invoking setter(paramId, value) for each parameter it owns.
 // Used by both the plugin (loadProgram) and the UI (preset combo) so the two stay
-// in lockstep. Gain link is forced on; Output Gain carries the preset's makeup trim
-// (added to the link's -input inverse). Parameters not listed keep their current value.
+// in lockstep. Gain link is forced on; Output Gain retains the preset's unlinked
+// makeup trim but cannot affect the linked -input inverse. Parameters not listed
+// keep their current value.
 template <class SetFn>
 inline void tmApplyPreset(int idx, SetFn&& set)
 {
@@ -169,8 +168,8 @@ inline void tmApplyPreset(int idx, SetFn&& set)
     set(kParamWowFlutterOn, 1.0f);
     set(kParamTransformer,  1.0f);
     set(kParamInputGain,    p.inputGain);
-    set(kParamOutputGain,   p.outTrim);                 // makeup trim on top of the gain-link inverse
-    set(kParamAutoComp,     1.0f);                      // gain link on (unity + outTrim output)
+    set(kParamOutputGain,   p.outTrim);                 // retained for unlinked operation
+    set(kParamAutoComp,     1.0f);                      // gain link on (exact -input inverse)
     set(kParamAutoCal,      p.autoCal ? 1.f : 0.f);
     set(kParamBias,         p.bias);
     set(kParamHighpassFreq, p.highpassFreq);

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -101,11 +101,6 @@ public:
         panel.setPalette(pal);
 
         scanUserPresets();
-
-        // Start the PEAK-lamp hold timers cleared: a host that hides (not destroys)
-        // the editor would otherwise freeze a mid-hold value and show a stale lit lamp
-        // on reopen. No DPF show/visibility hook exists here, so ctor-init is the guard.
-        clipHoldL = clipHoldR = 0.0f;
     }
 
 protected:
@@ -154,13 +149,9 @@ protected:
         const bool modalOpen = showAdvanced || showSupporters;
         if (modalOpen) ImGui::BeginDisabled();
         drawHeader(dl);
-        // The PEAK lamp follows the post-input-gain, pre-tape record level during normal
-        // processing and raw passthrough input while bypassed or in Thru. It lights at
-        // 0 dBFS (see drawVU), auto-holds 1.5 s after the last over, and click-clears.
-        const bool clipEnabled = true;
         const ImU32 accent = accentCol();
-        drawVU(dl, 68,  62, 388, 198, meterLevel(0), peakLevel(0), needleL, clipHoldL, clipEnabled, accent, "L");
-        drawVU(dl, 412, 62, 732, 198, meterLevel(1), peakLevel(1), needleR, clipHoldR, clipEnabled, accent, "R");
+        drawVU(dl, 68,  62, 388, 198, meterLevel(0), needleL, accent, "L");
+        drawVU(dl, 412, 62, 732, 198, meterLevel(1), needleR, accent, "R");
         drawSelectors(dl);
         drawControls(dl);
         if (modalOpen) ImGui::EndDisabled();
@@ -190,19 +181,6 @@ private:
             if (out) { if (tapeMachineGetVuL)   v = ch == 0 ? tapeMachineGetVuL(inst)   : tapeMachineGetVuR(inst); }
             else     { if (tapeMachineGetInVuL) v = ch == 0 ? tapeMachineGetInVuL(inst) : tapeMachineGetInVuR(inst); }
         }
-       #endif
-        return v;
-    }
-
-    // Sample peak for the PEAK lamp: post-input-gain/pre-tape during normal
-    // processing, raw passthrough input while bypassed or in Thru.
-    float peakLevel(int ch)
-    {
-        float v = 0.0f;
-       #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
-        if (void* const inst = getPluginInstancePointer())
-            if (tapeMachineGetInPeakL)
-                v = ch == 0 ? tapeMachineGetInPeakL(inst) : tapeMachineGetInPeakR(inst);
        #endif
         return v;
     }
@@ -746,8 +724,7 @@ private:
     static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
 
     void drawVU(ImDrawList* dl, float x0, float y0, float x1, float y1,
-                float level, float peak, float& needle, float& clipHold, bool clipEnabled,
-                ImU32 accent, const char* label)
+                float level, float& needle, ImU32 accent, const char* label)
     {
         // 0 VU = -12 dBFS: the reference/Swiss/American spec ("plug-in operates at an internal
         // level of -12 dBFS ... a -12 dBFS input equates to 0 dB on the meters").
@@ -822,44 +799,6 @@ private:
         // - (left) and + (red, right) marks in the top corners
         text(dl, fx0 + 10, fy0 + 3, 15.0f, ink, "-", -1, true);
         text(dl, fx1 - 10, fy0 + 3, 15.0f, red, "+", 1, true);
-
-        // over lamp (right). The peak comes from the post-input-gain, pre-tape
-        // record node during normal processing and raw passthrough input while
-        // bypassed or in Thru.
-        // `clipHold` is a HOLD TIMER in seconds: every over (re)arms it to 1.5 s, and
-        // between overs it counts down by the frame dt, so a brief transient stays lit ~1.5 s
-        // after it passes and a sustained hot signal keeps re-arming (stays lit). A click clears
-        // it immediately. (Replaces the old indefinite output-clip latch.)
-        static constexpr float kPeakThreshLin = 1.0f;          // 0 dBFS in linear amplitude
-        static constexpr float kPeakHoldSec   = 1.5f;          // auto-hold after the last over
-        if (clipEnabled && peak >= kPeakThreshLin)
-            clipHold = kPeakHoldSec;                           // (re)arm on every over
-        else if (clipHold > 0.0f)
-            clipHold -= ImGui::GetIO().DeltaTime;              // count the hold down between overs
-        const bool over = clipEnabled && clipHold > 0.0f;
-        const ImVec2 lp = P(fx1 - 15, pivotY - L * 0.20f);
-        if (clipEnabled)
-        {
-            char cid[8]; std::snprintf(cid, sizeof(cid), "clip%s", label);
-            ImGui::SetCursorScreenPos(ImVec2(lp.x - 8.0f * s, lp.y - 8.0f * s));
-            ImGui::InvisibleButton(cid, ImVec2(16.0f * s, 16.0f * s));
-            if (ImGui::IsItemClicked()) clipHold = 0.0f;
-        }
-        // Lit vs unlit must be unmistakable: LIT = hot red core + bright ring + glow
-        // halo; UNLIT = a clearly dark drilled recess. Click the lamp to clear the hold.
-        dl->AddCircleFilled(lp, 7.2f * s, IM_COL32(26, 20, 18, 255), 22);              // drilled socket shadow
-        if (over) dl->AddCircleFilled(lp, 10.5f * s, IM_COL32(232, 60, 40, 95), 24);   // glow halo
-        dl->AddCircleFilled(lp, 5.0f * s,
-            over ? IM_COL32(242, 68, 46, 255) : IM_COL32(44, 33, 31, 255), 18);        // lit core / dark recess
-        if (over)
-            dl->AddCircle(lp, 5.7f * s, IM_COL32(255, 152, 132, 225), 20, 1.2f * s);   // hot rim when lit
-        else
-            dl->AddCircle(lp, 5.0f * s, IM_COL32(10, 6, 6, 255), 18, 1.2f * s);        // recessed dark rim
-        dl->AddCircleFilled(ImVec2(lp.x - 1.4f * s, lp.y - 1.6f * s), 1.6f * s,
-                            IM_COL32(255, 205, 185, over ? 235 : 38), 10);             // specular dot
-        // small screened label so the click-to-reset lamp reads as PEAK without a tooltip
-        text(dl, fx1 - 15, pivotY - L * 0.20f + 8.5f, 7.5f,
-             over ? red : IM_COL32(118, 98, 78, 210), "PEAK", 0, true);
 
         // VU legend + channel tag
         text(dl, cx, pivotY - L * 0.46f, 11, ink, "VU", 0, true);
@@ -1227,7 +1166,6 @@ private:
     float   s = 1.0f;
     ImVec2  org = ImVec2(0, 0);
     float   needleL = 0.0f, needleR = 0.0f;
-    float   clipHoldL = 0.0f, clipHoldR = 0.0f;   // PEAK-lamp hold timers (seconds); 0 = unlit
     bool    outLinkActive_ = false;   // set only while the OUTPUT knob is drawn under GAIN LINK
     ImVec2  advScrimPressPos = ImVec2(0, 0);       // where an Advanced-scrim press began (travel guard)
     int     meterSource = 0;      // 0 = input (record/tape-drive level, like the hardware VU), 1 = output

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -1125,7 +1125,8 @@ private:
         // exact inverse of the input (drive the tape harder without a gain-stage level
         // change). The stored outputGain value is used only while the link is off; linked
         // preset changes therefore cannot add a hidden output-trim step. The link lives in
-        // the DSP so it works under host automation. To make the link read clearly the OUTPUT
+        // the DSP and its post-tape makeup holds the host-facing sample peak at the incoming
+        // level, including during guarded preset transitions. To make the link read clearly the OUTPUT
         // knob MIRRORS input under link — its needle AND readout show -input (an opposed pair,
         // e.g. +3 / -3) on the normal ±12 scale, and moving either knob moves the other the
         // opposite way (the drag is routed to INPUT in the setParam adapter, linkOffset = -input).

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -156,9 +156,9 @@ protected:
         const bool modalOpen = showAdvanced || showSupporters;
         if (modalOpen) ImGui::BeginDisabled();
         drawHeader(dl);
-        // The PEAK lamp follows the post-input-gain, pre-tape record level. It lights when
-        // that input node crosses 0 dBFS (see drawVU), auto-holds 1.5 s after the last over,
-        // and click-clears.
+        // The PEAK lamp follows the post-input-gain, pre-tape record level during normal
+        // processing and raw passthrough input while bypassed or in Thru. It lights at
+        // 0 dBFS (see drawVU), auto-holds 1.5 s after the last over, and click-clears.
         const bool clipEnabled = true;
         const ImU32 accent = accentCol();
         drawVU(dl, 68,  62, 388, 198, meterLevel(0), peakLevel(0), needleL, clipHoldL, clipEnabled, accent, "L");
@@ -196,8 +196,8 @@ private:
         return v;
     }
 
-    // Post-input-gain, pre-tape sample peak for the PEAK lamp. This is the record
-    // level entering the tape path, independent of output compensation.
+    // Sample peak for the PEAK lamp: post-input-gain/pre-tape during normal
+    // processing, raw passthrough input while bypassed or in Thru.
     float peakLevel(int ch)
     {
         float v = 0.0f;
@@ -826,8 +826,8 @@ private:
         text(dl, fx1 - 10, fy0 + 3, 15.0f, red, "+", 1, true);
 
         // over lamp (right). The peak comes from the post-input-gain, pre-tape
-        // record node, so it warns when the level driving the tape path crosses
-        // 0 dBFS regardless of the linked output compensation.
+        // record node during normal processing and raw passthrough input while
+        // bypassed or in Thru.
         // `clipHold` is a HOLD TIMER in seconds: every over (re)arms it to 1.5 s, and
         // between overs it counts down by the frame dt, so a brief transient stays lit ~1.5 s
         // after it passes and a sustained hot signal keeps re-arming (stays lit). A click clears

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -59,11 +59,9 @@ public:
     {
         // GAIN LINK mirror: the OUTPUT knob is drawn/edited as the opposed input (its
         // readout shows -input). Route every write it makes to INPUT so the two gains
-        // always read as an opposed pair — input = clamp(-displayed). The preset's baked
-        // OUTPUT trim (the recall CALIBRATION) is neither read nor written here: it stays
-        // in the outputGain param and the DSP keeps applying -input + trim, so the
-        // calibrated level is preserved while the knobs stay in sync. UI-only, no DSP
-        // change. This is the single point every OUTPUT-knob gesture funnels through.
+        // always read as an opposed pair — input = clamp(-displayed). The stored OUTPUT
+        // value is neither read nor written here and is used only with the link off.
+        // This is the single point every OUTPUT-knob gesture funnels through.
         if (outLinkActive_ && idx == kParamOutputGain)
         {
             const TmParam& in = kTmParams[kParamInputGain];
@@ -1023,11 +1021,9 @@ private:
         // GAIN LINK path (OUTPUT knob only): a MIRROR of INPUT. The knob shows the opposed
         // input (-input) on the normal ±12 dB output scale, so the two gains always read as
         // an opposed pair (+3 / -3). Its edits are routed to INPUT in the setParam adapter
-        // (input = -displayed). The preset's baked OUTPUT trim is the recall CALIBRATION: it
-        // is neither read nor shown here and stays in the outputGain param, so the DSP keeps
-        // applying -input + trim for the calibrated level while the knobs stay in sync.
-        // Because the readout is always -input, the two knobs cannot drift out of sync (an
-        // OUTPUT trim left behind by editing while UNLINKED is simply not shown under link).
+        // (input = -displayed). The stored OUTPUT value is neither read nor shown here and
+        // remains available for unlinked operation. Because the readout is always -input,
+        // the two knobs cannot drift out of sync.
         // Moving INPUT rotates this needle; moving this knob rotates the INPUT needle. UI-only.
         if (linked)
         {
@@ -1039,8 +1035,8 @@ private:
                        /*persistent*/ true, nullptr, /*rightClickReset*/ false, 1.0f,
                        /*dispAdd*/ 0.0f, l1, /*contextMenu*/ true, overrideText);
             outLinkActive_ = false;
-            // The INPUT mirror is applied in the setParam adapter; the baked OUTPUT trim and
-            // the DSP are left untouched, so nothing to store back here.
+            // The INPUT mirror is applied in the setParam adapter; the stored unlinked
+            // OUTPUT value is left untouched, so nothing is stored back here.
             return ch;
         }
         // Interaction is owned entirely by the shared knob widget so every knob
@@ -1126,15 +1122,15 @@ private:
         dl->AddLine(P(26, cellBot), P(774, cellBot), IM_COL32(150, 151, 153, 140), 1.0f * s);
 
         // GAIN STAGING — with GAIN LINK (autoComp) on, the DSP holds the output at the
-        // inverse of the input (drive the tape harder without the level rising): output gain
-        // = -input + trim, where trim is the outputGain param. Factory presets ship a fitted
-        // trim as recall CALIBRATION for each reference preset's loudness; the link lives in
+        // exact inverse of the input (drive the tape harder without a gain-stage level
+        // change). The stored outputGain value is used only while the link is off; linked
+        // preset changes therefore cannot add a hidden output-trim step. The link lives in
         // the DSP so it works under host automation. To make the link read clearly the OUTPUT
         // knob MIRRORS input under link — its needle AND readout show -input (an opposed pair,
         // e.g. +3 / -3) on the normal ±12 scale, and moving either knob moves the other the
         // opposite way (the drag is routed to INPUT in the setParam adapter, linkOffset = -input).
-        // The baked trim is deliberately NOT shown or changed by the knob, so the calibration
-        // is preserved untouched while the knobs stay in sync. Link off -> plain output gain / trim.
+        // The stored unlinked value is not shown or changed while the knobs stay in sync.
+        // Link off -> plain output gain / trim.
         const bool gainLink = values[kParamAutoComp] > 0.5f;
         knob(dl, "input",  kParamInputGain,  67.0f, cy, "INPUT",  "%.1f", " dB");
         knob(dl, "output", kParamOutputGain,163.0f, cy, "OUTPUT", "%.1f", " dB",

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -12,6 +12,7 @@
 #include "TapeMachineAccess.hpp"
 #include "TapeMachineParams.hpp"
 #include "TapeMachinePresets.hpp"
+#include "TapeMachineVersion.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp"   // shared DPF Patreon "Special Thanks" overlay (click title)
@@ -155,10 +156,9 @@ protected:
         const bool modalOpen = showAdvanced || showSupporters;
         if (modalOpen) ImGui::BeginDisabled();
         drawHeader(dl);
-        // The PEAK lamp is a digital-CLIP indicator: peakLevel(ch) reads the DSP's final-OUTPUT
-        // sample-peak hold, and the lamp lights when the output crosses 0 dBFS (see drawVU),
-        // auto-holds 1.5 s after the last over, and click-clears. Tape soft-saturates, so
-        // driving it for crunch does not trip it — only a genuine output over does.
+        // The PEAK lamp follows the post-input-gain, pre-tape record level. It lights when
+        // that input node crosses 0 dBFS (see drawVU), auto-holds 1.5 s after the last over,
+        // and click-clears.
         const bool clipEnabled = true;
         const ImU32 accent = accentCol();
         drawVU(dl, 68,  62, 388, 198, meterLevel(0), peakLevel(0), needleL, clipHoldL, clipEnabled, accent, "L");
@@ -168,7 +168,8 @@ protected:
         if (modalOpen) ImGui::EndDisabled();
         if (showAdvanced) drawAdvanced(dl);
         if (showSupporters)
-            duskdpf::drawSupportersOverlay(panel, dl, kDesignW, kDesignH, showSupporters, "TapeMachine 2", "");
+            duskdpf::drawSupportersOverlay(panel, dl, kDesignW, kDesignH, showSupporters,
+                                           "TapeMachine 2", TM2_VERSION_STRING);
 
         ImGui::End();
         ImGui::PopStyleVar(2);
@@ -195,18 +196,15 @@ private:
         return v;
     }
 
-    // OUTPUT-node true sample-peak for the PEAK lamp — the final signal the host receives.
-    // The lamp is a genuine digital-clip indicator (lights when the OUTPUT crosses 0 dBFS in
-    // drawVU). Tape soft-saturates, so hitting the tape harder for crunch does NOT trip it;
-    // only a real output over does. (Previously read the INPUT record node, which lit on any
-    // hot source + positive input gain even though nothing was clipping.)
+    // Post-input-gain, pre-tape sample peak for the PEAK lamp. This is the record
+    // level entering the tape path, independent of output compensation.
     float peakLevel(int ch)
     {
         float v = 0.0f;
        #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
         if (void* const inst = getPluginInstancePointer())
-            if (tapeMachineGetOutPeakL)
-                v = ch == 0 ? tapeMachineGetOutPeakL(inst) : tapeMachineGetOutPeakR(inst);
+            if (tapeMachineGetInPeakL)
+                v = ch == 0 ? tapeMachineGetInPeakL(inst) : tapeMachineGetInPeakR(inst);
        #endif
         return v;
     }
@@ -498,6 +496,8 @@ private:
         dl->AddRectFilled(P(30, 12), P(247, 40), IM_COL32(30, 30, 32, 255), 3.0f * s);
         dl->AddRect(P(30, 12), P(247, 40), IM_COL32(120, 120, 122, 255), 3.0f * s, 0, 1.4f * s);
         text(dl, 42, 17, 15, IM_COL32(232, 232, 228, 255), "TapeMachine 2", -1, true);
+        text(dl, 177, 21, 8.5f, IM_COL32(158, 158, 156, 255),
+             "v" TM2_VERSION_STRING, 0);
         {   // machine badge (accent-tinted). Options are hard-gated per machine, so
             // no non-standard state exists to flag.
             const char* badge = isSwiss() ? "Swiss" : "American";
@@ -825,12 +825,9 @@ private:
         text(dl, fx0 + 10, fy0 + 3, 15.0f, ink, "-", -1, true);
         text(dl, fx1 - 10, fy0 + 3, 15.0f, red, "+", 1, true);
 
-        // over lamp (right). A digital-CLIP indicator (peak = the DSP's final-OUTPUT sample-peak
-        // hold — the buffer the host receives). Lights when the OUTPUT crosses 0 dBFS (true
-        // digital over). Because the tape soft-saturates and the gain-link holds output ~unity,
-        // pushing the input for crunch does NOT clip the output, so the lamp stays dark under
-        // normal drive and lights only on a genuine over. (Earlier it read the INPUT record node
-        // and lit on any hot source + positive input gain, a false alarm the user reported.)
+        // over lamp (right). The peak comes from the post-input-gain, pre-tape
+        // record node, so it warns when the level driving the tape path crosses
+        // 0 dBFS regardless of the linked output compensation.
         // `clipHold` is a HOLD TIMER in seconds: every over (re)arms it to 1.5 s, and
         // between overs it counts down by the frame dt, so a brief transient stays lit ~1.5 s
         // after it passes and a sustained hot signal keeps re-arming (stays lit). A click clears

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineVersion.hpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineVersion.hpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// TapeMachineVersion.hpp — version shared by the TapeMachine 2 plugin metadata
+// and UI. CMake supplies these values from project(... VERSION ...); the
+// fallbacks keep non-CMake source builds usable.
+
+#pragma once
+
+#ifndef TM2_VERSION_MAJOR
+ #define TM2_VERSION_MAJOR 1
+ #define TM2_VERSION_MINOR 0
+ #define TM2_VERSION_PATCH 4
+#endif
+
+#define TM2_STRINGIFY_IMPL(value) #value
+#define TM2_STRINGIFY(value) TM2_STRINGIFY_IMPL(value)
+#define TM2_VERSION_STRING \
+    TM2_STRINGIFY(TM2_VERSION_MAJOR) "." \
+    TM2_STRINGIFY(TM2_VERSION_MINOR) "." \
+    TM2_STRINGIFY(TM2_VERSION_PATCH)

--- a/plugins/shared-dpf/ui/DuskImGuiFont.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiFont.hpp
@@ -45,6 +45,25 @@ inline const char* findCrispFontPath()
     return nullptr;
 }
 
+// Codepoints rasterized into the atlas. ImGui's default range is Basic Latin +
+// Latin-1 Supplement only, so anything above U+00FF renders as the face's fallback
+// box or '?'. Plugin labels use U+2033 DOUBLE PRIME for inches — a label ENDING in a
+// literal '"' emits invalid Turtle in the generated LV2 TTL (see the note on
+// tmparams::kHeadWidth), so the typographic mark is not cosmetic, it is the only
+// spelling that survives both the TTL generator and the UI. Listed as two extra
+// codepoints rather than all of General Punctuation to keep the atlas small: this
+// set is rasterized once per font size, and the sets run up to CrispFontSet::kMax.
+// A face missing these degrades to the same fallback glyph as before — no regression.
+inline const ImWchar* crispGlyphRanges()
+{
+    static const ImWchar ranges[] = {
+        0x0020, 0x00FF,   // Basic Latin + Latin-1 Supplement (the ImGui default)
+        0x2032, 0x2033,   // PRIME, DOUBLE PRIME (feet / inches)
+        0,
+    };
+    return ranges;
+}
+
 // Loads a bold face at pixelSize into the ImGui atlas and builds it.
 // Returns the ImFont* (or nullptr on failure). Kept for single-size callers.
 inline ImFont* loadCrispFont(float pixelSize)
@@ -56,6 +75,7 @@ inline ImFont* loadCrispFont(float pixelSize)
     cfg.OversampleH = 2;
     cfg.OversampleV = 2;
     cfg.PixelSnapH = false;
+    cfg.GlyphRanges = crispGlyphRanges();
     ImFont* font = io.Fonts->AddFontFromFileTTF(path, pixelSize, &cfg);
     if (font != nullptr) io.Fonts->Build();
     return font;
@@ -98,6 +118,7 @@ inline CrispFontSet loadCrispFontSet(const float* designSizes, int n, float scal
     cfg.OversampleH = 2;
     cfg.OversampleV = 2;
     cfg.PixelSnapH = false;
+    cfg.GlyphRanges = crispGlyphRanges();
 
     for (int i = 0; i < n && set.count < CrispFontSet::kMax; ++i)
     {


### PR DESCRIPTION
removed Peak light, fixed preset volume spike when changing presets. fixed tape dropdown font showing "?" instead of inches ".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gain Link now maintains smoother, more consistent levels during bypass, preset, and processing changes.
  - The plugin UI displays the current version.
  - Improved font rendering keeps prime and double-prime symbols crisp in labels.

- **Changes**
  - VU meters no longer use the previous digital-clip PEAK hold behavior.
  - Input and output peak readings now provide clearer diagnostic sample-peak information.
  - Gain Link mirroring and preset output-trim behavior are clarified and applied more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->