### PR TITLE
Tapeecho2/enhancements

### DIFF
--- a/.github/scripts/dpf_clap_validate.py
+++ b/.github/scripts/dpf_clap_validate.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""clap-validator gate for Dusk Audio DPF plugins.
+
+Purpose-built gate for our dusk-audio/DPF fork (see the DPF_REF comment in
+.github/workflows/dpf-build.yml). The fork exists because upstream DPF's CLAP
+wrapper called clap_host_latency::changed OUTSIDE clap_plugin::activate(),
+violating the CLAP spec. This script runs clap-validator on a built .clap and:
+
+  HARD FAIL  If the validator reports the 'clap_host_latency::changed' host
+             callback error, DPF has regressed to the upstream bug -> exit 1.
+             (In clap-validator 0.4.1 this shows only as a WARNING and does NOT
+             fail any test, so the exit code alone would miss it -- hence the
+             explicit signature check.)
+
+  ADVISORY   The rest of the clap-validator suite is run and printed, but does
+             NOT gate the build yet: TapeMachine 2 currently fails
+             process-varying-sample-rates (subnormals at extreme sample rates),
+             a separate DSP issue. Once the suite is clean, set SUITE_STRICT=1
+             to also fail on any failed test. NEVER add a per-test allowlist --
+             fix the plugin, then flip SUITE_STRICT on.
+
+Usage: dpf_clap_validate.py <path-to-plugin.clap>
+Env:
+  CLAP_VALIDATOR_BIN      Use this binary instead of downloading a release
+                          (Linux ARM64 has no prebuilt: cargo-install and point
+                          this at it, or put clap-validator on PATH).
+  CLAP_VALIDATOR_VERSION  Release tag to download (default 0.4.1).
+  SUITE_STRICT=1          Also fail the build on any failed validator test.
+"""
+import glob
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+
+VERSION = os.environ.get("CLAP_VALIDATOR_VERSION", "0.4.1")
+# The 0.4.1 release assets carry a git-describe suffix in their filenames. Pin it
+# alongside VERSION; bump both together (the inner tarball misreports an older
+# version, so we locate the binary by name, never by filename).
+ASSET_SUFFIX = "127-g152b982"
+# SHA-256 digests published by GitHub for the exact 0.4.1 release assets above.
+# Asset names are the keys so a version/suffix change fails closed until its
+# corresponding digest is deliberately reviewed and pinned here.
+ASSET_SHA256 = {
+    "clap-validator-0.4.1-127-g152b982-ubuntu-22.04.zip":
+        "49edadcfb407ea0dd946ce418300e853fbd2660fa4b0d00e4f19ff8eef24ad90",
+    "clap-validator-0.4.1-127-g152b982-macos-universal.zip":
+        "bbec8cd7d18274e549d5d8c12ece3cec54be966129388dd2e742b9957f2ba9f1",
+    "clap-validator-0.4.1-127-g152b982-windows.zip":
+        "d935c3af0a45c3911ea2e900f4aa5d6709dac82bb485f0c4ce28648ab2cd0c10",
+}
+LATENCY_SIGNATURE = "clap_host_latency::changed"
+RUN_TIMEOUT_S = 600
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def _asset_name():
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system == "Linux":
+        if machine in ("aarch64", "arm64"):
+            return None  # no prebuilt Linux ARM64 asset upstream
+        return f"clap-validator-{VERSION}-{ASSET_SUFFIX}-ubuntu-22.04.zip"
+    if system == "Darwin":
+        return f"clap-validator-{VERSION}-{ASSET_SUFFIX}-macos-universal.zip"
+    if system == "Windows":
+        return f"clap-validator-{VERSION}-{ASSET_SUFFIX}-windows.zip"
+    return None
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as archive:
+        for chunk in iter(lambda: archive.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def resolve_binary(workdir):
+    """Return a path to a runnable clap-validator, downloading if necessary."""
+    env_bin = os.environ.get("CLAP_VALIDATOR_BIN")
+    if env_bin:
+        if not os.path.exists(env_bin):
+            log(f"::error::CLAP_VALIDATOR_BIN set but not found: {env_bin}")
+            sys.exit(2)
+        return env_bin
+
+    on_path = shutil.which("clap-validator")
+    if on_path:
+        return on_path
+
+    asset = _asset_name()
+    if asset is None:
+        log("::error::No prebuilt clap-validator for this platform "
+            f"({platform.system()}/{platform.machine()}). Install it (e.g. "
+            "cargo install) and set CLAP_VALIDATOR_BIN or add it to PATH.")
+        sys.exit(2)
+
+    url = (f"https://github.com/free-audio/clap-validator/releases/download/"
+           f"{VERSION}/{asset}")
+    zpath = os.path.join(workdir, asset)
+    expected_sha256 = ASSET_SHA256.get(asset)
+    if expected_sha256 is None:
+        log("::error::No pinned SHA-256 digest for clap-validator asset "
+            f"{asset}. Add the reviewed release digest or set CLAP_VALIDATOR_BIN.")
+        sys.exit(2)
+
+    log(f"Downloading {url}")
+    urllib.request.urlretrieve(url, zpath)
+    actual_sha256 = _sha256(zpath)
+    if actual_sha256 != expected_sha256:
+        log("::error::clap-validator archive SHA-256 mismatch for "
+            f"{asset}: expected {expected_sha256}, got {actual_sha256}")
+        sys.exit(2)
+    log(f"Verified SHA-256: {actual_sha256}")
+
+    with zipfile.ZipFile(zpath) as z:
+        z.extractall(workdir)
+    # Linux/macOS assets wrap a .tar.gz; Windows ships the .exe directly.
+    for tgz in glob.glob(os.path.join(workdir, "*.tar.gz")):
+        with tarfile.open(tgz) as t:
+            t.extractall(workdir)
+
+    for root, _dirs, files in os.walk(workdir):
+        for name in ("clap-validator", "clap-validator.exe"):
+            if name in files:
+                p = os.path.join(root, name)
+                os.chmod(p, 0o755)
+                return p
+    log("::error::clap-validator binary not found after extraction")
+    sys.exit(2)
+
+
+def main():
+    if len(sys.argv) != 2:
+        log("usage: dpf_clap_validate.py <path-to.clap>")
+        sys.exit(2)
+    clap = sys.argv[1]
+    if not os.path.exists(clap):
+        log(f"::error::plugin not found: {clap}")
+        sys.exit(2)
+
+    workdir = tempfile.mkdtemp(prefix="clapval_")
+    try:
+        vbin = resolve_binary(workdir)
+        log(f"Using clap-validator: {vbin}")
+        try:
+            proc = subprocess.run(
+                [vbin, "validate", clap],
+                capture_output=True, text=True, timeout=RUN_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            log(f"::error::clap-validator timed out after {RUN_TIMEOUT_S}s on {clap}")
+            sys.exit(2)
+
+        out = (proc.stdout or "") + (proc.stderr or "")
+        log(out)
+
+        # HARD GATE: the DPF CLAP latency contract.
+        if LATENCY_SIGNATURE in out:
+            log(f"::error::DPF CLAP latency regression: '{LATENCY_SIGNATURE}' "
+                "reported -- latency changed outside clap_plugin::activate(). "
+                "This is the upstream bug the dusk-audio/DPF fork fixes; DPF has "
+                "regressed. Check DPF_REF and the fork branch.")
+            sys.exit(1)
+
+        # ADVISORY (or strict) on the remaining suite.
+        if proc.returncode != 0:
+            if os.environ.get("SUITE_STRICT") == "1":
+                log("::error::clap-validator reported failing tests (SUITE_STRICT=1).")
+                sys.exit(proc.returncode or 1)
+            log("::warning::clap-validator reported failing tests (advisory -- not "
+                "gating). Fix the suite, then set SUITE_STRICT=1. Latency contract PASSED.")
+        else:
+            log("clap-validator suite clean. Latency contract PASSED.")
+        sys.exit(0)
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -47,9 +47,19 @@ on:
       - 'plugins/shared-dpf/**'
       - '.github/workflows/dpf-build.yml'
 
-# Pinned DPF revisions — identical to tapemachine2-release.yml. Bump deliberately.
+# DPF is our fork (dusk-audio/DPF), branch dusk/clap-latency-activate. Upstream's
+# CLAP wrapper reported latency changes outside clap_plugin::activate(), violating
+# the CLAP spec (24 clap-validator failures); the fork constrains latency changes
+# to activate() and serves a constant snapshot while active. One file changed vs
+# upstream base 4238e1c. DPF_REF pins that fix commit. DPF-Widgets stays upstream
+# (DISTRHO/DPF-Widgets) — only DPF is forked.
+# To advance DPF: rebase the branch onto newer upstream in ~/projects/DPF,
+# re-run clap-validator, confirm the latency signature is absent, review any
+# remaining advisory suite failures, push to dusk-audio/DPF, THEN bump DPF_REF.
+# Drop the fork (repoint checkouts to DISTRHO/DPF) only once upstream merges an
+# equivalent fix, verified with clap-validator first. Bump deliberately.
 env:
-  DPF_REF: 4238e1c7f0351bbe488d79f0899c540543ac7583
+  DPF_REF: 2f98c651acd70cfbcd9f807b7e73ea1e39ecc2cb
   DPFWIDGETS_REF: 730da6397904da66d99667c1cb30fc77fc3d794a
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk
@@ -187,7 +197,7 @@ jobs:
       - name: Checkout DPF
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF
+          repository: dusk-audio/DPF
           ref: ${{ env.DPF_REF }}
           path: DPF
           submodules: recursive
@@ -215,7 +225,8 @@ jobs:
             apt-get update -o Acquire::Retries=3 && \
             apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
               build-essential pkg-config cmake ninja-build zip curl \
-              libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev
+              libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev \
+              xvfb python3
           }
           for i in 1 2 3 4 5; do
             install_deps && break
@@ -239,6 +250,16 @@ jobs:
         run: |
           cmake --build build --config Release -j"$(nproc)" \
             --target "${PLUGIN_BASE}-vst3" "${PLUGIN_BASE}-clap" "${PLUGIN_BASE}-lv2"
+
+      - name: Validate CLAP (clap-validator gate)
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: |
+          # Hard-fail on a DPF CLAP latency regression (clap_host_latency::changed
+          # outside clap_plugin::activate()); the rest of the suite is advisory for
+          # now (see .github/scripts/dpf_clap_validate.py). xvfb: clap-validator
+          # drives the plugin GUI, which needs an X display in this headless container.
+          xvfb-run -a python3 "${GITHUB_WORKSPACE}/.github/scripts/dpf_clap_validate.py" \
+            "build/bin/${PLUGIN_BASE}.clap"
 
       - name: Package
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -317,7 +338,7 @@ jobs:
       - name: Checkout DPF
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF
+          repository: dusk-audio/DPF
           ref: ${{ env.DPF_REF }}
           path: DPF
           submodules: recursive
@@ -343,7 +364,8 @@ jobs:
             apt-get update -o Acquire::Retries=3 && \
             apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
               build-essential pkg-config cmake ninja-build zip curl \
-              libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev
+              libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev \
+              xvfb python3
           }
           for i in 1 2 3 4 5; do
             install_deps && break
@@ -431,7 +453,7 @@ jobs:
       - name: Checkout DPF
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF
+          repository: dusk-audio/DPF
           ref: ${{ env.DPF_REF }}
           path: DPF
           submodules: recursive
@@ -651,7 +673,7 @@ jobs:
       - name: Checkout DPF
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF
+          repository: dusk-audio/DPF
           ref: ${{ env.DPF_REF }}
           path: DPF
           submodules: recursive

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -59,7 +59,7 @@ on:
 # Drop the fork (repoint checkouts to DISTRHO/DPF) only once upstream merges an
 # equivalent fix, verified with clap-validator first. Bump deliberately.
 env:
-  DPF_REF: 2f98c651acd70cfbcd9f807b7e73ea1e39ecc2cb
+  DPF_REF: f2c9f01f510cf0c04a7c9c5a2873921ac9ce2ee2
   DPFWIDGETS_REF: 730da6397904da66d99667c1cb30fc77fc3d794a
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/docs/dpf-migration/00-OVERVIEW.md
+++ b/docs/dpf-migration/00-OVERVIEW.md
@@ -49,7 +49,7 @@ Already written and validated inside tape-echo — reuse, do not rewrite:
 | Factory-preset table + host programs | `dpf-plugin/TapeEchoParams.hpp` + shell | preset headers |
 | CMake template | `dpf-plugin/CMakeLists.txt` | JUCE CMake |
 
-DPF checkout: `~/projects/DPF` (needs `git submodule update --init` for pugl).
+DPF checkout: `~/projects/DPF` — our fork `dusk-audio/DPF`, branch `dusk/clap-latency-activate` (CLAP latency-in-activate fix; remote `dusk`, `origin` stays upstream DISTRHO). Needs `git submodule update --init` for pugl.
 DPF-Widgets checkout: `~/projects/DPF-Widgets` (DearImGui wrapper).
 
 ## Landmines (all hit and fixed during tape-echo — do not rediscover them)

--- a/plugins/shared-dpf/cmake/DuskDpfPlugin.cmake
+++ b/plugins/shared-dpf/cmake/DuskDpfPlugin.cmake
@@ -21,7 +21,7 @@ set(DPF_PATH        "${_dusk_repo_root}/../DPF"         CACHE PATH "Path to DIST
 set(DPFWIDGETS_PATH "${_dusk_repo_root}/../DPF-Widgets" CACHE PATH "Path to DPF-Widgets (Dear ImGui wrapper)")
 
 if(NOT EXISTS "${DPF_PATH}/CMakeLists.txt")
-    message(FATAL_ERROR "DPF not found at ${DPF_PATH} — clone https://github.com/DISTRHO/DPF or pass -DDPF_PATH=...")
+    message(FATAL_ERROR "DPF not found at ${DPF_PATH} — clone https://github.com/dusk-audio/DPF (our fork, branch dusk/clap-latency-activate) or pass -DDPF_PATH=...")
 endif()
 if(NOT EXISTS "${DPFWIDGETS_PATH}/opengl/DearImGui.cpp")
     message(FATAL_ERROR "DPF-Widgets not found at ${DPFWIDGETS_PATH} — clone https://github.com/DISTRHO/DPF-Widgets or pass -DDPFWIDGETS_PATH=...")

--- a/plugins/tape-echo/Source/TapeEchoPresets.h
+++ b/plugins/tape-echo/Source/TapeEchoPresets.h
@@ -71,7 +71,7 @@ inline const std::vector<Preset>& getFactoryPresets()
           11, 0.0f, 1.0f, 50.0f, -8.0f, -60.0f, 0.0f, 0.0f, 10.0f, 50.0f },
 
         // --- Ambient ---
-        { "Space Echo", "Ambient",
+        { "Orbital Echo", "Ambient",
           4, 0.0f, 0.8f, 75.0f, -6.0f, -10.0f, 1.0f, -2.0f, 25.0f, 55.0f },
 
         { "Dark Wash", "Ambient",

--- a/plugins/tape-echo/core/INTEGRATION.md
+++ b/plugins/tape-echo/core/INTEGRATION.md
@@ -30,20 +30,26 @@ wire up — call the setters from wherever the host delivers values.
 | ID | Name          | Setter            | Range      | Default | Notes |
 |----|---------------|-------------------|------------|---------|-------|
 | 0  | Mode Selector | `setMode`         | 1–12 (int, stepped) | 1 | 12-position rotary switch |
-| 1  | Repeat Rate   | `setRepeatRate`   | 0–1        | 0.5     | 0 = 177 ms (slow motor), 1 = 69 ms |
-| 2  | Intensity     | `setIntensity`    | 0–1        | 0.4     | self-oscillates above ~0.75 |
-| 3  | Echo Volume   | `setEchoLevel`    | 0–1        | 0.8     | |
+| 1  | Repeat Rate   | `setRepeatRate`   | 0–1        | 0.0     | 0 = 178.50 ms (slow motor), 1 = 69.83 ms |
+| 2  | Intensity     | `setIntensity`    | 0–1        | 0.0     | self-oscillates above ~0.75 |
+| 3  | Echo Volume   | `setEchoLevel`    | 0–1        | 0.5     | |
 | 4  | Reverb Volume | `setReverbLevel`  | 0–1        | 0.0     | only audible in modes 5–12 |
 | 5  | Bass          | `setBass`         | −1–+1      | 0.0     | ±12 dB shelf @ 100 Hz, echo path only |
 | 6  | Treble        | `setTreble`       | −1–+1      | 0.0     | ±12 dB shelf @ 3 kHz, echo path only |
 | 7  | Input Volume  | `setInputGain`    | 0–1        | 0.5     | preamp drive / saturation amount |
-| 8  | Wow & Flutter | `setWowFlutter`   | 0–1        | 0.5     | ~7% residual wow always present (real transports are never perfect); knob adds on top |
+| 8  | Wow & Flutter | `setWowFlutter`   | 0–1        | 0.0     | transport modulation amount |
 | 9  | Dry Level     | `setDryLevel`     | 0–1        | 1.0     | instrument-through level |
-| 10 | Tempo Sync    | (shell-level)     | off/on     | off     | locks head-1 time to a host-tempo division, octave-folded into 69–177 ms |
+| 10 | Tempo Sync    | (shell-level)     | off/on     | off     | locks head-1 time to a host-tempo division, octave-folded into 69.83–178.50 ms |
 | 11 | Sync Division | (shell-level)     | 0–7 (int)  | 2 (1/16)| 1/32, 1/16T, 1/16, 1/8T, 1/16., 1/8, 1/8., 1/4 |
-| 12 | Tape Age      | `setTapeAge`      | 0–1        | 0.0     | 0 = fresh transport (bit-identical to pre-knob builds); worn: hiss onto tape (regenerates with intensity), extra wow, HF loss, level wobble |
-| 13 | Bypass        | `setBypass`       | off/on     | off     | host-designated; UI POWER switch, click-free clean passthrough |
-| 14 | Out Level     | `getOutputLevel`  | 0–3 (out)  | —       | peak meter, ~300 ms release; exposed as a host OUTPUT parameter the UI reads through the shell (out-of-process-safe). Single-binary formats may read the DSP peak directly via the weak-symbol access bridge as an optimization, never a requirement |
+| 12 | Tape Age      | `setTapeAge`      | 0–1        | 0.5     | 0 = fresh transport; worn settings add hiss, wow, HF loss, and level wobble |
+| 13 | Output Volume | `setOutputVolume` | 0–1        | 0.5     | −20 dB to +20 dB; midpoint is unity |
+| 14 | Echo Pan      | `setEchoPan`      | 0–1        | 0.5     | 0 = left, 0.5 = center, 1 = right |
+| 15 | Reverb Pan    | `setReverbPan`    | 0–1        | 0.5     | 0 = left, 0.5 = center, 1 = right |
+| 16 | Input Send    | `setInputSend`    | off/on     | on      | feeds the tape and spring paths |
+| 17 | Wet Solo      | `setWetSolo`      | off/on     | off     | mutes the dry path |
+| 18 | Loop Splice   | `triggerLoopSplice` | trigger  | off     | relocates the circulating tape splice |
+| 19 | Bypass        | `setBypass`       | off/on     | off     | host-designated; UI POWER switch, click-free clean passthrough |
+| 20 | Out Level     | `getOutputLevel`  | 0–3 (out)  | —       | peak meter, ~300 ms release; exposed as a host OUTPUT parameter the UI reads through the shell (out-of-process-safe). Single-binary formats may read the DSP peak directly via the weak-symbol access bridge as an optimization, never a requirement |
 
 Tempo sync lives in the plugin shell, not the DSP core: the shell converts
 division + host BPM to an equivalent Repeat Rate each block (see
@@ -64,7 +70,7 @@ runs native).
 
 ```
 tape-echo-dpf/
-├── dpf/                     # git submodule: github.com/DISTRHO/DPF
+├── dpf/                     # git submodule: github.com/dusk-audio/DPF (fork; branch dusk/clap-latency-activate)
 ├── plugin/
 │   ├── DistrhoPluginInfo.h
 │   ├── TapeEchoPlugin.cpp  # DSP wrapper (below)

--- a/plugins/tape-echo/core/TapeEchoDSP.cpp
+++ b/plugins/tape-echo/core/TapeEchoDSP.cpp
@@ -37,31 +37,40 @@ namespace
         { 1, 0, 0, 0 },   // 1:  Head 1
         { 0, 1, 0, 0 },   // 2:  Head 2
         { 0, 0, 1, 0 },   // 3:  Head 3
-        { 0, 1, 1, 0 },   // 4:  Heads 2 + 3
+        { 0, 0.724f, 0.724f, 0 }, // 4: Heads 2 + 3
         { 1, 0, 0, 1 },   // 5:  Head 1 + Reverb
         { 0, 1, 0, 1 },   // 6:  Head 2 + Reverb
         { 0, 0, 1, 1 },   // 7:  Head 3 + Reverb
-        { 1, 1, 0, 1 },   // 8:  Heads 1 + 2 + Reverb
-        { 0, 1, 1, 1 },   // 9:  Heads 2 + 3 + Reverb
-        { 1, 0, 1, 1 },   // 10: Heads 1 + 3 + Reverb
-        { 1, 1, 1, 1 },   // 11: Heads 1 + 2 + 3 + Reverb
+        { 0.724f, 0.724f, 0, 1 }, // 8: Heads 1 + 2 + Reverb
+        { 0, 0.724f, 0.724f, 1 }, // 9: Heads 2 + 3 + Reverb
+        { 0.724f, 0, 0.724f, 1 }, // 10: Heads 1 + 3 + Reverb
+        { 0.596f, 0.596f, 0.596f, 1 }, // 11: all heads + Reverb
         { 0, 0, 0, 1 },   // 12: Reverb only
     };
 
-    // Per-head playback trims: later heads sit slightly lower and duller on
-    // the real unit (longer tape wear path, playback amp voicing).
-    constexpr float kHeadTrim[3] = { 1.0f, 0.95f, 0.90f };
+    // Hosted single-head trims. Multi-head attenuation lives in the mode table
+    // above and keeps the summed programs near the single-head loudness.
+    constexpr float kHeadTrim[3] = { 1.0f, 1.122f, 0.958f };
 
-    // Wow & flutter depths (fraction of nominal delay time) at full depth.
-    // Tuned so the 0.5 default lands near real tape-transport figures
-    // (~0.15-0.25% peak pitch deviation); full depth is a musical extreme.
+    // Transport motion. Flutter frequency follows tape speed; its depth grows
+    // toward the slow end of the motor range. The second harmonic gives the
+    // measured capstan cycle its slightly non-sinusoidal shape.
     constexpr float kWowHz       = 0.5f;
-    constexpr float kFlutterHz   = 4.1f;
-    constexpr float kWowDepth    = 0.0055f;
-    constexpr float kFlutterDepth= 0.0012f;
-    constexpr float kNoiseDepth  = 0.0028f;
+    constexpr float kFlutterMaxHz= 3.857f;
+    constexpr float kWowDepth    = 0.0008f;
+    constexpr float kNoiseDepth  = 0.0004f;
 
     constexpr float kTwoPi = 6.28318530717958647692f;
+
+    // clap-validator exercises fractional sample rates down to 1 kHz. Keep
+    // every bilinear-transform design safely below Nyquist; this is a no-op
+    // throughout the plug-in's normal supported audio-rate range.
+    inline float safeBiquadFrequency(double sampleRate, float frequency) noexcept
+    {
+        return std::max(
+            1.0f,
+            std::min(frequency, 0.45f * (float)sampleRate));
+    }
 }
 
 //==============================================================================
@@ -101,26 +110,49 @@ void SpringReverb::Spring::prepare(double fs, float lengthSeconds, float fbAmoun
 {
     len = std::max(16, (int)std::lround(lengthSeconds * fs));
     buf.assign((size_t)len + 8, 0.0f);
+    // The return transducer and mounting add a short path beyond the nominal
+    // one-way spring length. This places the measured recurrences around
+    // 46--53 ms without moving the first pickup arrival.
+    const int feedbackLen =
+        len + std::max(1, (int)std::lround(0.0035 * fs));
+    feedbackBuf.assign((size_t)feedbackLen, 0.0f);
     writeIdx = 0;
+    feedbackWriteIdx = 0;
     feedback = fbAmount;
     lfoPhase = 0.0f;
     lfoInc   = kTwoPi * lfoHz / (float)fs;
-    // A few samples, rate-scaled — capped so the modulation excursion stays well
+    // A few samples, rate-scaled — capped so the modulation excursion stays
     // inside the +8 buffer guard band at any sample rate (6 < 8).
-    lfoDepth = std::min(1.5f + 0.00005f * (float)fs, 6.0f);
+    lfoDepth = std::min(
+        1.54f * (1.5f + 0.00005f * (float)fs), 6.0f);
     for (auto& ap : chain)
         ap.a = apCoeff;
-    damping.setCutoff(2800.0f, fs);
+    damping.setCutoff(17000.0f, fs);
+    feedbackHighPass.setCoeffs(Biquad::highPass(
+        fs, safeBiquadFrequency(fs, 51.0f), 0.70710678f));
+    highDamping.setCoeffs(Biquad::lowPass(
+        fs, safeBiquadFrequency(fs, 8000.0f), 0.70710678f));
+    airDamping.setCoeffs(Biquad::shelfSlope1(
+        fs, safeBiquadFrequency(fs, 6500.0f), -2.75f, true));
+    upperModeDamping.setCoeffs(Biquad::peak(
+        fs, safeBiquadFrequency(fs, 8000.0f), -0.70f, 3.0f));
     reset();
 }
 
 void SpringReverb::Spring::reset()
 {
     std::fill(buf.begin(), buf.end(), 0.0f);
+    std::fill(feedbackBuf.begin(), feedbackBuf.end(), 0.0f);
     for (auto& ap : chain)
         ap.z = 0.0f;
     damping.reset();
+    feedbackHighPass.reset();
+    highDamping.reset();
+    airDamping.reset();
+    upperModeDamping.reset();
+    lfoPhase = 0.0f;
     writeIdx = 0;
+    feedbackWriteIdx = 0;
 }
 
 float SpringReverb::Spring::process(float x) noexcept
@@ -148,9 +180,21 @@ float SpringReverb::Spring::process(float x) noexcept
     for (auto& ap : chain)
         y = ap.process(y);
 
-    y = damping.process(y);
+    y = highDamping.process(damping.process(y));
 
-    buf[(size_t)writeIdx] = x + feedback * y;
+    // A spring's pickup hears the first one-way wave, while feedback returns
+    // through the opposite direction of travel. Keeping that return delay
+    // separate preserves the initial arrival but makes the recurrence period
+    // a physical round trip instead of another one-way transit.
+    const float feedbackReturn =
+        upperModeDamping.process(airDamping.process(
+            feedbackHighPass.process(
+                feedbackBuf[(size_t)feedbackWriteIdx])));
+    feedbackBuf[(size_t)feedbackWriteIdx] = y;
+    if (++feedbackWriteIdx >= (int)feedbackBuf.size())
+        feedbackWriteIdx = 0;
+
+    buf[(size_t)writeIdx] = x + feedback * feedbackReturn;
     if (++writeIdx >= (int)buf.size())
         writeIdx = 0;
 
@@ -159,13 +203,59 @@ float SpringReverb::Spring::process(float x) noexcept
 
 void SpringReverb::prepare(double sampleRate, float detune)
 {
-    // Two unequal springs; slight per-channel detune decorrelates L/R.
-    // Feedback sets decay: ~1.4 dB loss per ~40 ms round trip gives the
-    // real three-spring tank's ~1.8 s RT60 (HF decays faster via damping).
-    springs[0].prepare(sampleRate, 0.0412f * detune, 0.855f, 0.31f, 0.62f);
-    springs[1].prepare(sampleRate, 0.0331f * detune, 0.835f, 0.47f, 0.66f);
+    // Four unequal springs build the tank's dense dispersive tail.
+    // Length-compensated feedback keeps the low-band decay close across the
+    // four unequal paths. The high damping corner preserves the measured
+    // upper-mid spring tail while still shortening the extreme top end.
+    springs[0].prepare(sampleRate, 0.0200f * detune, 0.8980f, 0.31f, 0.62f);
+    springs[1].prepare(sampleRate, 0.0215f * detune, 0.8900f, 0.47f, 0.66f);
+    springs[2].prepare(sampleRate, 0.0230f * detune, 0.8820f, 0.38f, 0.60f);
+    springs[3].prepare(sampleRate, 0.0245f * detune, 0.8740f, 0.53f, 0.68f);
+    pickupTap8  = std::max(1, (int)std::lround(0.008 * sampleRate));
+    pickupTap18 = std::max(1, (int)std::lround(0.018 * sampleRate));
+    pickupTap28 = std::max(1, (int)std::lround(0.028 * sampleRate));
+    pickupSpring3Tap85 =
+        std::max(1, (int)std::lround(0.0085 * sampleRate));
+    pickupSpring3Tap20 =
+        std::max(1, (int)std::lround(0.020 * sampleRate));
+    pickupSpring3Tap285 =
+        std::max(1, (int)std::lround(0.0285 * sampleRate));
+    const size_t pickupSize =
+        (size_t)std::max(pickupTap28, pickupSpring3Tap285) + 1;
+    pickupBuf.assign(pickupSize, 0.0f);
+    pickupSpring3Buf.assign(pickupSize, 0.0f);
+    pickupWriteIdx = 0;
+    outputDiffusionBuf.assign(
+        (size_t)std::max(1, (int)std::lround(0.0013 * sampleRate)),
+        0.0f);
+    outputDiffusionWriteIdx = 0;
     inputHP.setCutoff(140.0f, sampleRate);
     inputLP.setCutoff(4200.0f, sampleRate);
+    outputHP.setCoeffs(Biquad::highPass(
+        sampleRate, safeBiquadFrequency(sampleRate, 400.0f), 0.70710678f));
+    outputVoiceLP.setCoeffs(Biquad::lowPass(
+        sampleRate, safeBiquadFrequency(sampleRate, 1800.0f), 0.70710678f));
+    for (size_t i = 0; i < outputCeilingLP.size(); ++i)
+    {
+        const float theta =
+            ((2.0f * (float)i + 1.0f) * kDuskPi)
+            / (4.0f * (float)outputCeilingLP.size());
+        const float q = 1.0f / (2.0f * std::cos(theta));
+        outputCeilingLP[i].setCoeffs(Biquad::lowPass(
+            sampleRate, safeBiquadFrequency(sampleRate, 4900.0f), q));
+    }
+    outputLowContour.setCoeffs(Biquad::peak(
+        sampleRate, safeBiquadFrequency(sampleRate, 127.0f),
+        -5.0f, 2.0f));
+    outputBody.setCoeffs(Biquad::peak(
+        sampleRate, safeBiquadFrequency(sampleRate, 1000.0f),
+        1.6f, 0.70f));
+    outputPresence.setCoeffs(Biquad::peak(
+        sampleRate, safeBiquadFrequency(sampleRate, 5000.0f),
+        5.0f, 3.0f));
+    pickupImagePhaseInc = kTwoPi
+        * safeBiquadFrequency(sampleRate, 12000.0f)
+        / (float)sampleRate;
     reset();
 }
 
@@ -173,22 +263,130 @@ void SpringReverb::reset()
 {
     for (auto& s : springs)
         s.reset();
+    std::fill(pickupBuf.begin(), pickupBuf.end(), 0.0f);
+    std::fill(pickupSpring3Buf.begin(), pickupSpring3Buf.end(), 0.0f);
+    pickupWriteIdx = 0;
+    std::fill(outputDiffusionBuf.begin(), outputDiffusionBuf.end(), 0.0f);
+    outputDiffusionWriteIdx = 0;
     inputHP.reset();
     inputLP.reset();
     dcBlock.reset();
+    outputHP.reset();
+    outputVoiceLP.reset();
+    for (auto& lp : outputCeilingLP)
+        lp.reset();
+    outputLowContour.reset();
+    outputBody.reset();
+    outputPresence.reset();
+    pickupImagePhase = 0.057f;
 }
 
 float SpringReverb::process(float in) noexcept
 {
     const float voiced = inputLP.process(inputHP.process(in));
-    const float wet    = springs[0].process(voiced) + springs[1].process(voiced);
-    return dcBlock.process(0.6f * wet);
+    float wet = 0.0f;
+    float spring3Wet = 0.0f;
+    for (size_t i = 0; i < springs.size(); ++i)
+    {
+        const float springWet = springs[i].process(voiced);
+        wet += springWet;
+        if (i == 3)
+            spring3Wet = springWet;
+    }
+
+    // Secondary pickup modes bridge the quiet intervals between primary
+    // round trips. They are feed-forward only: the calibrated decay and
+    // stability of each spring loop remain unchanged.
+    const auto pickupAt = [this](const std::vector<float>& buffer,
+                                 int delay) noexcept
+    {
+        int index = pickupWriteIdx - delay;
+        if (index < 0)
+            index += (int)buffer.size();
+        return buffer[(size_t)index];
+    };
+    pickupBuf[(size_t)pickupWriteIdx] = wet;
+    pickupSpring3Buf[(size_t)pickupWriteIdx] = spring3Wet;
+    wet = 0.90f * wet
+        + 0.45f * pickupAt(pickupBuf, pickupTap8)
+        - 0.18f * pickupAt(pickupBuf, pickupTap18)
+        + 0.09f * pickupAt(pickupBuf, pickupTap28)
+        + 0.45f * (pickupAt(pickupSpring3Buf, pickupSpring3Tap85)
+                   - pickupAt(pickupSpring3Buf, pickupTap8))
+        - 0.18f * (pickupAt(pickupSpring3Buf, pickupSpring3Tap20)
+                   - pickupAt(pickupSpring3Buf, pickupTap18))
+        + 0.09f * (pickupAt(pickupSpring3Buf, pickupSpring3Tap285)
+                   - pickupAt(pickupSpring3Buf, pickupTap28));
+    if (++pickupWriteIdx >= (int)pickupBuf.size())
+        pickupWriteIdx = 0;
+
+    // A short all-pass at the pickup diffuses coherent reflection clusters
+    // without changing the tank's magnitude response or calibrated decay.
+    constexpr float kOutputDiffusion = 0.70f;
+    const float diffusionDelay =
+        outputDiffusionBuf[(size_t)outputDiffusionWriteIdx];
+    const float diffusedWet = diffusionDelay - kOutputDiffusion * wet;
+    outputDiffusionBuf[(size_t)outputDiffusionWriteIdx] =
+        wet + kOutputDiffusion * diffusedWet;
+    if (++outputDiffusionWriteIdx >= (int)outputDiffusionBuf.size())
+        outputDiffusionWriteIdx = 0;
+    wet = diffusedWet;
+
+    // Output trim is calibrated per channel. The wet path is mono and panned
+    // later; measuring an L/R average here would overstate the spring level
+    // because the former dual-mono tanks partially cancelled at center.
+    float voicedWet = outputHP.process(dcBlock.process(0.96f * wet));
+    voicedWet = outputVoiceLP.process(voicedWet);
+    for (auto& lp : outputCeilingLP)
+        voicedWet = lp.process(voicedWet);
+    voicedWet = outputLowContour.process(voicedWet);
+    const float springReturn =
+        outputPresence.process(outputBody.process(voicedWet));
+
+    // The pickup return carries a very quiet clock image of the tank signal.
+    // Keeping it feed-forward preserves the calibrated decay and adds only the
+    // measured upper-air sidebands around the 12 kHz carrier.
+    const float pickupImage =
+        0.00028f * springReturn * std::cos(pickupImagePhase);
+    pickupImagePhase += pickupImagePhaseInc;
+    if (pickupImagePhase >= kTwoPi)
+        pickupImagePhase -= kTwoPi;
+    return springReturn + pickupImage;
 }
 
 //==============================================================================
 // TapeEchoDSP
 //==============================================================================
 constexpr float TapeEchoDSP::kHeadRatio[3];
+
+float TapeEchoDSP::delayMsForRepeatRate(float v01) noexcept
+{
+    const float x  = clamp01(v01);
+    const float x2 = x * x;
+    // Monotonic endpoint-constrained fit to hosted head-1 arrivals at five
+    // motor positions. A linear knob law was over 10 ms early at midpoint.
+    const float slow01 = clamp01(
+        1.0f - 2.14728717f * x2
+             + 0.90911783f * x2 * x
+             + 0.23816934f * x2 * x2);
+    return kMinDelayMs + slow01 * (kMaxDelayMs - kMinDelayMs);
+}
+
+float TapeEchoDSP::repeatRateForDelayMs(float delayMs) noexcept
+{
+    const float target = clampF(delayMs, kMinDelayMs, kMaxDelayMs);
+    float lo = 0.0f;
+    float hi = 1.0f;
+    for (int i = 0; i < 24; ++i)
+    {
+        const float mid = 0.5f * (lo + hi);
+        if (delayMsForRepeatRate(mid) > target)
+            lo = mid;
+        else
+            hi = mid;
+    }
+    return 0.5f * (lo + hi);
+}
 
 void TapeEchoDSP::prepare(double sampleRate, int /*maxBlockSize*/)
 {
@@ -207,17 +405,46 @@ void TapeEchoDSP::prepare(double sampleRate, int /*maxBlockSize*/)
     for (auto& ch : channels)
     {
         ch.tape.assign((size_t)tapeLen, 0.0f);
-        ch.recordHP.setCutoff(55.0f, fs);
-        ch.recordLP.setCutoff(6200.0f, fs);
-        ch.recordLP2.setCutoff(4800.0f, fs);
+        ch.recordHP.setCoeffs(Biquad::highPass(
+            fs, safeBiquadFrequency(fs, 115.0f), 0.70710678f));
+        const float initialMs = delayMsForRepeatRate(
+            pRepeatRate.load(std::memory_order_relaxed));
+        const float initialSlow01 = clamp01(
+            (initialMs - kMinDelayMs) / (kMaxDelayMs - kMinDelayMs));
+        const float initialVoicing = 1.05f + 0.08f * initialSlow01
+            + 0.48f * initialSlow01 * (1.0f - initialSlow01);
+        ch.speedLP.setCoeffs(Biquad::lowPass(
+            fs, safeBiquadFrequency(
+                fs, 7200.0f * kMinDelayMs / initialMs * initialVoicing),
+            0.70710678f));
+        constexpr float kButterworthQ[4] =
+            { 0.50979558f, 0.60134489f, 0.89997622f, 2.56291545f };
+        for (int i = 0; i < 4; ++i)
+            ch.antiAliasLP[(size_t)i].setCoeffs(Biquad::lowPass(
+                fs, safeBiquadFrequency(
+                    fs, 11000.0f
+                        + 2000.0f * std::pow(1.0f - initialSlow01, 3.0f)),
+                kButterworthQ[i]));
+        // The direct monitor path retains full midrange level while its
+        // coupling network and output amplifier gently soften the extremes.
+        // These shelves are outside the echo/reverb sends.
+        ch.dryLowShelf.setCoeffs(Biquad::shelf(
+            fs, safeBiquadFrequency(fs, 46.3316f),
+            -6.17579f, 0.492074f, /*high=*/false));
+        ch.dryHighShelf.setCoeffs(Biquad::shelf(
+            fs, safeBiquadFrequency(fs, 13762.47f),
+            -6.13329f, 0.492299f, /*high=*/true));
         ch.spring.prepare(fs, detune);
         detune = 1.013f; // second channel slightly longer springs
     }
 
     noiseLP.setCutoff(2.0f, fs);
     wowInc     = kTwoPi * kWowHz     / (float)fs;
-    flutterInc = kTwoPi * kFlutterHz / (float)fs;
+    flutterInc = kTwoPi * kFlutterMaxHz / (float)fs;
     meterDecayPerSample = std::exp(-1.0f / (0.3f * (float)fs));
+    recordEnvelopeAttack =
+        1.0f - std::exp(-1.0f / (0.00005f * (float)fs));
+    recordEnvelopeRelease = std::exp(-1.0f / (0.12f * (float)fs));
     outputPeak.store(0.0f, std::memory_order_relaxed);
 
     delaySmoother.prepare(fs, 0.35f);        // motor/capstan inertia
@@ -228,18 +455,22 @@ void TapeEchoDSP::prepare(double sampleRate, int /*maxBlockSize*/)
     echoLevelSmoother.prepare(fs, 0.02f);
     reverbLevelSmoother.prepare(fs, 0.02f);
     dryLevelSmoother.prepare(fs, 0.02f);
+    outputVolumeSmoother.prepare(fs, 0.02f);
+    echoPanSmoother.prepare(fs, 0.02f);
+    reverbPanSmoother.prepare(fs, 0.02f);
+    inputSendSmoother.prepare(fs, 0.01f);
+    wetSoloSmoother.prepare(fs, 0.01f);
     driveSmoother.prepare(fs, 0.02f);
     wowFlutterSmoother.prepare(fs, 0.05f);
     powerSmoother.prepare(fs, 0.03f);
     ageSmoother.prepare(fs, 0.10f);
     hissVoice.setCutoff(4500.0f, fs);
-    hissVoiceR.setCutoff(4500.0f, fs);
     wobbleLP.setCutoff(5.0f, fs);
 
     // Snap smoothers to current parameter values so prepare() never glides.
     const auto& m = kModeTable[pMode.load(std::memory_order_relaxed) - 1];
-    const float t = kMinDelayMs + (1.0f - pRepeatRate.load(std::memory_order_relaxed))
-                                  * (kMaxDelayMs - kMinDelayMs);
+    const float t = delayMsForRepeatRate(
+        pRepeatRate.load(std::memory_order_relaxed));
     delaySmoother.snap(t * 0.001f * (float)fs);
     intensitySmoother.snap(pIntensity.load(std::memory_order_relaxed));
     headGain[0].snap(m.h1);
@@ -249,11 +480,18 @@ void TapeEchoDSP::prepare(double sampleRate, int /*maxBlockSize*/)
     echoLevelSmoother.snap(pEchoLevel.load(std::memory_order_relaxed));
     reverbLevelSmoother.snap(pReverbLevel.load(std::memory_order_relaxed));
     dryLevelSmoother.snap(pDryLevel.load(std::memory_order_relaxed));
+    outputVolumeSmoother.snap(
+        pOutputVolume.load(std::memory_order_relaxed));
+    echoPanSmoother.snap(pEchoPan.load(std::memory_order_relaxed));
+    reverbPanSmoother.snap(pReverbPan.load(std::memory_order_relaxed));
+    inputSendSmoother.snap(pInputSend.load(std::memory_order_relaxed));
+    wetSoloSmoother.snap(pWetSolo.load(std::memory_order_relaxed));
     driveSmoother.snap(pInputGain.load(std::memory_order_relaxed));
     wowFlutterSmoother.snap(pWowFlutter.load(std::memory_order_relaxed));
     powerSmoother.snap(1.0f - pBypass.load(std::memory_order_relaxed));
     ageSmoother.snap(pTapeAge.load(std::memory_order_relaxed));
-    lastAge = -1.0f; // force LP2 retune on first block
+    lastPlaybackCutoff = -1.0f;
+    lastAntiAliasCutoff = -1.0f;
 
     lastBass = lastTreble = -999.0f; // force shelf recompute
     reset();
@@ -268,18 +506,33 @@ void TapeEchoDSP::reset()
         ch.upA.reset(); ch.downA.reset();
         ch.upB.reset(); ch.downB.reset();
         ch.recordHP.reset();
-        ch.recordLP.reset();
-        ch.recordLP2.reset();
+        ch.speedLP.reset();
+        for (auto& lp : ch.antiAliasLP)
+            lp.reset();
         ch.bassShelf.reset();
         ch.trebleShelf.reset();
+        ch.dryLowShelf.reset();
+        ch.dryHighShelf.reset();
         ch.spring.reset();
+        ch.springCleanDelay.fill(0.0f);
+        ch.springCleanDelayWriteIdx = 0;
+        ch.recordEnvelope = 0.0f;
+        ch.magneticEnvelope = 0.0f;
     }
     noiseLP.reset();
     hissVoice.reset();
-    hissVoiceR.reset();
     wobbleLP.reset();
     writeIdx = 0;
     wowPhase = flutterPhase = 0.0f;
+    // Initial cartridge position is deterministic. Hosted captures place the
+    // first head-1 splice at about 7.0 s over most of the motor range and
+    // 9.1 s at the extreme fast end (after renderer pre-roll).
+    spliceSamplesToHead1 = 7.58f * (float)fs;
+    spliceClockStarted = false;
+    lastSpliceTrigger =
+        pSpliceTrigger.load(std::memory_order_relaxed);
+    lastClearRequest =
+        pClearRequest.load(std::memory_order_relaxed);
 }
 
 float TapeEchoDSP::readTape(const std::vector<float>& buf, float delaySamples) const noexcept
@@ -299,6 +552,16 @@ float TapeEchoDSP::readTape(const std::vector<float>& buf, float delaySamples) c
 
 void TapeEchoDSP::refreshBlockRateControls()
 {
+    const uint32_t clearRequest =
+        pClearRequest.load(std::memory_order_relaxed);
+    if (clearRequest != lastClearRequest)
+    {
+        // POWER off clears the circulating tape and spring tank. reset() only
+        // clears preallocated state, so it is allocation-free on this thread.
+        reset();
+        lastClearRequest = clearRequest;
+    }
+
     // Snapshot atomics once per block; smoothers handle the rest per sample.
     const auto& m = kModeTable[pMode.load(std::memory_order_relaxed) - 1];
     headGain[0].setTarget(m.h1);
@@ -307,29 +570,74 @@ void TapeEchoDSP::refreshBlockRateControls()
     reverbSendSmoother.setTarget(m.reverb);
 
     const float rate = pRepeatRate.load(std::memory_order_relaxed);
-    const float tMs  = kMinDelayMs + (1.0f - rate) * (kMaxDelayMs - kMinDelayMs);
+    if (!spliceClockStarted)
+    {
+        const float initialSpliceSeconds =
+            7.58f + 2.07f * std::pow(rate, 6.0f);
+        spliceSamplesToHead1 =
+            initialSpliceSeconds * (float)fs;
+        spliceClockStarted = true;
+    }
+    const float tMs  = delayMsForRepeatRate(rate);
     delaySmoother.setTarget(tMs * 0.001f * (float)fs);
 
     intensitySmoother.setTarget(pIntensity.load(std::memory_order_relaxed));
     echoLevelSmoother.setTarget(pEchoLevel.load(std::memory_order_relaxed));
     reverbLevelSmoother.setTarget(pReverbLevel.load(std::memory_order_relaxed));
     dryLevelSmoother.setTarget(pDryLevel.load(std::memory_order_relaxed));
+    outputVolumeSmoother.setTarget(
+        pOutputVolume.load(std::memory_order_relaxed));
+    echoPanSmoother.setTarget(pEchoPan.load(std::memory_order_relaxed));
+    reverbPanSmoother.setTarget(pReverbPan.load(std::memory_order_relaxed));
+    inputSendSmoother.setTarget(pInputSend.load(std::memory_order_relaxed));
+    wetSoloSmoother.setTarget(pWetSolo.load(std::memory_order_relaxed));
     driveSmoother.setTarget(pInputGain.load(std::memory_order_relaxed));
     wowFlutterSmoother.setTarget(pWowFlutter.load(std::memory_order_relaxed));
     powerSmoother.setTarget(1.0f - pBypass.load(std::memory_order_relaxed));
     ageSmoother.setTarget(pTapeAge.load(std::memory_order_relaxed));
 
-    // worn heads/tape lose top end: retune the second in-loop pole at block
-    // rate. age 0 recomputes the original 4.8 kHz coefficient exactly, so a
-    // fresh transport stays bit-identical.
+    const uint32_t spliceTrigger =
+        pSpliceTrigger.load(std::memory_order_relaxed);
+    if (spliceTrigger != lastSpliceTrigger)
+    {
+        lastSpliceTrigger = spliceTrigger;
+        // A manual trigger drops the splice at the write head. It reaches the
+        // first read head one head-delay later.
+        spliceSamplesToHead1 = delaySmoother.value();
+    }
+
+    // Playback bandwidth is proportional to tape speed. Worn tape narrows it
+    // further. This replaces the fixed-frequency poles that made slow and fast
+    // repeats incorrectly share the same spectrum.
     {
         const float age = ageSmoother.value();
-        if (age != lastAge)
+        const float slow01 = clamp01(
+            (tMs - kMinDelayMs) / (kMaxDelayMs - kMinDelayMs));
+        const float voicing = 1.05f + 0.08f * slow01
+                            + 0.48f * slow01 * (1.0f - slow01);
+        const float cutoff = safeBiquadFrequency(
+            fs, 7200.0f * kMinDelayMs / tMs * voicing
+              * (1.0f - 0.32f * age));
+        if (cutoff != lastPlaybackCutoff)
         {
-            lastAge = age;
-            const float fc2 = 4800.0f * (1.0f - 0.58f * age);
+            lastPlaybackCutoff = cutoff;
             for (int c = 0; c < kMaxChannels; ++c)
-                channels[(size_t)c].recordLP2.setCutoff(fc2, fs);
+                channels[(size_t)c].speedLP.setCoeffs(
+                    Biquad::lowPass(fs, cutoff, 0.70710678f));
+        }
+        const float antiAliasCutoff = safeBiquadFrequency(
+            fs,
+            (11000.0f + 2000.0f * std::pow(1.0f - slow01, 3.0f))
+            * (1.0f - 0.10f * age));
+        if (antiAliasCutoff != lastAntiAliasCutoff)
+        {
+            lastAntiAliasCutoff = antiAliasCutoff;
+            constexpr float kButterworthQ[4] =
+                { 0.50979558f, 0.60134489f, 0.89997622f, 2.56291545f };
+            for (int c = 0; c < kMaxChannels; ++c)
+                for (int i = 0; i < 4; ++i)
+                    channels[(size_t)c].antiAliasLP[(size_t)i].setCoeffs(
+                        Biquad::lowPass(fs, antiAliasCutoff, kButterworthQ[i]));
         }
     }
 
@@ -346,10 +654,35 @@ void TapeEchoDSP::refreshBlockRateControls()
         // default while channels[0] is shelved — an L/R mismatch.
         for (int c = 0; c < kMaxChannels; ++c)
         {
+            const float bassAmount = std::abs(bass);
+            const float bassGainDb = std::copysign(
+                bassAmount * (11.31f + 6.06f * bassAmount), bass);
+            const float bassFrequency =
+                67.55f + 86.70f * bassAmount;
+            const float bassQ =
+                1.074f - 0.580f * bassAmount;
             channels[(size_t)c].bassShelf.setCoeffs(
-                Biquad::shelfSlope1(fs, 100.0f, bass * 12.0f, /*high=*/false));
+                Biquad::shelf(
+                    fs, safeBiquadFrequency(fs, bassFrequency),
+                    bassGainDb, bassQ, /*high=*/false));
+
+            const float trebleAmount = std::abs(treble);
+            const float trebleGainDb = std::copysign(
+                trebleAmount * (4.375f + 13.09f * trebleAmount),
+                treble);
+            // The passive boost and cut arms have different turnover laws.
+            // Hosted impulse sweeps place the half-travel corners at 991 Hz
+            // (boost) and 1441 Hz (cut), converging near 3 kHz at full travel.
+            const float trebleFrequency = treble >= 0.0f
+                ? 2850.8f * std::pow(trebleAmount, 1.525f)
+                : 3440.8f * std::pow(trebleAmount, 1.255f);
+            const float trebleQ =
+                0.545f - 0.102f * trebleAmount;
             channels[(size_t)c].trebleShelf.setCoeffs(
-                Biquad::shelfSlope1(fs, 3000.0f, treble * 12.0f, /*high=*/true));
+                Biquad::shelf(
+                    fs, safeBiquadFrequency(
+                        fs, std::max(trebleFrequency, 20.0f)),
+                    trebleGainDb, trebleQ, /*high=*/true));
         }
     }
 }
@@ -370,32 +703,42 @@ void TapeEchoDSP::processBlock(const float* const* inputs, float* const* outputs
     for (int n = 0; n < numSamples; ++n)
     {
         //--- shared per-sample control signals (one motor, one tape) ----------
+        const float nominalT1 = delaySmoother.next();
+        const float nominalMs = nominalT1 * (1000.0f / (float)fs);
+        const float slow01 = clamp01(
+            (nominalMs - kMinDelayMs) / (kMaxDelayMs - kMinDelayMs));
+        // The recurring transport cycle speeds up with tape velocity: hosted
+        // 3150 Hz captures measured 2.00 Hz at midpoint and 3.857 Hz at fast.
+        flutterInc = kTwoPi * kFlutterMaxHz
+                   * (kMinDelayMs / nominalMs) / (float)fs;
+
         wowPhase += wowInc;
         if (wowPhase > kTwoPi)     wowPhase     -= kTwoPi;
         flutterPhase += flutterInc;
         if (flutterPhase > kTwoPi) flutterPhase -= kTwoPi;
 
-        // ~7% of full modulation depth is always present: real tape transports
-        // have residual wow even in perfect condition. Knob adds on top; a
-        // worn transport (Tape Age) adds more still.
+        // The reference transport always moves, even in its freshest state.
+        // The user control adds an intentionally wider creative range.
         const float age = ageSmoother.next();
-        const float wf  = 0.07f + 0.93f * wowFlutterSmoother.next() + 0.45f * age;
+        const float wf  = 1.0f + 1.5f * wowFlutterSmoother.next() + 0.20f * age;
         // slow playback-level wobble (worn pinch roller / dropout precursor);
         // exactly 1.0 at age 0.
         const float wobble = 1.0f + age * 0.11f * wobbleLP.process(ageRand());
         // hiss recorded onto the tape: regenerates with intensity like the
         // hardware. Voiced dark, exactly 0.0 at age 0.
-        const float hissL = age * 0.012f * hissVoice.process(ageRand());
-        const float hissR = age * 0.012f * hissVoiceR.process(ageRand());
-        const float mod = wf * (kWowDepth     * std::sin(wowPhase)
-                              + kFlutterDepth * std::sin(flutterPhase)
-                              + kNoiseDepth   * noiseLP.process(frand()));
+        const float hissL = age * 0.0000079f * hissVoice.process(ageRand());
+        const float flutterDepth = 0.00237f + 0.00242f * slow01;
+        const float flutterWave = std::sin(flutterPhase)
+                                + 0.088f * std::sin(2.0f * flutterPhase);
+        const float mod = wf * (kWowDepth * std::sin(wowPhase)
+                              + flutterDepth * flutterWave
+                              + kNoiseDepth * noiseLP.process(frand()));
 
         // The oversampled preamp delays the tape feed by a fixed group delay;
         // subtract it AFTER the head-ratio scaling so all three heads stay at
         // their exact mechanical times (subtracting from T would scale the
         // compensation by 1.9x/2.75x on the far heads).
-        const float t1 = delaySmoother.next() * (1.0f + mod);
+        const float t1 = nominalT1 * (1.0f + mod);
         const float d1 = clampF(t1                 - kPreampLatencySamples, 4.0f, maxDelaySamples);
         const float d2 = clampF(t1 * kHeadRatio[1] - kPreampLatencySamples, 4.0f, maxDelaySamples);
         const float d3 = clampF(t1 * kHeadRatio[2] - kPreampLatencySamples, 4.0f, maxDelaySamples);
@@ -407,63 +750,283 @@ void TapeEchoDSP::processBlock(const float* const* inputs, float* const* outputs
         // Intensity mapped past unity loop gain: > ~0.75 the loop exceeds
         // unity for small signals and the in-loop tape saturation clamps it
         // into stable, warm self-oscillation.
-        const float fbGain    = intensitySmoother.next() * 1.30f;
+        const float fbGain =
+            feedbackGainFromControl(intensitySmoother.next());
         const float revSend   = reverbSendSmoother.next();
-        // Level knobs use an audio (squared) taper, and the echo bus is
-        // trimmed so full Echo Volume lands near dry-signal loudness even
-        // with all three heads saturated (the raw head sum peaks ~3x).
+        // Level controls use measured analog-style tapers. The effect-volume
+        // curve includes a linear term, so low settings remain useful.
         const float echoRaw   = echoLevelSmoother.next();
-        const float echoLvl   = echoRaw * echoRaw * 0.55f;
+        const float echoLvl   = echoGainFromControl(echoRaw);
         const float revRaw    = reverbLevelSmoother.next();
-        const float revLvl    = revRaw * revRaw * revSend;
+        const float revLvl    = echoGainFromControl(revRaw) * revSend;
         const float dryLvl    = dryLevelSmoother.next();
+        const float outputVolume = outputVolumeSmoother.next();
+        // Hosted output trim is linear in decibels: -20 dB at zero, unity at
+        // midpoint, and +20 dB at maximum.
+        const float outputGain = std::pow(
+            10.0f, 2.0f * outputVolume - 1.0f);
         const float driveKnob = driveSmoother.next();
-        const float drive     = 0.4f + 2.6f * driveKnob * driveKnob; // audio taper: clean low, saturated high
-        const float driveComp = 1.0f / softClip(drive);
+        const float inputGain = inputGainFromControl(driveKnob);
+        // Equivalent-level hosted sweeps at multiple knob positions collapse
+        // onto one transfer curve: the input control is a gain taper feeding
+        // a fixed record-stage nonlinearity, not a second distortion control.
+        constexpr float kInputStageDrive = 2.65f;
+        constexpr float kInputStageTrim  = 0.459f;
         const float power     = powerSmoother.next(); // 0 = bypassed
 
-        //--- per-channel audio path -------------------------------------------
+        //--- mono effect path -------------------------------------------------
+        // The hosted unit sums its stereo input before both wet paths. A
+        // left-only impulse produces sample-identical L/R wet signals at
+        // center, while duplicated stereo material drives the nonlinear
+        // record stage about 6 dB harder. The 0.5 average here preserves the
+        // transfer calibration made with duplicated stereo stimuli; the
+        // measured pan matrix below restores the corresponding x2 wet gain.
+        const float inL = inputs[0][n];
+        const float inR = numChannels > 1 ? inputs[1][n] : inL;
+        const float inputSend = inputSendSmoother.next();
+        const float effectIn =
+            inputSend * power
+            * (numChannels > 1 ? 0.5f * (inL + inR) : inL);
+        Channel& ch = channels[0];
+        const float tapeInput = effectIn * inputGain;
+
+        // The hosted record path has a broad tape-compression knee above
+        // nominal level and asymptotically reaches about 4.5 dB of gain
+        // reduction. Most of that reduction happens before the saturator
+        // (limiting harmonic growth); the balance is clean record gain.
+        const float tapeMagnitude =
+            tapeInput < 0.0f ? -tapeInput : tapeInput;
+        if (tapeMagnitude > ch.recordEnvelope)
+            ch.recordEnvelope += recordEnvelopeAttack
+                               * (tapeMagnitude - ch.recordEnvelope);
+        else
+            ch.recordEnvelope *= recordEnvelopeRelease;
+        const float over = std::max(ch.recordEnvelope - 0.12f, 0.0f);
+        const float reductionDb = 4.5f * (1.0f - std::exp(-2.7f * over));
+        const float compression =
+            std::pow(10.0f, -reductionDb * (1.0f / 20.0f));
+        // Below the nominal tape threshold, gain reduction is clean and
+        // leaves the measured harmonic curve intact. Above it, a growing
+        // fraction moves ahead of the shaper so THD approaches the
+        // measured high-level plateau instead of climbing without bound.
+        const float preCompression01 = clamp01(
+            (ch.recordEnvelope - 0.45f) * (1.0f / 0.75f));
+        const float preExponent =
+            1.2f * std::pow(preCompression01, 0.8f);
+        const float postExponent =
+            std::max(1.0f - 0.3f * preExponent, 0.6f);
+        const float preDriveGain =
+            std::pow(compression, preExponent);
+        const float highLevel01 = clamp01(
+            (ch.recordEnvelope - 0.65f) * (1.0f / 0.59f));
+        const float highLevelTrim = std::pow(
+            10.0f, -1.1f * std::sqrt(highLevel01) * (1.0f / 20.0f));
+        const float postDriveGain =
+            std::pow(compression, postExponent) * highLevelTrim;
+
+        // FET preamp front-end, saturated at 4x to keep fold-back
+        // products out of the echo passband.
+        const float pre = ch.preampDC.process(
+                              preampOversampled(
+                                  ch, tapeInput * preDriveGain,
+                                  kInputStageDrive))
+                          * kInputStageTrim * postDriveGain;
+        // The spring send includes a clean feed around the record-stage
+        // shaper. This keeps the tank's drive and crest response while
+        // matching the hosted spring path's very low harmonic residue.
+        const float shapedSpringPre =
+            pre / std::max(postDriveGain, 0.5f);
+        float cleanReadPos =
+            (float)ch.springCleanDelayWriteIdx - kPreampLatencySamples;
+        if (cleanReadPos < 0.0f)
+            cleanReadPos += (float)ch.springCleanDelay.size();
+        const int cleanRead0 = (int)cleanReadPos;
+        const int cleanRead1 =
+            (cleanRead0 + 1) % (int)ch.springCleanDelay.size();
+        const float cleanReadFrac = cleanReadPos - (float)cleanRead0;
+        const float delayedTapeInput =
+            ch.springCleanDelay[(size_t)cleanRead0]
+            + cleanReadFrac
+                * (ch.springCleanDelay[(size_t)cleanRead1]
+                   - ch.springCleanDelay[(size_t)cleanRead0]);
+        ch.springCleanDelay[(size_t)ch.springCleanDelayWriteIdx] = tapeInput;
+        if (++ch.springCleanDelayWriteIdx >=
+            (int)ch.springCleanDelay.size())
+            ch.springCleanDelayWriteIdx = 0;
+        constexpr float kCleanSpringSendGain =
+            0.84f * kInputStageDrive * kInputStageTrim;
+        const float cleanSpringPre =
+            kCleanSpringSendGain * delayedTapeInput;
+        constexpr float kCleanSpringSendMix = 0.40f;
+        const float springPre =
+            (1.0f - kCleanSpringSendMix) * shapedSpringPre
+            + kCleanSpringSendMix * cleanSpringPre;
+
+        // Three playback heads off the shared tape.
+        // The joined ends of the physical tape create a recurring dropout.
+        // Its loop period is 9.23 s at the fastest motor setting and scales
+        // inversely with tape speed. A narrow join is followed by a broader
+        // loss region; age determines how audible both become.
+        const float speedScale = nominalMs / kMinDelayMs;
+        float spliceDepthDb;
+        if (age <= 0.5f)
+            spliceDepthDb = 1.34f + 4.0f * age;
+        else
+        {
+            const float old01 = (age - 0.5f) * 2.0f;
+            spliceDepthDb =
+                3.34f + 9.82f * std::pow(old01, 1.5f);
+        }
+        const auto spliceGain = [&](float samplesToEvent) noexcept
+        {
+            const float secondsToEvent =
+                samplesToEvent / (float)fs;
+            const float narrow =
+                std::exp(-0.5f * std::pow(
+                    secondsToEvent / 0.0075f, 2.0f));
+            const float broad =
+                std::exp(-0.5f * std::pow(
+                    secondsToEvent / (0.080f * speedScale), 2.0f));
+            const float shape = 0.65f * narrow + 0.35f * broad;
+            return std::pow(10.0f, -spliceDepthDb * shape * 0.05f);
+        };
+        const float h1 = readTape(ch.tape, d1)
+                       * spliceGain(spliceSamplesToHead1);
+        const float h2 = readTape(ch.tape, d2)
+                       * spliceGain(
+                           spliceSamplesToHead1 + (d2 - d1));
+        const float h3 = readTape(ch.tape, d3)
+                       * spliceGain(
+                           spliceSamplesToHead1 + (d3 - d1));
+        const float headSum = (h1 * g1 + h2 * g2 + h3 * g3) * wobble;
+
+        // Record chain: program + feedback -> head EQ -> magnetic
+        // saturation -> tape. Everything here is inside the loop, so
+        // repeats darken and compress cumulatively.
+        const float recorded = ch.recordHP.process(
+            ch.speedLP.process(
+                pre + hissL + fbGain * softClip(headSum)));
+        // The tape's low-level magnetisation curve is more strongly curved
+        // than the record preamp, but its slope remains positive at overload.
+        // This bounded cubic term raises the odd-harmonic ladder without
+        // changing small-signal loop gain or the separately calibrated spring
+        // send.
+        const float recorded2 = recorded * recorded;
+        // At low flux the measured odd harmonics fall much more slowly than a
+        // cubic polynomial can produce. A regularized, scale-covariant p=2.15
+        // term restores that quiet harmonic floor, then fades out before the
+        // main magnetic curve reaches its already-matched -18 dB operating
+        // point.
+        const float lowFloor01 = clamp01(
+            (ch.recordEnvelope - 0.02f) * (1.0f / 0.07f));
+        const float lowFloorSmooth =
+            lowFloor01 * lowFloor01 * (3.0f - 2.0f * lowFloor01);
+        const float lowFloorFade = 1.0f - lowFloorSmooth;
+        const float lowFloor = 1.325f * lowFloorFade * recorded
+            * std::pow(recorded2 + 0.006f * 0.006f, 0.575f);
+        const float magneticInput =
+            recorded * (1.0f - 5.0f * recorded2
+                        / (1.0f + 8.0f * recorded2))
+            - lowFloor;
+        const float baseTape = softClip(magneticInput);
+        const float baseMagnitude = std::abs(baseTape);
+        if (baseMagnitude > ch.magneticEnvelope)
+            ch.magneticEnvelope = baseMagnitude;
+        else
+            ch.magneticEnvelope *= recordEnvelopeRelease;
+
+        // At high record flux the hosted tape adds a steep odd-harmonic
+        // ladder while its fundamental has already reached a level plateau.
+        // Chebyshev terms supply those missing harmonics without changing the
+        // steady-state fundamental. Their envelope-gated, normalized sum is
+        // bounded to roughly thirteen percent of the tape signal and remains
+        // zero through the already-matched nominal range.
+        const float magneticAmplitude =
+            std::max(ch.magneticEnvelope, 1.0e-4f);
+        const float z = clampF(
+            baseTape / magneticAmplitude, -1.0f, 1.0f);
+        const float z2 = z * z;
+        const float z3 = z2 * z;
+        const float z5 = z3 * z2;
+        const float z7 = z5 * z2;
+        const float hot01 = clamp01(
+            (ch.recordEnvelope - 0.26f) * (1.0f / 0.21f));
+        const float hot =
+            hot01 * hot01 * (3.0f - 2.0f * hot01);
+        const float veryHot01 = clamp01(
+            (ch.recordEnvelope - 0.52f) * (1.0f / 0.16f));
+        const float veryHot =
+            veryHot01 * veryHot01 * (3.0f - 2.0f * veryHot01);
+        const float t3 = 4.0f * z3 - 3.0f * z;
+        const float t5 = 16.0f * z5 - 20.0f * z3 + 5.0f * z;
+        const float t7 =
+            64.0f * z7 - 112.0f * z5 + 56.0f * z3 - 7.0f * z;
+        const float c3 = -0.0983f * hot + 0.0209f * veryHot;
+        const float c5 = -0.0195f * hot - 0.0255f * veryHot;
+        const float c7 = 0.0f;
+        float toTape = baseTape + magneticAmplitude
+            * (c3 * t3 + c5 * t5 + c7 * t7);
+        // Restore the measured level plateau without undoing the magnetic
+        // curvature. The slowly tracked envelope makes this a program-level
+        // makeup law (not a sample-by-sample waveshaper), so harmonic ratios
+        // stay intact. It is inactive below ordinary musical peaks.
+        const float magneticMakeup01 = clamp01(
+            (ch.recordEnvelope - 0.18f) * (1.0f / 0.82f));
+        const float magneticMakeupDb =
+            1.8f * std::sqrt(std::sqrt(magneticMakeup01))
+            + 0.46f * hot + 0.06f * veryHot;
+        toTape *= std::pow(10.0f, magneticMakeupDb * (1.0f / 20.0f));
+        for (auto& lp : ch.antiAliasLP)
+            toTape = lp.process(toTape);
+        ch.tape[(size_t)writeIdx] = toTape;
+
+        // Echo output path only: bass/treble shelves (dry and reverb
+        // are unaffected, matching the hardware layout).
+        const float echoWet =
+            ch.trebleShelf.process(ch.bassShelf.process(headSum));
+
+        // Spring tank is fed from the same mono preamp signal.
+        const float rev = ch.spring.process(springPre * revSend);
+
+        // Both wet-path pan controls are measured linear amplitude laws.
+        // In stereo, the x2 factor pairs with the input average above:
+        // center (0.5/0.5) preserves the calibrated wet level, while a hard
+        // pan is 6.02 dB louder in its destination channel.
+        const float echoPan = echoPanSmoother.next();
+        const float reverbPan = reverbPanSmoother.next();
+        const float dryEnable = 1.0f - wetSoloSmoother.next();
         for (int c = 0; c < numChannels; ++c)
         {
-            Channel& ch = channels[(size_t)c];
-            const float in = inputs[c][n];
+            const float in = c == 0 ? inL : inR;
+            Channel& outputChannel = channels[(size_t)c];
+            const float dry = outputChannel.dryHighShelf.process(
+                outputChannel.dryLowShelf.process(in));
+            const float echoPanGain = numChannels == 1
+                ? 1.0f : 2.0f * (c == 0 ? 1.0f - echoPan : echoPan);
+            const float reverbPanGain = numChannels == 1
+                ? 1.0f : 2.0f * (c == 0 ? 1.0f - reverbPan : reverbPan);
+            const float wet = dryEnable * dryLvl * inputGain * dry
+                            + echoLvl * echoWet * echoPanGain
+                            + revLvl * rev * reverbPanGain;
+            // POWER off: clean passthrough. The wet state is cleared on the
+            // falling edge, so re-engaging starts with an empty tape loop.
+            outputs[c][n] = in + power * (outputGain * wet - in);
 
-            // FET preamp front-end, saturated at 4x to keep fold-back
-            // products out of the echo passband.
-            const float pre = ch.preampDC.process(preampOversampled(ch, in, drive)) * driveComp;
-
-            // Three playback heads off the shared tape.
-            const float h1 = readTape(ch.tape, d1);
-            const float h2 = readTape(ch.tape, d2);
-            const float h3 = readTape(ch.tape, d3);
-            const float headSum = (h1 * g1 + h2 * g2 + h3 * g3) * wobble;
-
-            // Record chain: program + feedback -> head EQ -> magnetic
-            // saturation -> tape. Everything here is inside the loop, so
-            // repeats darken and compress cumulatively.
-            const float hiss = (c == 0) ? hissL : hissR;
-            const float toTape = ch.recordHP.process(
-                                     ch.recordLP2.process(
-                                         ch.recordLP.process(pre + hiss + fbGain * softClip(headSum))));
-            ch.tape[(size_t)writeIdx] = softClip(toTape);
-
-            // Echo output path only: bass/treble shelves (dry and reverb
-            // are unaffected, matching the hardware layout).
-            const float echoWet = ch.trebleShelf.process(ch.bassShelf.process(headSum));
-
-            // Spring tank is fed from the preamp, as in the original.
-            const float rev = ch.spring.process(pre * revSend);
-
-            const float wet = dryLvl * in + echoLvl * echoWet + revLvl * rev;
-            // POWER off: clean passthrough; tape and springs keep running so
-            // re-engaging brings tails back, like pulling the output jack.
-            outputs[c][n] = in + power * (wet - in);
-
-            const float mag = power * (wet < 0.0f ? -wet : wet);
+            const float output = outputGain * wet;
+            const float mag = power * (output < 0.0f ? -output : output);
             blockPeak = mag > blockPeak ? mag : blockPeak;
         }
 
         writeIdx = (writeIdx + 1) & mask;
+        spliceSamplesToHead1 -= 1.0f;
+        const float spliceTailSamples =
+            0.8f * speedScale * (float)fs;
+        if (spliceSamplesToHead1 < -spliceTailSamples)
+        {
+            const float loopPeriodSamples =
+                9.23f * speedScale * (float)fs;
+            spliceSamplesToHead1 += loopPeriodSamples;
+        }
     }
 
     const float decayed = outputPeak.load(std::memory_order_relaxed)

--- a/plugins/tape-echo/core/TapeEchoDSP.hpp
+++ b/plugins/tape-echo/core/TapeEchoDSP.hpp
@@ -4,13 +4,13 @@
 // Framework-free: standard C++17 only. No JUCE, no host dependencies.
 // Designed to be wrapped by DPF, raw CLAP, or any other plugin shell.
 //
-// Signal flow (per channel, mirroring the hardware):
+// Signal flow (stereo input, mono wet paths, stereo dry path):
 //
-//   in ──► FET preamp (asymmetric soft clip + DC block) ──┬──► reverb send
+//   L+R ─► record preamp (odd soft clip + DC block) ───────┬──► reverb send
 //                                                         │
 //        ┌────────────────────────────────────────────────┘
 //        ▼
-//   [+]──► record EQ (HP 55 Hz / LP 6.2 kHz) ──► tape saturation ──► TAPE
+//   [+]──► record EQ (HP + speed-dependent LP) ──► tape saturation ──► TAPE
 //    ▲                                                                │
 //    │                                                     3 read heads (Hermite)
 //    │                                                     T · {1.00, 1.90, 2.75}
@@ -18,7 +18,8 @@
 //                                                             ▼
 //                                    bass/treble shelves (echo path only)
 //                                                             ▼
-//   out = dry·in + echoLevel·echoEQ + reverbLevel·spring(reverb send)
+//   out L/R = dry·input L/R + pan(echoLevel·echoEQ)
+//                           + pan(reverbLevel·spring(reverb send))
 //
 // The record EQ and tape saturation live INSIDE the feedback loop, so each
 // repeat progressively darkens and compresses — this is what lets high
@@ -55,9 +56,9 @@ namespace duskaudio
 //==============================================================================
 
 //==============================================================================
-// Spring reverb — simplified two-spring tank in the classic style.
+// Spring reverb — simplified four-path dispersive tank.
 //
-// Each of the two springs is a feedback delay loop containing a long chain of
+// Each spring path is a feedback delay loop containing a long chain of
 // identical first-order allpasses. The chain is dispersive (group delay falls with
 // frequency), so every trip around the loop smears transients into the
 // characteristic downward "boing" chirp. Damping in the loop keeps it dark;
@@ -87,11 +88,17 @@ private:
     struct Spring
     {
         std::vector<float>                       buf;
+        std::vector<float>                       feedbackBuf;
         int                                      len = 0, writeIdx = 0;
+        int                                      feedbackWriteIdx = 0;
         float                                    feedback = 0.0f;
         float                                    lfoPhase = 0.0f, lfoInc = 0.0f, lfoDepth = 0.0f;
         std::array<Allpass1, kNumAllpasses>      chain;
         OnePoleLP                                damping;
+        Biquad                                   feedbackHighPass;
+        Biquad                                   highDamping;
+        Biquad                                   airDamping;
+        Biquad                                   upperModeDamping;
 
         void  prepare(double fs, float lengthSeconds, float fbAmount,
                       float lfoHz, float apCoeff);
@@ -99,10 +106,27 @@ private:
         float process(float x) noexcept;
     };
 
-    std::array<Spring, 2> springs;
+    std::array<Spring, 4> springs;
+    std::vector<float> pickupBuf;
+    std::vector<float> pickupSpring3Buf;
+    int pickupWriteIdx = 0;
+    int pickupTap8 = 1, pickupTap18 = 1, pickupTap28 = 1;
+    int pickupSpring3Tap85 = 1;
+    int pickupSpring3Tap20 = 1;
+    int pickupSpring3Tap285 = 1;
+    std::vector<float> outputDiffusionBuf;
+    int outputDiffusionWriteIdx = 0;
     OnePoleHP inputHP;   // springs don't transmit deep lows
     OnePoleLP inputLP;   // dark transducer voicing
     DCBlocker dcBlock;
+    Biquad outputHP;
+    Biquad outputVoiceLP;
+    std::array<Biquad, 9> outputCeilingLP;
+    Biquad outputLowContour;
+    Biquad outputBody;
+    Biquad outputPresence;
+    float pickupImagePhase = 0.0f;
+    float pickupImagePhaseInc = 0.0f;
 };
 
 //==============================================================================
@@ -114,9 +138,11 @@ public:
     static constexpr int kNumModes    = 12;
     static constexpr int kMaxChannels = 2;
 
-    // Head-1 delay range from the hardware motor-speed span.
-    static constexpr float kMinDelayMs = 69.0f;
-    static constexpr float kMaxDelayMs = 177.0f;
+    // Hosted head-1 arrival endpoints. These include the record/playback path
+    // delay so rendered repeats align with the reference, not just the nominal
+    // motor labels.
+    static constexpr float kMinDelayMs = 69.83f;
+    static constexpr float kMaxDelayMs = 178.50f;
 
     // Mechanically fixed head spacing ratios.
     static constexpr float kHeadRatio[3] = { 1.0f, 1.90f, 2.75f };
@@ -146,8 +172,26 @@ public:
     void setTreble(float vMinus1to1) noexcept     { pTreble.store(clampF(vMinus1to1, -1.0f, 1.0f), std::memory_order_relaxed); }
     void setInputGain(float v01) noexcept         { pInputGain.store(clamp01(v01), std::memory_order_relaxed); }   // preamp drive
     void setWowFlutter(float v01) noexcept        { pWowFlutter.store(clamp01(v01), std::memory_order_relaxed); }
-    void setBypass(bool bypassed) noexcept        { pBypass.store(bypassed ? 1.0f : 0.0f, std::memory_order_relaxed); } // POWER off: clean passthrough, tape keeps spinning
+    void setBypass(bool bypassed) noexcept
+    {
+        const float next = bypassed ? 1.0f : 0.0f;
+        const float previous =
+            pBypass.exchange(next, std::memory_order_relaxed);
+        if (next > 0.5f && previous <= 0.5f)
+            pClearRequest.fetch_add(1u, std::memory_order_relaxed);
+    }
     void setTapeAge(float v01) noexcept           { pTapeAge.store(clamp01(v01), std::memory_order_relaxed); }   // 0 = fresh (bit-identical); worn tape: hiss, extra wow, HF loss, level wobble
+    void setOutputVolume(float v01) noexcept      { pOutputVolume.store(clamp01(v01), std::memory_order_relaxed); }
+    void setEchoPan(float v01) noexcept           { pEchoPan.store(clamp01(v01), std::memory_order_relaxed); }
+    void setReverbPan(float v01) noexcept         { pReverbPan.store(clamp01(v01), std::memory_order_relaxed); }
+    void setInputSend(bool enabled) noexcept      { pInputSend.store(enabled ? 1.0f : 0.0f, std::memory_order_relaxed); }
+    void setWetSolo(bool enabled) noexcept        { pWetSolo.store(enabled ? 1.0f : 0.0f, std::memory_order_relaxed); }
+    void triggerLoopSplice() noexcept             { pSpliceTrigger.fetch_add(1u, std::memory_order_relaxed); }
+
+    // The motor control is intentionally nonlinear. The inverse is used by
+    // tempo sync so a requested musical delay still lands at the right time.
+    static float delayMsForRepeatRate(float v01) noexcept;
+    static float repeatRateForDelayMs(float delayMs) noexcept;
 
     //--- metering (thread-safe: read from any thread) --------------------------
     // Peak output level with ~300 ms release, linear [0, ~3]. For VU/peak UI.
@@ -170,12 +214,65 @@ private:
         return x * (27.0f + x2) / (27.0f + 9.0f * x2);
     }
 
-    // FET preamp: mild asymmetry (even harmonics) + soft limiting. The x²
-    // term introduces DC, removed by a per-channel DC blocker downstream.
+    // Input-stage limiting is odd-symmetric. Hosted harmonic ladders show the
+    // even orders at the noise floor across the full input-control range.
     static float preampShape(float x) noexcept
     {
         x = clampF(x, -2.5f, 2.5f);
-        return softClip(x + 0.08f * x * x);
+        return softClip(x);
+    }
+
+    // Measured front-panel input taper. It is shared by the direct and effect
+    // paths, reaches unity at the midpoint, provides about +8.6 dB at maximum,
+    // and mutes exactly at zero.
+    static float inputGainFromControl(float x) noexcept
+    {
+        return x * (1.29212f + 1.40165f * x);
+    }
+
+    // Measured effect-volume taper. The linear term is important at low
+    // settings; a pure square law undershoots the lower half substantially.
+    static float echoGainFromControl(float x) noexcept
+    {
+        return x * (0.30355f + 0.69645f * x);
+    }
+
+    static float feedbackGainFromControl(float x) noexcept
+    {
+        x = clamp01(x);
+        float normalized;
+        if (x <= 0.7f)
+        {
+            normalized = 0.00063492f * x
+                       + 0.95619048f * x * x
+                       + 0.96507937f * x * x * x;
+            const float knee = clamp01((x - 0.65f) * 20.0f);
+            const float kneeSmooth = knee * knee * (3.0f - 2.0f * knee);
+            normalized -= 0.02728236f * kneeSmooth;
+        }
+        else
+        {
+            float loX, hiX, loGain, hiGain;
+            if (x <= 0.8f)
+            {
+                loX = 0.7f; hiX = 0.8f;
+                loGain = 0.77271764f; hiGain = 0.82074074f;
+            }
+            else if (x <= 0.9f)
+            {
+                loX = 0.8f; hiX = 0.9f;
+                loGain = 0.82074074f; hiGain = 0.85925926f;
+            }
+            else
+            {
+                loX = 0.9f; hiX = 1.0f;
+                loGain = 0.85925926f; hiGain = 0.88f;
+            }
+            const float t = (x - loX) / (hiX - loX);
+            const float smooth = t * t * (3.0f - 2.0f * t);
+            normalized = loGain + (hiGain - loGain) * smooth;
+        }
+        return 1.30f * normalized;
     }
 
     // Group delay of the 4x oversampling chain in base-rate samples
@@ -193,13 +290,18 @@ private:
         DCBlocker          preampDC;
         HalfbandFIR<47, 12> upA, downA;   // base <-> 2x (tight, -67 dB)
         HalfbandFIR<15, 4>  upB, downB;   // 2x <-> 4x (loose, -75 dB)
-        OnePoleHP          recordHP;   // in-loop
-        OnePoleLP          recordLP;   // in-loop, darkens every repeat
-        OnePoleLP          recordLP2;  // second pole: the record/repro chain of the
-                                       // hardware rolls off steeper than 6 dB/oct
+        Biquad             recordHP;   // in-loop, two-pole low-end cleanup
+        Biquad             speedLP;    // tape-speed-dependent playback bandwidth
+        std::array<Biquad, 4> antiAliasLP; // steep fixed record/repro ceiling
         Biquad             bassShelf;  // echo output path only
         Biquad             trebleShelf;
+        Biquad             dryLowShelf;  // direct-path coupling/amp bandwidth
+        Biquad             dryHighShelf;
         SpringReverb       spring;
+        std::array<float, 32> springCleanDelay {};
+        int                springCleanDelayWriteIdx = 0;
+        float              recordEnvelope = 0.0f;
+        float              magneticEnvelope = 0.0f;
     };
 
     std::array<Channel, kMaxChannels> channels;
@@ -215,6 +317,8 @@ private:
     //--- metering ---------------------------------------------------------------
     std::atomic<float> outputPeak { 0.0f };
     float meterDecayPerSample = 1.0f;
+    float recordEnvelopeAttack = 1.0f;
+    float recordEnvelopeRelease = 1.0f;
 
     //--- modulation (shared across channels: one motor, one tape) --------------
     float     wowPhase = 0.0f, wowInc = 0.0f;
@@ -230,17 +334,24 @@ private:
 
     //--- atomic parameter inputs -----------------------------------------------
     std::atomic<int>   pMode        { 1 };
-    std::atomic<float> pRepeatRate  { 0.5f };
-    std::atomic<float> pIntensity   { 0.4f };
-    std::atomic<float> pEchoLevel   { 0.8f };
+    std::atomic<float> pRepeatRate  { 0.0f };
+    std::atomic<float> pIntensity   { 0.0f };
+    std::atomic<float> pEchoLevel   { 0.5f };
     std::atomic<float> pReverbLevel { 0.0f };
     std::atomic<float> pDryLevel    { 1.0f };
     std::atomic<float> pBass        { 0.0f };
     std::atomic<float> pTreble      { 0.0f };
     std::atomic<float> pInputGain   { 0.5f };
-    std::atomic<float> pWowFlutter  { 0.5f };
+    std::atomic<float> pWowFlutter  { 0.0f };
     std::atomic<float> pBypass      { 0.0f };
-    std::atomic<float> pTapeAge     { 0.0f };
+    std::atomic<float> pTapeAge     { 0.5f };
+    std::atomic<float> pOutputVolume{ 0.5f };
+    std::atomic<float> pEchoPan     { 0.5f };
+    std::atomic<float> pReverbPan   { 0.5f };
+    std::atomic<float> pInputSend   { 1.0f };
+    std::atomic<float> pWetSolo     { 0.0f };
+    std::atomic<uint32_t> pSpliceTrigger { 0u };
+    std::atomic<uint32_t> pClearRequest { 0u };
 
     //--- smoothed control signals ----------------------------------------------
     SmoothedValue delaySmoother;                 // motor inertia -> pitch glide
@@ -248,6 +359,9 @@ private:
     SmoothedValue headGain[3];                   // mode switching, click-free
     SmoothedValue reverbSendSmoother;
     SmoothedValue echoLevelSmoother, reverbLevelSmoother, dryLevelSmoother;
+    SmoothedValue outputVolumeSmoother;
+    SmoothedValue echoPanSmoother, reverbPanSmoother;
+    SmoothedValue inputSendSmoother, wetSoloSmoother;
     SmoothedValue driveSmoother, wowFlutterSmoother;
     SmoothedValue powerSmoother;                 // bypass crossfade, click-free
     SmoothedValue ageSmoother;                   // tape age morph
@@ -255,9 +369,14 @@ private:
     // tape-age state: separate RNG so age 0 leaves the wow noise stream
     // (and therefore the output) bit-identical to builds without this knob
     uint32_t  ageRngState = 0x1F123BB5u;
-    OnePoleLP hissVoice, hissVoiceR;              // darken the injected hiss (per channel)
+    OnePoleLP hissVoice;                           // darken the mono tape hiss
     OnePoleLP wobbleLP;                           // slow playback-level wobble
-    float     lastAge = -1.0f;                    // block-rate LP2 retune guard
+    float     lastPlaybackCutoff = -1.0f;         // block-rate speed/age guard
+    float     lastAntiAliasCutoff = -1.0f;
+    uint32_t  lastSpliceTrigger = 0u;
+    uint32_t  lastClearRequest = 0u;
+    float     spliceSamplesToHead1 = 0.0f;
+    bool      spliceClockStarted = false;
 
     float ageRand() noexcept
     {

--- a/plugins/tape-echo/dpf-plugin/CMakeLists.txt
+++ b/plugins/tape-echo/dpf-plugin/CMakeLists.txt
@@ -8,7 +8,7 @@
 #   cmake --build build
 
 cmake_minimum_required(VERSION 3.15)
-project(TapeEchoDPF VERSION 0.1.0)
+project(TapeEchoDPF VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/plugins/tape-echo/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/tape-echo/dpf-plugin/DistrhoPluginInfo.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #define DISTRHO_PLUGIN_BRAND        "Dusk Audio"
-#define DISTRHO_PLUGIN_NAME         "Tape Echo"
+#define DISTRHO_PLUGIN_NAME         "Tape Echo 2"
 #define DISTRHO_PLUGIN_URI          "https://dusk-audio.github.io/plugins/tape-echo"
 #define DISTRHO_PLUGIN_CLAP_ID      "com.duskaudio.tape-echo"
 

--- a/plugins/tape-echo/dpf-plugin/TapeEchoAccess.hpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoAccess.hpp
@@ -2,10 +2,11 @@
 // Third-party components in the built plugins (DPF — ISC; Dear ImGui — MIT; and
 // others) are attributed in plugins/shared-dpf/THIRD_PARTY_LICENSES.md.
 //
-// TapeEchoAccess.hpp — UI-side accessor for same-process DSP data (the VU/peak
-// meter). Uses the shared weak-symbol bridge; see DuskAccessBridge.hpp for the
-// single-binary-vs-split-LV2 contract and the required UI-side null guard.
-// Strong definition lives in TapeEchoPlugin.cpp.
+// TapeEchoAccess.hpp — UI-side accessors for same-process DSP data (the VU/peak
+// meter and effective tempo-synced motor time). Uses the shared weak-symbol
+// bridge; see DuskAccessBridge.hpp for the single-binary-vs-split-LV2 contract
+// and the required UI-side null guard. Strong definitions live in
+// TapeEchoPlugin.cpp.
 
 #pragma once
 
@@ -13,3 +14,7 @@
 
 // Linear output peak (0..~3), ~300 ms release. Null in the split LV2 UI.
 DUSK_ACCESS_DECL(float, tapeEchoGetOutputLevel);
+
+// Effective head-1 motor time in milliseconds after tempo-sync octave folding.
+// Null in the split LV2 UI.
+DUSK_ACCESS_DECL(float, tapeEchoGetHead1DelayMs);

--- a/plugins/tape-echo/dpf-plugin/TapeEchoParams.hpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoParams.hpp
@@ -17,6 +17,12 @@ enum ParamId
     kParamTempoSync,    // 1 = head-1 delay locks to a division of host tempo
     kParamSyncDivision, // note division index into kSyncDivisions
     kParamTapeAge,      // 0 = fresh tape/serviced transport (bit-identical to before this knob existed)
+    kParamOutputVolume, // post-mix output trim, -20 to +20 dB
+    kParamEchoPan,      // linear wet-path pan: 0 = left, 0.5 = center, 1 = right
+    kParamReverbPan,    // linear spring-path pan: 0 = left, 0.5 = center, 1 = right
+    kParamInputSend,    // boolean input feed to tape and spring paths
+    kParamWetSolo,      // boolean dry-path mute
+    kParamLoopSplice,   // momentary relocation of the circulating tape splice
     kParamBypass,       // host-designated bypass; the UI POWER switch (1 = off)
     kParamOutLevel,     // output parameter: peak level for the VU meter
     kParamCount
@@ -37,45 +43,82 @@ static constexpr SyncDivision kSyncDivisions[] =
 };
 static constexpr int kNumSyncDivisions = (int)(sizeof(kSyncDivisions) / sizeof(kSyncDivisions[0]));
 
-// Head-1 delay for a division at the given tempo, octave-folded into the
-// motor's mechanical range (69-177 ms). The fold always converges because
-// the range spans more than one octave (177/69 > 2).
+// Requested head-1 delay for a division at the given tempo. The plugin wrapper
+// octave-folds this nominal value against TapeEchoDSP's measured motor bounds;
+// keeping that policy beside the DSP prevents these UI-facing definitions from
+// drifting away from the supported delay range.
 static inline double syncDelayMs(double bpm, int divisionIndex)
 {
     if (bpm < 20.0 || bpm > 999.0) bpm = 120.0;
     if (divisionIndex < 0) divisionIndex = 0;
     if (divisionIndex >= kNumSyncDivisions) divisionIndex = kNumSyncDivisions - 1;
-    double ms = kSyncDivisions[divisionIndex].beats * 60000.0 / bpm;
-    while (ms > 177.0) ms *= 0.5;
-    while (ms < 69.0)  ms *= 2.0;
-    return ms;
+    return kSyncDivisions[divisionIndex].beats * 60000.0 / bpm;
 }
 
-// Factory presets: classic RE-201 use cases (slapback, dub, ambient washes,
-// runaway drones, spring-only), same territory the commercial references
-// cover. Values for params kParamMode..kParamSyncDivision, in enum order.
+// Factory presets cover slapback, dub, ambient washes, runaway drones, and
+// spring-only effects. Values for params kParamMode..kParamSyncDivision, in
+// enum order.
 struct TapeEchoPreset
 {
     const char* name;
     float v[kParamTapeAge + 1]; // mode, rate, int, echo, rev, bass, treb, input, wow, dry, sync, div, age
+    float outputVolume = 0.5f;
+    float echoPan = 0.5f;
+    float reverbPan = 0.5f;
+    float inputSend = 1.0f;
+    float wetSolo = 0.0f;
+    float bypass = 0.0f;
 };
 
 static constexpr TapeEchoPreset kFactoryPresets[] =
 {
     //                          mode  rate  int   echo  rev   bass  treb  input wow   dry   sync div
-    { "Default",              {  1,   0.5f, 0.4f, 0.8f, 0.0f, 0.0f, 0.0f, 0.5f, 0.5f, 1.0f, 0,   2 ,   0 } },
-    { "Slapback Vocal",       {  1,   0.7f, 0.0f, 0.7f, 0.0f, 0.0f, 0.1f, 0.5f, 0.3f, 1.0f, 0,   2 ,   0 } },
-    { "Rockabilly Guitar",    {  1,   0.8f, 0.15f,0.75f,0.0f, 0.0f, 0.2f, 0.6f, 0.4f, 1.0f, 0,   2 ,   0 } },
-    { "Classic Tape Echo",    {  2,   0.35f,0.35f,0.8f, 0.0f, 0.0f, 0.0f, 0.5f, 0.5f, 1.0f, 0,   2 ,   0 } },
-    { "Dub Throw",            {  2,   0.3f, 0.68f,0.9f, 0.0f, 0.35f,-0.2f,0.55f,0.5f, 1.0f, 0,   2 ,   0 } },
-    { "Synced 1/8 Dub",       {  2,   0.5f, 0.6f, 0.85f,0.0f, 0.25f,-0.1f,0.5f, 0.5f, 1.0f, 1,   5 ,   0 } },
-    { "Multi-Head Bounce",    {  4,   0.45f,0.25f,0.8f, 0.0f, 0.0f, 0.0f, 0.5f, 0.45f,1.0f, 0,   2 ,   0 } },
-    { "Space Echo",           {  8,   0.4f, 0.40f,0.8f, 0.5f, 0.1f, 0.0f, 0.5f, 0.5f, 1.0f, 0,   2 ,   0 } },
+    { "Default",              {  1,   0.0f, 0.0f, 0.5f, 0.0f, 0.0f, 0.0f, 0.5f, 0.0f, 1.0f, 0,   2 ,   0.5f } },
+    { "Slapback Vocal",       {  1,   0.45498657f, 0.42501831f, 1.0f, 0.0f,
+                                  0.11999512f, -0.08996582f, 0.51000977f,
+                                  0.0f, 1.0f, 0, 2, 0.5f },
+                                0.48999023f, 0.5f, 0.49499512f },
+    { "Rockabilly Guitar",    {  1,   1.0f, 0.28646851f, 1.0f, 0.0f,
+                                 -0.42553711f, -0.59252930f, 0.5f,
+                                  0.0f, 1.0f, 0, 2, 0.5f },
+                                0.5f, 0.5f, 0.51315308f },
+    { "Classic Tape Echo",    {  6,   0.50497437f, 0.39001465f, 0.28500366f, 0.0f,
+                                  0.01000977f, 0.02001953f, 0.51000977f,
+                                  0.0f, 1.0f, 0, 2, 0.5f },
+                                0.47065759f },
+    { "Dub Throw",            {  6,   1.0f, 0.52313232f, 1.0f, 0.0f,
+                                 -0.42553711f, -0.59252930f, 0.5f,
+                                  0.0f, 1.0f, 0, 2, 0.5f },
+                                0.47153696f, 0.5f, 0.51315308f },
+    { "Synced 1/8 Dub",       {  6,   0.39999390f, 0.43499756f, 0.11499023f, 0.04000854f,
+                                  0.0f, 0.0f, 0.29000854f, 0.0f, 1.0f,
+                                  1, 5, 0.5f },
+                                0.66342163f },
+    { "Multi-Head Bounce",    {  9,   0.53500366f, 0.48001099f, 0.5f, 0.25997925f,
+                                  0.66998291f, 0.0f, 0.5f, 0.0f, 1.0f,
+                                  0, 2, 0.0f },
+                                0.5f, 1.0f },
+    { "Orbital Echo",         {  8,   0.39999390f, 0.45001221f, 0.5f, 0.66000366f,
+                                  0.80999756f, -0.40997314f, 0.5f, 0.0f, 1.0f,
+                                  1, 2, 0.5f },
+                                0.43145752f, 0.28500366f, 0.73001099f },
     { "Full Wash",            { 11,   0.5f, 0.22f,0.7f, 0.45f,0.0f, -0.1f,0.5f, 0.55f,1.0f, 0,   2 ,   0 } },
-    { "Ambient Trails",       {  7,   0.25f,0.72f,0.8f, 0.6f, 0.0f, -0.3f,0.45f,0.65f,1.0f, 0,   2 ,   0.25f } },
-    { "Worn Tape",            {  2,   0.4f, 0.45f,0.8f, 0.0f, 0.15f,-0.5f,0.6f, 0.95f,1.0f, 0,   2 ,   0.85f } },
-    { "Runaway Drone",        {  1,   0.5f, 0.95f,0.6f, 0.0f, 0.0f, 0.0f, 0.55f,0.5f, 1.0f, 0,   2 ,   0 } },
-    { "Spring Only",          { 12,   0.5f, 0.0f, 0.0f, 0.8f, 0.0f, 0.0f, 0.5f, 0.3f, 1.0f, 0,   2 ,   0 } },
+    { "Ambient Trails",       {  7,   0.81033325f, 0.57254028f, 0.53720093f,
+                                  0.58779907f, -0.07104492f, -0.57696533f,
+                                  0.47543335f, 0.0f, 1.0f, 0, 2, 1.0f },
+                                0.41147773f, 0.0f, 1.0f },
+    { "Worn Tape",            {  2,   0.20483398f, 0.61618042f, 0.53720093f, 0.0f,
+                                 -1.0f, 0.22f, 0.47543335f, 0.0f, 1.0f,
+                                  0, 2, 0.20f },
+                                0.492f, 0.48483276f, 0.54565430f },
+    { "Runaway Drone",        { 10,   0.0f, 0.59866333f, 1.0f, 0.0f,
+                                  0.66699219f, -0.49353027f, 0.30581665f,
+                                  0.0f, 1.0f, 0, 2, 0.0f },
+                                0.58154625f, 0.53262329f, 0.5f },
+    { "Spring Only",          { 12,   0.0f, 0.0f, 0.5f, 0.91986084f,
+                                 0.0f, 0.0f, 0.5f, 0.0f, 1.0f,
+                                 0,   0,   0.5f },
+                               0.38354333f },
 };
 static constexpr int kNumFactoryPresets = (int)(sizeof(kFactoryPresets) / sizeof(kFactoryPresets[0]));
 

--- a/plugins/tape-echo/dpf-plugin/TapeEchoPlugin.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoPlugin.cpp
@@ -56,7 +56,7 @@ protected:
     const char* getMaker() const override       { return "Dusk Audio"; }
     const char* getHomePage() const override    { return "https://dusk-audio.github.io/"; }
     const char* getLicense() const override     { return "GPL-3.0-or-later"; }
-    uint32_t    getVersion() const override     { return d_version(0, 1, 0); }
+    uint32_t    getVersion() const override     { return d_version(1, 0, 0); }
     int64_t     getUniqueId() const override    { return d_cconst('D', 's', 'T', 'E'); } // must match DISTRHO_PLUGIN_UNIQUE_ID (DsTE)
 
     //--- parameters ------------------------------------------------------------

--- a/plugins/tape-echo/dpf-plugin/TapeEchoPlugin.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoPlugin.cpp
@@ -16,24 +16,34 @@ public:
         : Plugin(kParamCount, kNumFactoryPresets, 0)
     {
         values[kParamMode]        = 1.0f;
-        values[kParamRepeatRate]  = 0.5f;
-        values[kParamIntensity]   = 0.4f;
-        values[kParamEchoLevel]   = 0.8f;
+        values[kParamRepeatRate]  = 0.0f;
+        values[kParamIntensity]   = 0.0f;
+        values[kParamEchoLevel]   = 0.5f;
         values[kParamReverbLevel] = 0.0f;
         values[kParamBass]        = 0.0f;
         values[kParamTreble]      = 0.0f;
         values[kParamInputGain]   = 0.5f;
-        values[kParamWowFlutter]  = 0.5f;
+        values[kParamWowFlutter]  = 0.0f;
         values[kParamDryLevel]    = 1.0f;
         values[kParamTempoSync]   = 0.0f;
         values[kParamSyncDivision] = 2.0f; // 1/16
-        values[kParamTapeAge]     = 0.0f;
+        values[kParamTapeAge]     = 0.5f;
+        values[kParamOutputVolume] = 0.5f;
+        values[kParamEchoPan]     = 0.5f;
+        values[kParamReverbPan]   = 0.5f;
+        values[kParamInputSend]   = 1.0f;
+        values[kParamWetSolo]     = 0.0f;
+        values[kParamLoopSplice]  = 0.0f;
         values[kParamBypass]      = 0.0f;
     }
 
 public:
-    // same-process meter access for the UI bridge (TapeEchoAccess.hpp)
+    // Same-process UI bridge access (TapeEchoAccess.hpp).
     float getOutputLevelForUI() const noexcept { return dsp.getOutputLevel(); }
+    float getHead1DelayMsForUI() const noexcept
+    {
+        return effectiveHead1DelayMs.load(std::memory_order_relaxed);
+    }
 
 protected:
     //--- metadata --------------------------------------------------------------
@@ -62,15 +72,15 @@ protected:
             break;
         case kParamRepeatRate:
             p.name = "Repeat Rate"; p.symbol = "repeat_rate";
-            p.ranges.def = 0.5f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            p.ranges.def = 0.0f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
             break;
         case kParamIntensity:
             p.name = "Intensity";   p.symbol = "intensity";
-            p.ranges.def = 0.4f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            p.ranges.def = 0.0f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
             break;
         case kParamEchoLevel:
             p.name = "Echo Volume"; p.symbol = "echo_volume";
-            p.ranges.def = 0.8f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            p.ranges.def = 0.5f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
             break;
         case kParamReverbLevel:
             p.name = "Reverb Volume"; p.symbol = "reverb_volume";
@@ -90,7 +100,7 @@ protected:
             break;
         case kParamWowFlutter:
             p.name = "Wow & Flutter"; p.symbol = "wow_flutter";
-            p.ranges.def = 0.5f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            p.ranges.def = 0.0f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
             break;
         case kParamDryLevel:
             p.name = "Dry Level";   p.symbol = "dry_level";
@@ -109,6 +119,33 @@ protected:
             break;
         case kParamTapeAge:
             p.name = "Tape Age";    p.symbol = "tape_age";
+            p.ranges.def = 0.5f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            break;
+        case kParamOutputVolume:
+            p.name = "Output Volume"; p.symbol = "output_volume";
+            p.ranges.def = 0.5f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            break;
+        case kParamEchoPan:
+            p.name = "Echo Pan";    p.symbol = "echo_pan";
+            p.ranges.def = 0.5f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            break;
+        case kParamReverbPan:
+            p.name = "Reverb Pan";  p.symbol = "reverb_pan";
+            p.ranges.def = 0.5f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            break;
+        case kParamInputSend:
+            p.hints |= kParameterIsBoolean | kParameterIsInteger;
+            p.name = "Input Send";  p.symbol = "input_send";
+            p.ranges.def = 1.0f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            break;
+        case kParamWetSolo:
+            p.hints |= kParameterIsBoolean | kParameterIsInteger;
+            p.name = "Wet Solo";    p.symbol = "wet_solo";
+            p.ranges.def = 0.0f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
+            break;
+        case kParamLoopSplice:
+            p.hints |= kParameterIsTrigger;
+            p.name = "Loop Splice"; p.symbol = "loop_splice";
             p.ranges.def = 0.0f;    p.ranges.min = 0.0f;  p.ranges.max = 1.0f;
             break;
         case kParamBypass:
@@ -135,7 +172,9 @@ protected:
     {
         if (index >= kParamOutLevel) // output params are not settable
             return;
-        values[index].store(value, std::memory_order_relaxed);
+        values[index].store(
+            index == kParamLoopSplice ? 0.0f : value,
+            std::memory_order_relaxed);
         switch (index)
         {
         case kParamBypass:      dsp.setBypass(value > 0.5f);      break;
@@ -145,6 +184,15 @@ protected:
             break;
         case kParamSyncDivision: break; // applied per-block in run()
         case kParamTapeAge:     dsp.setTapeAge(value);            break;
+        case kParamOutputVolume:dsp.setOutputVolume(value);        break;
+        case kParamEchoPan:     dsp.setEchoPan(value);             break;
+        case kParamReverbPan:   dsp.setReverbPan(value);           break;
+        case kParamInputSend:   dsp.setInputSend(value >= 0.5f);   break;
+        case kParamWetSolo:     dsp.setWetSolo(value >= 0.5f);     break;
+        case kParamLoopSplice:
+            if (value >= 0.5f)
+                dsp.triggerLoopSplice();
+            break;
         case kParamMode:        dsp.setMode((int)(value + 0.5f)); break;
         case kParamRepeatRate:
             if (values[kParamTempoSync].load(std::memory_order_relaxed) < 0.5f)
@@ -172,8 +220,15 @@ protected:
     {
         if (index >= (uint32_t)kNumFactoryPresets)
             return;
+        const TapeEchoPreset& preset = kFactoryPresets[index];
         for (uint32_t i = 0; i <= kParamTapeAge; ++i)
-            setParameterValue(i, kFactoryPresets[index].v[i]);
+            setParameterValue(i, preset.v[i]);
+        setParameterValue(kParamOutputVolume, preset.outputVolume);
+        setParameterValue(kParamEchoPan, preset.echoPan);
+        setParameterValue(kParamReverbPan, preset.reverbPan);
+        setParameterValue(kParamInputSend, preset.inputSend);
+        setParameterValue(kParamWetSolo, preset.wetSolo);
+        setParameterValue(kParamBypass, preset.bypass);
     }
 
     //--- lifecycle ---------------------------------------------------------------
@@ -194,22 +249,32 @@ protected:
     //--- audio -------------------------------------------------------------------
     void run(const float** inputs, float** outputs, uint32_t frames) override
     {
+        float effectiveMs = duskaudio::TapeEchoDSP::delayMsForRepeatRate(
+            values[kParamRepeatRate].load(std::memory_order_relaxed));
         if (values[kParamTempoSync].load(std::memory_order_relaxed) > 0.5f)
         {
             const TimePosition& tp = getTimePosition();
             if (tp.bbt.valid && tp.bbt.beatsPerMinute > 20.0)
                 lastBpm = tp.bbt.beatsPerMinute;
 
-            const double ms = syncDelayMs(lastBpm,
+            double foldedMs = syncDelayMs(lastBpm,
                 (int)(values[kParamSyncDivision].load(std::memory_order_relaxed) + 0.5f));
-            // Convert to the motor-speed knob's 0..1 range; the DSP's motor
-            // inertia smoother turns tempo changes into tape-style glides.
-            // Map the delay (ms) back onto the motor knob's 0..1 range using the
-            // DSP's own delay bounds so this stays aligned if they ever change.
-            constexpr double kMinMs = duskaudio::TapeEchoDSP::kMinDelayMs;
-            constexpr double kMaxMs = duskaudio::TapeEchoDSP::kMaxDelayMs;
-            dsp.setRepeatRate(1.0f - (float)((ms - kMinMs) / (kMaxMs - kMinMs)));
+            // Preserve the selected note division, but octave-fold requests
+            // outside the transport's measured range. Since the range spans
+            // more than one octave, either loop converges without overshooting
+            // the opposite bound; already-supported delays remain untouched.
+            while (foldedMs > duskaudio::TapeEchoDSP::kMaxDelayMs)
+                foldedMs *= 0.5;
+            while (foldedMs < duskaudio::TapeEchoDSP::kMinDelayMs)
+                foldedMs *= 2.0;
+
+            // Convert the folded delay to the motor-speed knob's 0..1 range;
+            // the DSP's inertia smoother turns tempo changes into tape glides.
+            dsp.setRepeatRate(
+                duskaudio::TapeEchoDSP::repeatRateForDelayMs((float)foldedMs));
+            effectiveMs = (float)foldedMs;
         }
+        effectiveHead1DelayMs.store(effectiveMs, std::memory_order_relaxed);
 
         dsp.processBlock(inputs, outputs, DISTRHO_PLUGIN_NUM_INPUTS, (int)frames);
     }
@@ -223,6 +288,9 @@ private:
 
     duskaudio::TapeEchoDSP dsp;
     double lastBpm = 120.0;
+    std::atomic<float> effectiveHead1DelayMs {
+        duskaudio::TapeEchoDSP::kMaxDelayMs
+    };
     // Parameter cache shared across threads: run() reads it on the audio thread
     // while setParameterValue()/loadProgram() write it from the host thread.
     // Atomic (relaxed) storage removes the data race — same pattern as the DSP
@@ -244,4 +312,10 @@ float tapeEchoGetOutputLevel(void* const pluginInstancePointer) noexcept
 {
     auto* const plugin = static_cast<DISTRHO_NAMESPACE::TapeEchoPlugin*>(pluginInstancePointer);
     return plugin != nullptr ? plugin->getOutputLevelForUI() : 0.0f;
+}
+
+float tapeEchoGetHead1DelayMs(void* const pluginInstancePointer) noexcept
+{
+    auto* const plugin = static_cast<DISTRHO_NAMESPACE::TapeEchoPlugin*>(pluginInstancePointer);
+    return plugin != nullptr ? plugin->getHead1DelayMsForUI() : 0.0f;
 }

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -7,10 +7,13 @@
 
 #include "DistrhoUI.hpp"
 #include "TapeEchoAccess.hpp"
+#include "TapeEchoDSP.hpp"
 #include "TapeEchoParams.hpp"
 #include "DuskImGuiFont.hpp"      // shared crisp-bold loader (candidate search + DPI)
 #include "DuskImGuiWidgets.hpp"   // shared DuskPanel: chrome knob, LED, text, value bubble
+#include "DuskSupportersOverlay.hpp" // shared DPF Patreon "Special Thanks" overlay
 
+#include <cfloat>
 #include <cmath>
 #include <cstdio>
 
@@ -37,18 +40,24 @@ namespace
     constexpr float kParamDefaults[kParamCount] =
     {
         1.0f,   // mode
-        0.5f,   // repeat rate
-        0.4f,   // intensity
-        0.8f,   // echo level
+        0.0f,   // repeat rate
+        0.0f,   // intensity
+        0.5f,   // echo level
         0.0f,   // reverb level
         0.0f,   // bass
         0.0f,   // treble
         0.5f,   // input gain
-        0.5f,   // wow & flutter
+        0.0f,   // wow & flutter
         1.0f,   // dry level
         0.0f,   // tempo sync off
         2.0f,   // sync division: 1/16
-        0.0f,   // tape age: fresh
+        0.5f,   // tape age: used
+        0.5f,   // output volume: unity
+        0.5f,   // echo pan: center
+        0.5f,   // reverb pan: center
+        1.0f,   // input send on
+        0.0f,   // wet solo off
+        0.0f,   // loop splice (momentary)
         0.0f,   // bypass (power ON)
         0.0f,   // out level (meter, output-only)
     };
@@ -69,7 +78,9 @@ public:
     {
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kParamDefaults[i];
-        setGeometryConstraints(450, 160, true);
+        // The 13-row preset popup is intentionally non-scrolling; keep the
+        // minimum canvas at the design size so every row remains visible.
+        setGeometryConstraints(900, 320, true);
 
         // Crisp bold label font via the shared loader (candidate search, DPI
         // scale + atlas build live in DuskImGuiFont.hpp so every Dusk UI matches).
@@ -82,6 +93,13 @@ protected:
     {
         if (index < kParamCount)
             values[index] = value;
+    }
+
+    void programLoaded(uint32_t index) override
+    {
+        currentPreset = index < (uint32_t)kNumFactoryPresets
+                      ? (int)index
+                      : -1;
     }
 
     void onImGuiDisplay() override
@@ -102,19 +120,32 @@ protected:
         ImGui::Begin("TapeEcho", nullptr,
                      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
                      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse |
-                     ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBackground);
+                     ImGuiWindowFlags_NoScrollbar |
+                     ImGuiWindowFlags_NoScrollWithMouse |
+                     ImGuiWindowFlags_NoBackground);
 
         ImDrawList* dl = ImGui::GetWindowDrawList();
 
         dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), IM_COL32(8, 8, 8, 255));
         dl->AddRectFilled(P(0, 0), P(kDesignW, kDesignH), kColChassis);
 
+        // Treat the supporters panel as a modal: background controls remain
+        // visible beneath its scrim but cannot receive click-through gestures.
+        // Snapshot before drawHeader(), where a title click can open it.
+        const bool modalOpen = showSupporters;
+        if (modalOpen)
+            ImGui::BeginDisabled();
         drawHeader(dl);
         drawMeterBlock(dl);
         drawInputRow(dl);
         drawModeSelector(dl);
         drawControlPanel(dl);
         drawPowerBlock(dl);
+        if (modalOpen)
+            ImGui::EndDisabled();
+        if (showSupporters)
+            duskdpf::drawSupportersOverlay(
+                panel, dl, kDesignW, kDesignH, showSupporters, "Tape Echo");
 
         ImGui::End();
         ImGui::PopStyleVar(2);
@@ -170,24 +201,48 @@ private:
         text(dl, 235, 15, 15, kColWhiteDim, "TE-3", -1, true);
         text(dl, kDesignW - 30, 14, 15, kColWhite, "Dusk Audio", 1, true);
 
+        // Match the other DPF plugins: clicking the title nameplate opens the
+        // generated Patreon "Special Thanks" panel.
+        ImGui::SetCursorScreenPos(P(38, 8));
+        if (ImGui::InvisibleButton(
+                "##titlecredits", ImVec2(322.0f * s, 30.0f * s)))
+            showSupporters = true;
+
         // preset dropdown
         ImGui::SetCursorScreenPos(P(392, 10));
         ImGui::SetNextItemWidth(210.0f * s);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(38, 38, 41, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(48, 48, 51, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IM_COL32(55, 55, 58, 255));
         ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(24, 24, 26, 255));
         ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(110, 45, 38, 255));
+        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, IM_COL32(132, 57, 48, 255));
+        ImGui::PushStyleColor(ImGuiCol_HeaderActive, IM_COL32(92, 39, 34, 255));
+        ImGui::PushStyleColor(ImGuiCol_Button, kColGreenDk);
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, kColGreen);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(40, 58, 27, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, kColWhite);
+        ImGui::PushStyleColor(ImGuiCol_NavHighlight, IM_COL32(122, 160, 84, 255));
         const char* preview = (currentPreset >= 0 && currentPreset < kNumFactoryPresets)
                                   ? kFactoryPresets[currentPreset].name : "Presets...";
+        // BeginCombo otherwise caps its popup at eight entries. An explicit
+        // identity constraint makes it auto-fit all 13 factory presets, so the
+        // complete list is visible without a scrollbar.
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(0.0f, 0.0f), ImVec2(FLT_MAX, FLT_MAX));
         if (ImGui::BeginCombo("##presets", preview))
         {
             for (int i = 0; i < kNumFactoryPresets; ++i)
             {
                 if (ImGui::Selectable(kFactoryPresets[i].name, i == currentPreset))
+                {
                     applyPreset(i);
+                    ImGui::CloseCurrentPopup();
+                }
             }
             ImGui::EndCombo();
         }
-        ImGui::PopStyleColor(3);
+        ImGui::PopStyleColor(12);
     }
 
     void applyPreset(int idx)
@@ -195,14 +250,22 @@ private:
         if (idx < 0 || idx >= kNumFactoryPresets)
             return;
         currentPreset = idx;
-        for (uint32_t i = 0; i <= (uint32_t)kParamTapeAge; ++i)
+        const auto apply = [this](uint32_t param, float value)
         {
-            const float v = kFactoryPresets[idx].v[i];
-            editParameter(i, true);
-            values[i] = v;
-            setParameterValue(i, v);
-            editParameter(i, false);
-        }
+            editParameter(param, true);
+            values[param] = value;
+            setParameterValue(param, value);
+            editParameter(param, false);
+        };
+        const TapeEchoPreset& preset = kFactoryPresets[idx];
+        for (uint32_t i = 0; i <= (uint32_t)kParamTapeAge; ++i)
+            apply(i, preset.v[i]);
+        apply(kParamOutputVolume, preset.outputVolume);
+        apply(kParamEchoPan, preset.echoPan);
+        apply(kParamReverbPan, preset.reverbPan);
+        apply(kParamInputSend, preset.inputSend);
+        apply(kParamWetSolo, preset.wetSolo);
+        apply(kParamBypass, preset.bypass);
     }
 
     void drawMeterBlock(ImDrawList* dl)
@@ -283,14 +346,20 @@ private:
 
     void drawInputRow(ImDrawList* dl)
     {
-        knobLabel(dl, 60, 165, "INPUT", "VOLUME");
-        knob("input", kParamInputGain, 0.0f, 1.0f, 60, 240, 26);
+        // Four evenly-spaced controls retain the original DIRECT path while
+        // keeping the newer output trim. Their tick rings remain clear of the
+        // mode-selector panel at x=288.
+        knobLabel(dl, 42, 165, "INPUT", "VOLUME");
+        knob("input", kParamInputGain, 0.0f, 1.0f, 42, 240, 25);
 
-        knobLabel(dl, 148, 165, "DIRECT", "SIGNAL");
-        knob("dry", kParamDryLevel, 0.0f, 1.0f, 148, 240, 26);
+        knobLabel(dl, 112, 165, "DRY", "LEVEL");
+        knob("dry", kParamDryLevel, 0.0f, 1.0f, 112, 240, 25);
 
-        knobLabel(dl, 236, 165, "WOW /", "FLUTTER");
-        knob("wow", kParamWowFlutter, 0.0f, 1.0f, 236, 240, 26);
+        knobLabel(dl, 182, 165, "WOW /", "FLUTTER");
+        knob("wow", kParamWowFlutter, 0.0f, 1.0f, 182, 240, 25);
+
+        knobLabel(dl, 252, 165, "OUTPUT", "VOLUME");
+        knob("output", kParamOutputVolume, 0.0f, 1.0f, 252, 240, 25);
     }
 
     void drawModeSelector(ImDrawList* dl)
@@ -326,10 +395,14 @@ private:
         text(dl, 310, 96, 9.5f, IM_COL32(20, 30, 12, 255), "REPEAT", -1, true);
         text(dl, 440, 96, 9.5f, IM_COL32(20, 30, 12, 255), "REVERB", 1, true);
         text(dl, 440, 107, 9.5f, IM_COL32(20, 30, 12, 255), "ECHO", 1, true);
-        text(dl, 375, 262, 9.5f, IM_COL32(20, 30, 12, 255), "REVERB ONLY", 0, true);
 
-        // active-path indicator (extra over hardware, but earns its place)
-        text(dl, 375, 282, 10.0f, kColWhite, kModeShort[mode], 0);
+        // Keep the selected routing legible at a glance, including the longer
+        // combined-head names, without competing with the numbered dial.
+        dl->AddRectFilled(P(304, 262), P(446, 294),
+                          IM_COL32(35, 52, 25, 150), 5.0f * s);
+        dl->AddRect(P(304, 262), P(446, 294),
+                    IM_COL32(111, 143, 85, 180), 5.0f * s, 0, 1.0f * s);
+        text(dl, 375, 270, 14.5f, kColWhite, kModeShort[mode], 0, true);
     }
 
     void drawControlPanel(ImDrawList* dl)
@@ -338,24 +411,77 @@ private:
         dl->AddRectFilled(P(x0 - 3, y0 - 3), P(x1 + 3, y1 + 3), kColMetal, 8.0f * s);
         dl->AddRectFilled(P(x0, y0), P(x1, y1), kColRecess, 6.0f * s);
 
-        knobLabel(dl, 540, 70, "BASS");
-        knob("bass", kParamBass, -1.0f, 1.0f, 540, 128, 24);
-        knobLabel(dl, 650, 70, "TREBLE");
-        knob("treble", kParamTreble, -1.0f, 1.0f, 650, 128, 24);
-        knobLabel(dl, 762, 70, "REVERB VOLUME");
-        knob("reverbvol", kParamReverbLevel, 0.0f, 1.0f, 762, 128, 24);
+        knobLabel(dl, 516, 70, "BASS");
+        knob("bass", kParamBass, -1.0f, 1.0f, 516, 124, 21);
+        knobLabel(dl, 596, 70, "TREBLE");
+        knob("treble", kParamTreble, -1.0f, 1.0f, 596, 124, 21);
+        knobLabel(dl, 688, 70, "REVERB", "VOLUME");
+        knob("reverbvol", kParamReverbLevel, 0.0f, 1.0f, 688, 124, 21);
+        knobLabel(dl, 786, 76, "REVERB PAN");
+        knob("reverbpan", kParamReverbPan, 0.0f, 1.0f, 786, 124, 16);
 
-        knobLabel(dl, 540, 186, "REPEAT RATE");
+        // Digital routing utilities. The first two latch; SPLICE is a
+        // momentary trigger that immediately returns to its off state.
+        const auto toggle = [&](const char* id, uint32_t param,
+                                float bx0, float bx1, const char* label)
+        {
+            const bool on = values[param] >= 0.5f;
+            const ImVec2 b0 = P(bx0, 158), b1 = P(bx1, 178);
+            ImGui::SetCursorScreenPos(b0);
+            ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+            if (ImGui::IsItemClicked())
+            {
+                const float next = on ? 0.0f : 1.0f;
+                editParameter(param, true);
+                values[param] = next;
+                setParameterValue(param, next);
+                editParameter(param, false);
+            }
+            dl->AddRectFilled(b0, b1, IM_COL32(38, 38, 41, 255), 3.0f * s);
+            dl->AddRect(b0, b1, on ? kColLedOn : IM_COL32(88, 88, 92, 255),
+                        3.0f * s, 0, 1.2f * s);
+            led(dl, bx0 + 8.0f, 168, on, 2.4f);
+            text(dl, 0.5f * (bx0 + bx1) + 4.0f, 162, 8.5f,
+                 on ? kColWhite : kColWhiteDim, label, 0, on);
+        };
+        toggle("inputsend", kParamInputSend, 486, 588, "INPUT SEND");
+        toggle("wetsolo", kParamWetSolo, 596, 684, "WET SOLO");
+
+        {
+            const ImVec2 b0 = P(692, 158), b1 = P(816, 178);
+            ImGui::SetCursorScreenPos(b0);
+            ImGui::InvisibleButton(
+                "loopsplice", ImVec2(b1.x - b0.x, b1.y - b0.y));
+            const bool pressed = ImGui::IsItemActive();
+            if (ImGui::IsItemClicked())
+            {
+                editParameter(kParamLoopSplice, true);
+                setParameterValue(kParamLoopSplice, 1.0f);
+                setParameterValue(kParamLoopSplice, 0.0f);
+                editParameter(kParamLoopSplice, false);
+            }
+            dl->AddRectFilled(b0, b1,
+                pressed ? IM_COL32(75, 38, 34, 255)
+                        : IM_COL32(38, 38, 41, 255), 3.0f * s);
+            dl->AddRect(b0, b1,
+                pressed ? kColLedOn : IM_COL32(88, 88, 92, 255),
+                3.0f * s, 0, 1.2f * s);
+            text(dl, 754, 162, 8.5f,
+                 pressed ? kColWhite : kColWhiteDim,
+                 "LOOP SPLICE", 0, pressed);
+        }
+
+        knobLabel(dl, 516, 188, "REPEAT RATE");
         const bool sync = values[kParamTempoSync] > 0.5f;
         if (sync) // knob steps through note divisions while synced
             knob("rate", kParamSyncDivision, 0.0f, (float)(kNumSyncDivisions - 1),
-                 540, 246, 24, true);
+                 516, 240, 21, true);
         else
-            knob("rate", kParamRepeatRate, 0.0f, 1.0f, 540, 246, 24);
+            knob("rate", kParamRepeatRate, 0.0f, 1.0f, 516, 240, 21);
 
-        // TEMPO SYNC button, right of the repeat-rate knob
+        // Tempo sync sits beneath the rate control.
         {
-            const ImVec2 b0 = P(570, 224), b1 = P(614, 240);
+            const ImVec2 b0 = P(482, 274), b1 = P(550, 294);
             ImGui::SetCursorScreenPos(b0);
             ImGui::InvisibleButton("syncbtn", ImVec2(b1.x - b0.x, b1.y - b0.y));
             if (ImGui::IsItemClicked())
@@ -370,18 +496,106 @@ private:
             dl->AddRect(b0, b1, sync ? IM_COL32(200, 60, 45, 255)
                                      : IM_COL32(90, 90, 94, 255), 3.0f * s, 0, 1.4f * s);
             if (sync)
-                dl->AddCircleFilled(P(577, 232), 2.6f * s, kColLedOn, 12);
-            text(dl, 594, 226, 10, sync ? kColWhite : kColWhiteDim, "SYNC", 0, sync);
-            if (sync)
-                text(dl, 592, 244, 11, kColWhite,
-                     kSyncDivisions[divIndex()].name, 0, true);
+                dl->AddCircleFilled(P(490, 284), 2.6f * s, kColLedOn, 12);
+            text(dl, 519, 278, 9.0f, sync ? kColWhite : kColWhiteDim,
+                 sync ? kSyncDivisions[divIndex()].name : "SYNC", 0, sync);
         }
-        knobLabel(dl, 650, 186, "INTENSITY");
-        knob("intensity", kParamIntensity, 0.0f, 1.0f, 650, 246, 24);
-        knobLabel(dl, 762, 186, "ECHO VOLUME");
-        knob("echovol", kParamEchoLevel, 0.0f, 1.0f, 762, 246, 24);
-        text(dl, 727, 288, 8.5f, kColWhiteDim, "STRAIGHT", -1);
-        text(dl, 800, 288, 8.5f, kColWhiteDim, "ECHO", 1);
+        knobLabel(dl, 596, 188, "INTENSITY");
+        knob("intensity", kParamIntensity, 0.0f, 1.0f, 596, 240, 21);
+        knobLabel(dl, 688, 188, "ECHO", "VOLUME");
+        knob("echovol", kParamEchoLevel, 0.0f, 1.0f, 688, 240, 21);
+        knobLabel(dl, 786, 194, "ECHO PAN");
+        knob("echopan", kParamEchoPan, 0.0f, 1.0f, 786, 240, 16);
+
+        drawHeadTimingStrip(dl, sync);
+    }
+
+    void drawHeadTimingStrip(ImDrawList* dl, bool sync)
+    {
+        float motorMs = duskaudio::TapeEchoDSP::delayMsForRepeatRate(
+            values[kParamRepeatRate]);
+        bool timingAvailable = true;
+
+        // Tempo sync octave-folds the selected division on the audio thread,
+        // so the manual Repeat Rate parameter no longer describes the motor.
+        // Read the effective target directly when the format is same-process.
+        if (sync)
+        {
+            timingAvailable = false;
+           #if DISTRHO_PLUGIN_WANT_DIRECT_ACCESS
+            if (tapeEchoGetHead1DelayMs != nullptr)
+                if (void* const inst = getPluginInstancePointer())
+                {
+                    const float syncedMs = tapeEchoGetHead1DelayMs(inst);
+                    if (syncedMs > 0.0f)
+                    {
+                        motorMs = syncedMs;
+                        timingAvailable = true;
+                    }
+                }
+           #endif
+        }
+
+        float slow01 =
+            (motorMs - duskaudio::TapeEchoDSP::kMinDelayMs)
+            / (duskaudio::TapeEchoDSP::kMaxDelayMs
+               - duskaudio::TapeEchoDSP::kMinDelayMs);
+        slow01 = slow01 < 0.0f ? 0.0f : (slow01 > 1.0f ? 1.0f : slow01);
+
+        // Front-panel nominal ranges. The first-head fast label is intentionally
+        // independent of the fixed mechanical head ratios, matching the visible
+        // timing convention while the calibrated DSP retains its measured
+        // audible arrival times.
+        constexpr float kFastMs[3] = { 60.0f, 131.0f, 189.0f };
+        constexpr float kSlowMs[3] = { 177.0f, 336.0f, 487.0f };
+        constexpr float kCellX[4] = { 558.0f, 644.0f, 730.0f, 816.0f };
+        constexpr const char* kLabels[3] = { "HEAD 1", "HEAD 2", "HEAD 3" };
+        constexpr uint8_t kHeadMask[12] =
+            { 1, 2, 4, 6, 1, 2, 4, 3, 6, 5, 7, 0 };
+        const uint8_t activeMask = kHeadMask[modeIndex()];
+
+        dl->AddRectFilled(P(kCellX[0], 270), P(kCellX[3], 298),
+                          IM_COL32(35, 35, 38, 255), 3.0f * s);
+        dl->AddRect(P(kCellX[0], 270), P(kCellX[3], 298),
+                    IM_COL32(82, 82, 86, 255), 3.0f * s, 0, 1.0f * s);
+
+        for (int i = 0; i < 3; ++i)
+        {
+            const bool active = (activeMask & (1u << i)) != 0;
+            const float cx = 0.5f * (kCellX[i] + kCellX[i + 1]);
+            if (active)
+                dl->AddRectFilled(
+                    P(kCellX[i] + 1.0f, 271),
+                    P(kCellX[i + 1] - 1.0f, 297),
+                    IM_COL32(45, 57, 39, 255), 2.0f * s);
+            if (i > 0)
+                dl->AddLine(P(kCellX[i], 272), P(kCellX[i], 296),
+                            IM_COL32(74, 74, 78, 255), 1.0f * s);
+
+            text(dl, cx, 272, 7.5f,
+                 active ? kColWhiteDim : IM_COL32(135, 134, 129, 255),
+                 kLabels[i], 0, active);
+
+            char valueText[16];
+            if (!active)
+            {
+                std::snprintf(valueText, sizeof(valueText), "---");
+            }
+            else if (timingAvailable)
+            {
+                const int delayMs = (int)std::lround(
+                    kFastMs[i] + slow01 * (kSlowMs[i] - kFastMs[i]));
+                std::snprintf(
+                    valueText, sizeof(valueText), "%d ms", delayMs);
+            }
+            else
+            {
+                std::snprintf(valueText, sizeof(valueText), "-- ms");
+            }
+            text(dl, cx, 283, 9.5f,
+                 active ? kColWhite : kColWhiteDim,
+                 valueText, 0, true);
+        }
     }
 
     void drawPowerBlock(ImDrawList* dl)
@@ -451,6 +665,7 @@ private:
     float  needlePos = 0.0f;
     float  meterLevel = 0.0f;
     int    currentPreset = -1;
+    bool   showSupporters = false;
     float  s = 1.0f;
     ImVec2 org = ImVec2(0, 0);
 

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -145,7 +145,7 @@ protected:
             ImGui::EndDisabled();
         if (showSupporters)
             duskdpf::drawSupportersOverlay(
-                panel, dl, kDesignW, kDesignH, showSupporters, "Tape Echo");
+                panel, dl, kDesignW, kDesignH, showSupporters, "Tape Echo 2");
 
         ImGui::End();
         ImGui::PopStyleVar(2);
@@ -197,7 +197,7 @@ private:
         // name plate
         dl->AddRect(P(38, 8), P(360, 38), IM_COL32(210, 210, 210, 200), 4.0f * s,
                     0, 1.6f * s);
-        text(dl, 52, 12, 20, kColWhite, "TAPE ECHO", -1, true);
+        text(dl, 52, 12, 20, kColWhite, "TAPE ECHO 2", -1, true);
         text(dl, 235, 15, 15, kColWhiteDim, "TE-3", -1, true);
         text(dl, kDesignW - 30, 14, 15, kColWhite, "Dusk Audio", 1, true);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tape Echo now includes expanded controls for output volume, stereo panning, input send, wet solo, and loop splice.
  * Added tempo-synced delay timing feedback in the interface.
  * Updated the spring reverb, tape behavior, presets, and signal processing for a richer sound.
  * Renamed the plugin to **Tape Echo 2** and updated its version to 1.0.0.

* **Bug Fixes**
  * Added automated CLAP validation to detect latency-related regressions during builds.

* **Documentation**
  * Updated migration and integration guidance for the revised DPF setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->