### PR TITLE
chore(dpf): bump the DPF pin to pick up the CLAP and UI-size fixes

### DIFF
--- a/.github/scripts/check_fork_sources.sh
+++ b/.github/scripts/check_fork_sources.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fail the build if anything would fetch framework source from upstream.
+#
+# DPF, DPF-Widgets and pugl are hard forks under dusk-audio with local patches
+# that upstream does not have. A build that pulls any of them from DISTRHO does
+# not contain those patches, and the divergence is silent: it compiles, it runs,
+# and the binary simply is not the one that was tested.
+#
+# Two leaks have happened for real, and neither was a typo:
+#   - workflow `repository:` fields copied from upstream examples, which name
+#     DISTRHO because that is where upstream lives;
+#   - the `url` in the fork's own .gitmodules, which GitHub copies verbatim when
+#     a fork is created, so pugl kept pointing at DISTRHO long after the fork.
+#
+#   ./.github/scripts/check_fork_sources.sh [dpf-checkout-path]
+#
+# The optional argument points at a checked-out DPF so the submodule URL is
+# checked too; without it only this repository's build config is scanned.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DPF_CHECKOUT="${1:-}"
+
+# Scan the files that decide where source comes from. Documentation may discuss
+# upstream freely, so it is deliberately out of scope.
+CONFIG_FILES=(
+    "$REPO_ROOT"/.github/workflows/dpf-build.yml
+    "$REPO_ROOT"/.github/workflows/dpf-release.yml
+    "$REPO_ROOT"/.github/workflows/dpf-au-test.yml
+    "$REPO_ROOT"/docker/build_release.sh
+)
+
+failed=0
+
+for f in "${CONFIG_FILES[@]}"; do
+    [ -f "$f" ] || continue
+
+    # Strip comments before matching: a comment explaining the fork policy is
+    # allowed to name upstream, a `repository:` field is not.
+    if hits="$(sed 's/#.*$//' "$f" | grep -nE 'DISTRHO/(DPF|DPF-Widgets|pugl)' || true)"; [ -n "$hits" ]; then
+        echo "FAIL  ${f#"$REPO_ROOT"/} fetches framework source from upstream:"
+        echo "$hits" | sed 's/^/        /'
+        failed=1
+    fi
+done
+
+if [ -n "$DPF_CHECKOUT" ] && [ -f "$DPF_CHECKOUT/.gitmodules" ]; then
+    if hits="$(grep -nE 'url *= *.*DISTRHO/' "$DPF_CHECKOUT/.gitmodules" || true)"; [ -n "$hits" ]; then
+        echo "FAIL  the DPF checkout's .gitmodules fetches a submodule from upstream:"
+        echo "$hits" | sed 's/^/        /'
+        echo "        fix it in dusk-audio/DPF, not here: a fork inherits this file"
+        failed=1
+    fi
+fi
+
+if [ "$failed" = "1" ]; then
+    echo
+    echo "Every framework dependency must come from dusk-audio. See the fork policy"
+    echo "in CLAUDE.md and docker/check_dpf_pins.sh for the local equivalent."
+    exit 1
+fi
+
+echo "OK    framework sources are all dusk-audio forks"

--- a/.github/workflows/dpf-au-test.yml
+++ b/.github/workflows/dpf-au-test.yml
@@ -11,7 +11,7 @@ on:
       - 'tape-echo-dpf-v*'
 
 env:
-  DPF_SHA: 45a7e30e5343231019e6d5f09629bae13f5899c7
+  DPF_SHA: bca31ac656228e8271e5baccfd106fcef2e44145
   DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
 
 jobs:

--- a/.github/workflows/dpf-au-test.yml
+++ b/.github/workflows/dpf-au-test.yml
@@ -11,8 +11,8 @@ on:
       - 'tape-echo-dpf-v*'
 
 env:
-  DPF_SHA: bca31ac656228e8271e5baccfd106fcef2e44145
-  DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
+  DPF_SHA: d8e5bc69fd7bf355de548e0eafe0f3b7784c68c6
+  DPFWIDGETS_SHA: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
 
 jobs:
   build-au-macos:
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -53,14 +53,14 @@ on:
 # DPF is our fork (dusk-audio/DPF), branch main — the permanent source of truth
 # for our DPF patches (CLAP latency changes constrained to activate(), AU
 # preset + CLAP state hardening, Wayland/CI work). DPF-Widgets stays upstream
-# (DISTRHO/DPF-Widgets) — only DPF is forked.
+# (dusk-audio/DPF-Widgets) — only DPF is forked.
 # To advance DPF: land changes on fork main in ~/projects/DPF, re-run
 # clap-validator and pluginval against the rebuilt plugins, push to
 # dusk-audio/DPF, THEN bump DPF_REF. Keep SHAs in sync with dpf-release.yml,
 # dpf-au-test.yml and docker/build_release.sh. Bump deliberately.
 env:
-  DPF_REF: bca31ac656228e8271e5baccfd106fcef2e44145
-  DPFWIDGETS_REF: 730da6397904da66d99667c1cb30fc77fc3d794a
+  DPF_REF: d8e5bc69fd7bf355de548e0eafe0f3b7784c68c6
+  DPFWIDGETS_REF: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk
 
@@ -230,7 +230,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_REF }}
           path: DPF-Widgets
           submodules: recursive
@@ -497,7 +497,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_REF }}
           path: DPF-Widgets
           submodules: recursive
@@ -611,7 +611,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_REF }}
           path: DPF-Widgets
           submodules: recursive
@@ -858,7 +858,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_REF }}
           path: DPF-Widgets
           submodules: recursive

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -50,14 +50,18 @@ on:
       # dpf_clap_validate.py never runs the gate it just changed.
       - '.github/scripts/**'
 
-# DPF is our fork (dusk-audio/DPF), branch main — the permanent source of truth
-# for our DPF patches (CLAP latency changes constrained to activate(), AU
-# preset + CLAP state hardening, Wayland/CI work). DPF-Widgets stays upstream
-# (dusk-audio/DPF-Widgets) — only DPF is forked.
+# Every framework dependency is a hard fork under dusk-audio and must be fetched
+# from there: DPF (CLAP latency constrained to activate(), AU preset + CLAP state
+# hardening, CLAP UI parameter delivery, UI size reconciliation, Wayland/CI work),
+# DPF-Widgets, and pugl. pugl is fetched through the url in the DPF fork's own
+# .gitmodules, not from anything here, which is how it kept pointing at upstream
+# unnoticed. check_fork_sources.sh below fails the build if any of that regresses.
 # To advance DPF: land changes on fork main in ~/projects/DPF, re-run
 # clap-validator and pluginval against the rebuilt plugins, push to
 # dusk-audio/DPF, THEN bump DPF_REF. Keep SHAs in sync with dpf-release.yml,
-# dpf-au-test.yml and docker/build_release.sh. Bump deliberately.
+# dpf-au-test.yml and docker/build_release.sh. Bump deliberately, and keep local
+# checkouts on the pinned SHAs (docker/check_dpf_pins.sh) so a hand-tested build
+# is the one CI produces.
 env:
   DPF_REF: d8e5bc69fd7bf355de548e0eafe0f3b7784c68c6
   DPFWIDGETS_REF: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
@@ -235,6 +239,12 @@ jobs:
           path: DPF-Widgets
           submodules: recursive
           persist-credentials: false
+
+      # Runs after the checkouts so it can inspect the fork's own .gitmodules,
+      # which is where pugl silently kept pointing at upstream. Cheap, so it
+      # gates the expensive build instead of reporting after it.
+      - name: Check framework sources are our forks
+        run: ./.github/scripts/check_fork_sources.sh "${GITHUB_WORKSPACE}/DPF"
 
       - name: Install Linux dependencies
         env:

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -59,7 +59,7 @@ on:
 # dusk-audio/DPF, THEN bump DPF_REF. Keep SHAs in sync with dpf-release.yml,
 # dpf-au-test.yml and docker/build_release.sh. Bump deliberately.
 env:
-  DPF_REF: 45a7e30e5343231019e6d5f09629bae13f5899c7
+  DPF_REF: bca31ac656228e8271e5baccfd106fcef2e44145
   DPFWIDGETS_REF: 730da6397904da66d99667c1cb30fc77fc3d794a
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -3,7 +3,7 @@ name: Build Sunset Circuits (DPF)
 # Release + CI-debug workflow for the DPF-based Sunset Circuits synth.
 #
 # The DPF ports live outside the JUCE release build graph (build.yml), so they
-# need their own matrix: this checks out dusk-audio/DPF (our fork) + DISTRHO/DPF-Widgets at
+# need their own matrix: this checks out dusk-audio/DPF (our fork) + dusk-audio/DPF-Widgets at
 # pinned SHAs and builds plugins/sunset-circuits/dpf-plugin (VST3 + CLAP + LV2
 # everywhere, plus a notarizable AU on macOS with an auval pass).
 #
@@ -43,8 +43,8 @@ on:
 # in sync with dpf-build.yml, dpf-au-test.yml and docker/build_release.sh, and
 # re-run the dispatch matrix before tagging.
 env:
-  DPF_SHA: bca31ac656228e8271e5baccfd106fcef2e44145
-  DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
+  DPF_SHA: d8e5bc69fd7bf355de548e0eafe0f3b7784c68c6
+  DPFWIDGETS_SHA: 668de17f06abdeb98d5a4b62594bd634f8d1ac2e
   PLUGIN_DIR: plugins/sunset-circuits/dpf-plugin
   SLUG: sunset-circuits
 
@@ -181,7 +181,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
@@ -293,7 +293,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
@@ -368,7 +368,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
@@ -541,7 +541,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive
@@ -740,7 +740,7 @@ jobs:
       - name: Checkout DPF-Widgets
         uses: actions/checkout@v4
         with:
-          repository: DISTRHO/DPF-Widgets
+          repository: dusk-audio/DPF-Widgets
           ref: ${{ env.DPFWIDGETS_SHA }}
           path: DPF-Widgets
           submodules: recursive

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -43,7 +43,7 @@ on:
 # in sync with dpf-build.yml, dpf-au-test.yml and docker/build_release.sh, and
 # re-run the dispatch matrix before tagging.
 env:
-  DPF_SHA: 45a7e30e5343231019e6d5f09629bae13f5899c7
+  DPF_SHA: bca31ac656228e8271e5baccfd106fcef2e44145
   DPFWIDGETS_SHA: 730da6397904da66d99667c1cb30fc77fc3d794a
   PLUGIN_DIR: plugins/sunset-circuits/dpf-plugin
   SLUG: sunset-circuits

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -18,8 +18,8 @@ IMAGE_NAME="dusk-plugins-builder"
 # DPF / DPF-Widgets SHAs — keep in sync with dpf-build.yml, dpf-release.yml and dpf-au-test.yml.
 # DPF comes from the dusk-audio/DPF fork (our patches live there); DPF-Widgets
 # stays on upstream DISTRHO (no fork).
-DPF_SHA="bca31ac656228e8271e5baccfd106fcef2e44145"
-DPFWIDGETS_SHA="730da6397904da66d99667c1cb30fc77fc3d794a"
+DPF_SHA="d8e5bc69fd7bf355de548e0eafe0f3b7784c68c6"
+DPFWIDGETS_SHA="668de17f06abdeb98d5a4b62594bd634f8d1ac2e"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)
 get_plugin_target() {
@@ -67,7 +67,7 @@ is_sunset() {
 }
 
 # Build Sunset Circuits (DPF) in the container. Unlike the JUCE plugins this does
-# NOT use the top-level JUCE build graph: it clones dusk-audio/DPF (our fork) + DISTRHO/DPF-Widgets at
+# NOT use the top-level JUCE build graph: it clones dusk-audio/DPF (our fork) + dusk-audio/DPF-Widgets at
 # the pinned SHAs inside the container and builds plugins/sunset-circuits/dpf-plugin
 # standalone (mirrors .github/workflows/dpf-release.yml). Produces VST3/CLAP/LV2.
 build_sunset() {
@@ -111,7 +111,7 @@ build_sunset() {
             }
             cd /tmp
             fetch_sha https://github.com/dusk-audio/DPF.git      "$DPF_SHA"        /tmp/dpf
-            fetch_sha https://github.com/DISTRHO/DPF-Widgets.git  "$DPFWIDGETS_SHA" /tmp/dpf-widgets
+            fetch_sha https://github.com/dusk-audio/DPF-Widgets.git  "$DPFWIDGETS_SHA" /tmp/dpf-widgets
             test -n "$(ls -A /tmp/dpf/dgl/src/pugl-upstream 2>/dev/null)" \
                 || { echo "ERROR: DPF pugl submodule missing after fetch"; exit 1; }
 

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -18,7 +18,7 @@ IMAGE_NAME="dusk-plugins-builder"
 # DPF / DPF-Widgets SHAs — keep in sync with dpf-build.yml, dpf-release.yml and dpf-au-test.yml.
 # DPF comes from the dusk-audio/DPF fork (our patches live there); DPF-Widgets
 # stays on upstream DISTRHO (no fork).
-DPF_SHA="45a7e30e5343231019e6d5f09629bae13f5899c7"
+DPF_SHA="bca31ac656228e8271e5baccfd106fcef2e44145"
 DPFWIDGETS_SHA="730da6397904da66d99667c1cb30fc77fc3d794a"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)

--- a/docker/check_dpf_pins.sh
+++ b/docker/check_dpf_pins.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Compare the local DPF and DPF-Widgets checkouts against the SHAs CI builds
+# with. A local build that uses different framework source than CI is a release
+# hazard: the binaries users get are not the ones that were tested by hand.
+#
+#   ./docker/check_dpf_pins.sh          report only, exit 1 on drift
+#   ./docker/check_dpf_pins.sh --fix    check the pinned SHAs out locally
+#
+# Docker release builds fetch the pins directly and are unaffected either way;
+# this is about ad-hoc local cmake builds that point DPF_PATH at a working tree.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/dpf-build.yml"
+
+DPF_PATH="${DPF_PATH:-$REPO_ROOT/../DPF}"
+DPFWIDGETS_PATH="${DPFWIDGETS_PATH:-$REPO_ROOT/../DPF-Widgets}"
+
+FIX=0
+[ "${1:-}" = "--fix" ] && FIX=1
+
+pin_from_workflow() {
+    grep -E "^\s+$1:" "$WORKFLOW" | head -1 | awk '{print $2}'
+}
+
+DPF_PIN="$(pin_from_workflow DPF_REF)"
+DPFWIDGETS_PIN="$(pin_from_workflow DPFWIDGETS_REF)"
+
+drift=0
+
+check_one() {
+    local name="$1" path="$2" pin="$3" expect_remote="$4"
+
+    if [ ! -d "$path/.git" ]; then
+        echo "MISSING  $name: no git checkout at $path"
+        drift=1
+        return
+    fi
+
+    local head remote dirty
+    head="$(git -C "$path" rev-parse HEAD)"
+    remote="$(git -C "$path" remote get-url origin 2>/dev/null || echo '(none)')"
+    dirty="$(git -C "$path" status --porcelain | wc -l)"
+
+    case "$remote" in
+        *"$expect_remote"*) ;;
+        *)
+            echo "REMOTE   $name: origin is $remote, expected $expect_remote"
+            drift=1
+            ;;
+    esac
+
+    if [ "$head" != "$pin" ]; then
+        echo "DRIFT    $name: local $(echo "$head" | cut -c1-12), CI builds $(echo "$pin" | cut -c1-12)"
+        drift=1
+        if [ "$FIX" = "1" ]; then
+            echo "         checking out the pinned commit"
+            git -C "$path" fetch -q origin
+            git -C "$path" checkout -q "$pin"
+            git -C "$path" submodule update -q --init --recursive
+        fi
+    else
+        echo "OK       $name: $(echo "$head" | cut -c1-12)"
+    fi
+
+    if [ "$dirty" != "0" ]; then
+        echo "DIRTY    $name: $dirty uncommitted file(s); a local build includes changes CI never sees"
+        drift=1
+    fi
+}
+
+echo "CI pins (from .github/workflows/dpf-build.yml):"
+echo "  DPF          $DPF_PIN"
+echo "  DPF-Widgets  $DPFWIDGETS_PIN"
+echo
+
+check_one "DPF"         "$DPF_PATH"         "$DPF_PIN"         "dusk-audio/DPF"
+check_one "DPF-Widgets" "$DPFWIDGETS_PATH"  "$DPFWIDGETS_PIN"  "dusk-audio/DPF-Widgets"
+
+# The submodule has to come from our fork too, otherwise a build still pulls
+# source from a repository we do not control.
+if [ -f "$DPF_PATH/.gitmodules" ]; then
+    pugl_url="$(git -C "$DPF_PATH" config -f .gitmodules --get submodule.dgl/src/pugl-upstream.url || echo '')"
+    case "$pugl_url" in
+        *dusk-audio/pugl*) echo "OK       pugl submodule: dusk-audio/pugl" ;;
+        *)                 echo "REMOTE   pugl submodule: $pugl_url, expected dusk-audio/pugl"; drift=1 ;;
+    esac
+fi
+
+echo
+if [ "$drift" = "0" ]; then
+    echo "Local checkouts match what CI builds."
+else
+    if [ "$FIX" = "1" ]; then
+        echo "Pinned commits checked out. Re-run without --fix to confirm."
+    else
+        echo "Local builds will not match CI. Re-run with --fix, or bump the pins if the"
+        echo "local commits are the ones that should ship."
+    fi
+    exit 1
+fi

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -118,7 +118,6 @@ public:
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kTeParams[i].def;
         setGeometryConstraints((uint32_t)kDesignW, (uint32_t)kDesignH, true);
-        adoptWindowSize();
 
         // Barlow Condensed is bundled under the SIL OFL. Unlike the previous
         // system-font search this produces identical metrics on every OS. Two
@@ -226,12 +225,6 @@ protected:
 
     void onImGuiDisplay() override
     {
-        // Cheap guard against the window and this widget drifting apart again
-        // after construction (see adoptWindowSize). A host resize normally
-        // reaches the widget through the window's own size event; when one is
-        // missed the whole frame would otherwise be scissored to a sliver.
-        adoptWindowSize();
-
         const float winW = (float)getWidth();
         const float winH = (float)getHeight();
         s   = std::min(winW / kDesignW, winH / kDesignH);
@@ -315,30 +308,6 @@ private:
 
     // Keep this widget the same size as the window it draws into.
     //
-    // DPF sizes the plugin *window* at the design size multiplied by the host
-    // DPI scale (DistrhoUI.cpp, createNextWindow), then UI::UI puts this
-    // *widget* straight back to the unscaled size. The two are normally
-    // reconciled by the window's first size event, but on Windows that event is
-    // delivered while the window is still being created, before this widget
-    // exists, so a host that never resizes the view itself (MuLab 9, issue
-    // #154) is left with a widget smaller than the GL surface for good.
-    // Everything then draws unscaled into the corner of a black window, and the
-    // ImGui backend, which derives its scissor box from the widget size rather
-    // than from the surface, clips every frame to the bottom
-    // (surfaceHeight - widgetHeight) band: only the utility rail survives.
-    //
-    // Adopting the window's real size restores both the scale and a
-    // full-surface clip. It is a no-op whenever the two already agree, which is
-    // every other host and platform, and it stays correct across later resizes
-    // because this UI does not use DGL's automatic scaling (which deliberately
-    // keeps widget and window sizes apart).
-    void adoptWindowSize()
-    {
-        const auto windowSize = getWindow().getSize();
-        if (windowSize.isValid() && windowSize != getSize())
-            DGL_NAMESPACE::Widget::setSize(windowSize);
-    }
-
     ImVec2 P(float x, float y) const { return ImVec2(org.x + x * s, org.y + y * s); }
 
     static ImU32 fade(ImU32 c, float amount)


### PR DESCRIPTION
Closes #153.

Bumps all four pin sites from 45a7e30e to bca31ac, picking up the two fixes merged into dusk-audio/DPF:

- dusk-audio/DPF#10 delivers UI parameter edits to CLAP hosts that are not processing. This is the Tape Echo 2 power switch report: the CLAP backend queued UI edits and drained them only inside process(), so a host that stops processing a bypassed FX (Reaper does) left the un-bypass edit queued forever and the switch could never turn back on. The spec requires request_flush() or request_process() for exactly this case and the backend called neither. Proven with a headless CLAP host that clicks the real GUI under Xvfb and reads the result through params.flush() without ever calling process(). Also in that PR: -1 wildcards on outgoing parameter events, allocation-failure survival in the UI event queue, and a request_process for UI-sent notes.
- dusk-audio/DPF#11 delivers the window size to the widget after the UI is constructed, the framework-level fix for the MuLab 9 display report (#154).

Also removes Tape Echo 2's plugin-side widget-size workaround, which shipped in #158 so the reporter did not have to wait for this bump. It is worse than redundant now: seeding the widget in the constructor makes the framework reconciliation a no-op, which suppresses the post-construction onResize a derived UI expects and, on formats that compile it in, the host size callback. The same defect disqualified the constructor-seed design at framework level; leaving it in one plugin would keep it alive there.

Verification against the merged fork: Tape Echo 2 builds clean, and at a forced 1.8 scale the rendered content spans the full 1620 px surface with the seed removed, where the defect confines it to 900 px. CI builds all four DPF plugins against the new pin, and the clap-validator gate has been strict since #157.

Note for the Windows VM used to verify #154: its GL context is GDI Generic 1.1 with a 1024 px texture limit, which is what the font atlas fit loop in #163 handles.