### PR TITLE
fix(tapemachine-2): clamp filter design frequencies to Nyquist

### DIFF
--- a/.github/scripts/dpf_clap_validate.py
+++ b/.github/scripts/dpf_clap_validate.py
@@ -13,10 +13,23 @@ violating the CLAP spec. This script runs clap-validator on a built .clap and:
              explicit signature check.)
 
   ADVISORY   The rest of the clap-validator suite is run and printed, but does
-             NOT gate the build yet: TapeMachine 2 currently fails
-             process-varying-sample-rates (subnormals at extreme sample rates),
-             a separate DSP issue. Once the suite is clean, set SUITE_STRICT=1
-             to also fail on any failed test. NEVER add a per-test allowlist --
+             NOT gate the build yet. Remaining blocker, measured against
+             clap-validator 0.4.1 on 2026-08-13:
+
+               4k-eq-2        FAILS process-varying-sample-rates (NaN at
+                              1234.57 Hz) -- same root cause TapeMachine 2 had:
+                              fixed filter design frequencies are not clamped to
+                              Nyquist, so at very low host rates the RBJ/bilinear
+                              prewarp wraps and the biquads get poles outside the
+                              unit circle.
+               tapemachine-2  clean (fixed: Nyquist-guarded designers).
+               tape-echo-2    clean.
+               multi-q-2      clean (process-audio-denormals can emit a timing
+                              WARNING on a loaded machine; warnings do not affect
+                              the validator exit status, so they never gate).
+
+             Flip SUITE_STRICT=1 once 4K EQ 2 is fixed -- doing it before that
+             breaks the 4k-eq-2 matrix leg. NEVER add a per-test allowlist --
              fix the plugin, then flip SUITE_STRICT on.
 
 Usage: dpf_clap_validate.py <path-to-plugin.clap>

--- a/plugins/TapeMachine/core/TapeMachineDSP.cpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.cpp
@@ -106,7 +106,7 @@ static inline float autoCalBiasFromTypeSpeed (TapeCore::TapeType type, TapeCore:
 //==============================================================================
 void TapeMachineDSP::prepare (double sampleRate, int maxBlockSize)
 {
-    if (sampleRate <= 0.0) sampleRate = 44100.0;
+    if (! std::isfinite (sampleRate) || sampleRate <= 0.0) sampleRate = 44100.0;
     if (maxBlockSize <= 0) maxBlockSize = 512;
 
     baseSampleRate = sampleRate;

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -551,7 +551,7 @@ public:
     float calculateModulation (float wowAmount, float flutterAmount,
                                float wowRate, float flutterRate, double sampleRate)
     {
-        if (sampleRate <= 0.0) sampleRate = 44100.0;
+        if (! std::isfinite (sampleRate) || sampleRate <= 0.0) sampleRate = 44100.0;
 
         const float osScale = static_cast<float> (oversamplingFactor);
         const double safeSampleRate = std::max (1.0, sampleRate);
@@ -786,7 +786,7 @@ public:
     // osRate/osFactor = oversampled rate/factor; maxOsRate sizes the wow/flutter buffer.
     void prepare (double osRate, int osFactor, double maxOsRate)
     {
-        if (osRate <= 0.0) osRate = 44100.0;
+        if (! std::isfinite (osRate) || osRate <= 0.0) osRate = 44100.0;
         if (osFactor < 1) osFactor = 1;
 
         currentSampleRate = osRate;

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -33,6 +33,33 @@ inline float  dbToGain (float db)  noexcept { return db > -100.0f ? std::pow (10
 inline double dbToGainD(double db) noexcept { return db > -100.0  ? std::pow (10.0,  db * 0.05)  : 0.0;  }
 
 //==============================================================================
+// Nyquist guard for FIXED filter design frequencies.
+//
+// Every bilinear/RBJ design here maps the analogue corner through tan(pi*f/fs) or
+// cos/sin(2*pi*f/fs), which are only meaningful for f < fs/2. Above Nyquist the
+// prewarp wraps: sin(w0) goes negative, so alpha goes negative, so the RBJ
+// denominator (1 + alpha/A) shrinks or changes sign and the resulting poles land
+// OUTSIDE the unit circle. The filter then diverges geometrically until float
+// overflow (+/-Inf), and the next transposed-direct-form-II update evaluates
+// Inf - Inf = NaN. That is exactly what happened at low host sample rates: the
+// core runs at 2x, so an 8 kHz host gives a 16 kHz internal rate with an 8 kHz
+// Nyquist, and the hardcoded 12 kHz alias/gap-loss shelves designed poles at
+// |z| ~ 2.4 (measured), blowing the output up inside ~70 samples.
+//
+// 0.45 * fs is the SAME ceiling the code already used ad hoc (safeFreq =
+// nyquist * 0.9 in TapeCore::prepare, maxFilterFreq = fs * 0.45 in
+// updateFilters); centralising it in the designers means no call site can skip
+// it. It is a no-op for every design frequency in this plugin at any host rate
+// >= 16.67 kHz (the highest fixed corner is 15 kHz), so all standard rates from
+// 22.05 kHz up are bit-for-bit unaffected.
+inline double nyquistSafeHz (double fs, double freq) noexcept
+{
+    const double maxFreq = fs * 0.45;
+    if (! (fs > 0.0) || ! std::isfinite (freq)) return 1.0;
+    return freq < 1.0 ? 1.0 : (freq > maxFreq ? maxFreq : freq);
+}
+
+//==============================================================================
 // DBiquad — DOUBLE-precision transposed-direct-form-II biquad (double for LF high-Q stability at 4x).
 //==============================================================================
 struct DBiquadCoeffs { double b0 = 1.0, b1 = 0.0, b2 = 0.0, a1 = 0.0, a2 = 0.0; };
@@ -54,6 +81,7 @@ public:
     // juce::dsp::IIR makePeakFilter (RBJ peaking EQ, alpha = sin(w0)/(2Q)).
     static DBiquadCoeffs peak (double fs, double freq, double gainDb, double Q) noexcept
     {
+        freq = nyquistSafeHz (fs, freq);
         const double A     = std::pow (10.0, gainDb / 40.0);
         const double w0    = kTwoPiD * freq / fs;
         const double cw    = std::cos (w0), sw = std::sin (w0);
@@ -71,6 +99,7 @@ public:
     // juce::dsp::IIR makeLowPass(fs, freq, Q).
     static DBiquadCoeffs lowPass (double fs, double freq, double Q) noexcept
     {
+        freq = nyquistSafeHz (fs, freq);
         const double n   = 1.0 / std::tan (kPiD * freq / fs);
         const double nSq = n * n;
         const double invQ = 1.0 / Q;
@@ -81,6 +110,7 @@ public:
     // juce::dsp::IIR makeHighPass(fs, freq, Q).
     static DBiquadCoeffs highPass (double fs, double freq, double Q) noexcept
     {
+        freq = nyquistSafeHz (fs, freq);
         const double n   = std::tan (kPiD * freq / fs);
         const double nSq = n * n;
         const double invQ = 1.0 / Q;
@@ -93,6 +123,7 @@ public:
     // matches the reference decks, which keep a broad LF bump nearly flat to ~10-15 Hz.
     static DBiquadCoeffs highPass1 (double fs, double freq) noexcept
     {
+        freq = nyquistSafeHz (fs, freq);
         const double k = std::tan (kPiD * freq / fs);
         const double n = 1.0 / (1.0 + k);
         return { n, -n, 0.0, (k - 1.0) * n, 0.0 };
@@ -101,6 +132,7 @@ public:
     // juce::dsp::IIR makeHighShelf / makeLowShelf (RBJ, alpha = sin(w0)/(2Q)).
     static DBiquadCoeffs shelf (double fs, double freq, double gainDb, double Q, bool high) noexcept
     {
+        freq = nyquistSafeHz (fs, freq);
         const double A     = std::pow (10.0, gainDb / 40.0);
         const double w0    = kTwoPiD * freq / fs;
         const double cw    = std::cos (w0), sw = std::sin (w0);
@@ -219,6 +251,11 @@ class SaturationSplitFilter
 public:
     void prepare (double sampleRate, double cutoffHz = 5000.0)
     {
+        // Same Nyquist guard as the DBiquad designers: this RBJ lowpass has no
+        // cancelling zeros, so an above-Nyquist corner puts both poles outside the
+        // unit circle and the split filter diverges on its own (measured |z| = 1.73
+        // at a 4 kHz host rate).
+        cutoffHz = nyquistSafeHz (sampleRate, cutoffHz);
         const double w0 = 2.0 * kPiD * cutoffHz / sampleRate;
         const double cosw0 = std::cos (w0);
         const double sinw0 = std::sin (w0);
@@ -320,7 +357,11 @@ public:
                 stages[i].state = 0.0f;
                 continue;
             }
-            float tanVal = std::tan (kPiF * breakFreqs[i] / static_cast<float> (currentSampleRate));
+            // Nyquist guard: tan(pi*f/fs) diverges at f == fs/2 and passes through -1
+            // just past it, where (tanVal + 1) is 0 and the coefficient becomes Inf/NaN.
+            const float bf = static_cast<float> (nyquistSafeHz (currentSampleRate,
+                                                               static_cast<double> (breakFreqs[i])));
+            float tanVal = std::tan (kPiF * bf / static_cast<float> (currentSampleRate));
             stages[i].coeff = (tanVal - 1.0f) / (tanVal + 1.0f);
             stages[i].active = true;
         }
@@ -375,7 +416,10 @@ struct ImprovedNoiseGenerator
         tiltCoeff = 1.0f - std::exp (-2.0f * kPiF * tiltFreq / static_cast<float> (sampleRate));
         envelopeCoeff = 1.0f - std::exp (-2.0f * kPiF * 100.0f / static_cast<float> (sampleRate));
 
-        float fc = 8500.0f, Q = 1.1f;   // HF-rise "scrape" band; fills the reference hiss rise up to 10 kHz
+        // HF-rise "scrape" band; fills the reference hiss rise up to 10 kHz. Nyquist-
+        // guarded like every other fixed corner: above Nyquist this RBJ bandpass has
+        // unstable poles and the idle hiss would diverge instead of hissing.
+        float fc = static_cast<float> (nyquistSafeHz (sampleRate, 8500.0)), Q = 1.1f;
         float w0 = 2.0f * kPiF * fc / static_cast<float> (sampleRate);
         float cosw0 = std::cos (w0), sinw0 = std::sin (w0);
         float alpha = sinw0 / (2.0f * Q);
@@ -1989,7 +2033,11 @@ private:
         float biasFreq, biasGainDb;
         if (machine == Swiss) { biasFreq = 8000.0f; biasGainDb = -(biasAmount - 0.5f) * 8.0f + 1.0f; }
         else                     { biasFreq = 7000.0f; biasGainDb = (0.5f - biasAmount) * 5.0f + 1.5f; }
-        biasFilter.setCoeffs (Biquad::shelf (currentSampleRate, biasFreq, biasGainDb, 0.707f, true));
+        // Nyquist-guarded at the call site: Biquad (shared DuskFilters.hpp) is used by the
+        // other DPF plugins too, so the clamp lives here rather than in the shared designer.
+        biasFilter.setCoeffs (Biquad::shelf (currentSampleRate,
+            static_cast<float> (nyquistSafeHz (currentSampleRate, static_cast<double> (biasFreq))),
+            biasGainDb, 0.707f, true));
 
         // DC blocker: 1st-order (6 dB/oct). Both reference decks keep a broad LF head bump nearly
         // flat down to ~10-15 Hz, then roll off gently below — a 2nd-order Butterworth corner


### PR DESCRIPTION
Part of #137.

TapeMachine 2 emitted NaN at low host sample rates because eleven filter design frequencies were hardcoded above the internal Nyquist. The tape core runs at a fixed 2x internal rate, so an 8 kHz host gives a 16 kHz internal rate with an 8 kHz Nyquist; the RBJ/bilinear prewarp is only valid below fs/2, and past it sin(w0) goes negative, alpha goes negative, and the poles land outside the unit circle. State grows geometrically until float overflow, and the next TDF-II update evaluates Inf - Inf = NaN. The divergence is input-independent, which is why clap-validator reported NaN at sample index 67 regardless of input.

Affected with default params at an 8 kHz host: aliasHfPre/Post (12 kHz corner, pole radius 2.449), gapLossFilter at 15 IPS (12 kHz, 2.412), reproHfShelf (9 kHz, 1.446). Rates from 4 kHz to just under 16 kHz are affected; presets widen the failing set down to 1 kHz. Several more corners were latent (SaturationSplitFilter 5 kHz, noise scrape BP 8.5 kHz, PhaseSmearingFilter allpass tan pole, biasFilter, level/preset/prog EQ corners).

Fix: a nyquistSafeHz clamp (floor first, ceiling last, 0.45 fs) applied inside every DBiquad designer so no call site can bypass it, plus the fixed corners that do not route through DBiquad. 0.45 fs is the ceiling the code already used ad hoc; the clamp is inert at any host rate from 16.67 kHz up.

Evidence:
- clap-validator 0.4.1 process-varying-sample-rates: fail before, pass after; full suite 33 passed, 0 failed, 0 warnings.
- Offline sweep, 60,030 configurations (1 kHz-768 kHz including fractional, all factory presets, all machine/speed/type/EQ combinations, adversarial corners): 0 non-finite, 0 subnormal. Pre-fix control: 40+ failures.
- Byte-compare matrix, 9 rates x 5 configs vs main: 43/45 identical; the two diffs are 30 IPS presets at a 16 kHz host rate only, max diff 4.5e-4 (70 dB below signal), where the 15 kHz corner sat at 0.94x Nyquist and produced cramped output anyway. Everything at 22.05 kHz and above is byte-identical.

The CLAP validation gate stays advisory in this PR; the strict flip lands in the follow-up PR stacked on this branch, together with the shared-designer clamp that fixes the remaining blocker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TapeMachine processing at extreme sample rates by preventing filter settings from exceeding safe frequency limits.
  - Increased stability across saturation, phase, noise, bias, and tone-shaping stages.
  - Resolved validation issues affecting 4K EQ 2 at extreme sample rates.

- **Quality Improvements**
  - Confirmed TapeMachine 2, Tape Echo 2, and Multi-Q 2 remain clean or non-gating in validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->