### PR TITLE
fix(tape-echo-2): repair the VST3 editor on hosts that never resize the view

### DIFF
--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -74,6 +74,7 @@ public:
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kTeParams[i].def;
         setGeometryConstraints((uint32_t)kDesignW, (uint32_t)kDesignH, true);
+        adoptWindowSize();
 
         // Barlow Condensed is bundled under the SIL OFL. Unlike the previous
         // system-font search this produces identical metrics on every OS. Two
@@ -151,6 +152,12 @@ protected:
 
     void onImGuiDisplay() override
     {
+        // Cheap guard against the window and this widget drifting apart again
+        // after construction (see adoptWindowSize). A host resize normally
+        // reaches the widget through the window's own size event; when one is
+        // missed the whole frame would otherwise be scissored to a sliver.
+        adoptWindowSize();
+
         const float winW = (float)getWidth();
         const float winH = (float)getHeight();
         s   = std::min(winW / kDesignW, winH / kDesignH);
@@ -231,6 +238,33 @@ protected:
 
 private:
     //--- helpers -----------------------------------------------------------------
+
+    // Keep this widget the same size as the window it draws into.
+    //
+    // DPF sizes the plugin *window* at the design size multiplied by the host
+    // DPI scale (DistrhoUI.cpp, createNextWindow), then UI::UI puts this
+    // *widget* straight back to the unscaled size. The two are normally
+    // reconciled by the window's first size event, but on Windows that event is
+    // delivered while the window is still being created, before this widget
+    // exists, so a host that never resizes the view itself (MuLab 9, issue
+    // #154) is left with a widget smaller than the GL surface for good.
+    // Everything then draws unscaled into the corner of a black window, and the
+    // ImGui backend, which derives its scissor box from the widget size rather
+    // than from the surface, clips every frame to the bottom
+    // (surfaceHeight - widgetHeight) band: only the utility rail survives.
+    //
+    // Adopting the window's real size restores both the scale and a
+    // full-surface clip. It is a no-op whenever the two already agree, which is
+    // every other host and platform, and it stays correct across later resizes
+    // because this UI does not use DGL's automatic scaling (which deliberately
+    // keeps widget and window sizes apart).
+    void adoptWindowSize()
+    {
+        const auto windowSize = getWindow().getSize();
+        if (windowSize.isValid() && windowSize != getSize())
+            DGL_NAMESPACE::Widget::setSize(windowSize);
+    }
+
     ImVec2 P(float x, float y) const { return ImVec2(org.x + x * s, org.y + y * s); }
 
     static ImU32 fade(ImU32 c, float amount)

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -87,13 +87,31 @@ public:
             { 7.0f, 9.0f, 11.0f, 14.0f, 18.0f, 24.0f, 28.0f, 32.0f, 48.0f, 72.0f };
         static constexpr float kRegularSizes[] =
             { 7.0f, 9.0f, 11.0f, 14.0f, 18.0f, 24.0f, 32.0f, 48.0f };
+        int labelCount   = (int)(sizeof(kLabelSizes) / sizeof(kLabelSizes[0]));
+        int regularCount = (int)(sizeof(kRegularSizes) / sizeof(kRegularSizes[0]));
+
+        // Baking all of those needs a 2048 px font atlas. Microsoft's software
+        // OpenGL 1.1 (a virtual machine with no 3D acceleration, or a Remote
+        // Desktop session) caps textures at 1024 px, and ImGui's GL2 backend
+        // reports nothing at all when that upload fails: it leaves the atlas
+        // texture incomplete, fixed-function texturing drops out for the glyph
+        // quads, and every label paints as a solid rectangle in the text color
+        // while the knobs and meters still look right. Drop the largest bakes
+        // on such a context so the atlas fits in 1024 px; the biggest text is
+        // then scaled up from a smaller face rather than disappearing.
+        GLint maxTextureSize = 0;
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+        if (maxTextureSize > 0 && maxTextureSize < 2048)
+        {
+            labelCount   = 6;   // 7..24 px
+            regularCount = 5;   // 7..18 px
+        }
+
         const float dpi = getScaleFactor();
         labelFonts = duskdpf::loadEmbeddedCrispFontSet(
-            kTeFontSemiBold, kTeFontSemiBold_len, kLabelSizes,
-            (int)(sizeof(kLabelSizes) / sizeof(kLabelSizes[0])), 1.0f);
+            kTeFontSemiBold, kTeFontSemiBold_len, kLabelSizes, labelCount, 1.0f);
         regularFonts = duskdpf::loadEmbeddedCrispFontSet(
-            kTeFontRegular, kTeFontRegular_len, kRegularSizes,
-            (int)(sizeof(kRegularSizes) / sizeof(kRegularSizes[0])), 1.0f);
+            kTeFontRegular, kTeFontRegular_len, kRegularSizes, regularCount, 1.0f);
         labelFont = labelFonts.pick(12.5f * dpi);
         panel.setFontSet(labelFonts);
 


### PR DESCRIPTION
Fixes #154.

Root cause (measured, reproduced on Linux): DPF creates the plugin window DPI-scaled (900x340 becomes 1620x612 at the reporter's 180% Windows display scale) but the UI constructor then sets the widget back to the unscaled size. Drawing happens 1:1 from the top-left of the scaled surface and the ImGui scissor derives from the widget size measured from the GL bottom, so the visible content is exactly the bottom strip of the panel on black: the reporter's screenshot decodes to window 1620x612, content bbox x 0..899 y 272..339, and 1620/900 = 612/340 = exactly 1.8. On X11 the first configure event silently repairs the mismatch; on Windows WM_SIZE fires before the widget exists, so nothing repairs it unless the host resizes the view afterwards. MuLab 9 does not. The CLAP build works in MuLab 10 because CLAP hosts call set_size, which repairs it.

This PR is the plugin-side fix so Tape Echo 2 works now: adopt the window size at construction plus a cheap per-frame guard (no-op whenever the two already agree, which is every state reachable outside the Windows creation-order hole). Renders are pixel-identical to the current release at scale 1.0 and 1.8. The root fix lands in the dusk-audio/DPF fork (post-construction size reconciliation, fleet-wide; all five DPF UIs share this defect); once the DPF pin is bumped, the first commit here becomes redundant and should be reverted.

Second commit, opportunistic hardening for a related report: the font atlas is clamped to GL_MAX_TEXTURE_SIZE (full bake is 2048x2048; reduced 512x1024 bake when the driver cap is lower, as on software GL in VMs where every label otherwise renders as a solid block). Inert on any real GPU driver.

Verification: builds clean (clap/vst3/lv2/jack) against post-#155 main, pluginval strictness 5 pass, pixel-compare vs release identical at both scales, runtime resize intact.

For the reporter: the Windows VST3 artifact from this PR's CI run should display correctly in MuLab 9; their Windows display scale is predicted to be 180%. A useful cross-check: current-release TapeMachine 2 or Multi-Q 2 VST3 in MuLab 9 should show the same black-window artifact, confirming the fleet-wide diagnosis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the tape echo interface’s responsiveness to window resizing.
  * Enhanced compatibility with graphics contexts that support smaller texture sizes.
  * Improved font rendering consistency across different display configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->