### PR TITLE
ci: register the Sunset Circuits DPF workflow on main

### DIFF
--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -1,0 +1,930 @@
+name: Build Sunset Circuits (DPF)
+
+# Release + CI-debug workflow for the DPF-based Sunset Circuits synth.
+#
+# The DPF ports live outside the JUCE release build graph (build.yml), so they
+# need their own matrix: this checks out DISTRHO/DPF + DISTRHO/DPF-Widgets at
+# pinned SHAs and builds plugins/sunset-circuits/dpf-plugin (VST3 + CLAP + LV2
+# everywhere, plus a notarizable AU on macOS with an auval pass).
+#
+# Triggers:
+#   - push tag 'sunset-circuits-v*'  -> full release (signs+notarizes mac, cuts a
+#                                       GitHub Release from the platform zips).
+#   - workflow_dispatch              -> the cross-platform compile/debug loop
+#                                       (unsigned; no Release job output).
+#   - pull_request touching this plugin -> test-linux ONLY (the gate suite +
+#                                       pluginval + clap-validator). Without it
+#                                       the gates only ever ran on a release or
+#                                       on a hand-fired dispatch, so a gate
+#                                       regression was first seen mid-release.
+#
+# WHY THE CI TRIGGER IS pull_request AND NOT ALSO push-to-branch. A `paths:`
+# filter under `push` applies to EVERY ref that block matches, tags included,
+# and a tag push whose diff does not touch those paths can then be filtered out
+# entirely -- which would silently skip a release. There is no way to give tags
+# and branches different path filters inside one `push` block, so the tag
+# trigger below is left exactly as it was and the path-filtered CI hangs off
+# `pull_request`. Every change reaches main through a PR here, so that is the
+# same coverage with none of the release risk.
+on:
+  push:
+    tags:
+      - 'sunset-circuits-v*'
+  pull_request:
+    paths:
+      - 'plugins/sunset-circuits/**'
+      - 'plugins/shared-dpf/**'
+      - '.github/workflows/dpf-release.yml'
+  workflow_dispatch:
+
+# DPF is pinned to the dusk-audio/DPF fork (branch dusk/clap-latency-activate):
+# upstream DISTRHO/DPF reports CLAP latency changes outside clap_plugin::activate
+# and fails 24 clap-validator tests. Drop the fork pin once upstream merges the
+# fix. DPF-Widgets stays on upstream. Bump both SHAs together and re-run the
+# dispatch matrix before tagging.
+env:
+  DPF_SHA: 2f98c651acd70cfbcd9f807b7e73ea1e39ecc2cb
+  DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
+  PLUGIN_DIR: plugins/sunset-circuits/dpf-plugin
+  SLUG: sunset-circuits
+
+jobs:
+  # Parse the release version out of the tag; empty on workflow_dispatch, which
+  # lets the DPF CMakeLists fall back to SUNSETCIRCUITS_DEFAULT_VERSION (1.0.0).
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      is_release: ${{ steps.v.outputs.is_release }}
+      prerelease: ${{ steps.v.outputs.prerelease }}
+    steps:
+      - name: Parse tag
+        id: v
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION=""
+          IS_RELEASE="false"
+          PRERELEASE="false"
+          if [[ "$GITHUB_REF" == refs/tags/sunset-circuits-v* ]]; then
+            RAW="${TAG#sunset-circuits-v}"
+            # Accept X.Y.Z with an optional prerelease suffix (-alpha, -beta.2,
+            # -rc1, ...). CMake's project(VERSION) only takes the numeric core,
+            # so export that; the validated suffix drives the prerelease flag in
+            # the release job. A malformed tag fails HERE, before any build or
+            # publish step, instead of silently shipping the default version.
+            if [[ "$RAW" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(-[A-Za-z0-9.]+)?$ ]]; then
+              IS_RELEASE="true"
+              VERSION="${BASH_REMATCH[1]}"
+              if [[ -n "${BASH_REMATCH[2]}" ]]; then PRERELEASE="true"; fi
+            else
+              echo "::error::malformed release tag '$TAG' (want sunset-circuits-vX.Y.Z or sunset-circuits-vX.Y.Z-<suffix>)"
+              exit 1
+            fi
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION:-<default 1.0.0>}  is_release: $IS_RELEASE  prerelease: $PRERELEASE"
+
+  build-linux-x64:
+    needs: setup
+    # RELEASE/DISPATCH ONLY. On a pull_request this job is skipped: CI runs the
+    # gate suite (test-linux) and nothing else, because the four platform builds
+    # exist to produce release artifacts and cost ~40 min each. github.ref is
+    # refs/pull/<n>/merge on a PR, so this is false there and true for both a
+    # tag push and a manual dispatch.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    container:
+      image: ubuntu:20.04  # glibc 2.31, matching the JUCE fleet (build.yml)
+    env:
+      PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Install base tools
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git ca-certificates software-properties-common wget gpg
+
+      - name: Install GCC 11 toolchain
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          # gcc-11 is not in focal's base repos; the toolchain PPA add is
+          # occasionally flaky, so retry (mirrors build.yml).
+          add_toolchain() { timeout 120 add-apt-repository -y ppa:ubuntu-toolchain-r/test && timeout 180 apt-get update; }
+          add_toolchain || { echo "PPA attempt 1 failed; retry in 15s"; sleep 15; add_toolchain; } \
+                        || { echo "PPA attempt 2 failed; retry in 30s"; sleep 30; add_toolchain; }
+          apt-get install -y gcc-11 g++-11
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
+          update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-11 100
+          update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-11 100
+          g++ --version
+
+      - name: Install modern CMake + Ninja + DPF deps
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            cmake ninja-build pkg-config zip unzip \
+            libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev \
+            libx11-dev libxext-dev libxrandr-dev libxinerama-dev libxcursor-dev \
+            libdbus-1-dev
+          cmake --version
+          ninja --version
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout DPF
+        uses: actions/checkout@v4
+        with:
+          repository: dusk-audio/DPF
+          ref: ${{ env.DPF_SHA }}
+          path: DPF
+          submodules: recursive
+
+      - name: Checkout DPF-Widgets
+        uses: actions/checkout@v4
+        with:
+          repository: DISTRHO/DPF-Widgets
+          ref: ${{ env.DPFWIDGETS_SHA }}
+          path: DPF-Widgets
+          submodules: recursive
+
+      - name: Configure
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DDUSK_DPF_INSTALL_LOCAL=OFF \
+            -DDPF_PATH="${GITHUB_WORKSPACE}/DPF" \
+            -DDPFWIDGETS_PATH="${GITHUB_WORKSPACE}/DPF-Widgets"
+
+      - name: Build (VST3 + CLAP + LV2)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          cmake --build build --target sunset_circuits-vst3 sunset_circuits-clap sunset_circuits-lv2 -j"$(nproc)"
+
+      - name: Package
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          mkdir -p out/VST3 out/CLAP out/LV2
+          cp -r build/bin/sunset_circuits.vst3 out/VST3/
+          cp    build/bin/sunset_circuits.clap out/CLAP/
+          cp -r build/bin/sunset_circuits.lv2  out/LV2/
+          test -f "out/VST3/sunset_circuits.vst3/Contents/x86_64-linux/sunset_circuits.so"
+          test -f "out/LV2/sunset_circuits.lv2/manifest.ttl"
+          ( cd out && zip -r "../${SLUG}-linux.zip" . )
+          echo "=== contents ==="; unzip -l "${SLUG}-linux.zip"
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SLUG }}-linux
+          path: ${{ env.PLUGIN_DIR }}/${{ env.SLUG }}-linux.zip
+          retention-days: 30
+
+  build-linux-arm64:
+    needs: setup
+    # RELEASE/DISPATCH ONLY. On a pull_request this job is skipped: CI runs the
+    # gate suite (test-linux) and nothing else, because the four platform builds
+    # exist to produce release artifacts and cost ~40 min each. github.ref is
+    # refs/pull/<n>/merge on a PR, so this is false there and true for both a
+    # tag push and a manual dispatch.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 40
+    container:
+      image: ubuntu:22.04  # glibc 2.35, matching build.yml's arm job
+    env:
+      PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Install base tools
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git ca-certificates software-properties-common wget gpg
+
+      - name: Install GCC 11 toolchain
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          # Ubuntu 22.04 ships gcc-11 natively — no PPA needed.
+          apt-get install -y gcc-11 g++-11
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
+          update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-11 100
+          update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-11 100
+          g++ --version
+
+      - name: Install modern CMake + Ninja + DPF deps
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            cmake ninja-build pkg-config zip unzip \
+            libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev \
+            libx11-dev libxext-dev libxrandr-dev libxinerama-dev libxcursor-dev \
+            libdbus-1-dev
+          cmake --version
+          ninja --version
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout DPF
+        uses: actions/checkout@v4
+        with:
+          repository: dusk-audio/DPF
+          ref: ${{ env.DPF_SHA }}
+          path: DPF
+          submodules: recursive
+
+      - name: Checkout DPF-Widgets
+        uses: actions/checkout@v4
+        with:
+          repository: DISTRHO/DPF-Widgets
+          ref: ${{ env.DPFWIDGETS_SHA }}
+          path: DPF-Widgets
+          submodules: recursive
+
+      - name: Configure
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DDUSK_DPF_INSTALL_LOCAL=OFF \
+            -DDPF_PATH="${GITHUB_WORKSPACE}/DPF" \
+            -DDPFWIDGETS_PATH="${GITHUB_WORKSPACE}/DPF-Widgets"
+
+      - name: Build (VST3 + CLAP + LV2)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          cmake --build build --target sunset_circuits-vst3 sunset_circuits-clap sunset_circuits-lv2 -j"$(nproc)"
+
+      - name: Package
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          mkdir -p out/VST3 out/CLAP out/LV2
+          cp -r build/bin/sunset_circuits.vst3 out/VST3/
+          cp    build/bin/sunset_circuits.clap out/CLAP/
+          cp -r build/bin/sunset_circuits.lv2  out/LV2/
+          test -f "out/VST3/sunset_circuits.vst3/Contents/aarch64-linux/sunset_circuits.so"
+          test -f "out/LV2/sunset_circuits.lv2/manifest.ttl"
+          ( cd out && zip -r "../${SLUG}-linux-arm64.zip" . )
+          echo "=== contents ==="; unzip -l "${SLUG}-linux-arm64.zip"
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SLUG }}-linux-arm64
+          path: ${{ env.PLUGIN_DIR }}/${{ env.SLUG }}-linux-arm64.zip
+          retention-days: 30
+
+  build-windows:
+    needs: setup
+    # RELEASE/DISPATCH ONLY. On a pull_request this job is skipped: CI runs the
+    # gate suite (test-linux) and nothing else, because the four platform builds
+    # exist to produce release artifacts and cost ~40 min each. github.ref is
+    # refs/pull/<n>/merge on a PR, so this is false there and true for both a
+    # tag push and a manual dispatch.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout DPF
+        uses: actions/checkout@v4
+        with:
+          repository: dusk-audio/DPF
+          ref: ${{ env.DPF_SHA }}
+          path: DPF
+          submodules: recursive
+
+      - name: Checkout DPF-Widgets
+        uses: actions/checkout@v4
+        with:
+          repository: DISTRHO/DPF-Widgets
+          ref: ${{ env.DPFWIDGETS_SHA }}
+          path: DPF-Widgets
+          submodules: recursive
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Pre-fetch Khronos GL headers for DPF
+        shell: pwsh
+        run: |
+          # DPF's MSVC path downloads GL/glext.h + KHR/khrplatform.h from
+          # khronos.org at configure time; that registry URL has moved and the
+          # fetch silently yields a broken header (NanoVG.cpp then fails with
+          # missing PFNGL*PROC typedefs). Pre-populate from the canonical Khronos
+          # GitHub registry so DPF's `if(NOT EXISTS)` skips the broken download.
+          # Pinned to immutable registry commits + SHA-256 verified, so a moved
+          # branch or tampered/truncated download fails loudly here rather than
+          # compiling (or shipping) against an unvetted header.
+          $gl = "${{ github.workspace }}/DPF/khronos/GL"
+          $khr = "${{ github.workspace }}/DPF/khronos/KHR"
+          New-Item -ItemType Directory -Force -Path $gl, $khr | Out-Null
+          $glRev  = "9d527dbc81bb76e35ba284fe385ed8a5ddb90cbc"  # KhronosGroup/OpenGL-Registry
+          $khrRev = "3d7796b3721d93976b6bfe536aa97bbc4bce8667"  # KhronosGroup/EGL-Registry
+          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/KhronosGroup/OpenGL-Registry/$glRev/api/GL/glext.h" -OutFile "$gl/glext.h"
+          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/KhronosGroup/EGL-Registry/$khrRev/api/KHR/khrplatform.h" -OutFile "$khr/khrplatform.h"
+          $expected = @{
+            "$gl/glext.h"        = "B381ABF98F9705E4B3EFACB6850D2A86982B3039F66CCE88FF7F0350F46F04BF"
+            "$khr/khrplatform.h" = "7B1E01AAA7AD8F6FC34B5C7BDF79EBF5189BB09E2C4D2E79FC5D350623D11E83"
+          }
+          foreach ($f in $expected.Keys) {
+            $h = (Get-FileHash -Algorithm SHA256 $f).Hash
+            if ($h -ne $expected[$f]) { Write-Error "checksum mismatch for ${f}: $h"; exit 1 }
+          }
+          Write-Host "glext.h size: $((Get-Item "$gl/glext.h").Length) bytes (checksums OK)"
+
+      - name: Patch DPF-Widgets for MSVC
+        shell: pwsh
+        run: |
+          # DPF-Widgets' DearImGui.cpp uses the GNU 'Elvis operator' (a ?: b),
+          # which MSVC does not accept. Rewrite the two occurrences to explicit
+          # ternaries so the pinned checkout compiles under cl. Deterministic
+          # (fresh pinned checkout each run); safe to drop when DPF-Widgets fixes
+          # this upstream.
+          $f = "${{ github.workspace }}/DPF-Widgets/opengl/DearImGui.cpp"
+          $c = [System.IO.File]::ReadAllText($f)
+          $c = $c.Replace('self->getWidth() ?: 640 * scaleFactor',  'self->getWidth() ? self->getWidth() : 640 * scaleFactor')
+          $c = $c.Replace('self->getHeight() ?: 480 * scaleFactor', 'self->getHeight() ? self->getHeight() : 480 * scaleFactor')
+          [System.IO.File]::WriteAllText($f, $c)
+          if ($c.Contains('?:')) { Write-Error "Elvis operator still present"; exit 1 }
+          Write-Host "Patched DearImGui.cpp"
+
+      - name: Configure
+        working-directory: ${{ env.PLUGIN_DIR }}
+        shell: pwsh
+        run: |
+          cmake -B build -G Ninja `
+            -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DDUSK_DPF_INSTALL_LOCAL=OFF `
+            -DDPF_PATH="${{ github.workspace }}/DPF" `
+            -DDPFWIDGETS_PATH="${{ github.workspace }}/DPF-Widgets"
+
+      - name: Build (VST3 + CLAP + LV2)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        shell: pwsh
+        run: |
+          cmake --build build --target sunset_circuits-vst3 sunset_circuits-clap sunset_circuits-lv2 -j $env:NUMBER_OF_PROCESSORS
+
+      - name: Package
+        working-directory: ${{ env.PLUGIN_DIR }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path out/VST3, out/CLAP, out/LV2 | Out-Null
+          Copy-Item -Recurse build/bin/sunset_circuits.vst3 out/VST3/
+          Copy-Item          build/bin/sunset_circuits.clap out/CLAP/
+          Copy-Item -Recurse build/bin/sunset_circuits.lv2  out/LV2/
+          Compress-Archive -Path out/* -DestinationPath "$env:SLUG-windows.zip" -Force
+          Write-Host "=== contents ==="
+          Get-ChildItem -Recurse out | Select-Object FullName
+
+      - name: Install pluginval
+        shell: pwsh
+        run: |
+          # pluginval ships a ready-to-run Windows binary in its GitHub releases;
+          # trivially installable, so we run a headless VST3 validation here.
+          # SHA-256 pinned: release assets are practically immutable but the tag
+          # is not cryptographically so — verify before executing anything.
+          Invoke-WebRequest -Uri "https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_Windows.zip" -OutFile pluginval.zip
+          $h = (Get-FileHash -Algorithm SHA256 pluginval.zip).Hash
+          if ($h -ne "4D83BDE21AEBAF4D52EC0CA6D9F0C7119AD4181288EB82DA103FADE31A8523AD") {
+            Write-Error "pluginval_Windows.zip checksum mismatch: $h"
+            exit 1
+          }
+          Expand-Archive pluginval.zip -DestinationPath pluginval -Force
+          Get-ChildItem -Recurse pluginval -Filter pluginval.exe | Select-Object -First 1
+
+      - name: Validate VST3 (pluginval, headless)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        shell: pwsh
+        run: |
+          $pv = Get-ChildItem -Recurse "$env:GITHUB_WORKSPACE/pluginval" -Filter pluginval.exe | Select-Object -First 1
+          if (-not $pv) { Write-Error "pluginval.exe not found after install"; exit 1 }
+          $vst3 = (Resolve-Path "build/bin/sunset_circuits.vst3").Path
+          # --skip-gui-tests: no display on the runner. pluginval crashes on DPF's
+          # headless plugin teardown (the known DPF editor-lifecycle issue,
+          # docs/dpf-migration/00-OVERVIEW.md landmine 9) AFTER the tests pass, so
+          # a non-zero exit is tolerated ONLY when the log shows tests actually
+          # ran and none failed. A missing executable, a plugin that fails to
+          # load, or a real test failure all fail the job — we must never release
+          # an unloadable VST3. This is the lighter of the two pluginval runs:
+          # the test-linux job below runs strictness 8 on Linux, and the real-DAW
+          # matrix in Phase 5 (QA checklist Part 2) remains the final word. The
+          # shipping Linux jobs above build and package only.
+          # --timeout-ms bounds a hung test rather than letting it ride the job
+          # timeout (landmine 9), matching the Linux job.
+          $log = & $pv.FullName --strictness-level 5 --skip-gui-tests --timeout-ms 270000 --validate $vst3 2>&1 | Out-String
+          Write-Host $log
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "pluginval: SUCCESS"
+            exit 0
+          }
+          if ($log -match 'Starting test' -and $log -notmatch 'FAILED') {
+            Write-Host "::warning::pluginval exited non-zero after tests ran clean (DPF headless teardown, known issue, non-fatal)"
+            exit 0
+          }
+          Write-Error "pluginval reported a real failure (load error or failed test)"
+          exit 1
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SLUG }}-windows
+          path: ${{ env.PLUGIN_DIR }}/${{ env.SLUG }}-windows.zip
+          retention-days: 30
+
+  build-macos:
+    needs: setup
+    # RELEASE/DISPATCH ONLY. On a pull_request this job is skipped: CI runs the
+    # gate suite (test-linux) and nothing else, because the four platform builds
+    # exist to produce release artifacts and cost ~40 min each. github.ref is
+    # refs/pull/<n>/merge on a PR, so this is false there and true for both a
+    # tag push and a manual dispatch.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    runs-on: macos-14
+    timeout-minutes: 60
+    env:
+      PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout DPF
+        uses: actions/checkout@v4
+        with:
+          repository: dusk-audio/DPF
+          ref: ${{ env.DPF_SHA }}
+          path: DPF
+          submodules: recursive
+
+      - name: Checkout DPF-Widgets
+        uses: actions/checkout@v4
+        with:
+          repository: DISTRHO/DPF-Widgets
+          ref: ${{ env.DPFWIDGETS_SHA }}
+          path: DPF-Widgets
+          submodules: recursive
+
+      - name: Install Ninja
+        run: brew install ninja
+
+      - name: Configure (Universal Binary)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DDUSK_DPF_INSTALL_LOCAL=OFF \
+            -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" \
+            -DDPF_PATH="${{ github.workspace }}/DPF" \
+            -DDPFWIDGETS_PATH="${{ github.workspace }}/DPF-Widgets"
+
+      - name: Build (VST3 + CLAP + LV2 + AU)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          cmake --build build --target sunset_circuits-vst3 sunset_circuits-clap sunset_circuits-lv2 sunset_circuits-au -j"$(sysctl -n hw.ncpu)"
+
+      - name: Verify universal binary
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          BIN="build/bin/sunset_circuits.vst3/Contents/MacOS/sunset_circuits"
+          lipo -info "$BIN"
+          lipo -info "$BIN" | grep -q "arm64" && lipo -info "$BIN" | grep -q "x86_64" \
+            && echo "Universal confirmed" || { echo "::error::VST3 not universal"; exit 1; }
+
+      - name: Install AU + auval
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          COMP=$(find build -name '*.component' -type d | head -1)
+          if [ -z "$COMP" ]; then echo "::error::No AU component built"; exit 1; fi
+          echo "AU: $COMP"
+          plutil -p "$COMP/Contents/Info.plist" || cat "$COMP/Contents/Info.plist"
+          mkdir -p "$HOME/Library/Audio/Plug-Ins/Components"
+          cp -R "$COMP" "$HOME/Library/Audio/Plug-Ins/Components/"
+          killall -9 AudioComponentRegistrar 2>/dev/null || true
+          echo "--- registered Dusk instruments ---"
+          auval -a | grep -i -E "dusk|DsSC" || echo "(not listed yet; validating by code)"
+          # Sunset Circuits is an instrument -> AU type 'aumu'; subtype DsSC, manufacturer Dusk.
+          auval -v aumu DsSC Dusk
+
+      - name: Import Code Signing Certificate
+        if: ${{ vars.MACOS_SIGNING_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/') }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security import certificate.p12 -P "$MACOS_CERTIFICATE_PWD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          rm certificate.p12
+
+      - name: Code Sign Plugins
+        if: ${{ vars.MACOS_SIGNING_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/') }}
+        working-directory: ${{ env.PLUGIN_DIR }}
+        env:
+          MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+        run: |
+          for plugin in build/bin/sunset_circuits.vst3 build/bin/sunset_circuits.component build/bin/sunset_circuits.clap; do
+            if [ -d "$plugin" ]; then
+              echo "Signing: $plugin"
+              codesign --force --deep --sign "$MACOS_SIGNING_IDENTITY" --options runtime --timestamp "$plugin"
+              codesign --verify --verbose "$plugin"
+            fi
+          done
+
+      - name: Notarize Plugins
+        if: ${{ vars.MACOS_SIGNING_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/') }}
+        working-directory: ${{ env.PLUGIN_DIR }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          mkdir -p notarize_staging
+          for plugin in build/bin/sunset_circuits.vst3 build/bin/sunset_circuits.component build/bin/sunset_circuits.clap; do
+            [ -d "$plugin" ] && cp -R "$plugin" notarize_staging/
+          done
+          ditto -c -k --keepParent notarize_staging plugins-macos-notarize.zip
+          xcrun notarytool submit plugins-macos-notarize.zip \
+            --apple-id "$APPLE_ID" --password "$APPLE_APP_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+          for plugin in notarize_staging/*.vst3 notarize_staging/*.component notarize_staging/*.clap; do
+            [ -d "$plugin" ] && xcrun stapler staple "$plugin"
+          done
+
+      - name: Package
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          mkdir -p out/VST3 out/CLAP out/LV2 out/AU
+          # Prefer notarized+stapled bundles when present.
+          if [ -d notarize_staging ]; then
+            cp -r notarize_staging/sunset_circuits.vst3      out/VST3/ 2>/dev/null || true
+            cp -r notarize_staging/sunset_circuits.clap      out/CLAP/ 2>/dev/null || true
+            cp -r notarize_staging/sunset_circuits.component out/AU/   2>/dev/null || true
+          fi
+          [ -e out/VST3/sunset_circuits.vst3 ]      || cp -r build/bin/sunset_circuits.vst3      out/VST3/
+          [ -e out/CLAP/sunset_circuits.clap ]      || cp -r build/bin/sunset_circuits.clap      out/CLAP/
+          [ -e out/AU/sunset_circuits.component ]   || cp -r build/bin/sunset_circuits.component out/AU/
+          cp -r build/bin/sunset_circuits.lv2 out/LV2/
+          ( cd out && zip -r "../${SLUG}-macos.zip" . )
+          echo "=== contents ==="; unzip -l "${SLUG}-macos.zip"
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SLUG }}-macos
+          path: ${{ env.PLUGIN_DIR }}/${{ env.SLUG }}-macos.zip
+          retention-days: 30
+
+  # Gate suite + Linux validation. Runs on BOTH triggers (tag push and
+  # workflow_dispatch), and the release job needs it, so a red gate blocks the
+  # publish rather than being noticed afterwards.
+  #
+  # Deliberately NOT in the ubuntu:20.04 container the shipping linux jobs use:
+  # this job produces no artifact, so it has no glibc floor to respect, and the
+  # plain runner gives it a modern python, liblilv and pluginval without fighting
+  # focal's package set. The binaries it builds are for testing only.
+  test-linux:
+    needs: setup
+    runs-on: ubuntu-latest
+    # Generous: the shipping linux job budgets 40 minutes for the build alone,
+    # and this one adds the gate suite and pluginval on top of a build of
+    # comparable size.
+    timeout-minutes: 75
+    env:
+      PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Install build + test deps
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build pkg-config unzip \
+            libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev \
+            libx11-dev libxext-dev libxrandr-dev libxinerama-dev libxcursor-dev \
+            libdbus-1-dev \
+            liblilv-dev \
+            xvfb
+          # liblilv-dev enables the suite's lv2_smoke target; without it that one
+          # gate self-skips and the LV2 host path would go unvalidated, so fail
+          # here rather than let the suite quietly skip it.
+          pkg-config --modversion lilv-0
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python gate deps
+        run: |
+          # Pinned to minor series: this job gates the release, and the gates
+          # compare measured numbers against fixed thresholds, so a numpy major
+          # bump must not silently move an answer. Bump deliberately, then
+          # re-run the suite.
+          #
+          # scipy is REQUIRED, not optional. fx_alias_gate imports
+          # scipy.signal.resample_poly and self-skips its resampling sections
+          # when the import fails -- so without scipy the "fx_alias_gate" step
+          # printed a skip notice while the step comment claimed it ran, and the
+          # effects-chain aliasing report was empty on every CI run.
+          python3 -m pip install 'numpy==1.26.*' 'soundfile==0.12.*' 'scipy==1.11.*'
+
+      - name: Checkout DPF
+        uses: actions/checkout@v4
+        with:
+          repository: dusk-audio/DPF
+          ref: ${{ env.DPF_SHA }}
+          path: DPF
+          submodules: recursive
+
+      - name: Checkout DPF-Widgets
+        uses: actions/checkout@v4
+        with:
+          repository: DISTRHO/DPF-Widgets
+          ref: ${{ env.DPFWIDGETS_SHA }}
+          path: DPF-Widgets
+          submodules: recursive
+
+      - name: Configure
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DDUSK_DPF_INSTALL_LOCAL=OFF \
+            -DDPF_PATH="${GITHUB_WORKSPACE}/DPF" \
+            -DDPFWIDGETS_PATH="${GITHUB_WORKSPACE}/DPF-Widgets"
+
+      - name: Build (VST3 + CLAP + LV2)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          # The suite's lv2_smoke gate hosts build/bin/sunset_circuits.lv2, so the
+          # LV2 bundle must exist before run_all.sh; pluginval below needs the
+          # VST3 and clap-validator needs the CLAP.
+          cmake --build build --target \
+            sunset_circuits-vst3 sunset_circuits-clap sunset_circuits-lv2 -j"$(nproc)"
+
+      - name: Core gate suite
+        run: |
+          # Full suite: every pass/fail gate, the fm and acid sub-suites, the
+          # 54-preset audit, lv2_smoke, and the cpu_bench sanity bar. The
+          # fx_alias 54-preset sweep stays opt-in (FX_ALIAS_FULL=1) -- it only
+          # changes answer when the factory presets change and is by far the
+          # slowest item in the suite.
+          plugins/sunset-circuits/core/tests/run_all.sh
+
+      - name: Install pluginval
+        run: |
+          # SHA-256 pinned: the release asset is practically immutable but the tag
+          # is not cryptographically so -- verify before executing anything.
+          # Staged in RUNNER_TEMP so nothing lands in the checkout.
+          cd "$RUNNER_TEMP"
+          curl -fsSL -o pluginval.zip \
+            https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_Linux.zip
+          echo "69adc87d6bbb2f7224a038d8f8c5e737ea5c906ea153752b8a546b6125e0564f  pluginval.zip" \
+            | sha256sum -c -
+          unzip -o pluginval.zip -d pluginval
+          # Locate the binary rather than assuming the archive layout (the
+          # Windows job does the same); a layout change should fail loudly.
+          PV="$(find pluginval -type f -name pluginval | head -n1)"
+          if [ -z "$PV" ]; then
+            echo "::error::pluginval binary not found after install"
+            exit 1
+          fi
+          chmod +x "$PV"
+          echo "PLUGINVAL=$RUNNER_TEMP/$PV" >> "$GITHUB_ENV"
+          "$RUNNER_TEMP/$PV" --version || true
+
+      - name: Validate VST3 (pluginval, headless)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          VST3="$(cd build/bin && pwd)/sunset_circuits.vst3"
+          test -d "$VST3"
+          # --skip-gui-tests is mandatory, not an optimisation: pluginval's editor
+          # tests segfault headless for every DPF plugin (host-side XEmbed issue,
+          # docs/dpf-migration/00-OVERVIEW.md landmine 9). Strictness 8 is the bar
+          # the QA checklist calls authoritative for the 222-parameter state
+          # round-trip; the Windows job runs 5 on top of this.
+          #
+          # Run under xvfb-run even though --skip-gui-tests means no editor is
+          # opened: that is the pattern 00-OVERVIEW.md prescribes and the one the
+          # local QA runs use, and this job gates the release -- not the place to
+          # rely on pluginval's untested no-X path.
+          #
+          # Output is tee'd, not captured: a hung pluginval hitting the job
+          # timeout with everything still in a shell variable would leave zero
+          # diagnostic output. The shell-level `timeout` bounds it well inside
+          # the job timeout so a hang fails with the partial log intact.
+          #
+          # Same tolerated-teardown rule as the Windows job: DPF can exit non-zero
+          # tearing down after a clean run, and that is accepted ONLY when the log
+          # shows tests actually ran and none failed. A plugin that fails to load
+          # or a real failed test still fails the job.
+          set +e
+          timeout 900 xvfb-run -a "$PLUGINVAL" \
+            --strictness-level 8 --skip-gui-tests --timeout-ms 270000 \
+            --validate "$VST3" 2>&1 | tee pluginval.log
+          STATUS=${PIPESTATUS[0]}
+          set -e
+          if [ "$STATUS" -eq 0 ]; then
+            echo "pluginval: SUCCESS"
+            exit 0
+          fi
+          if [ "$STATUS" -eq 124 ]; then
+            echo "::error::pluginval timed out after 900s (partial log above)"
+            exit 1
+          fi
+          if grep -q 'Starting test' pluginval.log && ! grep -q 'FAILED' pluginval.log; then
+            echo "::warning::pluginval exited non-zero after tests ran clean (DPF headless teardown, known issue, non-fatal)"
+            exit 0
+          fi
+          echo "::error::pluginval reported a real failure (load error or failed test)"
+          exit 1
+
+      - name: Install clap-validator
+        run: |
+          # The CLAP is built and shipped on every platform but was never
+          # validated anywhere -- pluginval only speaks VST3/AU. clap-validator
+          # is the reference CLAP conformance suite.
+          #
+          # SHA-256 pinned and staged in RUNNER_TEMP, exactly as pluginval above:
+          # the release asset is practically immutable but the tag is not
+          # cryptographically so, so verify before executing anything.
+          cd "$RUNNER_TEMP"
+          curl -fsSL -o clap-validator.zip \
+            https://github.com/free-audio/clap-validator/releases/download/0.4.1/clap-validator-0.4.1-127-g152b982-ubuntu-22.04.zip
+          echo "49edadcfb407ea0dd946ce418300e853fbd2660fa4b0d00e4f19ff8eef24ad90  clap-validator.zip" \
+            | sha256sum -c -
+          unzip -o clap-validator.zip -d clap-validator
+          # The published zip wraps a tarball, which holds the binary. Both
+          # layers are globbed rather than hardcoded (the inner tarball's
+          # embedded version string does not match the outer tag), and a layout
+          # change fails loudly below.
+          tar xzf clap-validator/clap-validator-*.tar.gz -C clap-validator
+          CV="$(find clap-validator -type f -name clap-validator | head -n1)"
+          if [ -z "$CV" ]; then
+            echo "::error::clap-validator binary not found after install"
+            exit 1
+          fi
+          chmod +x "$CV"
+          echo "CLAP_VALIDATOR=$RUNNER_TEMP/$CV" >> "$GITHUB_ENV"
+          "$RUNNER_TEMP/$CV" --version
+
+      - name: Validate CLAP (clap-validator)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          CLAP="$(cd build/bin && pwd)/sunset_circuits.clap"
+          test -f "$CLAP"
+          # Machine-readable output, classified below. The exit status is still
+          # captured separately so a timeout is distinguishable from a test
+          # failure, but the JSON is what decides pass/fail.
+          set +e
+          timeout 600 "$CLAP_VALIDATOR" validate --json "$CLAP" > clap-validator.json 2> clap-validator.err
+          STATUS=$?
+          set -e
+          cat clap-validator.err || true
+          if [ "$STATUS" -eq 124 ]; then
+            echo "::error::clap-validator timed out after 600s"
+            exit 1
+          fi
+          # No tolerated failures: any failed test fails the job.
+          #
+          # There used to be an allowlist here for
+          #   clap_host_latency::changed / Must only be called within 'clap_plugin::activate'
+          # a DPF CLAP-wrapper bug that failed 24 of 44 tests on any DPF plugin
+          # declaring a latency. It is fixed in DistrhoPluginCLAP.cpp by only
+          # announcing latency changes from within clap_plugin::activate; see the
+          # DPF_SHA TODO at the top of this file for the fork bump this depends on.
+          # Measured locally against the fixed DPF: 44 tests run, 33 passed,
+          # 10 skipped, 1 warning, 0 failed.
+          python3 - <<'PY'
+          import collections, json, sys
+
+          with open("clap-validator.json") as f:
+              results = json.load(f)["results"]
+
+          if not results:
+              print("::error::clap-validator produced no results")
+              sys.exit(1)
+
+          def test_name(r):
+              t = r["test"]
+              for k in ("plugin-instance", "plugin-library", "preset-discovery"):
+                  if k in t:
+                      return t[k]["test"]
+              return str(t)
+
+          counts = collections.Counter(r["status"]["code"] for r in results)
+          print("clap-validator: " + ", ".join(f"{v} {k}" for k, v in sorted(counts.items())))
+
+          failed = []
+          for r in results:
+              code = r["status"]["code"]
+              details = (r["status"].get("details") or "").strip()
+              if code == "failed":
+                  failed.append((test_name(r), details))
+              elif code == "warning":
+                  print(f"::warning::clap-validator {test_name(r)}: {details}")
+
+          if failed:
+              for name, details in failed:
+                  print(f"::error::clap-validator {name}: {details}")
+              sys.exit(1)
+
+          print("::notice::clap-validator: no failures")
+          PY
+
+      - name: Upload validation logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SLUG }}-validation-linux-logs
+          path: |
+            ${{ env.PLUGIN_DIR }}/pluginval.log
+            ${{ env.PLUGIN_DIR }}/clap-validator.json
+            ${{ env.PLUGIN_DIR }}/clap-validator.err
+          retention-days: 14
+          if-no-files-found: ignore
+
+  # Assemble the GitHub Release from the four platform zips (tags only).
+  # test-linux is in needs: so a red gate suite blocks the publish.
+  release:
+    needs: [setup, test-linux, build-linux-x64, build-linux-arm64, build-windows, build-macos]
+    runs-on: ubuntu-latest
+    if: needs.setup.outputs.is_release == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository (for tag message)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Assemble release notes
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#sunset-circuits-v}"
+          TAG_MESSAGE=$(git tag -l --format='%(contents)' "$TAG" 2>/dev/null || echo "")
+          CHANGELOG=$(echo "$TAG_MESSAGE" | tail -n +2 | sed '/^$/d; 1{/^$/d}')
+          {
+            echo "## Sunset Circuits v${VERSION}"
+            echo ""
+            if [ -n "$CHANGELOG" ]; then echo "$CHANGELOG"; echo ""; fi
+            echo "### Installation"
+            echo ""
+            echo "Each zip contains \`VST3/\`, \`CLAP/\`, \`LV2/\` and (macOS) \`AU/\` folders."
+            echo ""
+            echo "**Linux (x86_64 / ARM64):** copy \`.vst3\` to \`~/.vst3/\`, \`.lv2\` to \`~/.lv2/\`, \`.clap\` to \`~/.clap/\`."
+            echo ""
+            echo "**Windows:** copy \`.vst3\` to \`C:\\Program Files\\Common Files\\VST3\\\`, \`.clap\` to \`C:\\Program Files\\Common Files\\CLAP\\\`."
+            echo ""
+            echo "**macOS:** copy \`.vst3\` to \`~/Library/Audio/Plug-Ins/VST3/\`, \`.component\` to \`~/Library/Audio/Plug-Ins/Components/\`, \`.clap\` to \`~/Library/Audio/Plug-Ins/CLAP/\`."
+          } > release_body.md
+          echo "=== staged zips ==="; find artifacts -name '*.zip'
+
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/**/*.zip
+          generate_release_notes: true
+          body_path: release_body.md
+          draft: false
+          # Derived from the validated tag suffix in the setup job (any
+          # -<suffix> after X.Y.Z), not from a substring scan of the ref.
+          prerelease: ${{ needs.setup.outputs.prerelease == 'true' }}


### PR DESCRIPTION
workflow_dispatch only resolves workflows present on the default branch. This adds the Sunset Circuits dpf-release.yml (tag trigger sunset-circuits-v*, path-filtered PR trigger, dispatch) so the gate suite can be hand-fired against multi-synth/dpf-core before tagging. Inert for main itself: the tag trigger matches no main pushes and the workflow checks out the ref it runs against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated cross-platform plugin builds for Linux, Windows, and macOS.
  * Added packaging and publishing of VST3, CLAP, LV2, and AU release artifacts.
  * Added optional macOS code signing and notarization for distributed plugins.

* **Bug Fixes**
  * Added automated plugin validation and testing across supported platforms.
  * Release workflows now reject malformed version tags and failed validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->