### PR TITLE
Sunset circuits/v1.0.1 fixes

### DIFF
--- a/.github/scripts/dpf_clap_validate.py
+++ b/.github/scripts/dpf_clap_validate.py
@@ -170,7 +170,7 @@ def main():
             log(f"::error::DPF CLAP latency regression: '{LATENCY_SIGNATURE}' "
                 "reported -- latency changed outside clap_plugin::activate(). "
                 "This is the upstream bug the dusk-audio/DPF fork fixes; DPF has "
-                "regressed. Check DPF_REF and the fork branch.")
+                "regressed. Check DPF_REF against dusk-audio/DPF main.")
             sys.exit(1)
 
         # ADVISORY (or strict) on the remaining suite.

--- a/.github/workflows/dpf-au-test.yml
+++ b/.github/workflows/dpf-au-test.yml
@@ -10,6 +10,10 @@ on:
     tags:
       - 'tape-echo-dpf-v*'
 
+env:
+  DPF_SHA: 45a7e30e5343231019e6d5f09629bae13f5899c7
+  DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
+
 jobs:
   build-au-macos:
     name: Build + auval Tape Echo AU (macOS)
@@ -17,6 +21,8 @@ jobs:
     steps:
       - name: Checkout plugins repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # DPF comes from the dusk-audio/DPF fork (our patches live there);
       # DPF-Widgets stays on upstream DISTRHO (no fork). Keep SHAs in sync
@@ -25,17 +31,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dusk-audio/DPF
-          ref: a9b033c241f80da2f141977819691322c2da988f
+          ref: ${{ env.DPF_SHA }}
           path: DPF
           submodules: recursive
+          persist-credentials: false
 
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
           repository: DISTRHO/DPF-Widgets
-          ref: 730da6397904da66d99667c1cb30fc77fc3d794a
+          ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Ninja
         run: brew install ninja

--- a/.github/workflows/dpf-au-test.yml
+++ b/.github/workflows/dpf-au-test.yml
@@ -18,10 +18,14 @@ jobs:
       - name: Checkout plugins repo
         uses: actions/checkout@v4
 
+      # DPF comes from the dusk-audio/DPF fork (our patches live there);
+      # DPF-Widgets stays on upstream DISTRHO (no fork). Keep SHAs in sync
+      # with dpf-build.yml, dpf-release.yml and docker/build_release.sh.
       - name: Checkout DPF
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF
+          repository: dusk-audio/DPF
+          ref: a9b033c241f80da2f141977819691322c2da988f
           path: DPF
           submodules: recursive
 
@@ -29,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: DISTRHO/DPF-Widgets
+          ref: 730da6397904da66d99667c1cb30fc77fc3d794a
           path: DPF-Widgets
           submodules: recursive
 

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -56,7 +56,7 @@ on:
 # dusk-audio/DPF, THEN bump DPF_REF. Keep SHAs in sync with dpf-release.yml,
 # dpf-au-test.yml and docker/build_release.sh. Bump deliberately.
 env:
-  DPF_REF: a9b033c241f80da2f141977819691322c2da988f
+  DPF_REF: 45a7e30e5343231019e6d5f09629bae13f5899c7
   DPFWIDGETS_REF: 730da6397904da66d99667c1cb30fc77fc3d794a
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -47,19 +47,16 @@ on:
       - 'plugins/shared-dpf/**'
       - '.github/workflows/dpf-build.yml'
 
-# DPF is our fork (dusk-audio/DPF), branch dusk/clap-latency-activate. Upstream's
-# CLAP wrapper reported latency changes outside clap_plugin::activate(), violating
-# the CLAP spec (24 clap-validator failures); the fork constrains latency changes
-# to activate() and serves a constant snapshot while active. One file changed vs
-# upstream base 4238e1c. DPF_REF pins that fix commit. DPF-Widgets stays upstream
+# DPF is our fork (dusk-audio/DPF), branch main — the permanent source of truth
+# for our DPF patches (CLAP latency changes constrained to activate(), AU
+# preset + CLAP state hardening, Wayland/CI work). DPF-Widgets stays upstream
 # (DISTRHO/DPF-Widgets) — only DPF is forked.
-# To advance DPF: rebase the branch onto newer upstream in ~/projects/DPF,
-# re-run clap-validator, confirm the latency signature is absent, review any
-# remaining advisory suite failures, push to dusk-audio/DPF, THEN bump DPF_REF.
-# Drop the fork (repoint checkouts to DISTRHO/DPF) only once upstream merges an
-# equivalent fix, verified with clap-validator first. Bump deliberately.
+# To advance DPF: land changes on fork main in ~/projects/DPF, re-run
+# clap-validator and pluginval against the rebuilt plugins, push to
+# dusk-audio/DPF, THEN bump DPF_REF. Keep SHAs in sync with dpf-release.yml,
+# dpf-au-test.yml and docker/build_release.sh. Bump deliberately.
 env:
-  DPF_REF: f2c9f01f510cf0c04a7c9c5a2873921ac9ce2ee2
+  DPF_REF: a9b033c241f80da2f141977819691322c2da988f
   DPFWIDGETS_REF: 730da6397904da66d99667c1cb30fc77fc3d794a
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -37,13 +37,13 @@ on:
       - '.github/workflows/dpf-release.yml'
   workflow_dispatch:
 
-# DPF is pinned to the dusk-audio/DPF fork (branch dusk/clap-latency-activate):
-# upstream DISTRHO/DPF reports CLAP latency changes outside clap_plugin::activate
-# and fails 24 clap-validator tests. Drop the fork pin once upstream merges the
-# fix. DPF-Widgets stays on upstream. Bump both SHAs together and re-run the
-# dispatch matrix before tagging.
+# DPF is pinned to the dusk-audio/DPF fork (branch main), which is the
+# permanent source of truth for our DPF patches (CLAP latency-in-activate fix
+# and later work). DPF-Widgets stays on upstream DISTRHO (no fork). Keep SHAs
+# in sync with dpf-build.yml, dpf-au-test.yml and docker/build_release.sh, and
+# re-run the dispatch matrix before tagging.
 env:
-  DPF_SHA: 2f98c651acd70cfbcd9f807b7e73ea1e39ecc2cb
+  DPF_SHA: a9b033c241f80da2f141977819691322c2da988f
   DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
   PLUGIN_DIR: plugins/sunset-circuits/dpf-plugin
   SLUG: sunset-circuits

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -3,7 +3,7 @@ name: Build Sunset Circuits (DPF)
 # Release + CI-debug workflow for the DPF-based Sunset Circuits synth.
 #
 # The DPF ports live outside the JUCE release build graph (build.yml), so they
-# need their own matrix: this checks out DISTRHO/DPF + DISTRHO/DPF-Widgets at
+# need their own matrix: this checks out dusk-audio/DPF (our fork) + DISTRHO/DPF-Widgets at
 # pinned SHAs and builds plugins/sunset-circuits/dpf-plugin (VST3 + CLAP + LV2
 # everywhere, plus a notarizable AU on macOS with an auval pass).
 #
@@ -43,7 +43,7 @@ on:
 # in sync with dpf-build.yml, dpf-au-test.yml and docker/build_release.sh, and
 # re-run the dispatch matrix before tagging.
 env:
-  DPF_SHA: a9b033c241f80da2f141977819691322c2da988f
+  DPF_SHA: 45a7e30e5343231019e6d5f09629bae13f5899c7
   DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
   PLUGIN_DIR: plugins/sunset-circuits/dpf-plugin
   SLUG: sunset-circuits
@@ -118,6 +118,8 @@ jobs:
     # tag push and a manual dispatch.
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     timeout-minutes: 40
     container:
       image: ubuntu:20.04  # glibc 2.31, matching the JUCE fleet (build.yml)
@@ -164,6 +166,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout DPF
         uses: actions/checkout@v4
@@ -172,6 +176,7 @@ jobs:
           ref: ${{ env.DPF_SHA }}
           path: DPF
           submodules: recursive
+          persist-credentials: false
 
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
@@ -180,6 +185,7 @@ jobs:
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
+          persist-credentials: false
 
       - name: Configure
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -228,6 +234,8 @@ jobs:
     # tag push and a manual dispatch.
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
     timeout-minutes: 40
     container:
       image: ubuntu:22.04  # glibc 2.35, matching build.yml's arm job
@@ -270,6 +278,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout DPF
         uses: actions/checkout@v4
@@ -278,6 +288,7 @@ jobs:
           ref: ${{ env.DPF_SHA }}
           path: DPF
           submodules: recursive
+          persist-credentials: false
 
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
@@ -286,6 +297,7 @@ jobs:
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
+          persist-credentials: false
 
       - name: Configure
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -333,12 +345,16 @@ jobs:
     # tag push and a manual dispatch.
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: windows-2022
+    permissions:
+      contents: read
     timeout-minutes: 60
     env:
       PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout DPF
         uses: actions/checkout@v4
@@ -347,6 +363,7 @@ jobs:
           ref: ${{ env.DPF_SHA }}
           path: DPF
           submodules: recursive
+          persist-credentials: false
 
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
@@ -355,6 +372,7 @@ jobs:
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
@@ -500,12 +518,16 @@ jobs:
     # tag push and a manual dispatch.
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: macos-14
+    permissions:
+      contents: read
     timeout-minutes: 60
     env:
       PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout DPF
         uses: actions/checkout@v4
@@ -514,6 +536,7 @@ jobs:
           ref: ${{ env.DPF_SHA }}
           path: DPF
           submodules: recursive
+          persist-credentials: false
 
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
@@ -522,6 +545,7 @@ jobs:
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Ninja
         run: brew install ninja
@@ -654,6 +678,8 @@ jobs:
   test-linux:
     needs: setup
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     # Generous: the shipping linux job budgets 40 minutes for the build alone,
     # and this one adds the gate suite and pluginval on top of a build of
     # comparable size.
@@ -680,6 +706,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -707,6 +735,7 @@ jobs:
           ref: ${{ env.DPF_SHA }}
           path: DPF
           submodules: recursive
+          persist-credentials: false
 
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
@@ -715,6 +744,7 @@ jobs:
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
+          persist-credentials: false
 
       - name: Configure
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -864,7 +894,7 @@ jobs:
           # a DPF CLAP-wrapper bug that failed 24 of 44 tests on any DPF plugin
           # declaring a latency. It is fixed in DistrhoPluginCLAP.cpp by only
           # announcing latency changes from within clap_plugin::activate; see the
-          # DPF_SHA TODO at the top of this file for the fork bump this depends on.
+          # DPF_SHA pin at the top of this file.
           # Measured locally against the fixed DPF: 44 tests run, 33 passed,
           # 10 skipped, 1 warning, 0 failed.
           python3 - <<'PY'
@@ -930,6 +960,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ cmake --build plugins/sunset-circuits/dpf-plugin/build
 
 The container/CI path (`./docker/build_release.sh sunset`,
 `.github/workflows/dpf-release.yml`) is the reproducible way to build a DPF plugin
-from clean — it pins DISTRHO/DPF and DPF-Widgets at known-good SHAs.
+from clean — it pins dusk-audio/DPF (our fork) and DISTRHO/DPF-Widgets at known-good SHAs.
 
 ### Installation Paths
 - **macOS AU**: `~/Library/Audio/Plug-Ins/Components/`

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -15,10 +15,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 IMAGE_NAME="dusk-plugins-builder"
 
-# DPF / DPF-Widgets SHAs — keep in sync with .github/workflows/dpf-release.yml.
+# DPF / DPF-Widgets SHAs — keep in sync with dpf-build.yml, dpf-release.yml and dpf-au-test.yml.
 # DPF comes from the dusk-audio/DPF fork (our patches live there); DPF-Widgets
 # stays on upstream DISTRHO (no fork).
-DPF_SHA="a9b033c241f80da2f141977819691322c2da988f"
+DPF_SHA="45a7e30e5343231019e6d5f09629bae13f5899c7"
 DPFWIDGETS_SHA="730da6397904da66d99667c1cb30fc77fc3d794a"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)
@@ -67,7 +67,7 @@ is_sunset() {
 }
 
 # Build Sunset Circuits (DPF) in the container. Unlike the JUCE plugins this does
-# NOT use the top-level JUCE build graph: it clones DISTRHO/DPF + DPF-Widgets at
+# NOT use the top-level JUCE build graph: it clones dusk-audio/DPF (our fork) + DISTRHO/DPF-Widgets at
 # the pinned SHAs inside the container and builds plugins/sunset-circuits/dpf-plugin
 # standalone (mirrors .github/workflows/dpf-release.yml). Produces VST3/CLAP/LV2.
 build_sunset() {

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -16,7 +16,9 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 IMAGE_NAME="dusk-plugins-builder"
 
 # DPF / DPF-Widgets SHAs — keep in sync with .github/workflows/dpf-release.yml.
-DPF_SHA="4238e1c7f0351bbe488d79f0899c540543ac7583"
+# DPF comes from the dusk-audio/DPF fork (our patches live there); DPF-Widgets
+# stays on upstream DISTRHO (no fork).
+DPF_SHA="a9b033c241f80da2f141977819691322c2da988f"
 DPFWIDGETS_SHA="730da6397904da66d99667c1cb30fc77fc3d794a"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)
@@ -108,7 +110,7 @@ build_sunset() {
                 cd /tmp
             }
             cd /tmp
-            fetch_sha https://github.com/DISTRHO/DPF.git         "$DPF_SHA"        /tmp/dpf
+            fetch_sha https://github.com/dusk-audio/DPF.git      "$DPF_SHA"        /tmp/dpf
             fetch_sha https://github.com/DISTRHO/DPF-Widgets.git  "$DPFWIDGETS_SHA" /tmp/dpf-widgets
             test -n "$(ls -A /tmp/dpf/dgl/src/pugl-upstream 2>/dev/null)" \
                 || { echo "ERROR: DPF pugl submodule missing after fetch"; exit 1; }

--- a/docs/dpf-migration/00-OVERVIEW.md
+++ b/docs/dpf-migration/00-OVERVIEW.md
@@ -49,7 +49,7 @@ Already written and validated inside tape-echo — reuse, do not rewrite:
 | Factory-preset table + host programs | `dpf-plugin/TapeEchoParams.hpp` + shell | preset headers |
 | CMake template | `dpf-plugin/CMakeLists.txt` | JUCE CMake |
 
-DPF checkout: `~/projects/DPF` — our fork `dusk-audio/DPF`, branch `dusk/clap-latency-activate` (CLAP latency-in-activate fix; remote `dusk`, `origin` stays upstream DISTRHO). Needs `git submodule update --init` for pugl.
+DPF checkout: `~/projects/DPF` — our fork `dusk-audio/DPF`, branch `main` (permanent home of our DPF patches: CLAP latency-in-activate, AU/CLAP/VST3 state hardening, Wayland LV2 UIs). Keep the checkout on the SHA pinned by `DPF_REF` in `.github/workflows/dpf-build.yml`. Needs `git submodule update --init` for pugl.
 DPF-Widgets checkout: `~/projects/DPF-Widgets` (DearImGui wrapper).
 
 ## Landmines (all hit and fixed during tape-echo — do not rediscover them)

--- a/plugins/4k-eq/dpf-plugin/FourKEQUI.cpp
+++ b/plugins/4k-eq/dpf-plugin/FourKEQUI.cpp
@@ -177,8 +177,33 @@ protected:
         if (showCredits)
             drawCredits(dl, winW, winH);
 
+        // Own resize grip, submitted LAST so it wins ImGui's hover race (over the
+        // preset popup and the credits card alike) and paints over everything.
+        // AUv2 hosts (Logic) never provide a window grip of their own; on VST3/CLAP
+        // the host's grip stays available and this is simply a second way to do the
+        // same thing. `designH`, not kDesignH: the design is shorter with the graph
+        // hidden, and the grip must drive the same aspect the host is constrained
+        // to (see updateSizeConstraints) or the two would fight over the height.
+        const duskdpf::ResizeGripState grip =
+            panel.resizeGrip(dl, winW, winH, kDesignW, designH);
+
         ImGui::End();
         ImGui::PopStyleVar(2);
+
+        // Cursor feedback. The DPF-Widgets ImGui backend never forwards
+        // ImGui::SetMouseCursor() to the window, so drive DGL's cursor directly.
+        // Edge-triggered: setCursor() is a window-level call, not a per-frame one.
+        if (grip.hot != gripCursorSet)
+        {
+            gripCursorSet = grip.hot;
+            setCursor(gripCursorSet ? DGL_NAMESPACE::kMouseCursorUpLeftDownRight
+                                    : DGL_NAMESPACE::kMouseCursorArrow);
+        }
+
+        // Applied after End() so a host that services the resize synchronously
+        // cannot re-enter the UI in the middle of this window's submission.
+        if (grip.resized)
+            setSize(grip.width, grip.height);
     }
 
     // Control-area vertical remap: maps a design Y in the [220..662] band to the
@@ -1199,6 +1224,7 @@ private:
     bool showFft = true;         // spectrum analyzer overlay on the graph
     int  graphRangeIdx = 2;      // 0:+-6 1:+-12 2:+-18 3:+-30 4:Warped
     bool needResize = false;
+    bool gripCursorSet = false;  // NWSE cursor currently pushed to the window
     float ctlDstTop_ = 220.0f, ctlScaleY_ = 1.0f;
     float stepDragT = 0.0f; // stepped filter-knob drag origin (HPF/LPF)
     bool  stepModReset_ = false; // Ctrl/Cmd+click reset in progress (suppress drag)

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -160,8 +160,31 @@ protected:
             duskdpf::drawSupportersOverlay(panel, dl, kDesignW, kDesignH, showSupporters,
                                            "TapeMachine 2", TM2_VERSION_STRING);
 
+        // Own resize grip, submitted LAST so it wins ImGui's hover race (over the
+        // Advanced card and the supporters overlay alike) and paints over
+        // everything. AUv2 hosts (Logic) never provide a window grip of their own;
+        // on VST3/CLAP the host's grip stays available and this is simply a second
+        // way to do the same thing.
+        const duskdpf::ResizeGripState grip =
+            panel.resizeGrip(dl, winW, winH, kDesignW, kDesignH);
+
         ImGui::End();
         ImGui::PopStyleVar(2);
+
+        // Cursor feedback. The DPF-Widgets ImGui backend never forwards
+        // ImGui::SetMouseCursor() to the window, so drive DGL's cursor directly.
+        // Edge-triggered: setCursor() is a window-level call, not a per-frame one.
+        if (grip.hot != gripCursorSet)
+        {
+            gripCursorSet = grip.hot;
+            setCursor(gripCursorSet ? DGL_NAMESPACE::kMouseCursorUpLeftDownRight
+                                    : DGL_NAMESPACE::kMouseCursorArrow);
+        }
+
+        // Applied after End() so a host that services the resize synchronously
+        // cannot re-enter the UI in the middle of this window's submission.
+        if (grip.resized)
+            setSize(grip.width, grip.height);
     }
 
 private:
@@ -1179,6 +1202,7 @@ private:
     char    saveBuf[64] = {};
     bool    showAdvanced = false;   // hidden advanced (Repro EQ) panel toggle
     bool    showSupporters = false; // Patreon "Special Thanks" overlay (click the title nameplate)
+    bool    gripCursorSet = false;  // NWSE cursor currently pushed to the window
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TapeMachineUI)
 };

--- a/plugins/multi-q/dpf-plugin/MultiQUI.cpp
+++ b/plugins/multi-q/dpf-plugin/MultiQUI.cpp
@@ -343,8 +343,33 @@ protected:
         if (showHelpOverlay_)
             drawHelpOverlay(dl, winW, winH);
 
+        // Own resize grip, submitted LAST so it wins ImGui's hover race (over the
+        // preset popup, the credits card and the '?' overlay alike) and paints over
+        // everything. AUv2 hosts (Logic) never provide a window grip of their own;
+        // on VST3/CLAP the host's grip stays available and this is simply a second
+        // way to do the same thing. `designH`, not kDesignH: the British skin's
+        // design is shorter with the graph hidden, and the grip has to drive the
+        // same aspect this frame was letterboxed to.
+        const duskdpf::ResizeGripState grip =
+            panel.resizeGrip(dl, winW, winH, kDesignW, designH);
+
         ImGui::End();
         ImGui::PopStyleVar(2);
+
+        // Cursor feedback. The DPF-Widgets ImGui backend never forwards
+        // ImGui::SetMouseCursor() to the window, so drive DGL's cursor directly.
+        // Edge-triggered: setCursor() is a window-level call, not a per-frame one.
+        if (grip.hot != gripCursorSet)
+        {
+            gripCursorSet = grip.hot;
+            setCursor(gripCursorSet ? DGL_NAMESPACE::kMouseCursorUpLeftDownRight
+                                    : DGL_NAMESPACE::kMouseCursorArrow);
+        }
+
+        // Applied after End() so a host that services the resize synchronously
+        // cannot re-enter the UI in the middle of this window's submission.
+        if (grip.resized)
+            setSize(grip.width, grip.height);
     }
 
     // Control-area vertical remap (see FourKEQUI): maps a design Y in the
@@ -4092,6 +4117,7 @@ private:
     int  digPreset_ = -1;      // Digital: selected factory preset index (-1 = Init/none)
     int  tubePreset_ = -1;     // Tube: selected factory preset index (-1 = Init/none)
     bool uiPresetsSynced_ = false; // one-shot: restore dropdown selection from plugin state on open
+    bool gripCursorSet = false;    // NWSE cursor currently pushed to the window
 
     // Digital analyzer state (own FFT + buffers, kept separate from British `fft`/
     // `specDb` so the two skins never fight over the FFT size). digFrozen_ + snapshot

--- a/plugins/shared-dpf/cmake/DuskDpfPlugin.cmake
+++ b/plugins/shared-dpf/cmake/DuskDpfPlugin.cmake
@@ -21,7 +21,7 @@ set(DPF_PATH        "${_dusk_repo_root}/../DPF"         CACHE PATH "Path to DIST
 set(DPFWIDGETS_PATH "${_dusk_repo_root}/../DPF-Widgets" CACHE PATH "Path to DPF-Widgets (Dear ImGui wrapper)")
 
 if(NOT EXISTS "${DPF_PATH}/CMakeLists.txt")
-    message(FATAL_ERROR "DPF not found at ${DPF_PATH} — clone https://github.com/dusk-audio/DPF (our fork, branch dusk/clap-latency-activate) or pass -DDPF_PATH=...")
+    message(FATAL_ERROR "DPF not found at ${DPF_PATH} — clone https://github.com/dusk-audio/DPF (our fork; do not use upstream DISTRHO/DPF) or pass -DDPF_PATH=...")
 endif()
 if(NOT EXISTS "${DPFWIDGETS_PATH}/opengl/DearImGui.cpp")
     message(FATAL_ERROR "DPF-Widgets not found at ${DPFWIDGETS_PATH} — clone https://github.com/DISTRHO/DPF-Widgets or pass -DDPFWIDGETS_PATH=...")

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -7,7 +7,8 @@
 // Extracted from plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp. Provides a fixed
 // design-space coordinate mapper, a chrome knob (drag / shift-fine / wheel /
 // double-click-reset, single active-knob drag state), LED, toggle, styled text,
-// plus an analytic response-curve polyline mapper and a small real-FFT +
+// a bottom-right window resize grip for hosts that provide none, plus an
+// analytic response-curve polyline mapper and a small real-FFT +
 // spectrum drawer for EQ/analyzer UIs. Colors come from a Palette struct;
 // host parameter edits go through a ParamHost interface so this stays free of
 // any DPF include (the UI subclass adapts editParameter/setParameterValue).
@@ -46,6 +47,18 @@ struct Palette
     ImU32 ledGlow  = IM_COL32(255, 70, 45, 90);
     ImU32 ledOff   = IM_COL32(70, 20, 15, 255);
     ImU32 accent   = IM_COL32(120, 170, 235, 255);
+};
+
+// One frame of DuskPanel::resizeGrip() state. The two things it implies --
+// applying the new size and showing a diagonal mouse cursor -- are both DPF
+// window calls, which this header deliberately cannot make, so the caller
+// performs them (see the resizeGrip() comment for the exact contract).
+struct ResizeGripState
+{
+    bool     hot     = false;  // hovered or dragged: caller shows the NWSE cursor
+    bool     resized = false;  // a size change is being asked for this frame
+    uint32_t width   = 0;      // requested window size, valid when resized
+    uint32_t height  = 0;
 };
 
 class DuskPanel
@@ -557,6 +570,106 @@ public:
         return toggled;
     }
 
+    //--- bottom-right window resize grip -------------------------------------
+    // AUv2 hosts (Logic above all) never hand a plugin window a resize handle of
+    // their own, so a resizable UI has to draw its own and resize itself. This is
+    // the DPF counterpart of what plugins/shared/ScalableEditorHelper does for the
+    // JUCE plugins via juce::ResizableCornerComponent.
+    //
+    // winW/winH are WINDOW space -- the UI's getWidth()/getHeight() -- not design
+    // space, so the grip stays welded to the real corner even when an off-aspect
+    // window letterboxes the design box. Its own size still tracks the panel scale.
+    //
+    // Aspect is locked. The pointer delta is projected onto the design diagonal
+    // (least-squares fit of the single step t for which the box grows by
+    // t*designW x t*designH), so both axes drive one uniform scale, which is then
+    // clamped to [minScale, maxScale] of the design size. minScale must match the
+    // minimum handed to setGeometryConstraints(designW, designH, true): DPF clamps
+    // the window to that and re-derives the aspect from the same ratio, and a grip
+    // that disagreed would just fight the window.
+    //
+    // UNITS, measured not assumed: DGL/pugl report window sizes in BACKING PIXELS
+    // (a 900x320-point plugin window on a 2x display reports 1800x640), and neither
+    // UI::getScaleFactor() nor Window::getScaleFactor() exposes that factor -- both
+    // read 1.0 under AU. So the scale here, like DPF's own constraint, is in device
+    // pixels: on a 2x display [1.0, 3.0] spans 450..1350 points, i.e. half to 1.5x
+    // the nominal window, with the design always drawn at >= 1 device pixel per
+    // design pixel. Change the bounds if a plugin wants a different physical range;
+    // there is no way to express one in points from inside the UI.
+    //
+    // CALLER RULES:
+    //  - submit this LAST in the frame: it has to win ImGui's hover race against
+    //    anything it overlaps, and it should paint over it.
+    //  - apply width/height AFTER ImGui::End(), never mid-window -- a host may run
+    //    the resize (and therefore the window's event handling) synchronously.
+    //  - map `hot` onto a real cursor yourself; the DPF-Widgets ImGui backend has
+    //    no cursor support, so the ImGui::SetMouseCursor() below is advisory only.
+    ResizeGripState resizeGrip(ImDrawList* dl, float winW, float winH,
+                               float designW, float designH,
+                               float minScale = 1.0f, float maxScale = 3.0f)
+    {
+        ResizeGripState st;
+        if (designW <= 0.0f || designH <= 0.0f)
+            return st;
+
+        const float g = 14.0f * s;                     // hotspot == painted area
+        ImGui::SetCursorScreenPos(ImVec2(winW - g, winH - g));
+        ImGui::InvisibleButton("##duskresizegrip", ImVec2(g, g));
+        const bool hovered = ImGui::IsItemHovered();
+        const bool active  = ImGui::IsItemActive();
+        st.hot = hovered || active;
+        if (st.hot)
+            ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNWSE);
+
+        // Anchor the gesture to the scale at press time and drive it from the
+        // absolute pointer delta. setSize() is asynchronous (DPF: "will not change
+        // the widget's size right away, but be pending on the OS resizing the
+        // window"), so folding a per-frame delta into whatever size the window
+        // currently reports would re-apply every still-pending resize and run away.
+        if (ImGui::IsItemActivated())
+        {
+            const float sw = winW / designW, sh = winH / designH;
+            gripStartScale_ = sw < sh ? sw : sh;   // matches the caller's own `s`
+            gripReqW_ = (uint32_t) (winW + 0.5f);
+            gripReqH_ = (uint32_t) (winH + 0.5f);
+        }
+
+        if (active)
+        {
+            const ImVec2 d = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left, 0.0f);
+            const float t = (d.x * designW + d.y * designH)
+                          / (designW * designW + designH * designH);
+            float scale = gripStartScale_ + t;
+            scale = scale < minScale ? minScale : (scale > maxScale ? maxScale : scale);
+
+            const uint32_t w = (uint32_t) (designW * scale + 0.5f);
+            const uint32_t h = (uint32_t) (designH * scale + 0.5f);
+            // Only ask when the ask differs from the LAST ask, not from winW/winH:
+            // setSize() is asynchronous, so while a resize is pending the window
+            // still reports the old size and comparing against it would re-fire
+            // the identical request every frame until the host catches up.
+            if (w != gripReqW_ || h != gripReqH_)
+            {
+                gripReqW_ = w;
+                gripReqH_ = h;
+                st.resized = true;
+                st.width   = w;
+                st.height  = h;
+            }
+        }
+
+        // Three hatch lines stepping out from the corner: readable as a grip,
+        // dim enough to disappear into the chassis until it is pointed at.
+        const ImU32 col = st.hot ? IM_COL32(238, 236, 228, 175) : IM_COL32(238, 236, 228, 70);
+        const float cx = winW - 3.0f * s, cy = winH - 3.0f * s;
+        for (int i = 1; i <= 3; ++i)
+        {
+            const float o = (float) i * 3.6f * s;
+            dl->AddLine(ImVec2(cx - o, cy), ImVec2(cx, cy - o), col, 1.3f * s);
+        }
+        return st;
+    }
+
     // Map a (log-frequency, dB) point into a pixel inside a design-space rect.
     ImVec2 curvePoint(float rx0, float ry0, float rx1, float ry1,
                       float freq, float db, float fMin, float fMax, float dbRange) const
@@ -576,6 +689,8 @@ private:
     Palette pal;
     CrispFontSet fontSet;  // multi-size faces; pickFont() chooses nearest
     float dragValue = 0.0f;
+    float gripStartScale_ = 1.0f;  // resizeGrip(): scale when the drag started
+    uint32_t gripReqW_ = 0, gripReqH_ = 0;  // resizeGrip(): last size asked of the host
 
     // Inline value-entry state (double-click a knob to type a value).
     std::string valueEditId_;

--- a/plugins/sunset-circuits/dpf-plugin/MultiSynthUI.cpp
+++ b/plugins/sunset-circuits/dpf-plugin/MultiSynthUI.cpp
@@ -289,8 +289,10 @@ protected:
             dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), IM_COL32(0, 0, 0, 170)); // scrim on bg list
             beginLayerScreen("MSsave", 0, 0, winW, winH, true);
             drawSaveModalOverlay();
+            const duskdpf::ResizeGripState grip = submitGrip(winW, winH);
             endLayer(kLayerModal);
             ImGui::PopStyleVar(2);
+            applyGrip(grip);
            #ifdef MSYNTH_FRAME_PROFILE
             profileFrame(_t0);
            #endif
@@ -302,8 +304,10 @@ protected:
             dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), IM_COL32(0, 0, 0, 170)); // scrim on bg list
             beginLayerScreen("MSbrowse", 0, 0, winW, winH, true);
             drawPresetBrowserOverlay();
+            const duskdpf::ResizeGripState grip = submitGrip(winW, winH);
             endLayer(kLayerBrowse);
             ImGui::PopStyleVar(2);
+            applyGrip(grip);
            #ifdef MSYNTH_FRAME_PROFILE
             profileFrame(_t0);
            #endif
@@ -315,8 +319,10 @@ protected:
             dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), IM_COL32(0, 0, 0, 170)); // scrim on bg list
             beginLayerScreen("MSmodal", 0, 0, winW, winH, true);
             drawModMatrixOverlay();
+            const duskdpf::ResizeGripState grip = submitGrip(winW, winH);
             endLayer(kLayerModal);
             ImGui::PopStyleVar(2);
+            applyGrip(grip);
            #ifdef MSYNTH_FRAME_PROFILE
             profileFrame(_t0);
            #endif
@@ -357,9 +363,15 @@ protected:
         drawFXStrip();
         drawWheels();
         drawKeyboard();
+        // MSbottom owns the window's bottom-right corner (the design is aspect-
+        // locked, so the letterbox margin here is sub-pixel), and it is the last
+        // base layer submitted, hence the frontmost -- so the grip both wins the
+        // hover race and paints over the keyboard it overlaps.
+        const duskdpf::ResizeGripState grip = submitGrip(winW, winH);
         endLayer(kLayerBottom);
 
         ImGui::PopStyleVar(2);
+        applyGrip(grip);
        #ifdef MSYNTH_FRAME_PROFILE
         profileFrame(_t0);
        #else
@@ -455,6 +467,47 @@ protected:
         if (!inputs) f |= ImGuiWindowFlags_NoInputs;
         ImGui::Begin(name, nullptr, f);
         dl = ImGui::GetWindowDrawList();
+    }
+
+    // Own in-UI resize grip. AUv2 hosts (Logic) never provide a window grip of
+    // their own; on VST3/CLAP the host's grip stays available and this is simply
+    // a second way to do the same thing.
+    //
+    // Shared by every terminal path of onImGuiDisplay because this UI has four of
+    // them -- three modals that REPLACE the panels, plus the base frame -- and the
+    // grip has to be in all of them or the window would stop being resizable
+    // whenever an overlay is up.
+    //
+    // Submitted into the FRONTMOST LAYER rather than a full-window grip layer of
+    // its own: the layer windows are deliberately non-overlapping (see the vertex
+    // census above), and one stacked over all of them would steal hover from every
+    // panel underneath. The window that owns the bottom-right corner is MSbottom
+    // in the base frame and the modal's own full-window layer otherwise, so
+    // calling this last in that layer gives the grip exactly the hover priority it
+    // needs and nothing more. Costs ~24 vertices, i.e. nothing against MSbottom's
+    // measured 22094/65535 worst case.
+    duskdpf::ResizeGripState submitGrip(float winW, float winH)
+    {
+        return panel.resizeGrip(dl, winW, winH, kDesignW, kDesignH);
+    }
+
+    // The grip's two side effects, both DPF window calls the shared widget header
+    // deliberately cannot make. Applied AFTER the owning layer's ImGui::End(): a
+    // host may service setSize() synchronously and re-enter the UI, which must not
+    // happen in the middle of a window's submission.
+    void applyGrip(const duskdpf::ResizeGripState& grip)
+    {
+        // The DPF-Widgets ImGui backend never forwards ImGui::SetMouseCursor() to
+        // the window, so drive DGL's cursor directly. Edge-triggered: setCursor()
+        // is a window-level call, not a per-frame one.
+        if (grip.hot != gripCursorSet)
+        {
+            gripCursorSet = grip.hot;
+            setCursor(gripCursorSet ? DGL_NAMESPACE::kMouseCursorUpLeftDownRight
+                                    : DGL_NAMESPACE::kMouseCursorArrow);
+        }
+        if (grip.resized)
+            setSize(grip.width, grip.height);
     }
 
 private:
@@ -4007,6 +4060,7 @@ private:
     const char* tips[kNumCoreParams] = {};
     float  s = 1.0f;
     ImVec2 org = ImVec2(0, 0);
+    bool   gripCursorSet = false;  // NWSE cursor currently pushed to the window
 
     // The one edit gesture that can be open at a time, or -1. Written only by the
     // beginEdit/endEdit overrides; read by closeOrphanedEdit() and the destructor.

--- a/plugins/tape-echo/core/INTEGRATION.md
+++ b/plugins/tape-echo/core/INTEGRATION.md
@@ -70,7 +70,7 @@ runs native).
 
 ```
 tape-echo-dpf/
-├── dpf/                     # git submodule: github.com/dusk-audio/DPF (fork; branch dusk/clap-latency-activate)
+├── dpf/                     # git submodule: github.com/dusk-audio/DPF (our fork)
 ├── plugin/
 │   ├── DistrhoPluginInfo.h
 │   ├── TapeEchoPlugin.cpp  # DSP wrapper (below)

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -147,8 +147,30 @@ protected:
             duskdpf::drawSupportersOverlay(
                 panel, dl, kDesignW, kDesignH, showSupporters, "Tape Echo 2");
 
+        // Own resize grip, submitted LAST so it wins ImGui's hover race and
+        // paints over everything. AUv2 hosts (Logic) never provide a window
+        // grip of their own; on VST3/CLAP the host's grip stays available and
+        // this is simply a second way to do the same thing.
+        const duskdpf::ResizeGripState grip =
+            panel.resizeGrip(dl, winW, winH, kDesignW, kDesignH);
+
         ImGui::End();
         ImGui::PopStyleVar(2);
+
+        // Cursor feedback. The DPF-Widgets ImGui backend never forwards
+        // ImGui::SetMouseCursor() to the window, so drive DGL's cursor directly.
+        // Edge-triggered: setCursor() is a window-level call, not a per-frame one.
+        if (grip.hot != gripCursorSet)
+        {
+            gripCursorSet = grip.hot;
+            setCursor(gripCursorSet ? DGL_NAMESPACE::kMouseCursorUpLeftDownRight
+                                    : DGL_NAMESPACE::kMouseCursorArrow);
+        }
+
+        // Applied after End() so a host that services the resize synchronously
+        // cannot re-enter the UI in the middle of this window's submission.
+        if (grip.resized)
+            setSize(grip.width, grip.height);
     }
 
 private:
@@ -666,6 +688,7 @@ private:
     float  meterLevel = 0.0f;
     int    currentPreset = -1;
     bool   showSupporters = false;
+    bool   gripCursorSet = false;   // NWSE cursor currently pushed to the window
     float  s = 1.0f;
     ImVec2 org = ImVec2(0, 0);
 


### PR DESCRIPTION
Repoints every DPF source reference to the dusk-audio/DPF fork and pins a single SHA (`a9b033c`, fork `main`) across `dpf-build.yml`, `dpf-release.yml`, `dpf-au-test.yml`, and `docker/build_release.sh`. Fork `main` is now the permanent source of truth for our DPF patches (CLAP latency-in-activate, AU preset + CLAP/VST3 state hardening, Wayland LV2 UIs); the interim `dusk/clap-latency-activate` branch model is retired. DPF-Widgets stays on upstream DISTRHO, pinned at `730da63`.

**Behavior change beyond the pin swap:** `docker/build_release.sh` previously fetched DPF at the upstream DISTRHO base (`4238e1c`), so local Sunset Circuits container builds produced CLAP binaries *without* the latency-in-activate fix and diverged from CI artifacts. It now fetches the fork at the same pinned SHA as CI, so locally built Linux artifacts change accordingly and match releases.

Follow-ups included on this branch:

- `persist-credentials: false` on all checkouts in `dpf-au-test.yml` and `dpf-release.yml` (matching `dpf-build.yml`), plus explicit `permissions: contents: read` on the `dpf-release.yml` build jobs.
- `dpf-au-test.yml` now takes its SHAs from `DPF_SHA` / `DPFWIDGETS_SHA` env vars instead of inline literals, so pin bumps are greppable in one place per file.
- Stale comments/docs referencing DISTRHO/DPF as the source or the retired fork branch updated (`dpf-release.yml` header, `docker/build_release.sh`, `README.md`, `docs/dpf-migration/00-OVERVIEW.md`, `.github/scripts/dpf_clap_validate.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI/build/release workflows (and the release build container) to use consistent, pinned DPF and DPF-Widgets revisions.
  - Improved automation checkout security by disabling credential persistence.

- **Bug Fixes**
  - Improved plugin window resize behavior and cursor feedback by ensuring the resize grip reliably captures hover/input priority across relevant UIs.

- **Documentation**
  - Refreshed DPF integration, migration, and build instructions to reflect the current pinned DPF source references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
