### PR TITLE
fix(tape-echo-2): fit the font atlas to the GPU texture limit

### DIFF
--- a/plugins/shared-dpf/ui/DuskImGuiFont.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiFont.hpp
@@ -172,4 +172,123 @@ inline CrispFontSet loadEmbeddedCrispFontSet(
     return set;
 }
 
+// One face family to bake: a static TTF blob plus the design sizes wanted from it.
+struct EmbeddedFontRequest
+{
+    const unsigned char* ttfData    = nullptr;
+    unsigned int         ttfSize    = 0;
+    const float*         designSizes = nullptr;
+    int                  count      = 0;
+};
+
+// What the fit loop settled on. Callers that want to report it (a debug log, an
+// about panel) can; nothing depends on it.
+struct AtlasFitResult
+{
+    int atlasWidth   = 0;
+    int atlasHeight  = 0;
+    int oversample   = 0;   // 2 = crisp, 1 = fell back
+    int droppedSizes = 0;   // largest bakes dropped per request
+    int attempts     = 0;
+    bool fits        = false;
+};
+
+// Bake every request into the shared ImGui atlas, shrinking until the BUILT
+// atlas fits maxTextureSize in both axes.
+//
+// Measuring beats predicting here. The atlas dimensions depend on the glyph
+// range, the oversampling factor (2x2 costs four times the area per glyph) and
+// stb's packing, so a face count that fits on one machine overflows on another.
+// A texture wider or taller than GL_MAX_TEXTURE_SIZE fails to upload, and the
+// GL2 backend does not report it: the atlas texture stays incomplete, texturing
+// drops out for the glyph quads, and every label paints as a solid rectangle in
+// the text colour while shapes still draw correctly.
+//
+// maxTextureSize comes from the caller because this header stays free of GL
+// includes. Pass GL_MAX_TEXTURE_SIZE, or 1024 if the query returned nothing:
+// unknown must mean conservative, never unlimited.
+inline void loadEmbeddedCrispFontSets(const EmbeddedFontRequest* requests, int requestCount,
+                                      CrispFontSet* outSets, float scaleFactor,
+                                      int maxTextureSize, AtlasFitResult* outFit = nullptr)
+{
+    if (requests == nullptr || outSets == nullptr || requestCount <= 0)
+        return;
+
+    if (maxTextureSize <= 0)
+        maxTextureSize = 1024;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    int largestCount = 0;
+    for (int r = 0; r < requestCount; ++r)
+        if (requests[r].count > largestCount)
+            largestCount = requests[r].count;
+
+    AtlasFitResult fit;
+
+    // Attempt 0 keeps 2x2 oversampling, attempt 1 drops to 1x1 (a quarter of the
+    // area, still legible), then each further attempt drops the largest bake from
+    // every request. Large text scaled up from a smaller face beats no text.
+    for (int attempt = 0;; ++attempt)
+    {
+        const int oversample = attempt == 0 ? 2 : 1;
+        const int dropped    = attempt <= 1 ? 0 : attempt - 1;
+
+        fit.attempts   = attempt + 1;
+        fit.oversample = oversample;
+        fit.droppedSizes = dropped;
+
+        io.Fonts->Clear();
+
+        for (int r = 0; r < requestCount; ++r)
+        {
+            outSets[r] = CrispFontSet();
+
+            const EmbeddedFontRequest& req = requests[r];
+            if (req.ttfData == nullptr || req.ttfSize == 0 || req.designSizes == nullptr)
+                continue;
+
+            const int wanted = req.count - dropped > 1 ? req.count - dropped : 1;
+
+            for (int i = 0; i < wanted && outSets[r].count < CrispFontSet::kMax; ++i)
+            {
+                ImFontConfig cfg;
+                cfg.OversampleH = oversample;
+                cfg.OversampleV = oversample;
+                cfg.PixelSnapH = false;
+                cfg.FontDataOwnedByAtlas = false;
+                cfg.GlyphRanges = crispGlyphRanges();
+
+                const float px = req.designSizes[i] * scaleFactor;
+                if (ImFont* f = io.Fonts->AddFontFromMemoryTTF(
+                        const_cast<unsigned char*>(req.ttfData), static_cast<int>(req.ttfSize),
+                        px, &cfg, crispGlyphRanges()))
+                {
+                    outSets[r].faces[outSets[r].count]    = f;
+                    outSets[r].nativePx[outSets[r].count] = px;
+                    ++outSets[r].count;
+                }
+            }
+        }
+
+        io.Fonts->Build();
+
+        fit.atlasWidth  = io.Fonts->TexWidth;
+        fit.atlasHeight = io.Fonts->TexHeight;
+        fit.fits = io.Fonts->TexWidth <= maxTextureSize && io.Fonts->TexHeight <= maxTextureSize;
+
+        if (fit.fits)
+            break;
+
+        // Every request is down to a single face and it still does not fit: stop
+        // rather than loop forever. Text will be broken, but so would any other
+        // outcome on a context this small, and the caller can report it.
+        if (dropped >= largestCount - 1)
+            break;
+    }
+
+    if (outFit != nullptr)
+        *outFit = fit;
+}
+
 } // namespace duskdpf

--- a/plugins/shared-dpf/ui/DuskImGuiFont.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiFont.hpp
@@ -219,10 +219,22 @@ inline void loadEmbeddedCrispFontSets(const EmbeddedFontRequest* requests, int r
 
     ImGuiIO& io = ImGui::GetIO();
 
+    // A request can only ever contribute CrispFontSet::kMax faces, so clamp here
+    // rather than at each use: an oversized count would otherwise drive the retry
+    // loop through attempts that cannot change the outcome, and a zero count with
+    // a non-null size array would still read designSizes[0] through the floor in
+    // `wanted` below.
+    const auto usableCount = [](const EmbeddedFontRequest& req) -> int
+    {
+        if (req.count <= 0)
+            return 0;
+        return req.count < CrispFontSet::kMax ? req.count : CrispFontSet::kMax;
+    };
+
     int largestCount = 0;
     for (int r = 0; r < requestCount; ++r)
-        if (requests[r].count > largestCount)
-            largestCount = requests[r].count;
+        if (usableCount(requests[r]) > largestCount)
+            largestCount = usableCount(requests[r]);
 
     AtlasFitResult fit;
 
@@ -245,10 +257,12 @@ inline void loadEmbeddedCrispFontSets(const EmbeddedFontRequest* requests, int r
             outSets[r] = CrispFontSet();
 
             const EmbeddedFontRequest& req = requests[r];
-            if (req.ttfData == nullptr || req.ttfSize == 0 || req.designSizes == nullptr)
+            const int available = usableCount(req);
+            if (req.ttfData == nullptr || req.ttfSize == 0 || req.designSizes == nullptr
+                || available <= 0)
                 continue;
 
-            const int wanted = req.count - dropped > 1 ? req.count - dropped : 1;
+            const int wanted = available - dropped > 1 ? available - dropped : 1;
 
             for (int i = 0; i < wanted && outSets[r].count < CrispFontSet::kMax; ++i)
             {

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -68,6 +68,44 @@ public:
         setParameterValue(idx, v);
     }
 
+    // Opt-in field diagnostic: set DUSK_GL_DEBUG=1 in the host's environment to
+    // drop one line per editor open describing the GL context and what the font
+    // atlas settled on. Silent otherwise, so nothing is written on a user's
+    // machine unless they are helping debug a rendering report.
+    static void logGlDiagnostics(GLint maxTextureSize, const duskdpf::AtlasFitResult& fit)
+    {
+        if (std::getenv("DUSK_GL_DEBUG") == nullptr)
+            return;
+
+        const char* const vendor   = (const char*)glGetString(GL_VENDOR);
+        const char* const renderer = (const char*)glGetString(GL_RENDERER);
+        const char* const version  = (const char*)glGetString(GL_VERSION);
+
+        std::string path;
+       #ifdef DISTRHO_OS_WINDOWS
+        if (const char* const appData = std::getenv("LOCALAPPDATA"))
+            path = std::string(appData) + "\\dusk-gl-debug.log";
+       #else
+        if (const char* const home = std::getenv("HOME"))
+            path = std::string(home) + "/dusk-gl-debug.log";
+       #endif
+        if (path.empty())
+            return;
+
+        if (FILE* const f = std::fopen(path.c_str(), "a"))
+        {
+            std::fprintf(f,
+                "tape-echo-2 vendor=%s renderer=%s version=%s max_texture=%d "
+                "atlas=%dx%d oversample=%d dropped=%d attempts=%d fits=%d\n",
+                vendor != nullptr ? vendor : "?",
+                renderer != nullptr ? renderer : "?",
+                version != nullptr ? version : "?",
+                (int)maxTextureSize, fit.atlasWidth, fit.atlasHeight,
+                fit.oversample, fit.droppedSizes, fit.attempts, fit.fits ? 1 : 0);
+            std::fclose(f);
+        }
+    }
+
     TapeEchoUI()
         : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT)
     {
@@ -87,31 +125,43 @@ public:
             { 7.0f, 9.0f, 11.0f, 14.0f, 18.0f, 24.0f, 28.0f, 32.0f, 48.0f, 72.0f };
         static constexpr float kRegularSizes[] =
             { 7.0f, 9.0f, 11.0f, 14.0f, 18.0f, 24.0f, 32.0f, 48.0f };
-        int labelCount   = (int)(sizeof(kLabelSizes) / sizeof(kLabelSizes[0]));
-        int regularCount = (int)(sizeof(kRegularSizes) / sizeof(kRegularSizes[0]));
-
-        // Baking all of those needs a 2048 px font atlas. Microsoft's software
-        // OpenGL 1.1 (a virtual machine with no 3D acceleration, or a Remote
-        // Desktop session) caps textures at 1024 px, and ImGui's GL2 backend
-        // reports nothing at all when that upload fails: it leaves the atlas
-        // texture incomplete, fixed-function texturing drops out for the glyph
-        // quads, and every label paints as a solid rectangle in the text color
-        // while the knobs and meters still look right. Drop the largest bakes
-        // on such a context so the atlas fits in 1024 px; the biggest text is
-        // then scaled up from a smaller face rather than disappearing.
+        // Both faces share one ImGui atlas, so the size that matters is the one
+        // built from every bake together. Software OpenGL (a virtual machine with
+        // no 3D acceleration, a Remote Desktop session) caps textures far below
+        // what those bakes need at 2x2 oversampling, the oversized upload fails
+        // silently, and every label then paints as a solid rectangle in the text
+        // colour while the knobs and meters still look right. Hand the loader the
+        // real limit and let it measure the built atlas and shrink until it fits,
+        // rather than guessing a face count that happens to work on one machine.
         GLint maxTextureSize = 0;
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
-        if (maxTextureSize > 0 && maxTextureSize < 2048)
+
+        // DUSK_GL_MAX_TEXTURE reproduces a small-texture context on hardware that
+        // has no such limit, which is the only practical way to exercise the
+        // shrink path without the machine that reported the bug.
+        if (const char* const forced = std::getenv("DUSK_GL_MAX_TEXTURE"))
         {
-            labelCount   = 6;   // 7..24 px
-            regularCount = 5;   // 7..18 px
+            const int v = std::atoi(forced);
+            if (v > 0)
+                maxTextureSize = (GLint)v;
         }
 
+        const duskdpf::EmbeddedFontRequest fontRequests[2] = {
+            { kTeFontSemiBold, kTeFontSemiBold_len, kLabelSizes,
+              (int)(sizeof(kLabelSizes) / sizeof(kLabelSizes[0])) },
+            { kTeFontRegular, kTeFontRegular_len, kRegularSizes,
+              (int)(sizeof(kRegularSizes) / sizeof(kRegularSizes[0])) },
+        };
+        duskdpf::CrispFontSet fontSets[2];
+        duskdpf::AtlasFitResult fit;
+        duskdpf::loadEmbeddedCrispFontSets(
+            fontRequests, 2, fontSets, 1.0f, (int)maxTextureSize, &fit);
+
         const float dpi = getScaleFactor();
-        labelFonts = duskdpf::loadEmbeddedCrispFontSet(
-            kTeFontSemiBold, kTeFontSemiBold_len, kLabelSizes, labelCount, 1.0f);
-        regularFonts = duskdpf::loadEmbeddedCrispFontSet(
-            kTeFontRegular, kTeFontRegular_len, kRegularSizes, regularCount, 1.0f);
+        labelFonts   = fontSets[0];
+        regularFonts = fontSets[1];
+
+        logGlDiagnostics(maxTextureSize, fit);
         labelFont = labelFonts.pick(12.5f * dpi);
         panel.setFontSet(labelFonts);
 

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -83,7 +83,6 @@ public:
 
         // Try each plausible writable root rather than one per platform: a host
         // can run without HOME set, and a log nobody can find is a log nobody reads.
-        std::string path;
         const char* const roots[] = { std::getenv("LOCALAPPDATA"), std::getenv("HOME"),
                                       std::getenv("USERPROFILE"), std::getenv("TMPDIR"),
                                       std::getenv("TEMP") };
@@ -91,14 +90,15 @@ public:
         {
             if (root == nullptr || root[0] == '\0')
                 continue;
-            path = std::string(root) + "/dusk-gl-debug.log";
-            break;
-        }
-        if (path.empty())
-            return;
 
-        if (FILE* const f = std::fopen(path.c_str(), "a"))
-        {
+            // Keep trying: a root can exist in the environment and still be
+            // unwritable for this process, and stopping at the first candidate
+            // would then lose the log for no reason.
+            const std::string path = std::string(root) + "/dusk-gl-debug.log";
+            FILE* const f = std::fopen(path.c_str(), "a");
+            if (f == nullptr)
+                continue;
+
             std::fprintf(f,
                 "tape-echo-2 vendor=%s renderer=%s version=%s max_texture=%d "
                 "atlas=%dx%d oversample=%d dropped=%d attempts=%d fits=%d\n",
@@ -108,6 +108,7 @@ public:
                 (int)maxTextureSize, fit.atlasWidth, fit.atlasHeight,
                 fit.oversample, fit.droppedSizes, fit.attempts, fit.fits ? 1 : 0);
             std::fclose(f);
+            return;
         }
     }
 

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -81,14 +81,19 @@ public:
         const char* const renderer = (const char*)glGetString(GL_RENDERER);
         const char* const version  = (const char*)glGetString(GL_VERSION);
 
+        // Try each plausible writable root rather than one per platform: a host
+        // can run without HOME set, and a log nobody can find is a log nobody reads.
         std::string path;
-       #ifdef DISTRHO_OS_WINDOWS
-        if (const char* const appData = std::getenv("LOCALAPPDATA"))
-            path = std::string(appData) + "\\dusk-gl-debug.log";
-       #else
-        if (const char* const home = std::getenv("HOME"))
-            path = std::string(home) + "/dusk-gl-debug.log";
-       #endif
+        const char* const roots[] = { std::getenv("LOCALAPPDATA"), std::getenv("HOME"),
+                                      std::getenv("USERPROFILE"), std::getenv("TMPDIR"),
+                                      std::getenv("TEMP") };
+        for (const char* const root : roots)
+        {
+            if (root == nullptr || root[0] == '\0')
+                continue;
+            path = std::string(root) + "/dusk-gl-debug.log";
+            break;
+        }
         if (path.empty())
             return;
 


### PR DESCRIPTION
Follow-up to #158, which shipped a font-atlas guard that did not work on the machine it was written for.

Measured on a Windows VM with no 3D acceleration, running Reaper 7.78:

    vendor=Microsoft Corporation renderer=GDI Generic version=1.1.0 max_texture=1024

Both faces share one ImGui atlas, and at 2x2 oversampling (four times the pixel area per glyph) the full bake is 2048x2048. That exceeds a 1024 px limit, the upload fails, and the GL2 backend does not report it: the atlas texture stays incomplete, so shapes still draw correctly while every glyph quad samples nothing and paints as a solid rectangle in the text colour. That is exactly the report from #154's follow-up and what the VM showed.

The previous guard mapped a sub-2048 limit to a hardcoded six and five baked faces, which is a prediction about packing rather than a measurement, and it skipped the reduction entirely when the query returned zero, so an unknown limit was treated as unlimited.

This bakes, measures the built atlas, and shrinks until it fits: first by dropping oversampling to 1x1, and only then by dropping the largest faces. At a 1024 px limit that now keeps every font size instead of deleting four of them, and an unknown limit is treated as 1024 rather than unlimited. The loop lives in shared-dpf so the other DPF UIs can adopt it.

Verification, forcing the limit with the new DUSK_GL_MAX_TEXTURE override:

| limit | result |
|---|---|
| 16384 | 2048x2048, oversample 2, first attempt |
| 2048 | 2048x2048, oversample 2, first attempt |
| 1024 | 1024x1024, oversample 1, every size kept |
| 512 | 512x512, oversample 1, two largest dropped |

On the VM the shipped path now reports  and every label renders: the product marks, knob captions, values, rail legends and VU markings. Screenshot before and after are in the issue thread.

Also here: DUSK_GL_DEBUG writes one line per editor open recording the context and what the atlas settled on, to the first writable location among LOCALAPPDATA, HOME, USERPROFILE and the temp directories. Silent unless the variable is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved embedded font loading with support for multiple font families and sizes.
  * Automatically adapts font rendering to available graphics texture limits.
  * Added optional OpenGL diagnostics for font-atlas and graphics configuration troubleshooting.
  * Supports configurable maximum texture limits for advanced compatibility.

* **Bug Fixes**
  * Prevented oversized font atlases from exceeding supported texture limits.
  * Added safer handling for invalid or unavailable embedded font data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->