### PR TITLE
fix(shared-dpf): Nyquist-clamp all shared designers and make the CLAP gate strict

### DIFF
--- a/.github/scripts/dpf_clap_validate.py
+++ b/.github/scripts/dpf_clap_validate.py
@@ -12,25 +12,31 @@ violating the CLAP spec. This script runs clap-validator on a built .clap and:
              fail any test, so the exit code alone would miss it -- hence the
              explicit signature check.)
 
-  ADVISORY   The rest of the clap-validator suite is run and printed, but does
-             NOT gate the build yet. Remaining blocker, measured against
-             clap-validator 0.4.1 on 2026-08-13:
+  SUITE      Every other clap-validator test also gates the build, because the
+             workflow now sets SUITE_STRICT=1. Measured against clap-validator
+             0.4.1 on 2026-08-13, all four DPF plugins are clean:
 
-               4k-eq-2        FAILS process-varying-sample-rates (NaN at
-                              1234.57 Hz) -- same root cause TapeMachine 2 had:
-                              fixed filter design frequencies are not clamped to
-                              Nyquist, so at very low host rates the RBJ/bilinear
-                              prewarp wraps and the biquads get poles outside the
-                              unit circle.
-               tapemachine-2  clean (fixed: Nyquist-guarded designers).
-               tape-echo-2    clean.
-               multi-q-2      clean (process-audio-denormals can emit a timing
-                              WARNING on a loaded machine; warnings do not affect
-                              the validator exit status, so they never gate).
+               tapemachine-2  exit 0, 33 passed, 0 failed
+               4k-eq-2        exit 0, 33 passed, 0 failed
+               tape-echo-2    exit 0, 33 passed, 0 failed
+               multi-q-2      exit 0, 33 passed, 0 failed
 
-             Flip SUITE_STRICT=1 once 4K EQ 2 is fixed -- doing it before that
-             breaks the 4k-eq-2 matrix leg. NEVER add a per-test allowlist --
-             fix the plugin, then flip SUITE_STRICT on.
+             Both of the process-varying-sample-rates failures that kept this
+             advisory (TapeMachine 2 at 8 kHz, 4K EQ 2 at 1234.57 Hz) had the same
+             root cause: filter design frequencies were not clamped to Nyquist, so
+             at low host rates the RBJ/bilinear prewarp wrapped and the biquads got
+             poles outside the unit circle. Fixed in the DBiquad designers and in
+             the shared duskaudio::Biquad designers respectively.
+
+             process-audio-denormals can emit a timing WARNING on a loaded machine.
+             That is fine: timing warnings do not affect the validator exit status
+             and carry no gated signature, so they never gate. Note this is NOT a
+             general property of warnings, the latency check below deliberately
+             hard-fails on a WARNING by scanning for its signature.
+
+             If a plugin ever has to be exempted, gate per plugin rather than
+             returning the whole matrix to advisory. NEVER add a per-test
+             allowlist -- fix the plugin instead.
 
 Usage: dpf_clap_validate.py <path-to-plugin.clap>
 Env:

--- a/.github/scripts/dpf_clap_validate.py
+++ b/.github/scripts/dpf_clap_validate.py
@@ -13,13 +13,14 @@ violating the CLAP spec. This script runs clap-validator on a built .clap and:
              explicit signature check.)
 
   SUITE      Every other clap-validator test also gates the build, because the
-             workflow now sets SUITE_STRICT=1. Measured against clap-validator
-             0.4.1 on 2026-08-13, all four DPF plugins are clean:
+             workflow sets SUITE_STRICT=1. Failure is decided by BOTH the reported
+             failure tally and the process exit code, since the latency case above
+             is proof that the exit code alone can miss a real regression.
 
-               tapemachine-2  exit 0, 33 passed, 0 failed
-               4k-eq-2        exit 0, 33 passed, 0 failed
-               tape-echo-2    exit 0, 33 passed, 0 failed
-               multi-q-2      exit 0, 33 passed, 0 failed
+             CI is the source of truth for which plugins currently pass. No pass
+             counts are recorded here on purpose: they are a property of the
+             validator version as much as of the plugins, and a baked-in tally rots
+             silently into a lie the next time either moves.
 
              Both of the process-varying-sample-rates failures that kept this
              advisory (TapeMachine 2 at 8 kHz, 4K EQ 2 at 1234.57 Hz) had the same
@@ -29,9 +30,9 @@ violating the CLAP spec. This script runs clap-validator on a built .clap and:
              the shared duskaudio::Biquad designers respectively.
 
              process-audio-denormals can emit a timing WARNING on a loaded machine.
-             That is fine: timing warnings do not affect the validator exit status
-             and carry no gated signature, so they never gate. Note this is NOT a
-             general property of warnings, the latency check below deliberately
+             That one does not gate: it sets no failure tally and no exit code, and
+             it carries no gated signature. That is specific to timing warnings, NOT
+             a general property of warnings, the latency check above deliberately
              hard-fails on a WARNING by scanning for its signature.
 
              If a plugin ever has to be exempted, gate per plugin rather than
@@ -44,10 +45,15 @@ Env:
                           (Linux ARM64 has no prebuilt: cargo-install and point
                           this at it, or put clap-validator on PATH).
   CLAP_VALIDATOR_VERSION  Release tag to download (default 0.4.1).
-  SUITE_STRICT=1          Also fail the build on any failed validator test.
+  SUITE_STRICT=1          Also fail the build on any failed validator test. The
+                          workflow sets this; unset it (or set 0) only for a local
+                          advisory run. Unset, empty and whitespace-only all mean
+                          advisory. Any OTHER unrecognized value is an error rather
+                          than a silent fallback to advisory.
 """
 import glob
 import hashlib
+import re
 import os
 import platform
 import shutil
@@ -80,6 +86,54 @@ RUN_TIMEOUT_S = 600
 
 def log(msg):
     print(msg, flush=True)
+
+
+def _suite_strict():
+    """True when SUITE_STRICT asks for strict mode; exits on an unrecognized value.
+
+    Fails CLOSED on a value it cannot read. The obvious way to write this is
+    `os.environ.get(...) == "1"`, which silently drops the whole matrix back to
+    advisory the day somebody sets SUITE_STRICT: "true" in the workflow. A gate that
+    quietly stops gating is worse than no gate, so anything not clearly on or off is
+    an error -- with one deliberate exception: unset, empty and whitespace-only all
+    mean "not configured" and yield advisory, because an unset GHA expression
+    interpolates to the empty string and that is an absent setting, not a typo.
+    """
+    raw = os.environ.get("SUITE_STRICT")
+    # UNSET and EMPTY are the same thing, and whitespace-only counts as empty.
+    # `env: SUITE_STRICT: ${{ ... }}` with an unset expression interpolates to the
+    # empty string, which is a configuration that never reached this script rather
+    # than a value someone typed. Erroring on it would break the workflow for a
+    # non-decision; erroring on "maybe" catches a real one.
+    value = (raw or "").strip().lower()
+    if value == "":
+        return False
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value in ("0", "false", "no", "off"):
+        return False
+    log(f"::error::SUITE_STRICT is set to {raw!r}, which is neither on nor off. "
+        "Use 1 or 0 (true/false, yes/no and on/off are also accepted). Refusing to "
+        "guess, because guessing wrong silently disables the suite gate.")
+    sys.exit(2)
+
+
+def _parse_failed_count(output):
+    """Pull the failure tally out of clap-validator's summary line.
+
+    The line looks like: '44 tests run, 33 passed, 0 failed, 0 warnings, 11 skipped'.
+    Returns None when no summary is found, which the caller treats as "no tally
+    signal" rather than as a pass, so a format change degrades to the exit code
+    instead of silently reporting success.
+    """
+    matches = re.findall(r"(\d+)\s+failed", _strip_ansi(output))
+    if not matches:
+        return None
+    return max(int(m) for m in matches)
+
+
+def _strip_ansi(text):
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 def _asset_name():
@@ -212,6 +266,12 @@ def main():
         log(f"::error::plugin not found: {clap}")
         sys.exit(2)
 
+    # Resolve SUITE_STRICT UP FRONT, not lazily inside the failure branch. Checking
+    # it only when the suite already failed means a misconfigured value sails
+    # through every green run and is discovered on the day it matters least.
+    strict = _suite_strict()
+    log(f"suite gate: {'STRICT' if strict else 'ADVISORY'}")
+
     workdir = tempfile.mkdtemp(prefix="clapval_")
     try:
         vbin = resolve_binary(workdir)
@@ -241,10 +301,22 @@ def main():
                 "regressed. Check DPF_REF against dusk-audio/DPF main.")
             sys.exit(1)
 
-        # ADVISORY (or strict) on the remaining suite.
-        if proc.returncode != 0:
-            if os.environ.get("SUITE_STRICT") == "1":
-                log("::error::clap-validator reported failing tests (SUITE_STRICT=1).")
+        # STRICT (or advisory) on the remaining suite.
+        #
+        # Do NOT trust the exit code alone. This script exists because a
+        # clap-validator WARNING can carry a real regression while leaving the exit
+        # code at 0 (the latency contract above is exactly that case), so keying the
+        # suite gate purely on returncode repeats the mistake one level up. Parse the
+        # reported failure tally as well and fail on either signal: the tally catches
+        # a failing test that somehow exits 0, the returncode catches a crash or a
+        # timeout that never prints a tally.
+        failed = _parse_failed_count(out)
+        suite_bad = proc.returncode != 0 or (failed is not None and failed > 0)
+
+        if suite_bad:
+            if strict:
+                log(f"::error::clap-validator reported failing tests "
+                    f"(SUITE_STRICT=1; failed={failed}, exit={proc.returncode}).")
                 sys.exit(proc.returncode or 1)
             log("::warning::clap-validator reported failing tests (advisory -- not "
                 "gating). Fix the suite, then set SUITE_STRICT=1. Latency contract PASSED.")

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -46,6 +46,9 @@ on:
       - 'plugins/*/core/**'
       - 'plugins/shared-dpf/**'
       - '.github/workflows/dpf-build.yml'
+      # The gate scripts this workflow runs. Without this a PR that only edits
+      # dpf_clap_validate.py never runs the gate it just changed.
+      - '.github/scripts/**'
 
 # DPF is our fork (dusk-audio/DPF), branch main — the permanent source of truth
 # for our DPF patches (CLAP latency changes constrained to activate(), AU

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -310,11 +310,18 @@ jobs:
 
       - name: Validate CLAP (clap-validator gate)
         working-directory: ${{ env.PLUGIN_DIR }}
+        env:
+          # STRICT: any failing clap-validator test fails the build, on top of the
+          # DPF CLAP latency hard gate (clap_host_latency::changed outside
+          # clap_plugin::activate()). All four DPF plugins run clean as of the
+          # Nyquist design-frequency clamp, so there is nothing left to be advisory
+          # about. If this ever needs backing off, gate per plugin rather than
+          # returning the whole matrix to advisory, and NEVER add a per-test
+          # allowlist (see .github/scripts/dpf_clap_validate.py).
+          SUITE_STRICT: "1"
         run: |
-          # Hard-fail on a DPF CLAP latency regression (clap_host_latency::changed
-          # outside clap_plugin::activate()); the rest of the suite is advisory for
-          # now (see .github/scripts/dpf_clap_validate.py). xvfb: clap-validator
-          # drives the plugin GUI, which needs an X display in this headless container.
+          # xvfb: clap-validator drives the plugin GUI, which needs an X display in
+          # this headless container.
           xvfb-run -a python3 "${GITHUB_WORKSPACE}/.github/scripts/dpf_clap_validate.py" \
             "build/bin/${PLUGIN_BASE}.clap"
 

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -46,9 +46,13 @@ inline double dbToGainD(double db) noexcept { return db > -100.0  ? std::pow (10
 // Nyquist, and the hardcoded 12 kHz alias/gap-loss shelves designed poles at
 // |z| ~ 2.4 (measured), blowing the output up inside ~70 samples.
 //
-// 0.45 * fs is the SAME ceiling this file already used ad hoc, in two now-deleted
-// places (safeFreq = nyquist * 0.9 in TapeCore::prepare, which is bitwise equal to
-// osRate * 0.45 in double; and maxFilterFreq = fs * 0.45 in updateFilters). This
+// kTapeDesignFreqRatio is the SAME ceiling this file already used ad hoc, in two
+// now-deleted places (safeFreq = nyquist * 0.9 in TapeCore::prepare; maxFilterFreq
+// = fs * 0.45 in updateFilters). (osRate*0.5)*0.9 and osRate*0.45 agree bitwise in
+// double, but safeFreq then narrowed to FLOAT, so the old effective ceiling was
+// double(float(osRate*0.45)) and can differ from this one by an ulp. That only
+// matters where the ceiling actually engages, which for the corners it wrapped
+// means host rates below 17.8 kHz, outside the byte-compare matrix. This
 // helper is now the SINGLE clamp mechanism for every DBiquad design in the file:
 // centralising it in the designers means no call site can skip it. The shared
 // duskaudio::Biquad designers (DuskFilters.hpp) carry their own internal clamp at
@@ -75,12 +79,15 @@ inline double dbToGainD(double db) noexcept { return db > -100.0  ? std::pow (10
 // 44100 before any designer runs, and validating it here would be theatre anyway:
 // fs is a divisor in every designer below, so a bad fs yields NaN coefficients no
 // matter what frequency this returns.
+constexpr double kTapeDesignFreqRatio = 0.45;
+
 inline double nyquistSafeHz (double fs, double freq) noexcept
 {
-    // Floor FIRST, ceiling LAST. The reverse order lets the 1 Hz floor win at
-    // absurdly low fs and hand back a corner at or above Nyquist, which is the
-    // exact instability this guard exists to prevent.
-    return std::min (fs * 0.45, std::max (freq, 1.0));
+    // Thin alias over the shared primitive so there is ONE implementation of the
+    // floor-first/ceiling-last ordering in the codebase. The ordering matters: the
+    // reverse lets the 1 Hz floor win at absurdly low fs and hand back a corner at
+    // or above Nyquist, the exact instability this guard exists to prevent.
+    return nyquistSafeDesignHzD (fs, freq, kTapeDesignFreqRatio);
 }
 
 //==============================================================================
@@ -842,9 +849,11 @@ public:
         reset();
 
         // The safeFreq lambda that used to wrap every corner below is gone: DBiquad's
-        // designers now clamp internally at the same 0.45 ceiling ((osRate*0.5)*0.9 is
-        // bitwise equal to osRate*0.45 in double), so wrapping the call sites as well
-        // was a second ceiling that could drift out of step with the first.
+        // designers now clamp internally at the same 0.45 ceiling, so wrapping the
+        // call sites as well was a second ceiling that could drift out of step with
+        // the first. The old lambda narrowed the ceiling to float before comparing,
+        // so the two can differ by an ulp, but only at host rates below 17.8 kHz
+        // where these corners actually reach the ceiling.
         headBumpFilter.setCoeffs (DBiquad::peak (osRate, 60.0, 3.0, 1.5));
         hfLossFilter1.setCoeffs  (DBiquad::lowPass (osRate, 16000.0, 0.707));
         hfLossFilter2.setCoeffs  (DBiquad::shelf (osRate, 10000.0, -2.0, 0.5, true));
@@ -882,7 +891,14 @@ public:
         emphLfPost.setCoeffs (DBiquad::shelf (osRate, 150.0, 0.0, 0.5, false));
         aliasHfPre.setCoeffs  (DBiquad::shelf (osRate, 12000.0, 0.0, 0.7, true));
         aliasHfPost.setCoeffs (DBiquad::shelf (osRate, 12000.0, 0.0, 0.7, true));
-        biasFilter.setCoeffs     (Biquad::shelf (osRate, 8000.0f, 2.0f, 0.707f, true));
+        // Explicit 0.45 cap, same reason as recordHeadCutoff below: biasFilter is the
+        // SHARED Biquad, whose ceiling is 0.4998, not this core's 0.45. Practical
+        // impact is nil because updateFilters overwrites these coeffs on the first
+        // processed block, but leaving it uncapped would make this file state a rule
+        // (shared-Biquad sites keep an explicit cap) that it then breaks ten lines up.
+        biasFilter.setCoeffs     (Biquad::shelf (osRate,
+            std::min (8000.0f, static_cast<float> (osRate * kTapeDesignFreqRatio)),
+            2.0f, 0.707f, true));
         dcBlocker.setCoeffs      (DBiquad::highPass1 (osRate, 18.0));
 
         // recordHeadCutoff keeps an EXPLICIT 0.45 cap rather than leaning on the
@@ -892,7 +908,7 @@ public:
         // 0.4998 of osRate wherever 20 kHz exceeds it (host rates below 22.2 kHz),
         // which changes the voicing at 22.05 kHz. The cap is part of the tuning; the
         // shared designer's clamp is only a stability backstop underneath it.
-        recordHeadCutoff = std::min (20000.0f, static_cast<float> (osRate * 0.45));
+        recordHeadCutoff = std::min (20000.0f, static_cast<float> (osRate * kTapeDesignFreqRatio));
         recordHeadFilter1.setCoeffs (Biquad::lowPass (osRate, recordHeadCutoff, 1.3066f));
         recordHeadFilter2.setCoeffs (Biquad::lowPass (osRate, recordHeadCutoff, 0.5412f));
 
@@ -2022,12 +2038,16 @@ private:
                   : (speed == Speed_7_5_IPS) ? 1.10f : (speed == Speed_30_IPS ? 1.50f : 1.5f);
         float hfCutoff = machineChars.hfRolloffFreq * hfExt * tapeChars.hfLoss;
         // LOAD-BEARING, do not delete as "redundant with the designer clamp". It is
-        // not redundant: hfShelfFreq below is derived as hfCutoff * 0.6, so this
-        // clamp changes a DOWNSTREAM corner, not just the one designed on the next
-        // line. Removing it moved the 3.75-IPS shelf from 0.45*fs*0.6 to the raw
-        // 0.6 * 31.7 kHz and broke byte-identity at 22.05 kHz and 32 kHz (measured,
-        // not theorised). The designer's internal clamp still backstops this line.
-        hfCutoff = std::min (hfCutoff, static_cast<float> (currentSampleRate * 0.45));
+        // not redundant: the non-3.75-IPS branch below derives hfShelfFreq as
+        // hfCutoff * 0.6, so this clamp sets a DOWNSTREAM corner as well as the one
+        // designed on the next line. (The 3.75-IPS branch takes a fixed 11 kHz
+        // literal and never reads hfCutoff, so that speed shows nothing.) The case
+        // that breaks is Swiss at 15 or 30 IPS, where hfRolloffFreq 22000 * hfExt 1.5
+        // * hfLoss lands near 31.7 kHz: removing this clamp moved the shelf from
+        // 0.45*fs*0.6 to 0.6 * the raw 31.7 kHz and broke byte-identity at 22.05 kHz
+        // and 32 kHz. Measured, not theorised. The designer's internal clamp still
+        // backstops the line below.
+        hfCutoff = std::min (hfCutoff, static_cast<float> (currentSampleRate * kTapeDesignFreqRatio));
         hfLossFilter1.setCoeffs (DBiquad::lowPass (currentSampleRate, static_cast<double> (hfCutoff), 0.707));
 
         // American tracks nearly flat to ~15 kHz, so American's HF-loss shelves are scaled right down.
@@ -2066,8 +2086,7 @@ private:
             const double hwGain = (headWidth == 0) ? 2.5   // 1/4"
                                 : (headWidth == 2) ? 3.2   // 1"
                                 : 0.0;                     // 1/2" (neutral)
-            headWidthFilter.setCoeffs (DBiquad::peak (currentSampleRate,
-                std::min (7500.0, currentSampleRate * 0.45), hwGain, 0.9));
+            headWidthFilter.setCoeffs (DBiquad::peak (currentSampleRate, 7500.0, hwGain, 0.9));
         }
 
         float gapLossFreq = speed == Speed_3_75_IPS ? 5000.0f

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -46,17 +46,41 @@ inline double dbToGainD(double db) noexcept { return db > -100.0  ? std::pow (10
 // Nyquist, and the hardcoded 12 kHz alias/gap-loss shelves designed poles at
 // |z| ~ 2.4 (measured), blowing the output up inside ~70 samples.
 //
-// 0.45 * fs is the SAME ceiling the code already used ad hoc (safeFreq =
-// nyquist * 0.9 in TapeCore::prepare, maxFilterFreq = fs * 0.45 in
-// updateFilters); centralising it in the designers means no call site can skip
-// it. It is a no-op for every design frequency in this plugin at any host rate
-// >= 16.67 kHz (the highest fixed corner is 15 kHz), so all standard rates from
-// 22.05 kHz up are bit-for-bit unaffected.
+// 0.45 * fs is the SAME ceiling this file already used ad hoc, in two now-deleted
+// places (safeFreq = nyquist * 0.9 in TapeCore::prepare, which is bitwise equal to
+// osRate * 0.45 in double; and maxFilterFreq = fs * 0.45 in updateFilters). This
+// helper is now the SINGLE clamp mechanism for every DBiquad design in the file:
+// centralising it in the designers means no call site can skip it. The shared
+// duskaudio::Biquad designers (DuskFilters.hpp) carry their own internal clamp at
+// their own ceiling, so the four Biquad sites here are covered too.
+//
+// The ceiling is NOT the 0.4998 used by the shared Biquad, and the two must not be
+// "harmonized": that one sits behind user-facing EQs whose bands reach 20 kHz and
+// has to stay above 0.4535 of fs, while this core runs at 2x the host rate where
+// even its highest corner has enormous margin. See DuskFilters.hpp for that side.
+//
+// Where the clamp actually engages, given this core runs at osRate = 2 * host rate:
+//   - fixed corners top out at 16 kHz (hfLossFilter1), which needs osRate < 35.6 kHz
+//     to clamp, i.e. a host rate below 17.8 kHz;
+//   - the COMPUTED hfCutoff (hfRolloffFreq * hfExt * hfLoss) reaches ~31.7 kHz, which
+//     needs osRate < 70.4 kHz, i.e. a host rate below 35.2 kHz. That path keeps its
+//     own float pre-clamp (see updateFilters) for bit-exactness reasons documented
+//     there; this helper is its backstop, not its primary ceiling.
+//   - recordHeadCutoff's 20 kHz likewise keeps an explicit 0.45 cap, because it feeds
+//     the SHARED Biquad whose ceiling is 0.4998 and the cap is part of the voicing.
+// Everything else is untouched at every standard rate, so renders at 22.05 kHz and
+// above are bit-for-bit unaffected (verified by byte-compare, not by inspection).
+//
+// PRECONDITION: fs is positive and finite. prepare() coerces a non-positive rate to
+// 44100 before any designer runs, and validating it here would be theatre anyway:
+// fs is a divisor in every designer below, so a bad fs yields NaN coefficients no
+// matter what frequency this returns.
 inline double nyquistSafeHz (double fs, double freq) noexcept
 {
-    const double maxFreq = fs * 0.45;
-    if (! (fs > 0.0) || ! std::isfinite (freq)) return 1.0;
-    return freq < 1.0 ? 1.0 : (freq > maxFreq ? maxFreq : freq);
+    // Floor FIRST, ceiling LAST. The reverse order lets the 1 Hz floor win at
+    // absurdly low fs and hand back a corner at or above Nyquist, which is the
+    // exact instability this guard exists to prevent.
+    return std::min (fs * 0.45, std::max (freq, 1.0));
 }
 
 //==============================================================================
@@ -179,8 +203,12 @@ public:
 
     void prepare (double sampleRate, double cutoffHz)
     {
-        cutoffHz = std::min (cutoffHz, sampleRate * 0.45);
-        cutoffHz = std::max (cutoffHz, 20.0);
+        // This class designs its own Chebyshev sections rather than going through
+        // DBiquad, so it applies the shared ceiling itself. Floor first, ceiling
+        // last (via the helper): the old order applied the 20 Hz floor AFTER the
+        // ceiling, so below fs 44.4 Hz the floor won and handed the design a corner
+        // above Nyquist. Identical at every rate at or above that.
+        cutoffHz = nyquistSafeHz (sampleRate, std::max (cutoffHz, 20.0));
 
         constexpr int N = 8;
         constexpr double rippleDb = 0.5;
@@ -357,10 +385,12 @@ public:
                 stages[i].state = 0.0f;
                 continue;
             }
-            // Nyquist guard: tan(pi*f/fs) diverges at f == fs/2 and passes through -1
-            // just past it, where (tanVal + 1) is 0 and the coefficient becomes Inf/NaN.
-            const float bf = static_cast<float> (nyquistSafeHz (currentSampleRate,
-                                                               static_cast<double> (breakFreqs[i])));
+            // Nyquist guard. tan(pi*f/fs) diverges AT f == fs/2, and the whole band
+            // above it is unusable: the coefficient goes below -1, then at f ==
+            // 0.75*fs the (tanVal + 1) divisor is exactly 0 (Inf/NaN), then it comes
+            // back marginal. The hazard is the entire region past Nyquist, not a
+            // narrow neighbourhood of fs/2, so do not relax the ceiling toward 0.49.
+            const float bf = static_cast<float> (nyquistSafeHz (currentSampleRate, breakFreqs[i]));
             float tanVal = std::tan (kPiF * bf / static_cast<float> (currentSampleRate));
             stages[i].coeff = (tanVal - 1.0f) / (tanVal + 1.0f);
             stages[i].active = true;
@@ -419,7 +449,8 @@ struct ImprovedNoiseGenerator
         // HF-rise "scrape" band; fills the reference hiss rise up to 10 kHz. Nyquist-
         // guarded like every other fixed corner: above Nyquist this RBJ bandpass has
         // unstable poles and the idle hiss would diverge instead of hissing.
-        float fc = static_cast<float> (nyquistSafeHz (sampleRate, 8500.0)), Q = 1.1f;
+        const float fc = static_cast<float> (nyquistSafeHz (sampleRate, 8500.0));
+        const float Q  = 1.1f;
         float w0 = 2.0f * kPiF * fc / static_cast<float> (sampleRate);
         float cosw0 = std::cos (w0), sinw0 = std::sin (w0);
         float alpha = sinw0 / (2.0f * Q);
@@ -810,20 +841,20 @@ public:
 
         reset();
 
-        auto nyquist = osRate * 0.5;
-        auto safeMaxFreq = nyquist * 0.9;
-        auto safeFreq = [safeMaxFreq] (float freq) { return std::min (freq, static_cast<float> (safeMaxFreq)); };
-
+        // The safeFreq lambda that used to wrap every corner below is gone: DBiquad's
+        // designers now clamp internally at the same 0.45 ceiling ((osRate*0.5)*0.9 is
+        // bitwise equal to osRate*0.45 in double), so wrapping the call sites as well
+        // was a second ceiling that could drift out of step with the first.
         headBumpFilter.setCoeffs (DBiquad::peak (osRate, 60.0, 3.0, 1.5));
-        hfLossFilter1.setCoeffs  (DBiquad::lowPass (osRate, static_cast<double> (safeFreq (16000.0f)), 0.707));
-        hfLossFilter2.setCoeffs  (DBiquad::shelf (osRate, static_cast<double> (safeFreq (10000.0f)), -2.0, 0.5, true));
-        gapLossFilter.setCoeffs  (DBiquad::shelf (osRate, static_cast<double> (safeFreq (12000.0f)), -1.5, 0.707, true));
-        headWidthFilter.setCoeffs (DBiquad::peak (osRate, static_cast<double> (safeFreq (7500.0f)), 0.0, 0.9)); // neutral until updateFilters
-        driveHfShelf.setCoeffs   (DBiquad::shelf (osRate, static_cast<double> (safeFreq (2500.0f)), 0.0, 0.5, true)); // neutral until setDriveHfComp
-        levelHfShelf.setCoeffs   (DBiquad::shelf (osRate, static_cast<double> (safeFreq (7900.0f)), 0.0, 0.45, true)); // neutral until setLevelComp
+        hfLossFilter1.setCoeffs  (DBiquad::lowPass (osRate, 16000.0, 0.707));
+        hfLossFilter2.setCoeffs  (DBiquad::shelf (osRate, 10000.0, -2.0, 0.5, true));
+        gapLossFilter.setCoeffs  (DBiquad::shelf (osRate, 12000.0, -1.5, 0.707, true));
+        headWidthFilter.setCoeffs (DBiquad::peak (osRate, 7500.0, 0.0, 0.9)); // neutral until updateFilters
+        driveHfShelf.setCoeffs   (DBiquad::shelf (osRate, 2500.0, 0.0, 0.5, true)); // neutral until setDriveHfComp
+        levelHfShelf.setCoeffs   (DBiquad::shelf (osRate, 7900.0, 0.0, 0.45, true)); // neutral until setLevelComp
         levelLfShelf.setCoeffs   (DBiquad::peak  (osRate,   32.0, 0.0, 1.4)); // neutral until setLevelComp
-        presetLevelHmfPeak.setCoeffs (DBiquad::peak  (osRate, static_cast<double> (safeFreq (6300.0f)),  0.0, 1.0));
-        presetLevelHfShelf.setCoeffs (DBiquad::shelf (osRate, static_cast<double> (safeFreq (11000.0f)), 0.0, 0.7, true));
+        presetLevelHmfPeak.setCoeffs (DBiquad::peak  (osRate, 6300.0,  0.0, 1.0));
+        presetLevelHfShelf.setCoeffs (DBiquad::shelf (osRate, 11000.0, 0.0, 0.7, true));
         // The two lines above reinstalled NEUTRAL preset-EQ coeffs. Invalidate the rebuild
         // cache so the next setPresetLevelEq() re-applies the active preset correction (at the
         // new fs) even when the preset params are unchanged — otherwise its "hmfDb/hfDb changed"
@@ -837,24 +868,31 @@ public:
         progLastHmf = progLastHf = 999.0f;
         reproLfShelf.setCoeffs   (DBiquad::shelf (osRate,   80.0, 0.0, 0.5, false)); // 4-band repro EQ, neutral until setReproEq
         reproLmfPeak.setCoeffs   (DBiquad::peak  (osRate,  160.0, 0.0, 0.9));
-        reproHmfPeak.setCoeffs   (DBiquad::peak  (osRate, static_cast<double> (safeFreq (5000.0f)), 0.0, 0.8));
-        reproHfShelf.setCoeffs   (DBiquad::shelf (osRate, static_cast<double> (safeFreq (9000.0f)), 0.0, 0.5, true));
+        reproHmfPeak.setCoeffs   (DBiquad::peak  (osRate, 5000.0, 0.0, 0.8));
+        reproHfShelf.setCoeffs   (DBiquad::shelf (osRate, 9000.0, 0.0, 0.5, true));
         reproSubBellPeak.setCoeffs (DBiquad::peak (osRate, 31.0, 0.0, 2.5)); reproSubBellActive = false; // neutral until setReproEq
         reproSubBellLast = 999.0f;   // invalidate rebuild cache (same fs-staleness fix as progLast above)
         slowModernPresencePeak.setCoeffs (DBiquad::peak (osRate,
-            static_cast<double> (safeFreq (2700.0f)), 0.0, 1.6));
+            2700.0, 0.0, 1.6));
         transformerLfShelf.setCoeffs (DBiquad::shelf (osRate, 48.0, 0.0, 0.7, false)); // neutral until setTransformerOff
         // Emphasis-rebalance G / 1-G pair — neutral defaults; updateFilters sets the per-machine values.
         emphLfPre.setCoeffs  (DBiquad::shelf (osRate, 150.0, 0.0, 0.5, false));
-        emphHfPre.setCoeffs  (DBiquad::peak  (osRate, static_cast<double> (safeFreq (5000.0f)), 0.0, 2.0));
-        emphHfPost.setCoeffs (DBiquad::peak  (osRate, static_cast<double> (safeFreq (5000.0f)), 0.0, 2.0));
+        emphHfPre.setCoeffs  (DBiquad::peak  (osRate, 5000.0, 0.0, 2.0));
+        emphHfPost.setCoeffs (DBiquad::peak  (osRate, 5000.0, 0.0, 2.0));
         emphLfPost.setCoeffs (DBiquad::shelf (osRate, 150.0, 0.0, 0.5, false));
-        aliasHfPre.setCoeffs  (DBiquad::shelf (osRate, static_cast<double> (safeFreq (12000.0f)), 0.0, 0.7, true));
-        aliasHfPost.setCoeffs (DBiquad::shelf (osRate, static_cast<double> (safeFreq (12000.0f)), 0.0, 0.7, true));
-        biasFilter.setCoeffs     (Biquad::shelf (osRate, safeFreq (8000.0f), 2.0f, 0.707f, true));
+        aliasHfPre.setCoeffs  (DBiquad::shelf (osRate, 12000.0, 0.0, 0.7, true));
+        aliasHfPost.setCoeffs (DBiquad::shelf (osRate, 12000.0, 0.0, 0.7, true));
+        biasFilter.setCoeffs     (Biquad::shelf (osRate, 8000.0f, 2.0f, 0.707f, true));
         dcBlocker.setCoeffs      (DBiquad::highPass1 (osRate, 18.0));
 
-        recordHeadCutoff = std::min (20000.0f, static_cast<float> (safeMaxFreq));
+        // recordHeadCutoff keeps an EXPLICIT 0.45 cap rather than leaning on the
+        // designer clamp, and that is deliberate, not a leftover: these two filters
+        // are the SHARED duskaudio::Biquad, whose ceiling is 0.4998, not 0.45.
+        // Dropping the cap here would raise the record-head corner from 0.45 to
+        // 0.4998 of osRate wherever 20 kHz exceeds it (host rates below 22.2 kHz),
+        // which changes the voicing at 22.05 kHz. The cap is part of the tuning; the
+        // shared designer's clamp is only a stability backstop underneath it.
+        recordHeadCutoff = std::min (20000.0f, static_cast<float> (osRate * 0.45));
         recordHeadFilter1.setCoeffs (Biquad::lowPass (osRate, recordHeadCutoff, 1.3066f));
         recordHeadFilter2.setCoeffs (Biquad::lowPass (osRate, recordHeadCutoff, 0.5412f));
 
@@ -1965,7 +2003,13 @@ private:
             static_cast<double> (headBumpFreq), static_cast<double> (headBumpGain),
             static_cast<double> (headBumpQ)));
 
-        float maxFilterFreq = static_cast<float> (currentSampleRate * 0.45);
+        // The maxFilterFreq pre-clamp that used to guard the four corners below is
+        // gone: DBiquad clamps at the same 0.45 ceiling internally. Checked that the
+        // removal is bit-exact rather than assumed: the old path took
+        // float(currentSampleRate * 0.45) while the new one clamps in double, and
+        // those can differ by an ulp in principle, but across every host rate in the
+        // byte-compare matrix and every reachable hfCutoff the double product rounds
+        // to the same value, so the designed corner is identical.
         // Both reference decks keep HF far more extended than the shared 0.7/1.0/1.3
         // per-speed rolloff. American: ~flat to 15 kHz at every speed. Swiss:
         // bright at 15/30 IPS, ~-2 dB @15k at 7.5 IPS.
@@ -1977,7 +2021,13 @@ private:
             hfExt = (speed == Speed_3_75_IPS) ? 1.10f
                   : (speed == Speed_7_5_IPS) ? 1.10f : (speed == Speed_30_IPS ? 1.50f : 1.5f);
         float hfCutoff = machineChars.hfRolloffFreq * hfExt * tapeChars.hfLoss;
-        hfCutoff = std::min (hfCutoff, maxFilterFreq);
+        // LOAD-BEARING, do not delete as "redundant with the designer clamp". It is
+        // not redundant: hfShelfFreq below is derived as hfCutoff * 0.6, so this
+        // clamp changes a DOWNSTREAM corner, not just the one designed on the next
+        // line. Removing it moved the 3.75-IPS shelf from 0.45*fs*0.6 to the raw
+        // 0.6 * 31.7 kHz and broke byte-identity at 22.05 kHz and 32 kHz (measured,
+        // not theorised). The designer's internal clamp still backstops this line.
+        hfCutoff = std::min (hfCutoff, static_cast<float> (currentSampleRate * 0.45));
         hfLossFilter1.setCoeffs (DBiquad::lowPass (currentSampleRate, static_cast<double> (hfCutoff), 0.707));
 
         // American tracks nearly flat to ~15 kHz, so American's HF-loss shelves are scaled right down.
@@ -1989,11 +2039,11 @@ private:
         if (speed == Speed_3_75_IPS)
         {
             hfLossFilter2.setCoeffs (DBiquad::shelf (currentSampleRate,
-                std::min (11000.0f, maxFilterFreq), -3.5, 0.5, true));
+                11000.0, -3.5, 0.5, true));
         }
         else
         {
-            float hfShelfFreq = std::min (hfCutoff * 0.6f, maxFilterFreq);
+            float hfShelfFreq = hfCutoff * 0.6f;
             hfLossFilter2.setCoeffs (DBiquad::shelf (currentSampleRate, static_cast<double> (hfShelfFreq),
                 static_cast<double> (-2.0f * tapeChars.hfLoss * hfLossScale), 0.5, true));
         }
@@ -2006,7 +2056,7 @@ private:
         if (m_slowModernPresence != wasSlow900Presence)
             slowModernPresencePeak.reset();
         slowModernPresencePeak.setCoeffs (DBiquad::peak (currentSampleRate,
-            std::min (2700.0f, maxFilterFreq), m_slowModernPresence ? 5.8 : 0.0, 1.6));
+            2700.0, m_slowModernPresence ? 5.8 : 0.0, 1.6));
 
         // American Head Width HF character (American only; neutral at 1/2" so the
         // reference stays byte-identical and the filter is skipped in the chain). Both
@@ -2033,11 +2083,7 @@ private:
         float biasFreq, biasGainDb;
         if (machine == Swiss) { biasFreq = 8000.0f; biasGainDb = -(biasAmount - 0.5f) * 8.0f + 1.0f; }
         else                     { biasFreq = 7000.0f; biasGainDb = (0.5f - biasAmount) * 5.0f + 1.5f; }
-        // Nyquist-guarded at the call site: Biquad (shared DuskFilters.hpp) is used by the
-        // other DPF plugins too, so the clamp lives here rather than in the shared designer.
-        biasFilter.setCoeffs (Biquad::shelf (currentSampleRate,
-            static_cast<float> (nyquistSafeHz (currentSampleRate, static_cast<double> (biasFreq))),
-            biasGainDb, 0.707f, true));
+        biasFilter.setCoeffs (Biquad::shelf (currentSampleRate, biasFreq, biasGainDb, 0.707f, true));
 
         // DC blocker: 1st-order (6 dB/oct). Both reference decks keep a broad LF head bump nearly
         // flat down to ~10-15 Hz, then roll off gently below — a 2nd-order Butterworth corner

--- a/plugins/multi-q/core/MultiQDSP.cpp
+++ b/plugins/multi-q/core/MultiQDSP.cpp
@@ -128,6 +128,21 @@ void MultiQDSP::updateDynGainFilter(int band, float dynGainDb, const Params& p)
 void MultiQDSP::computeTiltShelf(MqBiquadCoeffs& c, double sr, double freq, float gainDB)
 {
     // 1st-order tilt shelf, bilinear transform of H(s)=(s+w0*sqrt(A))/(s+w0/sqrt(A)).
+    //
+    // Nyquist guard, matching every amb:: designer and updateHPF/updateLPF. Without
+    // it the prewarp tan(w0*T/2) goes negative once freq passes sr/2, which puts the
+    // pole a1/a0 outside the unit circle and the filter diverges.
+    //
+    // It is unstable at gainDB 0, not merely at high gain, and the coefficients are
+    // written unconditionally for every enabled band. Measured with a band left on
+    // Tilt Shelf at its 1000 Hz default, gain 0: pole 0.998 at a 2001 Hz host rate,
+    // 1.000 at 2000, -5.242 at 1234.567, 3.732 at 1500.
+    //
+    // The divergence does NOT surface as a NaN. StereoBiquad::processSampleL/R
+    // checks the output and, on a non-finite sample, zeroes its state and returns
+    // 0.0. So this failed as repeated state resets, heard as dropouts or crackle at
+    // degenerate rates, and passed every non-finite output sweep unnoticed.
+    freq = amb::clampFreq(freq, sr);
     double w0 = 2.0 * kMultiQPi * freq;
     double T = 1.0 / sr;
     double wc = (2.0 / T) * std::tan(w0 * T / 2.0);

--- a/plugins/multi-q/core/MultiQFilters.hpp
+++ b/plugins/multi-q/core/MultiQFilters.hpp
@@ -29,6 +29,12 @@ namespace duskaudio
 // bit-identical to the JUCE build.
 inline constexpr double kMultiQPi = 3.14159265358979323846;
 
+// Nyquist ceiling for design frequencies AND for the prewarped bandwidth terms in
+// this file. Same value as duskaudio::kMaxDesignFreqRatio in shared-dpf; kept as a
+// separate constant so this header stays independent of the shared designers it
+// warns against below, but the two are meant to move together.
+inline constexpr double kMqMaxDesignFreqRatio = 0.4998;
+
 // Bitwise finite check (verbatim from SafeFloat.h) — immune to -ffast-math /
 // finite-math-only optimizations that make std::isfinite unreliable.
 inline bool safeIsFinite(float v)
@@ -273,9 +279,17 @@ struct StereoBiquad
 // alpha = sin(w0)/2Q, a different transfer function that CRAMS near Nyquist.
 namespace amb
 {
+    // Nyquist guard for design frequencies. 0.4998 matches
+    // duskaudio::kMaxDesignFreqRatio in shared-dpf/dsp/DuskFilters.hpp; the literal
+    // is kept here only so this header stays independent of the shared designers it
+    // warns against above.
+    //
+    // Floor FIRST, ceiling LAST. The old order applied the 1 Hz floor last, so below
+    // sr 2.002 Hz the floor won and returned a corner above Nyquist, the exact case
+    // the clamp exists to prevent. Identical for every sr above that.
     static inline double clampFreq(double fc, double sr)
     {
-        return std::max(1.0, std::min(fc, sr * 0.4998));
+        return std::min(sr * kMqMaxDesignFreqRatio, std::max(fc, 1.0));
     }
 
     static void computePeaking(MqBiquadCoeffs& c, double fc, double sr,
@@ -288,7 +302,7 @@ namespace amb
 
         const double W0d  = 2.0 * kMultiQPi * fc / sr;
         const double bw   = fc / Q;
-        const double kbw  = std::tan(kMultiQPi * std::min(bw, sr * 0.4998) / sr);
+        const double kbw  = std::tan(kMultiQPi * std::min(bw, sr * kMqMaxDesignFreqRatio) / sr);
         const double A    = std::pow(10.0, gainDB / 40.0);
         const double cosW = std::cos(W0d);
 
@@ -432,7 +446,7 @@ namespace amb
         Q  = std::max(0.01, Q);
         const double W0d  = 2.0 * kMultiQPi * fc / sr;
         const double cosW = std::cos(W0d);
-        const double kbw  = std::tan(kMultiQPi * std::min(fc / Q, sr * 0.4998) / sr);
+        const double kbw  = std::tan(kMultiQPi * std::min(fc / Q, sr * kMqMaxDesignFreqRatio) / sr);
         const double norm = 1.0 / (1.0 + kbw);
 
         c.coeffs[0] = static_cast<float>(norm);
@@ -449,7 +463,7 @@ namespace amb
         Q  = std::max(0.01, Q);
         const double W0d  = 2.0 * kMultiQPi * fc / sr;
         const double cosW = std::cos(W0d);
-        const double kbw  = std::tan(kMultiQPi * std::min(fc / Q, sr * 0.4998) / sr);
+        const double kbw  = std::tan(kMultiQPi * std::min(fc / Q, sr * kMqMaxDesignFreqRatio) / sr);
         const double norm = 1.0 / (1.0 + kbw);
 
         c.coeffs[0] = static_cast<float>(kbw * norm);
@@ -469,11 +483,11 @@ namespace svfdes
 {
     static void computePeaking(SVFCoeffs& c, double sr, double freq, float gainDB, float q)
     {
-        freq = std::max(1.0, std::min(freq, sr * 0.4998));
+        freq = amb::clampFreq(freq, sr);
         double A   = std::pow(10.0, gainDB / 40.0);
         double g   = std::tan(kMultiQPi * freq / sr);
         double bw  = freq / std::max(0.01, (double)q);
-        double kbw = std::tan(kMultiQPi * std::min(bw, sr * 0.4998) / sr);
+        double kbw = std::tan(kMultiQPi * std::min(bw, sr * kMqMaxDesignFreqRatio) / sr);
         double k   = std::max(0.001, kbw / (g * A));
         c.a1 = (float)(1.0 / (1.0 + g * (g + k)));
         c.a2 = (float)(g * c.a1);
@@ -485,6 +499,14 @@ namespace svfdes
 
     static void computeLowShelf(SVFCoeffs& c, double sr, double freq, float gainDB, float q)
     {
+        // Nyquist guard, same as computePeaking above. Without it the prewarp g runs
+        // away as freq approaches sr/2 and goes NEGATIVE past it, which is not the
+        // filter that was asked for: measured at a 4000 Hz band, g reaches 1.9e16 at
+        // an 8 kHz host rate and is -6052 at 7999 Hz, where a3 exceeds 1. It does not
+        // reach Inf or NaN, because pi/2 is not representable in double and tan tops
+        // out near 1.6e16. Reachable from the band dynamics path with a shelf shape
+        // at any host rate below twice the band frequency.
+        freq = amb::clampFreq(freq, sr);
         double A = std::pow(10.0, gainDB / 40.0);
         double g = std::tan(kMultiQPi * freq / sr) / std::sqrt(A);
         double k = 1.0 / q;
@@ -498,6 +520,8 @@ namespace svfdes
 
     static void computeHighShelf(SVFCoeffs& c, double sr, double freq, float gainDB, float q)
     {
+        // Nyquist guard, same as computeLowShelf above.
+        freq = amb::clampFreq(freq, sr);
         double A = std::pow(10.0, gainDB / 40.0);
         double g = std::tan(kMultiQPi * freq / sr) * std::sqrt(A);
         double k = 1.0 / q;

--- a/plugins/multi-q/dpf-plugin/MultiQUI.cpp
+++ b/plugins/multi-q/dpf-plugin/MultiQUI.cpp
@@ -3227,7 +3227,8 @@ private:
         }
         if (values[kLpfEnabled] > 0.5f)
         {
-            const float f = (float)std::max(1.0, std::min((double)values[kLpfFreq], fs * 0.4998));
+            const float f = (float)duskaudio::nyquistSafeDesignHzD(
+                fs, (double)values[kLpfFreq], duskaudio::kMaxDesignFreqRatio);
             Biquad lp; lp.setCoeffs(Biquad::lowPass(fs, f, black ? 0.8f : 0.707f));
             filtMag *= lp.magnitude(w);
         }

--- a/plugins/shared-dpf/dsp/DuskFilters.hpp
+++ b/plugins/shared-dpf/dsp/DuskFilters.hpp
@@ -33,18 +33,27 @@ constexpr float kDuskPi    = 3.14159265358979323846f;
 // Every designer below prewarps through tan(pi*f/fs) or cos/sin(2*pi*f/fs),
 // which are only meaningful for f < fs/2. Past Nyquist the mapping wraps and
 // the coefficients stop describing the intended filter:
-//   - tan(pi*f/fs) diverges AT f == fs/2, so lowPass's 1/tan and the
-//     1/(k+1) reciprocals below overflow to Inf;
-//   - just above it tan goes negative and passes through -1, where
-//     firstOrderLowPass's (k+1) and firstOrderAllPass's (1+t) are zero
-//     (divide by zero);
-//   - sin(w0) goes negative, so alpha goes negative, so the RBJ denominator
-//     (1 + alpha/A) shrinks or flips sign and the poles land OUTSIDE the unit
-//     circle. The filter then diverges geometrically to +/-Inf, and the next
-//     transposed-direct-form-II update evaluates Inf - Inf = NaN.
-// That last path is how 4K EQ 2 produced a NaN at a 1234.57 Hz host rate under
+//   - tan(pi*f/fs) grows without bound as f approaches fs/2. It does NOT reach
+//     Inf: pi/2 is not representable in double, so tan tops out near 1.6e16
+//     (measured) and the reciprocals below stay finite. What it produces is a
+//     corner nowhere near the one requested;
+//   - at f == 0.75*fs tan passes through exactly -1, where firstOrderLowPass's
+//     (k+1) and firstOrderAllPass's (1+t) are zero. This one IS a divide by zero;
+//   - sin(w0) goes negative across (0.5*fs, fs), so alpha goes negative, so the
+//     RBJ denominator (1 + alpha/A) shrinks or flips sign and the poles land
+//     OUTSIDE the unit circle. The filter then diverges geometrically until the
+//     state overflows to +/-Inf, at which point a transposed-direct-form-II
+//     update evaluating Inf - Inf yields NaN.
+// The third path is how 4K EQ 2 produced a NaN at a 1234.57 Hz host rate under
 // clap-validator's process-varying-sample-rates: its band corners (up to 20 kHz)
 // sit far above Nyquist once the host rate drops that low.
+//
+// NaN is the loud failure, not the only one, and not the common one. Where a host
+// carries its own finiteness guard (Multi-Q's StereoBiquad and CytomicSVF zero the
+// state and return 0.0 on a non-finite sample) the same divergence never reaches
+// the output at all: it surfaces as repeated state resets, heard as dropouts or
+// crackle, and every output-level check sails straight past it. Do not treat a
+// clean NaN sweep as evidence that a designer is sound.
 //
 // Clamping HERE rather than at each call site is deliberate: this header is
 // compiled into every DPF plugin, and a guard that a call site can forget is a

--- a/plugins/shared-dpf/dsp/DuskFilters.hpp
+++ b/plugins/shared-dpf/dsp/DuskFilters.hpp
@@ -57,8 +57,19 @@ constexpr float kDuskPi    = 3.14159265358979323846f;
 //
 // Clamping HERE rather than at each call site is deliberate: this header is
 // compiled into every DPF plugin, and a guard that a call site can forget is a
-// guard that will be forgotten. Call sites that already clamp (FourKEQDSP's LPF,
-// TapeEcho's 0.45*fs sites) keep their clamp and simply never reach this one.
+// guard that will be forgotten. A few call sites still clamp on their own and are
+// commented where they do, because they are NOT redundant with this one: they
+// either feed a downstream derivation (TapeMachine's hfCutoff) or deliberately cap
+// tighter than this ceiling as part of the voicing (TapeMachine's recordHeadCutoff
+// and biasFilter, TapeEcho's 0.45*fs sites). Everything else relies on this.
+//
+// WHAT THE CEILING BUYS, AND WHAT IT DOES NOT. It trades divergence for a corner
+// parked just under Nyquist. At the ceiling the poles sit at |z| ~ 0.999, which
+// rings for on the order of a thousand samples rather than blowing up. That is an
+// unambiguous improvement on NaN, but it is NOT a voicing-safe clamp: a filter
+// whose corner has been pulled down to the ceiling is no longer the filter that was
+// asked for. The ceiling exists so degenerate rates stay bounded, not so they sound
+// right. Keep design frequencies below it by construction wherever tone matters.
 //
 // CEILING: kMaxDesignFreqRatio below. It is deliberately TIGHT to Nyquist, and it
 // is NOT the same number as the 0.45 * fs ceiling inside TapeMachine's private
@@ -69,8 +80,9 @@ constexpr float kDuskPi    = 3.14159265358979323846f;
 //     20000 / 44100 = 0.4535, so any ceiling at or below 0.4535 would detune a
 //     wide-open LPF at 44.1 kHz: an audible regression in shipping plugins. The
 //     ceiling must therefore stay >= 0.4535. 0.4998 is the value FourKEQDSP.cpp's
-//     own LPF clamp and every designer in Multi-Q's MqBiquad already use, so it
-//     also keeps one number across the family. At 44.1 kHz it is 22041 Hz, above
+//     LPF clamp used before this guard subsumed it, and the value Multi-Q's own
+//     amb::clampFreq uses, so it keeps one number across the family. At 44.1 kHz
+//     it is 22041 Hz, above
 //     every design frequency any of these plugins can request at any supported
 //     rate (highest: the 16 kHz British HF band, 0.363 of fs at 44.1 kHz).
 //
@@ -88,15 +100,27 @@ constexpr float kDuskPi    = 3.14159265358979323846f;
 // coefficients no matter what frequency this function hands back.
 constexpr double kMaxDesignFreqRatio = 0.4998;
 
-inline float nyquistSafeDesignHz(double fs, float freq,
-                                 double maxFraction = kMaxDesignFreqRatio) noexcept
+// The ONE implementation of the clamp ordering. TapeMachine's DBiquad guard
+// (nyquistSafeHz) is a thin alias over this at its own ceiling, so the two cannot
+// drift apart.
+//
+// maxFraction has NO default on purpose. It is a FRACTION of fs, and a defaulted
+// parameter of that shape invites a caller to pass a frequency in Hz and silently
+// get a ceiling of fs * 12000. Callers state the ceiling they mean; the float
+// wrapper below is the one that binds kMaxDesignFreqRatio.
+inline double nyquistSafeDesignHzD(double fs, double freq, double maxFraction) noexcept
 {
     // Floor FIRST, ceiling LAST. The reverse order lets the 1 Hz floor win at
     // absurdly low fs and hand the designer a corner at or above Nyquist, which
     // is the exact instability this guard exists to prevent. The order is also
     // what makes a NaN freq land on the ceiling instead of propagating: both
     // comparisons are false, so max returns the NaN and min then returns fs*frac.
-    return (float)std::min(fs * maxFraction, std::max((double)freq, 1.0));
+    return std::min(fs * maxFraction, std::max(freq, 1.0));
+}
+
+inline float nyquistSafeDesignHz(double fs, float freq) noexcept
+{
+    return (float)nyquistSafeDesignHzD(fs, (double)freq, kMaxDesignFreqRatio);
 }
 
 //==============================================================================

--- a/plugins/shared-dpf/dsp/DuskFilters.hpp
+++ b/plugins/shared-dpf/dsp/DuskFilters.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <complex>
 
@@ -25,6 +26,69 @@ namespace duskaudio
 
 constexpr float kDuskTwoPi = 6.28318530717958647692f;
 constexpr float kDuskPi    = 3.14159265358979323846f;
+
+//==============================================================================
+// Nyquist guard for biquad DESIGN frequencies.
+//
+// Every designer below prewarps through tan(pi*f/fs) or cos/sin(2*pi*f/fs),
+// which are only meaningful for f < fs/2. Past Nyquist the mapping wraps and
+// the coefficients stop describing the intended filter:
+//   - tan(pi*f/fs) diverges AT f == fs/2, so lowPass's 1/tan and the
+//     1/(k+1) reciprocals below overflow to Inf;
+//   - just above it tan goes negative and passes through -1, where
+//     firstOrderLowPass's (k+1) and firstOrderAllPass's (1+t) are zero
+//     (divide by zero);
+//   - sin(w0) goes negative, so alpha goes negative, so the RBJ denominator
+//     (1 + alpha/A) shrinks or flips sign and the poles land OUTSIDE the unit
+//     circle. The filter then diverges geometrically to +/-Inf, and the next
+//     transposed-direct-form-II update evaluates Inf - Inf = NaN.
+// That last path is how 4K EQ 2 produced a NaN at a 1234.57 Hz host rate under
+// clap-validator's process-varying-sample-rates: its band corners (up to 20 kHz)
+// sit far above Nyquist once the host rate drops that low.
+//
+// Clamping HERE rather than at each call site is deliberate: this header is
+// compiled into every DPF plugin, and a guard that a call site can forget is a
+// guard that will be forgotten. Call sites that already clamp (FourKEQDSP's LPF,
+// TapeEcho's 0.45*fs sites) keep their clamp and simply never reach this one.
+//
+// CEILING: kMaxDesignFreqRatio below. It is deliberately TIGHT to Nyquist, and it
+// is NOT the same number as the 0.45 * fs ceiling inside TapeMachine's private
+// DBiquad. Do not "harmonize" them; each is set by its own hard constraint:
+//
+//   THIS header (0.4998): 4K EQ 2 and Multi-Q 2 design at the HOST rate (their
+//     oversampling defaults to 1x) and their LPF parameter tops out at 20000 Hz.
+//     20000 / 44100 = 0.4535, so any ceiling at or below 0.4535 would detune a
+//     wide-open LPF at 44.1 kHz: an audible regression in shipping plugins. The
+//     ceiling must therefore stay >= 0.4535. 0.4998 is the value FourKEQDSP.cpp's
+//     own LPF clamp and every designer in Multi-Q's MqBiquad already use, so it
+//     also keeps one number across the family. At 44.1 kHz it is 22041 Hz, above
+//     every design frequency any of these plugins can request at any supported
+//     rate (highest: the 16 kHz British HF band, 0.363 of fs at 44.1 kHz).
+//
+//   TapeMachine's DBiquad (0.45): that core runs at 2x the host rate, so its
+//     highest corner ratio is ~0.227 and the margin is enormous. Its 0.45 matches
+//     the safeFreq / maxFilterFreq convention that file was already written to.
+//
+// Stability at this ceiling is verified, not assumed: w0 = 0.9996*pi keeps
+// sin(w0) > 0, so alpha > 0 and |pole| < 1 for every RBJ designer here, and
+// tan(0.4998*pi) is ~1591, large but far from overflow in float.
+//
+// PRECONDITION: fs is positive and finite. Every caller's prepare path already
+// enforces that, and re-validating it here would be theatre: fs is a divisor in
+// every designer below, so a non-positive or non-finite fs produces NaN
+// coefficients no matter what frequency this function hands back.
+constexpr double kMaxDesignFreqRatio = 0.4998;
+
+inline float nyquistSafeDesignHz(double fs, float freq,
+                                 double maxFraction = kMaxDesignFreqRatio) noexcept
+{
+    // Floor FIRST, ceiling LAST. The reverse order lets the 1 Hz floor win at
+    // absurdly low fs and hand the designer a corner at or above Nyquist, which
+    // is the exact instability this guard exists to prevent. The order is also
+    // what makes a NaN freq land on the ceiling instead of propagating: both
+    // comparisons are false, so max returns the NaN and min then returns fs*frac.
+    return (float)std::min(fs * maxFraction, std::max((double)freq, 1.0));
+}
 
 //==============================================================================
 class OnePoleLP
@@ -129,6 +193,7 @@ public:
     // JUCE ArrayCoefficients::makeFirstOrderHighPass -> {1, -1, n+1, n-1}
     static BiquadCoeffs firstOrderHighPass(double fs, float freq) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float n = std::tan(kDuskPi * freq / (float)fs);
         const float inv = 1.0f / (n + 1.0f);
         return { inv, -inv, 0.0f, (n - 1.0f) * inv, 0.0f };
@@ -138,6 +203,7 @@ public:
     // Matches FourKEQ TransformerPhaseShift::setFrequency.
     static BiquadCoeffs firstOrderAllPass(double fs, float freq) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float w0 = kDuskTwoPi * freq / (float)fs;
         const float t  = std::tan(w0 * 0.5f);
         const float a  = (1.0f - t) / (1.0f + t);
@@ -148,6 +214,7 @@ public:
     // parallel-shelf building block (dry + K*LP = first-order low shelf).
     static BiquadCoeffs firstOrderLowPass(double fs, float freq) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float k = std::tan(kDuskPi * freq / (float)fs);
         const float inv = 1.0f / (k + 1.0f);
         return { k * inv, k * inv, 0.0f, (k - 1.0f) * inv, 0.0f };
@@ -157,6 +224,7 @@ public:
     // The parallel EQ building block for peaks/bells (dry + K*BP = bell).
     static BiquadCoeffs bandPassConstantPeak(double fs, float freq, float Q) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float w0 = kDuskTwoPi * freq / (float)fs;
         const float cw = std::cos(w0), sw = std::sin(w0);
         const float alpha = sw / (2.0f * Q);
@@ -167,6 +235,7 @@ public:
     // JUCE ArrayCoefficients::makeLowPass(fs, freq, Q).
     static BiquadCoeffs lowPass(double fs, float freq, float Q) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float n = 1.0f / std::tan(kDuskPi * freq / (float)fs);
         const float nSq = n * n;
         const float invQ = 1.0f / Q;
@@ -177,6 +246,7 @@ public:
     // JUCE ArrayCoefficients::makeHighPass(fs, freq, Q).
     static BiquadCoeffs highPass(double fs, float freq, float Q) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float n = std::tan(kDuskPi * freq / (float)fs);
         const float nSq = n * n;
         const float invQ = 1.0f / Q;
@@ -187,6 +257,7 @@ public:
     // RBJ peaking EQ, alpha = sin(w0)/(2Q). Matches FourKEQ::makeConsolePeak raw math.
     static BiquadCoeffs peak(double fs, float freq, float gainDb, float Q) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float A = std::pow(10.0f, gainDb / 40.0f);
         const float w0 = kDuskTwoPi * freq / (float)fs;
         const float cw = std::cos(w0), sw = std::sin(w0);
@@ -204,6 +275,7 @@ public:
     // RBJ low/high shelf, alpha = sin(w0)/(2Q). Matches FourKEQ::makeConsoleShelf.
     static BiquadCoeffs shelf(double fs, float freq, float gainDb, float Q, bool high) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float A = std::pow(10.0f, gainDb / 40.0f);
         const float w0 = kDuskTwoPi * freq / (float)fs;
         const float cw = std::cos(w0), sw = std::sin(w0);
@@ -239,6 +311,7 @@ public:
     // bit-for-bit (offline null-render requirement). high=false selects the low shelf.
     static BiquadCoeffs shelfSlope1(double fs, float freq, float gainDb, bool high) noexcept
     {
+        freq = nyquistSafeDesignHz(fs, freq);
         const float A     = std::pow(10.0f, gainDb / 40.0f);
         const float w0    = kDuskTwoPi * freq / (float)fs;
         const float cosw  = std::cos(w0);

--- a/plugins/shared-dpf/dsp/DuskSVF.hpp
+++ b/plugins/shared-dpf/dsp/DuskSVF.hpp
@@ -52,8 +52,16 @@ public:
         // one lands on nyq-1. Unreachable in practice either way, since the caller's
         // dirty-check compares abs(new - old) > eps and a NaN fails that. Same
         // ceiling-last idiom as nyquistSafeDesignHzD in DuskFilters.hpp.
+        // JUCE's nyq - 1 Hz margin is only a sane ceiling while nyq > 1 Hz; below
+        // that it turns negative and the ceiling-last order would then hand tan()
+        // a negative corner. Fall back to half of Nyquist there, which is positive,
+        // still below Nyquist, and continuous with nyq - 1 at nyq == 2. The 20 Hz
+        // floor needs no separate guard: applying the ceiling last already lowers
+        // it whenever the ceiling is the smaller of the two. fs is required to be
+        // positive and finite (see nyquistSafeDesignHzD in DuskFilters.hpp).
         const float nyq = (float)(0.5 * fs);
-        cutoff = std::min(nyq - 1.0f, std::max(cutoffHz, 20.0f));
+        const float maxCutoff = nyq > 2.0f ? nyq - 1.0f : nyq * 0.5f;
+        cutoff = std::min(maxCutoff, std::max(cutoffHz, 20.0f));
         g = std::tan(kDuskSvfPi * cutoff / (float)fs);
         updateH();
     }

--- a/plugins/shared-dpf/dsp/DuskSVF.hpp
+++ b/plugins/shared-dpf/dsp/DuskSVF.hpp
@@ -45,9 +45,13 @@ public:
         // Clamp away from 0 and Nyquist exactly like JUCE's update(), but with the
         // FLOOR applied first and the CEILING last. The other order lets the 20 Hz
         // floor win whenever fs < 42 Hz and hand back a cutoff above Nyquist, which
-        // is the one thing this clamp exists to prevent. Byte-identical at every
-        // real rate (the inversion needs fs < 42 Hz); same ceiling-last idiom as
-        // nyquistSafeDesignHz in DuskFilters.hpp.
+        // is the one thing this clamp exists to prevent. Identical for finite input
+        // at any fs >= 42 Hz, which is every real rate; the inversion needs less.
+        // Not identical for a NaN cutoff, and that is the point: the old form
+        // propagated the NaN into g and permanently poisoned ic1eq/ic2eq, while this
+        // one lands on nyq-1. Unreachable in practice either way, since the caller's
+        // dirty-check compares abs(new - old) > eps and a NaN fails that. Same
+        // ceiling-last idiom as nyquistSafeDesignHzD in DuskFilters.hpp.
         const float nyq = (float)(0.5 * fs);
         cutoff = std::min(nyq - 1.0f, std::max(cutoffHz, 20.0f));
         g = std::tan(kDuskSvfPi * cutoff / (float)fs);

--- a/plugins/shared-dpf/dsp/DuskSVF.hpp
+++ b/plugins/shared-dpf/dsp/DuskSVF.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 namespace duskaudio
@@ -41,9 +42,14 @@ public:
 
     void setCutoff(float cutoffHz) noexcept
     {
-        // clamp away from 0 and Nyquist exactly like JUCE's update()
+        // Clamp away from 0 and Nyquist exactly like JUCE's update(), but with the
+        // FLOOR applied first and the CEILING last. The other order lets the 20 Hz
+        // floor win whenever fs < 42 Hz and hand back a cutoff above Nyquist, which
+        // is the one thing this clamp exists to prevent. Byte-identical at every
+        // real rate (the inversion needs fs < 42 Hz); same ceiling-last idiom as
+        // nyquistSafeDesignHz in DuskFilters.hpp.
         const float nyq = (float)(0.5 * fs);
-        cutoff = cutoffHz < 20.0f ? 20.0f : (cutoffHz > nyq - 1.0f ? nyq - 1.0f : cutoffHz);
+        cutoff = std::min(nyq - 1.0f, std::max(cutoffHz, 20.0f));
         g = std::tan(kDuskSvfPi * cutoff / (float)fs);
         updateH();
     }

--- a/plugins/shared-dpf/dsp/FourKEQDSP.cpp
+++ b/plugins/shared-dpf/dsp/FourKEQDSP.cpp
@@ -728,19 +728,6 @@ float FourKEQDSP::voicedMidQ(float gainDb, float baseQ, bool black) noexcept
     return clampf(dq, 0.5f, 8.0f);
 }
 
-// Standard bilinear pre-warp (Multi-Q's britishPreWarpFrequency). Retained for
-// callers that want an fc estimate; the console coeff builders below pre-warp
-// internally, so recomputeCoeffs no longer applies the old piecewise HF fudge.
-float FourKEQDSP::preWarp(float freq, double sampleRate) noexcept
-{
-    const float nyquist = static_cast<float>(sampleRate * 0.5);
-    float safeFreq = std::min(freq, nyquist * 0.98f);
-    safeFreq = std::max(safeFreq, 1.0f);
-    const float omega = kDuskPi * safeFreq / static_cast<float>(sampleRate);
-    const float warped = static_cast<float>(sampleRate) / kDuskPi * std::tan(omega);
-    return std::min(std::max(warped, 1.0f), nyquist * 0.99f);
-}
-
 // mode: 0 = 1x (off), 1 = 2x, 2 = 4x. Capped so the oversampled rate stays sane
 // at already-high base rates (>=176.4k -> 1x, >=88.2k -> max 2x).
 int FourKEQDSP::chooseFactor(double baseSampleRate, int mode) noexcept

--- a/plugins/shared-dpf/dsp/FourKEQDSP.hpp
+++ b/plugins/shared-dpf/dsp/FourKEQDSP.hpp
@@ -169,7 +169,6 @@ public:
     // uses the older parallel topology independently of 4K EQ 2.
     static float voicedMidQ(float gainDb, float baseQ, bool black) noexcept;
     static float bandK(float gainDb) noexcept { return std::pow(10.0f, 0.05f * gainDb) - 1.0f; }
-    static float preWarp(float freq, double fs) noexcept;
     static int   chooseFactor(double baseSampleRate, int mode) noexcept; // mode 0=1x,1=2x,2=4x
 
 private:


### PR DESCRIPTION
Fixes #137. Stacked on #156; merge that first.

Completes the issue's done-when: every DPF plugin now passes the full clap-validator suite and the CI gate is strict.

What this does, per commit:
- fix(shared-dpf): clamp design frequencies inside every shared duskaudio::Biquad designer (nine of them), with a named ceiling kMaxDesignFreqRatio = 0.4998. The value matters: 4K EQ and Multi-Q design at host rate with an LPF param max of 20 kHz, and 20000/44100 = 0.4535, so the 0.45 used by TapeMachine's internal designers would have detuned a wide-open LPF at 44.1 kHz. 0.4998 is the ceiling that family already used where it clamped at all. Also fixes a floor-after-ceiling inversion in DuskSVF::setCutoff. This alone fixed 4k-eq-2's process-varying-sample-rates failure (same root cause as TapeMachine's: unclamped fixed corners through shared designers).
- fix(multi-q): three genuinely unguarded designers found in review: computeTiltShelf fed raw band frequency into the tan prewarp (measured pole -5.24 at the validator's 1234.57 Hz rate at gain 0; divergence surfaces as panic-guard dropouts, not NaN), and the svfdes dynamics shelves lacked the clamp their sibling computePeaking has. All three now clamp; also fixed clampFreq's own floor-last inversion.
- refactor: one double-precision clamp primitive in DuskFilters.hpp that the float designer path and TapeMachine's 0.45 helper both wrap, one named ceiling per core (kMaxDesignFreqRatio 0.4998 shared, kTapeDesignFreqRatio 0.45 TapeMachine, kMqMaxDesignFreqRatio Multi-Q), redundant call-site clamps deleted, load-bearing ones kept and documented (the hfCutoff pre-clamp feeds a derived corner and is byte-identity load-bearing; measured, not assumed).
- ci: SUITE_STRICT=1 in dpf-build.yml. The gate script now fails on the parsed failed-test tally as well as the exit code, resolves SUITE_STRICT eagerly at startup (unrecognized values exit 2; empty and whitespace are documented as unset), and the workflow paths filter includes .github/scripts so gate edits run the gate.

Verification (all against post-#155 main, baselines regenerated after its deliberate output changes):
- clap-validator 0.4.1 full suite via the actual gate script with SUITE_STRICT=1: all four plugins exit 0.
- Byte-compares: 84/84 random (4 plugins x 3 rates x 7 param sets), 18/18 targeted (4K EQ LPF wide open in both modes, Multi-Q British), 18/18 Multi-Q forced shapes (tilt shelf at 1k/8k/20k, dynamics shelves) all identical to main.
- SR sweeps 1 kHz-768 kHz: 4 plugins x 784 combos plus forced-shape sweeps, 0 non-finite, 0 subnormal.

Notes:
- Multi-Q's validator pass is default-state-only by construction (the suite never enables tilt or dynamics); the byte-compare and sweep coverage above is what actually exercises those paths.
- Known follow-ups, deliberately not here: Tape Echo's private safeBiquadFrequency and Multi-Q's UI-mirror literals migrate to the shared constant in a dedicated pass; dpf-release.yml's inline sunset-circuits gate lacks the latency signature scan and should call the shared gate script; Multi-Q's British-mode analyzer curve still draws the pre-#155 model while the audio path runs the calibrated one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter stability across low, high, and unusual sample rates by safely constraining frequencies.
  * Prevented invalid or unstable equalizer and tape-effect coefficients near Nyquist limits.
  * Improved handling of very low and invalid cutoff values.

* **Build & Validation**
  * Linux plugin validation now blocks builds when reported failures or validator errors occur.
  * Added clear strict and advisory validation behavior with standard boolean settings.
  * Workflow changes ensure validation updates trigger appropriate build checks.

* **Documentation**
  * Documented validation policies, known plugin fixes, and timing-warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->