### PR TITLE
Add crash capture to DPF plugins

### DIFF
--- a/plugins/4k-eq/dpf-plugin/FourKEQPlugin.cpp
+++ b/plugins/4k-eq/dpf-plugin/FourKEQPlugin.cpp
@@ -10,11 +10,14 @@
 #include "FourKEQParams.hpp"
 #include "FourKEQPresetRuntime.hpp"
 #include "FourKEQVersion.hpp"
+#include "util/CrashLog.hpp"
 
 START_NAMESPACE_DISTRHO
 
 class FourKEQPlugin : public Plugin
 {
+    DuskCrashLog::ScopedRegistration crashLog_ { "4K EQ 2", FOURKEQ2_VERSION_STRING };
+
 public:
     FourKEQPlugin()
         : Plugin(kParamCount, kNumFactoryPresets, 0)

--- a/plugins/4k-eq/dpf-plugin/FourKEQUI.cpp
+++ b/plugins/4k-eq/dpf-plugin/FourKEQUI.cpp
@@ -23,6 +23,7 @@
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp" // shared DPF Patreon "Special Thanks" overlay
+#include "util/CrashLog.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -100,6 +101,8 @@ public:
     FourKEQUI()
         : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT)
     {
+        supportersOverlay.setActionLink("Open crash log folder",
+                                        [] { DuskCrashLog::openLogFolder(); });
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kDefault(i);
         // No hard aspect lock: the Hide Graph toggle changes the window aspect
@@ -213,7 +216,7 @@ protected:
         if (showSupporters)
             duskdpf::drawSupportersOverlay(
                 panel, dl, kDesignW, designH, showSupporters, "4K EQ 2",
-                FOURKEQ2_VERSION_STRING);
+                FOURKEQ2_VERSION_STRING, &supportersOverlay);
 
         // Own resize grip, submitted LAST so it wins ImGui's hover race (over
         // the credits card too) and paints over everything.
@@ -1862,6 +1865,7 @@ private:
     }
 
     duskdpf::DuskPanel panel;
+    duskdpf::SupportersOverlay supportersOverlay;
     duskdpf::DuskImGuiTextInputFocus textInputFocus;
     duskdpf::RealFFT fft;
     std::vector<float> specDb;

--- a/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachinePlugin.cpp
@@ -10,6 +10,7 @@
 #include "TapeMachinePresets.hpp"
 #include "TapeMachineVersion.hpp"
 #include "TapeMachineDSP.hpp"
+#include "util/CrashLog.hpp"
 
 #include <atomic>
 #include <cmath>
@@ -18,6 +19,8 @@ START_NAMESPACE_DISTRHO
 
 class TapeMachinePlugin : public Plugin
 {
+    DuskCrashLog::ScopedRegistration crashLog_ { "TapeMachine 2", TM2_VERSION_STRING };
+
 public:
     TapeMachinePlugin()
         : Plugin(kParamCount, kNumTmPresets, 0)

--- a/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/dpf-plugin/TapeMachineUI.cpp
@@ -17,6 +17,7 @@
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp"   // shared DPF Patreon "Special Thanks" overlay (click title)
+#include "util/CrashLog.hpp"
 
 #include <cmath>
 #include <cstdio>
@@ -101,6 +102,9 @@ public:
         pal.whiteDim = IM_COL32(70, 68, 64, 255);   // darker than kColInkDim so knob readouts stay legible on the gray panel
         panel.setPalette(pal);
 
+        supportersOverlay.setActionLink("Open crash log folder",
+                                        [] { DuskCrashLog::openLogFolder(); });
+
         scanUserPresets();
     }
 
@@ -159,7 +163,8 @@ protected:
         if (showAdvanced) drawAdvanced(dl);
         if (showSupporters)
             duskdpf::drawSupportersOverlay(panel, dl, kDesignW, kDesignH, showSupporters,
-                                           "TapeMachine 2", TM2_VERSION_STRING);
+                                           "TapeMachine 2", TM2_VERSION_STRING,
+                                           &supportersOverlay);
 
         // Own resize grip, submitted LAST so it wins ImGui's hover race (over the
         // Advanced card and the supporters overlay alike) and paints over
@@ -1193,6 +1198,7 @@ private:
 
     //--- state -----------------------------------------------------------------
     duskdpf::DuskPanel panel;
+    duskdpf::SupportersOverlay supportersOverlay;
     duskdpf::DuskImGuiTextInputFocus textInputFocus;
     duskdpf::CrispFontSet fontSet;
     ImFont* labelFont = nullptr;

--- a/plugins/multi-q/dpf-plugin/CMakeLists.txt
+++ b/plugins/multi-q/dpf-plugin/CMakeLists.txt
@@ -38,6 +38,12 @@ target_include_directories(multi_q_2 PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/../core"
     ${DUSK_DPF_INCLUDE_DIRS})
 
+# Single source of truth for host metadata and crash-log diagnostics.
+target_compile_definitions(multi_q_2 PUBLIC
+    MQ2_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
+    MQ2_VERSION_MINOR=${PROJECT_VERSION_MINOR}
+    MQ2_VERSION_PATCH=${PROJECT_VERSION_PATCH})
+
 # Auto-deploy the built CLAP/VST3/LV2 into the user plugin dirs after each build
 # (disable with -DDUSK_DPF_INSTALL_LOCAL=OFF).
 dusk_dpf_install_local(multi_q_2 LV2_PROGRAMS)

--- a/plugins/multi-q/dpf-plugin/MultiQPlugin.cpp
+++ b/plugins/multi-q/dpf-plugin/MultiQPlugin.cpp
@@ -12,7 +12,9 @@
 #include "MultiQAccess.hpp"
 #include "MultiQParams.hpp"
 #include "MultiQProgramPresets.hpp"  // Digital factory presets (host programs)
+#include "MultiQVersion.hpp"
 #include "MultiQDSP.hpp"
+#include "util/CrashLog.hpp"
 
 #include <atomic>
 #include <cmath>
@@ -23,6 +25,8 @@ START_NAMESPACE_DISTRHO
 
 class MultiQPlugin : public Plugin
 {
+    DuskCrashLog::ScopedRegistration crashLog_ { "Multi-Q 2", MQ2_VERSION_STRING };
+
 public:
     MultiQPlugin()
         : Plugin(kParamCount,
@@ -110,7 +114,8 @@ protected:
     const char* getMaker() const override    { return "Dusk Audio"; }
     const char* getHomePage() const override { return "https://dusk-audio.github.io/"; }
     const char* getLicense() const override  { return "GPL-3.0-or-later"; }
-    uint32_t    getVersion() const override  { return d_version(2, 0, 1); }
+    uint32_t    getVersion() const override
+    { return d_version(MQ2_VERSION_MAJOR, MQ2_VERSION_MINOR, MQ2_VERSION_PATCH); }
     int64_t     getUniqueId() const override { return d_cconst('D', 's', 'M', 'q'); } // DsMq
 
     //--- parameters ------------------------------------------------------------

--- a/plugins/multi-q/dpf-plugin/MultiQUI.cpp
+++ b/plugins/multi-q/dpf-plugin/MultiQUI.cpp
@@ -29,6 +29,7 @@
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "PatreonBackersDpf.hpp"
+#include "util/CrashLog.hpp"
 
 #include <cmath>
 #include <complex>
@@ -3355,11 +3356,26 @@ private:
             for (const char* nm : tier.names) { ctext(y, 15.f, IM_COL32(220, 220, 216, 255), nm, false); y += LN; }
             y += GAP;
         }
-        ctext(c1.y - 24.f * s, 11.f, IM_COL32(140, 142, 148, 255), "click anywhere to close", false);
+        static const char* const actionLabel = "Open crash log folder";
+        ImFont* const actionFont = panel.pickFont(12.f * s);
+        const ImVec2 actionSize = actionFont->CalcTextSizeA(12.f * s, FLT_MAX, 0.f, actionLabel);
+        const ImVec2 actionPos(cc.x - 0.5f * actionSize.x, c1.y - 49.f * s);
+        ImGui::SetCursorScreenPos(ImVec2(actionPos.x - 5.f * s, actionPos.y - 3.f * s));
+        const bool actionClicked = ImGui::InvisibleButton(
+            "##creditsCrashLog", ImVec2(actionSize.x + 10.f * s, actionSize.y + 6.f * s));
+        const ImU32 actionColor = ImGui::IsItemHovered() ? IM_COL32(218, 178, 126, 255)
+                                                         : IM_COL32(184, 144, 96, 255);
+        if (ImGui::IsItemHovered()) ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+        dl->AddText(actionFont, 12.f * s, actionPos, actionColor, actionLabel);
+        dl->AddLine(ImVec2(actionPos.x, actionPos.y + actionSize.y + 1.f * s),
+                    ImVec2(actionPos.x + actionSize.x, actionPos.y + actionSize.y + 1.f * s),
+                    actionColor, 1.f * s);
+        ctext(c1.y - 22.f * s, 11.f, IM_COL32(140, 142, 148, 255), "click anywhere else to close", false);
 
-        if (ImGui::IsKeyPressed(ImGuiKey_Escape)) showCredits = false;
+        if (actionClicked) DuskCrashLog::openLogFolder();
+        else if (ImGui::IsKeyPressed(ImGuiKey_Escape)) showCredits = false;
         else if (!creditsArmed) { if (!ImGui::IsMouseDown(0)) creditsArmed = true; }
-        else if (ImGui::IsMouseClicked(0)) showCredits = false;
+        else if (ImGui::IsMouseReleased(0) && !ImGui::IsAnyItemActive()) showCredits = false;
     }
 
     void drawGraph(ImDrawList* dl)

--- a/plugins/multi-q/dpf-plugin/MultiQVersion.hpp
+++ b/plugins/multi-q/dpf-plugin/MultiQVersion.hpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Dusk Audio - GNU GPL v3.0 or later (see repository LICENSE).
+//
+// MultiQVersion.hpp - version shared by Multi-Q 2 metadata and diagnostics.
+// CMake supplies these values from project(... VERSION ...); the fallbacks keep
+// non-CMake source builds usable.
+
+#pragma once
+
+#ifndef MQ2_VERSION_MAJOR
+ #define MQ2_VERSION_MAJOR 2
+ #define MQ2_VERSION_MINOR 0
+ #define MQ2_VERSION_PATCH 1
+#endif
+
+#define MQ2_STRINGIFY_IMPL(value) #value
+#define MQ2_STRINGIFY(value) MQ2_STRINGIFY_IMPL(value)
+#define MQ2_VERSION_STRING \
+    MQ2_STRINGIFY(MQ2_VERSION_MAJOR) "." \
+    MQ2_STRINGIFY(MQ2_VERSION_MINOR) "." \
+    MQ2_STRINGIFY(MQ2_VERSION_PATCH)

--- a/plugins/shared-dpf/ui/DuskSupportersOverlay.hpp
+++ b/plugins/shared-dpf/ui/DuskSupportersOverlay.hpp
@@ -21,9 +21,41 @@
 #include <algorithm>   // std::min
 #include <cstdio>      // std::snprintf
 #include <cstring>     // std::strcmp
+#include <functional>
+#include <string>
+#include <utility>
 
 namespace duskdpf
 {
+
+// Persistent action state for the immediate-mode overlay. The setter mirrors
+// the JUCE SupportersOverlay API while the draw function remains compatible
+// with existing callers that do not need an action.
+class SupportersOverlay
+{
+public:
+    void setActionLink(std::string label, std::function<void()> onClick)
+    {
+        actionLabel = std::move(label);
+        onActionClick = std::move(onClick);
+    }
+
+    bool hasActionLink() const noexcept
+    {
+        return !actionLabel.empty() && static_cast<bool>(onActionClick);
+    }
+
+    const std::string& actionLinkLabel() const noexcept { return actionLabel; }
+    void triggerAction() const { if (onActionClick) onActionClick(); }
+    bool isDismissArmed() const noexcept { return dismissArmed; }
+    void armDismiss() noexcept { dismissArmed = true; }
+    void resetDismiss() noexcept { dismissArmed = false; }
+
+private:
+    std::string actionLabel;
+    std::function<void()> onActionClick;
+    bool dismissArmed = false;
+};
 
 // Per-tier accent colour, matched to the JUCE SupportersOverlay palette (HUGS is DPF-only, warm).
 inline ImU32 supporterTierColor(const char* title) noexcept
@@ -42,19 +74,30 @@ inline ImU32 supporterTierColor(const char* title) noexcept
 // Coordinates are the plugin's DESIGN space (0..designW/H); the shared DuskPanel maps to screen.
 inline void drawSupportersOverlay(DuskPanel& panel, ImDrawList* dl,
                                   float designW, float designH, bool& open,
-                                  const char* pluginName, const char* version = "")
+                                  const char* pluginName, const char* version = "",
+                                  SupportersOverlay* overlay = nullptr)
 {
     if (!open)
         return;
 
     const float s = panel.scale();
+    const bool hasAction = overlay != nullptr && overlay->hasActionLink();
+    const bool canDismiss = hasAction && overlay->isDismissArmed();
+    if (hasAction && !canDismiss && !ImGui::IsMouseDown(ImGuiMouseButton_Left))
+        overlay->armDismiss();
 
     // --- scrim + click-to-dismiss (any click outside the scrolling name list) ---------------
     dl->AddRectFilled(panel.P(0.0f, 0.0f), panel.P(designW, designH), IM_COL32(16, 16, 16, 242));
-    ImGui::SetCursorScreenPos(panel.P(0.0f, 0.0f));
-    ImGui::SetNextItemAllowOverlap();
-    if (ImGui::InvisibleButton("##supscrim", ImVec2(designW * s, designH * s)))
-        open = false;
+    // With an action link, dismissal is handled after the panel items so the
+    // full-canvas target cannot take ActiveId before the link. Existing callers
+    // without an action retain the original immediate-mode scrim button.
+    if (!hasAction)
+    {
+        ImGui::SetCursorScreenPos(panel.P(0.0f, 0.0f));
+        ImGui::SetNextItemAllowOverlap();
+        if (ImGui::InvisibleButton("##supscrim", ImVec2(designW * s, designH * s)))
+            open = false;
+    }
 
     // --- centred panel (design coords) ------------------------------------------------------
     const float pw = std::min(384.0f, designW - 56.0f);
@@ -73,10 +116,12 @@ inline void drawSupportersOverlay(DuskPanel& panel, ImDrawList* dl,
 
     // --- scrolling tier/name list -----------------------------------------------------------
     const float listTop = py + 76.0f;
-    const float footerH = 40.0f;
+    const float footerH = hasAction ? 60.0f : 40.0f;
     const float listH   = ph - (listTop - py) - footerH;
+    const ImVec2 listMin = panel.P(px + 14.0f, listTop);
+    const ImVec2 listMax = panel.P(px + pw - 14.0f, listTop + listH);
 
-    ImGui::SetCursorScreenPos(panel.P(px + 14.0f, listTop));
+    ImGui::SetCursorScreenPos(listMin);
     ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(0, 0, 0, 0));
     ImGui::BeginChild("##suplist", ImVec2((pw - 28.0f) * s, listH * s), false,
                       ImGuiWindowFlags_None);   // native scrollbar appears only when the list overflows
@@ -127,8 +172,48 @@ inline void drawSupportersOverlay(DuskPanel& panel, ImDrawList* dl,
     // --- footer -----------------------------------------------------------------------------
     dl->AddRectFilled(panel.P(px + 26.0f, py + ph - footerH), panel.P(px + pw - 26.0f, py + ph - footerH + 1.0f),
                       IM_COL32(58, 58, 58, 255));
-    panel.text(dl, px + pw * 0.5f, py + ph - footerH + 8.0f, 10.0f, IM_COL32(96, 96, 96, 255),
-               "Click anywhere to close", 0);
+    if (hasAction)
+    {
+        const float linkY = py + ph - footerH + 7.0f;
+        ImFont* const font = panel.pickFont(10.0f * s);
+        const ImVec2 textSize = font->CalcTextSizeA(10.0f * s, FLT_MAX, 0.0f,
+                                                    overlay->actionLinkLabel().c_str());
+        const ImVec2 hitMin = panel.P(px + 0.5f * pw, linkY);
+        ImGui::SetCursorScreenPos(ImVec2(hitMin.x - 0.5f * textSize.x - 5.0f * s,
+                                        hitMin.y - 3.0f * s));
+        const bool actionPressed = ImGui::InvisibleButton(
+            "##supaction", ImVec2(textSize.x + 10.0f * s, textSize.y + 6.0f * s));
+        const bool actionHovered = ImGui::IsItemHovered();
+        if (actionHovered)
+            ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+        const ImU32 linkColor = actionHovered ? IM_COL32(218, 178, 126, 255)
+                                              : IM_COL32(184, 144, 96, 255);
+        panel.text(dl, px + pw * 0.5f, linkY, 10.0f, linkColor,
+                   overlay->actionLinkLabel().c_str(), 0);
+        dl->AddLine(ImVec2(hitMin.x - 0.5f * textSize.x, hitMin.y + textSize.y + 1.0f * s),
+                    ImVec2(hitMin.x + 0.5f * textSize.x, hitMin.y + textSize.y + 1.0f * s),
+                    linkColor, 1.0f * s);
+        if (actionPressed)
+        {
+            overlay->triggerAction();
+        }
+        else if (canDismiss && ImGui::IsMouseReleased(ImGuiMouseButton_Left)
+                 && !actionHovered && !ImGui::IsAnyItemActive())
+        {
+            const ImVec2 mouse = ImGui::GetIO().MousePos;
+            const bool overList = mouse.x >= listMin.x && mouse.x < listMax.x
+                               && mouse.y >= listMin.y && mouse.y < listMax.y;
+            if (!overList)
+            {
+                open = false;
+                overlay->resetDismiss();
+            }
+        }
+    }
+
+    panel.text(dl, px + pw * 0.5f, py + ph - footerH + (hasAction ? 29.0f : 8.0f),
+               10.0f, IM_COL32(96, 96, 96, 255),
+               hasAction ? "Click anywhere else to close" : "Click anywhere to close", 0);
 
     char credit[128];
     if (pluginName == nullptr || pluginName[0] == '\0')
@@ -137,7 +222,8 @@ inline void drawSupportersOverlay(DuskPanel& panel, ImDrawList* dl,
         std::snprintf(credit, sizeof(credit), "%s by Dusk Audio", pluginName);
     else
         std::snprintf(credit, sizeof(credit), "%s v%s by Dusk Audio", pluginName, version);
-    panel.text(dl, px + pw * 0.5f, py + ph - footerH + 23.0f, 10.0f, IM_COL32(80, 80, 80, 255), credit, 0);
+    panel.text(dl, px + pw * 0.5f, py + ph - footerH + (hasAction ? 44.0f : 23.0f),
+               10.0f, IM_COL32(80, 80, 80, 255), credit, 0);
 }
 
 } // namespace duskdpf

--- a/plugins/shared-dpf/util/CrashLog.hpp
+++ b/plugins/shared-dpf/util/CrashLog.hpp
@@ -1,0 +1,1215 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Framework-free crash-log helper for Dusk Audio DPF plugins.
+//
+// On install(), CHAINS a crash handler in front of whatever the host already had
+// and writes a stack trace + plugin name + version + timestamp to a shared log
+// file under the user's application-support directory. No network calls; users
+// attach the file manually when filing a GitHub issue.
+//
+// Usage - prefer a ScopedRegistration as the first plugin-class member:
+//   DuskCrashLog::ScopedRegistration crashLog_ { "My Plugin", VERSION_STRING };
+//
+// To open the folder from a UI button:
+//   DuskCrashLog::openLogFolder();
+//
+// ============================================================================
+// WHY THIS IS NOT juce::SystemStats::setApplicationCrashHandler
+// ============================================================================
+// It used to be, and that was measurably harmful. JUCE's helper
+// (juce_SystemStats.cpp) does two things a plugin must never do to its host:
+//
+//   static void handleCrash (int signum)
+//   {
+//       globalCrashHandler (...);
+//       ::kill (getpid(), SIGKILL);      // uncatchable, unconditional
+//   }
+//   ...
+//   ::signal (signals[i], handleCrash);  // REPLACES the host's handler
+//
+// Measured with a probe that installed a host-style SIGSEGV handler, then
+// dereferenced null: without install() the host handler ran and the process
+// exited cleanly; with install() the host handler NEVER RAN and the process
+// died by SIGKILL. So a plugin scan was enough to cost the user their DAW's
+// autosave, crash reporter and recovery path, for a fault anywhere in the
+// process, including in the host or another vendor's plugin.
+//
+// This implementation instead:
+//   * uses sigaction, saves the previous disposition, and CHAINS to it, so the
+//     host still gets its crash. Several Dusk plugins chain to each other and
+//     every one of them logs.
+//   * never calls kill(). When the chain ends it restores SIG_DFL and re-raises
+//     so the OS produces its normal core dump / crash report.
+//   * is async-signal-safe in everything WE do. The handler's whole external
+//     call graph, verified by disassembling the built .so, is: open, write,
+//     close, raise, sigaction, sigemptyset, pthread_self, time, strlen,
+//     __errno_location, backtrace and backtrace_symbols_fd. It allocates
+//     nothing, takes no lock of its own, restores errno, and never touches
+//     juce::String or juce::File. The directory is created in install(), on the
+//     message thread, so the handler only opens the file. The previous version
+//     allocated, locked and built juce::Strings, so a heap-corruption crash
+//     deadlocked in the handler and hung the DAW with no log.
+//
+//     The honest exception is glibc's backtrace()/backtrace_symbols_fd(): they
+//     walk the loaded-object list and take the dynamic loader lock, so a fault
+//     raised while another thread is inside dlopen() (a plugin scan, say) can
+//     still deadlock there. That is why the record is written in the order it
+//     is: signal, time and the plugin list all reach the file through unbuffered
+//     write() calls BEFORE the backtrace is attempted, so a deadlock in the
+//     unwinder costs the stack, not the whole record. Replacing it with a
+//     self-contained unwinder is the remaining improvement.
+//   * refcounts, and restores the previous disposition when the last instance
+//     goes away, so the handler does not outlive the binary it lives in. The
+//     previous version never uninstalled at all, leaving the process-wide
+//     disposition pointing into unmapped memory after the host dlclose()d us.
+//
+// KNOWN LIMITS, stated rather than papered over:
+//   * The registry is per-BINARY, not per-process. Each plugin has its own copy
+//     of these statics, so each logs only itself. Chaining is what makes the
+//     multi-plugin case work: every chained handler appends its own entry.
+//   * If another handler chained on top of ours after we installed, we cannot
+//     safely unlink from the middle of the chain, so uninstall leaves it alone.
+//     See uninstall() for why that beats forcing SIG_DFL.
+//   * The timestamp is a raw unix epoch, because localtime_r and strftime are
+//     not async-signal-safe. Convert when reading: `date -d @<value>`.
+//   * At most kMaxRecordsPerProcess records are written per process, so a host
+//     that recovers from faults in a loop cannot fill the disk.
+//   * Windows frames are bare addresses; symbolising needs dbghelp, which
+//     allocates and locks. The current DPF release workflows do not ship PDBs,
+//     so those frames have limited diagnostic value until symbols are retained.
+//   * The backtrace step can deadlock against the dynamic loader lock (see
+//     above). Everything except the stack is already on disk when it runs.
+//   * A handler we chain into that recovers by siglongjmp rather than returning
+//     will make us log that thread's next fault twice. Bounded by the record
+//     cap, and preferred over the alternative; see crashHandler().
+//   * STACK OVERFLOW is not reliably covered. SA_ONSTACK is set, but it only
+//     takes effect if the faulting thread already has an alternate stack, and
+//     installing one ourselves is rejected in install() for the reasons given
+//     there. With no host-provided stack, an overflow SIGSEGV re-faults in the
+//     handler, the kernel forces SIG_DFL, and neither the log nor the chained
+//     host handler runs. The handler's own frame is kept small (a 512-byte
+//     buffer plus 64 frame pointers) to widen the margin, not to close it.
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#if defined(_WIN32)
+    #define DUSK_CRASHLOG_WINDOWS 1
+    #ifndef NOMINMAX
+        #define NOMINMAX 1
+    #endif
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN 1
+    #endif
+    #include <windows.h>
+#else
+    #define DUSK_CRASHLOG_WINDOWS 0
+    #include <cerrno>
+    #include <csignal>
+    #include <ctime>
+    #include <dlfcn.h>
+    #include <fcntl.h>
+    #include <pthread.h>
+    #include <pwd.h>
+    #include <spawn.h>
+    #include <sys/types.h>
+    #include <sys/wait.h>
+    #include <unistd.h>
+    #if __has_include(<execinfo.h>)
+        #define DUSK_CRASHLOG_HAS_EXECINFO 1
+        #include <execinfo.h>
+    #else
+        #define DUSK_CRASHLOG_HAS_EXECINFO 0
+    #endif
+#endif
+
+#if ! DUSK_CRASHLOG_WINDOWS
+extern char** environ;
+#endif
+
+namespace DuskCrashLog
+{
+    namespace path_detail
+    {
+      #if DUSK_CRASHLOG_WINDOWS
+        inline std::filesystem::path absoluteEnvironmentPath (const wchar_t* name)
+        {
+            const DWORD required = ::GetEnvironmentVariableW (name, nullptr, 0);
+            if (required == 0)
+                return {};
+
+            std::wstring value ((std::size_t) required, L'\0');
+            const DWORD written = ::GetEnvironmentVariableW (name, value.data(), required);
+            if (written == 0 || written >= required)
+                return {};
+
+            value.resize ((std::size_t) written);
+            const std::filesystem::path path (value);
+            return path.is_absolute() ? path : std::filesystem::path {};
+        }
+      #endif
+
+        inline std::filesystem::path homeDirectory()
+        {
+        #if DUSK_CRASHLOG_WINDOWS
+            const std::filesystem::path profile = absoluteEnvironmentPath (L"USERPROFILE");
+            if (! profile.empty())
+                return profile;
+
+            std::error_code ec;
+            const std::filesystem::path temporary = std::filesystem::temp_directory_path (ec);
+            if (! ec && temporary.is_absolute())
+                return temporary / L"dusk-audio-fallback";
+            return std::filesystem::path (L"C:\\Temp") / L"dusk-audio-fallback";
+        #else
+            if (const char* const home = std::getenv ("HOME"); home != nullptr && home[0] != '\0')
+            {
+                const std::filesystem::path path (home);
+                if (path.is_absolute())
+                    return path;
+            }
+
+            struct passwd pwd {};
+            struct passwd* result = nullptr;
+            char buffer[4096] {};
+            if (::getpwuid_r (::getuid(), &pwd, buffer, sizeof (buffer), &result) == 0
+                && result != nullptr && result->pw_dir != nullptr)
+            {
+                const std::filesystem::path path (result->pw_dir);
+                if (path.is_absolute())
+                    return path;
+            }
+
+            std::error_code ec;
+            const std::filesystem::path temporary = std::filesystem::temp_directory_path (ec);
+            const std::string fallbackName = "dusk-audio-" + std::to_string ((unsigned long long) ::getuid());
+            if (! ec && temporary.is_absolute())
+                return temporary / fallbackName;
+            return std::filesystem::path ("/tmp") / fallbackName;
+        #endif
+        }
+    }
+
+    // Match juce::File::userApplicationDataDirectory exactly so JUCE and DPF
+    // builds append to the same crash.log: Roaming AppData on Windows,
+    // ~/Library on macOS, and ~/.config on Linux.
+    inline std::filesystem::path getLogFolder()
+    {
+    #if DUSK_CRASHLOG_WINDOWS
+        const std::filesystem::path configured = path_detail::absoluteEnvironmentPath (L"APPDATA");
+        const std::filesystem::path base = configured.is_absolute()
+                                             ? configured
+                                             : path_detail::homeDirectory() / L"AppData" / L"Roaming";
+        return base / L"Dusk Audio";
+    #elif defined(__APPLE__)
+        return path_detail::homeDirectory() / "Library" / "Dusk Audio";
+    #else
+        return path_detail::homeDirectory() / ".config" / "Dusk Audio";
+    #endif
+    }
+
+    inline std::filesystem::path getLogFile()
+    {
+        return getLogFolder() / "crash.log";
+    }
+
+    namespace detail
+    {
+        constexpr int kMaxPlugins   = 16;
+        constexpr int kMaxEntryLen  = 96;    // "Name vVersion"
+        constexpr int kMaxPathLen   = 1024;
+
+        static_assert (std::atomic<int>::is_always_lock_free,
+                       "CrashLog requires lock-free integer atomics");
+        static_assert (std::atomic<bool>::is_always_lock_free,
+                       "CrashLog requires lock-free boolean atomics");
+        static_assert (std::atomic<std::uintptr_t>::is_always_lock_free,
+                       "CrashLog requires lock-free pointer-sized atomics");
+
+        // Native destination for the report writer. This used to be a bare int
+        // on both platforms, with the Windows HANDLE squeezed through
+        // (int)(intptr_t)h and cast back. A 64-bit HANDLE with bit 31 set
+        // truncates and then sign-extends to a different value, so every
+        // WriteFile would fail and the record would be silently empty.
+    #if DUSK_CRASHLOG_WINDOWS
+        using LogHandle = HANDLE;
+    #else
+        using LogHandle = int;
+    #endif
+
+        // Plugin list, readable from the signal handler. Fixed storage and an
+        // atomic count instead of std::vector + CriticalSection: the handler
+        // must not allocate or lock. Entries are fully written before the count
+        // is released, so a handler that runs mid-install sees a consistent
+        // prefix rather than a half-built string.
+        inline char (&entries())[kMaxPlugins][kMaxEntryLen]
+        {
+            static char storage[kMaxPlugins][kMaxEntryLen] {};
+            return storage;
+        }
+
+        inline std::atomic<int>& entryCount()
+        {
+            static std::atomic<int> instance { 0 };
+            return instance;
+        }
+
+        // Log path, resolved once on the message thread. The handler cannot
+        // build it: filesystem paths allocate.
+        inline char* logPath()
+        {
+            static char storage[kMaxPathLen] {};
+            return storage;
+        }
+
+    #if DUSK_CRASHLOG_WINDOWS
+        // Wide form, because the crash path must use CreateFileW. See the
+        // filter for why the ANSI form is not good enough.
+        inline wchar_t* logPathW()
+        {
+            static wchar_t storage[kMaxPathLen] {};
+            return storage;
+        }
+    #endif
+
+        // Guards install/uninstall against each other. NEVER taken in the
+        // handler.
+        inline std::mutex& installLock()
+        {
+            static std::mutex instance;
+            return instance;
+        }
+
+        inline int& installCount()      { static int instance = 0;   return instance; }
+        inline bool& handlerInstalled() { static bool instance = false; return instance; }
+
+        // PER-SIGNAL, not one flag for the set. uninstall() can restore some
+        // signals and not others (we are only allowed to unlink the ones we are
+        // still on top of), and a single flag then made a later install() an
+        // early-return, permanently losing crash logging for exactly the signals
+        // that HAD been restored. That is the realistic case, not a corner one:
+        // Breakpad and JIT runtimes chain over some of these signals and not
+        // others.
+    #if ! DUSK_CRASHLOG_WINDOWS
+        inline bool* installedForSignal() noexcept
+        {
+            static bool storage[8] {};
+            return storage;
+        }
+    #endif
+
+        // Reentrancy guard, tracked per thread by id in a fixed lock-free table.
+        //
+        // It must be per-thread: a single global flag made two threads faulting
+        // at once pathological, because the second thread would see the first
+        // thread's flag, skip to the default disposition and kill the process,
+        // bypassing the host's handler. That is the regression this file exists
+        // to remove.
+        //
+        // It must NOT be thread_local. In a shared library, which is what every
+        // plugin is, a thread_local resolves through __tls_get_addr, and that
+        // takes the dynamic loader lock and can allocate on first touch in a
+        // dlopen'd module. Verified by disassembling the .so: the thread_local
+        // version put __tls_get_addr in the handler's call graph. The
+        // initial-exec TLS model would avoid the call but risks "cannot
+        // allocate memory in static TLS block" when a host dlopen()s us.
+        //
+        // Atomic loads/CAS on a pointer-sized integer are lock-free and
+        // async-signal-safe, and pthread_self / GetCurrentThreadId are too.
+        constexpr int kMaxConcurrentHandlers = 8;
+
+        inline std::atomic<std::uintptr_t>* handlerThreads() noexcept
+        {
+            static std::atomic<std::uintptr_t> slots[kMaxConcurrentHandlers] {};
+            return slots;
+        }
+
+        inline std::uintptr_t currentThreadId() noexcept
+        {
+        #if DUSK_CRASHLOG_WINDOWS
+            const std::uintptr_t id = (std::uintptr_t) ::GetCurrentThreadId();
+        #else
+            const std::uintptr_t id = (std::uintptr_t) ::pthread_self();
+        #endif
+            return id != 0 ? id : 1;   // 0 is the "slot empty" sentinel
+        }
+
+        // Recursion and "no free slot" are NOT the same thing and must not be
+        // treated the same. Recursion means our own handler faulted, so the only
+        // safe move is the default disposition. A full table just means more
+        // threads are crashing at once than we budgeted for: that thread should
+        // skip writing but MUST still chain, or it silently steals the host's
+        // crash handling.
+        enum class HandlerEntry { Acquired, Recursion, TableFull };
+
+        inline HandlerEntry enterHandler (std::uintptr_t me) noexcept
+        {
+            auto* slots = handlerThreads();
+
+            for (int i = 0; i < kMaxConcurrentHandlers; ++i)
+                if (slots[i].load (std::memory_order_relaxed) == me)
+                    return HandlerEntry::Recursion;
+
+            for (int i = 0; i < kMaxConcurrentHandlers; ++i)
+            {
+                std::uintptr_t expected = 0;
+                if (slots[i].compare_exchange_strong (expected, me,
+                                                      std::memory_order_acq_rel,
+                                                      std::memory_order_relaxed))
+                    return HandlerEntry::Acquired;
+            }
+
+            return HandlerEntry::TableFull;
+        }
+
+        inline void leaveHandler (std::uintptr_t me) noexcept
+        {
+            auto* slots = handlerThreads();
+            for (int i = 0; i < kMaxConcurrentHandlers; ++i)
+            {
+                std::uintptr_t expected = me;
+                if (slots[i].compare_exchange_strong (expected, (std::uintptr_t) 0,
+                                                      std::memory_order_acq_rel,
+                                                      std::memory_order_relaxed))
+                    return;
+            }
+        }
+
+        // Cap on records per process, sized against the two failure modes it
+        // sits between.
+        //
+        // Too high and a runaway spin fills the disk: the SIG_IGN bug this file
+        // used to have produced 35398 records and 34 MB of crash.log in five
+        // seconds. Too low and it becomes the bug instead, because recovered
+        // SIGSEGV/SIGFPE are routine under Wine/yabridge and in hosts embedding
+        // a JIT or GC. Each of those burns a slot, so a small cap means the REAL
+        // crash arrives after the budget is spent and goes unlogged.
+        //
+        // At roughly 1 KB per record, 64 bounds a runaway at about 64 KB, which
+        // is nothing, while leaving room for a long session of recovered faults
+        // before the useful one. Hitting the cap also writes a one-line marker
+        // so a truncated log never passes for a complete one.
+        constexpr int kMaxRecordsPerProcess = 64;
+
+        inline std::atomic<int>& recordsWritten()
+        {
+            static std::atomic<int> instance { 0 };
+            return instance;
+        }
+
+        // Claim a record slot, SATURATING at the cap. A bare fetch_add would
+        // keep incrementing past it and eventually wrap negative at INT_MAX,
+        // silently re-enabling logging: precisely in the recoverable-fault loop
+        // the cap exists to survive.
+        inline bool claimRecordSlot() noexcept
+        {
+            int seen = recordsWritten().load (std::memory_order_relaxed);
+            while (seen < kMaxRecordsPerProcess)
+            {
+                if (recordsWritten().compare_exchange_weak (seen, seen + 1,
+                                                            std::memory_order_relaxed,
+                                                            std::memory_order_relaxed))
+                    return true;
+            }
+            return false;
+        }
+
+        // True exactly once, for the first caller that finds the budget spent,
+        // so the suppression marker is written a single time rather than on
+        // every subsequent fault.
+        inline bool claimSuppressionNotice() noexcept
+        {
+            static std::atomic<bool> written { false };
+            bool expected = false;
+            return written.compare_exchange_strong (expected, true,
+                                                    std::memory_order_relaxed,
+                                                    std::memory_order_relaxed);
+        }
+
+        //--------------------------------------------------------------------
+        // Async-signal-safe output helpers. No stdio, no allocation.
+        //--------------------------------------------------------------------
+        inline void writeAll (LogHandle fd, const char* data, size_t len) noexcept
+        {
+        #if ! DUSK_CRASHLOG_WINDOWS
+            while (len > 0)
+            {
+                const ssize_t n = ::write (fd, data, len);
+                if (n <= 0)
+                {
+                    if (n < 0 && errno == EINTR) continue;
+                    return;
+                }
+                data += n;
+                len -= (size_t) n;
+            }
+        #else
+            while (len > 0)
+            {
+                const DWORD requested = len > (std::size_t) MAXDWORD
+                                            ? MAXDWORD : (DWORD) len;
+                DWORD written = 0;
+                if (::WriteFile (fd, data, requested, &written, nullptr) == 0
+                    || written == 0)
+                    return;
+                data += written;
+                len -= (std::size_t) written;
+            }
+        #endif
+        }
+
+        inline void writeStr (LogHandle fd, const char* s) noexcept
+        {
+            if (s != nullptr)
+                writeAll (fd, s, std::strlen (s));
+        }
+
+    #if DUSK_CRASHLOG_WINDOWS
+        // Hex, for anything matched against a map file or a PDB. Addresses in
+        // decimal are useless for symbolisation. POSIX has no caller: there the
+        // frames come out of backtrace_symbols_fd already formatted.
+        inline void writeHex (LogHandle fd, unsigned long long v) noexcept
+        {
+            static const char digits[] = "0123456789abcdef";
+            char buf[20];
+            int i = (int) sizeof (buf);
+            buf[--i] = '\0';
+            if (v == 0)
+                buf[--i] = '0';
+            while (v > 0 && i > 0)
+            {
+                buf[--i] = digits[(std::size_t) (v & 0xFULL)];
+                v >>= 4;
+            }
+            writeStr (fd, buf + i);
+        }
+    #endif
+
+        // Copies at most destSize-1 bytes and always terminates. strncpy does
+        // not guarantee the terminator.
+        inline void copyBounded (char* dest, size_t destSize, const char* src) noexcept
+        {
+            if (destSize == 0) return;
+            size_t i = 0;
+            for (; src != nullptr && src[i] != '\0' && i + 1 < destSize; ++i)
+                dest[i] = src[i];
+            dest[i] = '\0';
+        }
+
+        // Appends into a caller-owned buffer, FLUSHING when it fills rather than
+        // truncating. Used to assemble a whole record before a single write()
+        // instead of a dozen small ones; see writeReport for why that matters.
+        //
+        // Flush-on-full rather than a buffer sized for the worst case, because
+        // the worst case is kMaxPlugins * kMaxEntryLen = 1536 bytes of registry
+        // plus the header, and putting that much on a signal stack is its own
+        // hazard: SA_ONSTACK means we may be running on a host-provided
+        // alternate stack that can be as small as MINSIGSTKSZ. A realistic
+        // record is one write; only a fully populated 16-plugin registry costs
+        // two, and a spliced record beats a truncated one.
+        struct Appender
+        {
+            char* buf;
+            std::size_t cap;
+            LogHandle fd;
+            std::size_t len = 0;
+
+            void flush() noexcept
+            {
+                if (len > 0) { writeAll (fd, buf, len); len = 0; }
+            }
+
+            void str (const char* s) noexcept
+            {
+                if (s == nullptr) return;
+                while (*s != '\0')
+                {
+                    if (len + 1 >= cap) flush();
+                    buf[len++] = *s++;
+                }
+            }
+
+            void uns (unsigned long long v, bool hex = false) noexcept
+            {
+                char tmp[24];
+                int i = (int) sizeof (tmp);
+                tmp[--i] = '\0';
+                if (v == 0) tmp[--i] = '0';
+                if (hex)
+                {
+                    static const char digits[] = "0123456789abcdef";
+                    while (v > 0 && i > 0) { tmp[--i] = digits[(std::size_t) (v & 0xFULL)]; v >>= 4; }
+                }
+                else
+                {
+                    while (v > 0 && i > 0) { tmp[--i] = (char) ('0' + (int) (v % 10ULL)); v /= 10ULL; }
+                }
+                str (tmp + i);
+            }
+
+            void sgn (long long v) noexcept
+            {
+                if (v < 0) { str ("-"); uns ((unsigned long long) (-v)); }
+                else       { uns ((unsigned long long) v); }
+            }
+        };
+
+        // Body shared by the POSIX and Windows handlers.
+        // causeAsHex: Windows exception codes are only recognisable in hex
+        // (0xC0000005, not 3221225477); POSIX signal numbers read as decimal.
+        inline void writeReport (LogHandle fd, const char* causeLabel, long long causeValue,
+                                 bool causeAsHex = false) noexcept
+        {
+            // The whole metadata block is assembled here and emitted with ONE
+            // write(). Up to kMaxConcurrentHandlers threads are deliberately
+            // allowed inside the handler at once, and a dozen separate write()
+            // calls per record let two simultaneous faults splice their headers
+            // into one unattributable block in the very file the user is asked
+            // to attach to an issue. A single append-mode write of a whole
+            // record cannot interleave with another.
+            //
+            // Stack-allocated, so still no heap in the handler.
+            char buf[512];
+            Appender out { buf, sizeof (buf), fd };
+
+            out.str ("============================================\n");
+            out.str ("Dusk Audio crash log\n");
+            out.str (causeLabel);
+            if (causeAsHex) { out.str ("0x"); out.uns ((unsigned long long) causeValue, true); }
+            else            { out.sgn (causeValue); }
+            out.str ("\n");
+
+            // Thread id, so records that DO end up adjacent (the backtrace lines
+            // below still arrive as separate writes) can be told apart.
+            out.str ("thread: 0x");
+            out.uns ((unsigned long long) currentThreadId(), true);
+            out.str ("\n");
+
+            // Raw unix epoch on both platforms. localtime_r and strftime are not
+            // async-signal-safe, so no formatting happens here; convert when
+            // reading with `date -d @<value>` (or `Get-Date -UnixTimeSeconds`).
+            // Windows needs its own clock call because time() is not available
+            // in the SEH filter path on all toolchains.
+            out.str ("unix time: ");
+        #if ! DUSK_CRASHLOG_WINDOWS
+            out.sgn ((long long) ::time (nullptr));
+        #else
+            {
+                FILETIME ft {};
+                ::GetSystemTimeAsFileTime (&ft);
+                // FILETIME counts 100 ns ticks from 1601-01-01; 11644473600 is
+                // the offset to the unix epoch.
+                const unsigned long long ticks =
+                    ((unsigned long long) ft.dwHighDateTime << 32) | ft.dwLowDateTime;
+                out.sgn ((long long) (ticks / 10000000ULL) - 11644473600LL);
+            }
+        #endif
+            out.str ("\n");
+
+            out.str ("plugins in this binary:\n");
+            {
+                const int count = entryCount().load (std::memory_order_acquire);
+                for (int i = 0; i < count && i < kMaxPlugins; ++i)
+                {
+                    out.str ("  - ");
+                    out.str (entries()[i]);
+                    out.str ("\n");
+                }
+            }
+            out.str ("stack:\n");
+            out.flush();
+
+            // Everything above is now durably on disk. The unwinder below can
+            // deadlock against the dynamic loader lock, so it deliberately runs
+            // last: a hang there costs the stack, not the whole record.
+        #if ! DUSK_CRASHLOG_WINDOWS && DUSK_CRASHLOG_HAS_EXECINFO
+            {
+                void* frames[64];
+                const int n = ::backtrace (frames, 64);
+                // backtrace_symbols_fd, unlike backtrace_symbols, writes without
+                // calling malloc. That is the whole reason it is used here.
+                ::backtrace_symbols_fd (frames, n, fd);
+            }
+        #elif DUSK_CRASHLOG_WINDOWS
+            {
+                void* frames[64];
+                const USHORT n = ::CaptureStackBackTrace (0, 64, frames, nullptr);
+                // Addresses only: symbolising needs dbghelp, which allocates and
+                // takes a lock. The current DPF packages do not retain PDBs,
+                // which limits offline symbolisation of these addresses.
+                for (USHORT i = 0; i < n; ++i)
+                {
+                    writeStr (fd, "  0x");
+                    writeHex (fd, (unsigned long long) (std::uintptr_t) frames[i]);
+                    writeStr (fd, "\n");
+                }
+            }
+        #else
+            writeStr (fd, "  <no backtrace facility on this platform>\n");
+        #endif
+            writeStr (fd, "\n");
+        }
+
+    #if ! DUSK_CRASHLOG_WINDOWS
+        inline const int* handledSignals (int& count) noexcept
+        {
+            static const int signals[] = { SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGABRT, SIGSYS };
+            count = (int) (sizeof (signals) / sizeof (signals[0]));
+            return signals;
+        }
+
+        inline struct sigaction* previousActions() noexcept
+        {
+            static struct sigaction storage[8] {};
+            return storage;
+        }
+
+        inline int signalSlot (int sig) noexcept
+        {
+            int n = 0;
+            const int* sigs = handledSignals (n);
+            for (int i = 0; i < n; ++i)
+                if (sigs[i] == sig)
+                    return i;
+            return -1;
+        }
+
+        inline void restoreDefaultAndReraise (int sig) noexcept
+        {
+            struct sigaction dfl {};
+            dfl.sa_handler = SIG_DFL;
+            sigemptyset (&dfl.sa_mask);
+            dfl.sa_flags = 0;
+            ::sigaction (sig, &dfl, nullptr);
+            ::raise (sig);
+        }
+
+        // Hand the crash on to whoever held the signal before us: the host's
+        // reporter, another Dusk plugin, or the default disposition. This is the
+        // part JUCE's helper replaced with kill(getpid(), SIGKILL).
+        inline void chainOrDefault (int sig, siginfo_t* info, void* context) noexcept
+        {
+            const int slot = signalSlot (sig);
+            if (slot >= 0)
+            {
+                const struct sigaction& prev = previousActions()[slot];
+
+                // sa_handler and sa_sigaction alias the same storage, and
+                // SIG_DFL/SIG_IGN are 0/1, so testing sa_handler identifies the
+                // two sentinels whichever member is the live one.
+                const bool isDefault = prev.sa_handler == SIG_DFL;
+                const bool isIgnored = prev.sa_handler == SIG_IGN;
+
+                if (! isDefault && ! isIgnored)
+                {
+                    if ((prev.sa_flags & SA_SIGINFO) != 0)
+                    {
+                        if (prev.sa_sigaction != nullptr)
+                        {
+                            prev.sa_sigaction (sig, info, context);
+                            return;
+                        }
+                    }
+                    else if (prev.sa_handler != nullptr)
+                    {
+                        prev.sa_handler (sig);
+                        return;
+                    }
+                }
+
+                // SIG_IGN needs splitting by signal, because "ignore" means two
+                // different things here.
+                //
+                // For the four NON-RESUMABLE faults, returning resumes the
+                // faulting instruction, which faults again immediately: an
+                // unkillable spin that re-enters this handler forever. Measured
+                // before this was handled at 35398 records and 34 MB of
+                // crash.log in five seconds. POSIX leaves SIG_IGN undefined for
+                // those, so falling through to the default disposition is both
+                // safe and honest.
+                //
+                // SIGABRT and SIGSYS are different: they resume normally on
+                // return, so a host that sets SIG_IGN for them means it. Forcing
+                // the default there would kill a process solely because a Dusk
+                // plugin happened to be loaded, which is the class of harm this
+                // whole file exists to undo.
+                if (isIgnored && (sig == SIGABRT || sig == SIGSYS))
+                    return;
+            }
+
+            restoreDefaultAndReraise (sig);
+        }
+
+        inline void crashHandler (int sig, siginfo_t* info, void* context) noexcept
+        {
+            // A signal handler must leave errno exactly as it found it. open(),
+            // write() and close() below all set it, and on the resumable-fault
+            // path this file supports, the interrupted code could otherwise read
+            // OUR errno between its own failing syscall and its check of it.
+            const int savedErrno = errno;
+            struct ErrnoRestorer
+            {
+                int value;
+                ~ErrnoRestorer() { errno = value; }
+            } errnoRestorer { savedErrno };
+
+            // A fault inside our own handler on THIS thread must not recurse.
+            // Other threads are unaffected: the guard is keyed by thread id.
+            const std::uintptr_t me = currentThreadId();
+            const HandlerEntry entry = enterHandler (me);
+
+            if (entry == HandlerEntry::Recursion)
+            {
+                restoreDefaultAndReraise (sig);
+                return;
+            }
+
+            if (entry == HandlerEntry::Acquired)
+            {
+                // O_APPEND keeps concurrent writers appending rather than
+                // overwriting each other. open/write/close are all on the
+                // async-signal-safe list.
+                const int fd = ::open (logPath(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+                if (fd >= 0)
+                {
+                    const bool haveBudget = claimRecordSlot();
+                    if (haveBudget)
+                        writeReport (fd, "signal: ", (long long) sig);
+                    else if (claimSuppressionNotice())
+                        writeStr (fd, "\n[Dusk Audio] record budget spent; "
+                                      "further crash records suppressed.\n");
+                    ::close (fd);
+                }
+
+                // Released BEFORE chaining, deliberately, and this is a real
+                // trade-off rather than an oversight. Both orderings have a
+                // failure mode:
+                //
+                //   release before chaining - if the handler we chain into
+                //     faults, that fault re-enters us as a fresh Acquired, so we
+                //     log a second record and call the host's handler
+                //     reentrantly.
+                //   release after chaining  - if the handler we chain into never
+                //     returns, which is what siglongjmp-based recovery does
+                //     (Wine/yabridge, JIT and GC guard pages), the slot leaks.
+                //     The thread's NEXT genuine fault then reads as Recursion
+                //     and is forced to SIG_DFL, so the host handler is skipped.
+                //
+                // The first is what would happen anyway if we were not in the
+                // chain at all: a host handler that faults re-enters itself with
+                // or without us. The second is a failure that exists ONLY
+                // because we are here, and it suppresses host crash handling,
+                // which is the precise regression this file was written to
+                // remove. So take the one that preserves existing behaviour.
+                // Repeat logging is bounded by kMaxRecordsPerProcess.
+                leaveHandler (me);
+            }
+
+            // Reached for Acquired AND TableFull. Chaining is never skipped just
+            // because we could not claim a slot to log with.
+            chainOrDefault (sig, info, context);
+        }
+    #else
+        inline LPTOP_LEVEL_EXCEPTION_FILTER& previousFilter() noexcept
+        {
+            static LPTOP_LEVEL_EXCEPTION_FILTER instance = nullptr;
+            return instance;
+        }
+
+        inline LONG WINAPI crashFilter (LPEXCEPTION_POINTERS ep) noexcept
+        {
+            // Same three-way decision as the POSIX handler. This branch used to
+            // test `! enterHandler(me)`, which does not even compile against the
+            // scoped enum, and conflated a full slot table with self-recursion.
+            const std::uintptr_t me = currentThreadId();
+            const HandlerEntry entry = enterHandler (me);
+
+            if (entry == HandlerEntry::Recursion)
+            {
+                // Our own filter faulted. Do not try to log again; hand straight
+                // on so the host or the OS terminates us properly.
+                return EXCEPTION_CONTINUE_SEARCH;
+            }
+
+            if (entry == HandlerEntry::Acquired)
+            {
+                // CreateFileW, not CreateFileA: the A form interprets the path
+                // in the system ANSI code page, so a UTF-8 path from a profile
+                // with any non-ASCII character in the user name fails to open.
+                const HANDLE h = ::CreateFileW (logPathW(), FILE_APPEND_DATA,
+                                                FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                                                OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+                if (h != INVALID_HANDLE_VALUE)
+                {
+                    const bool haveBudget = claimRecordSlot();
+                    if (haveBudget)
+                    {
+                        const long long code = ep != nullptr && ep->ExceptionRecord != nullptr
+                                                 ? (long long) ep->ExceptionRecord->ExceptionCode
+                                                 : 0;
+                        writeReport (h, "exception code: ", code, true);
+                    }
+                    else if (claimSuppressionNotice())
+                        writeStr (h, "\n[Dusk Audio] record budget spent; "
+                                     "further crash records suppressed.\n");
+                    ::CloseHandle (h);
+                }
+
+                leaveHandler (me);
+            }
+            // TableFull falls through to the chain below without logging.
+
+            // Chain, then let the host / OS reporter run. Never
+            // EXCEPTION_EXECUTE_HANDLER, which would swallow the crash.
+            if (previousFilter() != nullptr)
+                return previousFilter() (ep);
+
+            return EXCEPTION_CONTINUE_SEARCH;
+        }
+    #endif
+
+        // If uninstall cannot remove us from the middle of a handler chain,
+        // the handler above still owns a function pointer into this module.
+        // DPF modules really are unmapped by dlclose(), unlike the JUCE module
+        // measured by the original implementation. Pin only in that exceptional
+        // case so the saved pointer cannot become executable use-after-unmap.
+        // Never called from the crash path.
+        inline bool pinContainingModule()
+        {
+        #if DUSK_CRASHLOG_WINDOWS
+            static HMODULE pinned = nullptr;
+            if (pinned != nullptr)
+                return true;
+            HMODULE module = nullptr;
+            if (::GetModuleHandleExW (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                                      reinterpret_cast<LPCWSTR> (&crashFilter), &module) == 0)
+                return false;
+            pinned = module; // deliberately never FreeLibrary(): the chain still points here
+            return true;
+        #else
+            static void* pinned = nullptr;
+            if (pinned != nullptr)
+                return true;
+            Dl_info info {};
+            if (::dladdr (reinterpret_cast<const void*> (&crashHandler), &info) == 0
+                || info.dli_fname == nullptr)
+                return false;
+            pinned = ::dlopen (info.dli_fname, RTLD_NOW | RTLD_LOCAL);
+            return pinned != nullptr; // deliberately never dlclose(): see above
+        #endif
+        }
+    }
+
+    // Registers this plugin and, on the first call in this binary, chains our
+    // handler in front of the host's. Message thread only.
+    inline void install (const std::string& pluginName, const std::string& version)
+    {
+        const std::lock_guard<std::mutex> lock (detail::installLock());
+
+        ++detail::installCount();
+
+        // Resolve the log path and create the folder HERE, where allocating and
+        // hitting the filesystem is legal. The handler only open()s it.
+      #if DUSK_CRASHLOG_WINDOWS
+        const bool pathNeedsResolution = detail::logPathW()[0] == L'\0';
+      #else
+        const bool pathNeedsResolution = detail::logPath()[0] == '\0';
+      #endif
+        if (pathNeedsResolution)
+        {
+            const auto folder = getLogFolder();
+            std::error_code ec;
+            std::filesystem::create_directories (folder, ec);
+            const auto path = getLogFile();
+        #if DUSK_CRASHLOG_WINDOWS
+            {
+                const std::wstring& wide = path.native();
+                std::size_t i = 0;
+                for (; i < wide.size() && i + 1 < (std::size_t) detail::kMaxPathLen; ++i)
+                    detail::logPathW()[i] = wide[i];
+                detail::logPathW()[i] = L'\0';
+            }
+        #else
+            detail::copyBounded (detail::logPath(), detail::kMaxPathLen,
+                                 path.native().c_str());
+        #endif
+        }
+
+        // Add to the plugin list unless an identical entry is already there
+        // (hosts instantiate a plugin many times).
+        {
+            const std::string entry = pluginName + " v" + version;
+            const int count = detail::entryCount().load (std::memory_order_relaxed);
+            bool alreadyListed = false;
+
+            for (int i = 0; i < count && i < detail::kMaxPlugins; ++i)
+                if (std::strcmp (detail::entries()[i], entry.c_str()) == 0)
+                    alreadyListed = true;
+
+            if (! alreadyListed && count < detail::kMaxPlugins)
+            {
+                detail::copyBounded (detail::entries()[count], detail::kMaxEntryLen,
+                                     entry.c_str());
+                // Release: the text above must be visible before the count that
+                // exposes it to a handler running on another thread.
+                detail::entryCount().store (count + 1, std::memory_order_release);
+            }
+        }
+
+    #if ! DUSK_CRASHLOG_WINDOWS
+        // backtrace() lazily dlopen()s its unwinder on first use, which
+        // allocates. Force that to happen once here so the handler never does
+        // it, without unwinding again for every plugin instance.
+       #if DUSK_CRASHLOG_HAS_EXECINFO
+        static bool unwinderWarmed = false;
+        if (! unwinderWarmed)
+        {
+            void* warmup[4];
+            (void) ::backtrace (warmup, 4);
+            unwinderWarmed = true;
+        }
+       #endif
+
+        int numSignals = 0;
+        const int* signals = detail::handledSignals (numSignals);
+
+        struct sigaction action {};
+        action.sa_sigaction = &detail::crashHandler;
+        sigemptyset (&action.sa_mask);
+        // SA_ONSTACK is opportunistic, NOT a stack-overflow guarantee: it only
+        // does anything if an alternate stack already exists on the faulting
+        // thread, and we deliberately do not install one. sigaltstack() is
+        // per-thread, so installing it here would cover only the message thread
+        // and miss the audio thread where an overflow is most likely, and
+        // replacing a stack the host installed is the same class of harm as
+        // replacing its handler. So: free benefit when the host provides one,
+        // and a documented gap when it does not. See KNOWN LIMITS.
+        //
+        // SA_NODEFER is deliberately NOT set: the reentrancy guard handles
+        // recursion, and leaving the signal blocked inside the handler is what
+        // stops a fault in our own code looping.
+        action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_RESTART;
+
+        // Arm each signal we are not already armed for. Doing this per signal,
+        // rather than gating the whole loop on one flag, is what lets a
+        // reinstall recover the signals a partial uninstall gave back.
+        bool anySignalInstalled = false;
+        for (int i = 0; i < numSignals; ++i)
+        {
+            if (detail::installedForSignal()[i])
+            {
+                anySignalInstalled = true;
+                continue;
+            }
+
+            // Seed the saved disposition BEFORE publishing our handler. The
+            // kernel installs the new action before libc copies oldact back to
+            // userspace, so passing the zero-initialised registry directly as
+            // oldact leaves a window where another thread can enter us and see
+            // SIG_DFL instead of the host reporter. A query followed by the set
+            // makes the fallback valid throughout that publication window.
+            // POSIX offers no compare-and-swap for dispositions; a component
+            // replacing the same signal between these two calls remains an
+            // unavoidable process-wide race.
+            if (::sigaction (signals[i], nullptr, &detail::previousActions()[i]) != 0)
+                continue;
+            if (::sigaction (signals[i], &action, nullptr) == 0)
+            {
+                detail::installedForSignal()[i] = true;
+                anySignalInstalled = true;
+            }
+        }
+        detail::handlerInstalled() = anySignalInstalled;
+    #else
+        if (! detail::handlerInstalled())
+            detail::previousFilter() = ::SetUnhandledExceptionFilter (&detail::crashFilter);
+        detail::handlerInstalled() = true;
+    #endif
+    }
+
+    // Pair with install(). On the last instance the handler is removed, so it
+    // cannot outlive the binary it lives in. Message thread only.
+    inline void uninstall (const std::string& /*pluginName*/, const std::string& /*version*/)
+    {
+        const std::lock_guard<std::mutex> lock (detail::installLock());
+
+        if (detail::installCount() > 0)
+            --detail::installCount();
+
+        if (detail::installCount() > 0 || ! detail::handlerInstalled())
+            return;
+
+        bool fullyUnlinked = true;
+
+    #if ! DUSK_CRASHLOG_WINDOWS
+        int numSignals = 0;
+        const int* signals = detail::handledSignals (numSignals);
+
+        for (int i = 0; i < numSignals; ++i)
+        {
+            // A failed install never put our handler in this signal's chain and
+            // therefore cannot leave a pointer into this module behind.
+            if (! detail::installedForSignal()[i])
+                continue;
+
+            struct sigaction current {};
+            if (::sigaction (signals[i], nullptr, &current) != 0)
+            {
+                // We believe we are installed but cannot prove it is safe to
+                // unload. Retain the module rather than risk a dangling handler.
+                fullyUnlinked = false;
+                continue;
+            }
+
+            const bool stillOurs = (current.sa_flags & SA_SIGINFO) != 0
+                                && current.sa_sigaction == &detail::crashHandler;
+
+            // Only unlink when we are still the TOP of the chain. If someone
+            // chained on top of us they hold a pointer into this binary and we
+            // cannot unlink from the middle, so the chain is left exactly as it
+            // is.
+            //
+            // The obvious alternative, forcing SIG_DFL, is worse. Once several
+            // Dusk plugins chain to each other, "another handler is on top of
+            // us" is the NORMAL case, so unloading any one of them would strip
+            // the host's crash reporter and autosave for the rest of the
+            // process. Trading a guaranteed, common loss of host crash handling
+            // against a rare conditional one is the wrong way round.
+            //
+            // DPF modules DO unmap after dlclose(). If any signal is still
+            // linked through us, pinContainingModule() below deliberately
+            // retains this module for the rest of the process so the upper
+            // handler's saved function pointer stays executable.
+            if (stillOurs)
+            {
+                if (::sigaction (signals[i], &detail::previousActions()[i], nullptr) == 0)
+                {
+                    // Record it per signal, so a later install() re-arms exactly
+                    // this one rather than assuming the whole set is still live.
+                    detail::installedForSignal()[i] = false;
+                }
+                else
+                {
+                    fullyUnlinked = false;
+                }
+            }
+            else
+            {
+                fullyUnlinked = false;
+            }
+        }
+    #else
+        // Same policy as the POSIX branch: unlink only if we are still the top
+        // filter. SetUnhandledExceptionFilter returns the filter it replaced, so
+        // if that is not ours then somebody chained above us and holds a pointer
+        // into this binary; put their filter straight back and leave the chain
+        // alone rather than stripping the host's reporter.
+        LPTOP_LEVEL_EXCEPTION_FILTER current = ::SetUnhandledExceptionFilter (detail::previousFilter());
+        if (current != &detail::crashFilter)
+        {
+            ::SetUnhandledExceptionFilter (current);
+            fullyUnlinked = false;
+        }
+    #endif
+
+        // Only forget that we are installed if we actually came out of the
+        // chain. If we are still in it, clearing this would let a later
+        // install() add us a SECOND time and save OUR OWN handler as the
+        // "previous" one. The chain would then contain us twice, the second
+        // traversal would hit the reentrancy guard, and the guard would go
+        // straight to SIG_DFL, so the host's reporter would never run: exactly
+        // the failure this file exists to remove.
+        if (fullyUnlinked)
+            detail::handlerInstalled() = false;
+        else
+            (void) detail::pinContainingModule();
+    }
+
+    // Preferred over calling install()/uninstall() by hand: hold one as a member
+    // of the processor and the pair cannot be broken by an early return or a
+    // defaulted destructor.
+    //
+    //   class MyPlugin : public DISTRHO::Plugin
+    //   {
+    //       DuskCrashLog::ScopedRegistration crashLog_ { "My Plugin", VERSION_STRING };
+    //   };
+    //
+    // Declare it FIRST among the members so it outlives everything whose
+    // construction could crash.
+    class ScopedRegistration
+    {
+    public:
+        ScopedRegistration (std::string pluginName, std::string version)
+            : name (std::move (pluginName)), ver (std::move (version))
+        {
+            install (name, ver);
+        }
+
+        ~ScopedRegistration() { uninstall (name, ver); }
+
+        ScopedRegistration (const ScopedRegistration&) = delete;
+        ScopedRegistration& operator= (const ScopedRegistration&) = delete;
+
+    private:
+        std::string name, ver;
+    };
+
+    // Opens the folder containing the crash log in the OS file manager.
+    inline void openLogFolder()
+    {
+        const auto folder = getLogFolder();
+        std::error_code ec;
+        std::filesystem::create_directories (folder, ec);
+
+    #if DUSK_CRASHLOG_WINDOWS
+        std::wstring command = L"explorer.exe \"" + folder.native() + L"\"";
+        STARTUPINFOW startup {};
+        startup.cb = sizeof (startup);
+        PROCESS_INFORMATION process {};
+        if (::CreateProcessW (nullptr, command.data(), nullptr, nullptr, FALSE, 0,
+                              nullptr, nullptr, &startup, &process) != 0)
+        {
+            ::CloseHandle (process.hThread);
+            ::CloseHandle (process.hProcess);
+        }
+    #else
+        const std::string path = folder.native();
+      #if defined(__APPLE__)
+        const char* const opener = "open";
+      #else
+        const char* const opener = "xdg-open";
+      #endif
+        // Spawn a fresh, single-threaded shell which backgrounds the opener.
+        // This avoids fork()ing the multithreaded host, and the UI waits only
+        // for the tiny helper shell rather than for the file manager itself.
+        const char* const script = "\"$1\" \"$2\" >/dev/null 2>&1 &";
+        char* const arguments[] = {
+            const_cast<char*> ("/bin/sh"),
+            const_cast<char*> ("-c"),
+            const_cast<char*> (script),
+            const_cast<char*> ("DuskCrashLog"),
+            const_cast<char*> (opener),
+            const_cast<char*> (path.c_str()),
+            nullptr
+        };
+        pid_t child = -1;
+        if (::posix_spawn (&child, "/bin/sh", nullptr, nullptr, arguments, environ) == 0)
+        {
+            int status = 0;
+            while (::waitpid (child, &status, 0) < 0 && errno == EINTR) {}
+        }
+    #endif
+    }
+}
+
+#undef DUSK_CRASHLOG_WINDOWS

--- a/plugins/shared-dpf/util/tests/CrashLogModule.cpp
+++ b/plugins/shared-dpf/util/tests/CrashLogModule.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Test-only DSO wrapper used to prove that separately loaded plugin binaries
+// chain correctly and that a partial unlink pins the binary that owns a saved
+// handler address.
+
+#include "CrashLog.hpp"
+
+#ifndef CRASHLOG_MODULE_NAME
+ #define CRASHLOG_MODULE_NAME "CrashLog probe module"
+#endif
+
+#ifndef CRASHLOG_MODULE_VERSION
+ #define CRASHLOG_MODULE_VERSION "1.0.0"
+#endif
+
+#if defined(_WIN32)
+ #define CRASHLOG_TEST_EXPORT __declspec(dllexport)
+#else
+ #define CRASHLOG_TEST_EXPORT __attribute__((visibility("default")))
+#endif
+
+extern "C" CRASHLOG_TEST_EXPORT void crashlog_module_install()
+{
+    DuskCrashLog::install(CRASHLOG_MODULE_NAME, CRASHLOG_MODULE_VERSION);
+}
+
+extern "C" CRASHLOG_TEST_EXPORT void crashlog_module_uninstall()
+{
+    DuskCrashLog::uninstall(CRASHLOG_MODULE_NAME, CRASHLOG_MODULE_VERSION);
+}

--- a/plugins/shared-dpf/util/tests/CrashLogProbe.cpp
+++ b/plugins/shared-dpf/util/tests/CrashLogProbe.cpp
@@ -1,0 +1,697 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Linux behavioural probe for the framework-free DPF CrashLog.
+
+#include "../CrashLog.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <csetjmp>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace
+{
+static_assert(std::atomic<int>::is_always_lock_free,
+              "the probe's signal counter must be lock-free");
+std::atomic<int> gHostCalls { 0 };
+volatile sig_atomic_t gUpperCalls = 0;
+volatile sig_atomic_t gReturningCalls = 0;
+volatile sig_atomic_t gJumped = 0;
+sigjmp_buf gJumpBuffer;
+struct sigaction gUpperPrevious {};
+
+void hostHandler(int) noexcept
+{
+    gHostCalls.fetch_add(1, std::memory_order_relaxed);
+}
+
+void hostExit42(int) noexcept
+{
+    ::_exit(42);
+}
+
+void returningHandler(int) noexcept
+{
+    ++gReturningCalls;
+}
+
+void jumpHandler(int) noexcept
+{
+    gHostCalls.fetch_add(1, std::memory_order_relaxed);
+    if (gJumped == 0)
+    {
+        gJumped = 1;
+        ::siglongjmp(gJumpBuffer, 1);
+    }
+}
+
+void invokeAction(const struct sigaction& action, int sig,
+                  siginfo_t* info, void* context) noexcept
+{
+    if ((action.sa_flags & SA_SIGINFO) != 0)
+    {
+        if (action.sa_sigaction != nullptr)
+            action.sa_sigaction(sig, info, context);
+    }
+    else if (action.sa_handler != nullptr
+             && action.sa_handler != SIG_DFL
+             && action.sa_handler != SIG_IGN)
+    {
+        action.sa_handler(sig);
+    }
+}
+
+void upperHandler(int sig, siginfo_t* info, void* context) noexcept
+{
+    ++gUpperCalls;
+    invokeAction(gUpperPrevious, sig, info, context);
+}
+
+void setSimpleHandler(int sig, void (*handler)(int))
+{
+    struct sigaction action {};
+    action.sa_handler = handler;
+    ::sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_RESTART;
+    if (::sigaction(sig, &action, nullptr) != 0)
+    {
+        std::perror("sigaction");
+        std::exit(2);
+    }
+}
+
+void setSiginfoHandler(int sig,
+                       void (*handler)(int, siginfo_t*, void*),
+                       struct sigaction* previous = nullptr)
+{
+    struct sigaction action {};
+    action.sa_sigaction = handler;
+    ::sigemptyset(&action.sa_mask);
+    action.sa_flags = SA_SIGINFO | SA_RESTART;
+    if (::sigaction(sig, &action, previous) != 0)
+    {
+        std::perror("sigaction");
+        std::exit(2);
+    }
+}
+
+struct sigaction currentAction(int sig)
+{
+    struct sigaction action {};
+    if (::sigaction(sig, nullptr, &action) != 0)
+    {
+        std::perror("sigaction query");
+        std::exit(2);
+    }
+    return action;
+}
+
+bool isCrashHandler(const struct sigaction& action)
+{
+    return (action.sa_flags & SA_SIGINFO) != 0
+        && action.sa_sigaction == &DuskCrashLog::detail::crashHandler;
+}
+
+bool sameSimpleHandler(const struct sigaction& action, void (*handler)(int))
+{
+    return (action.sa_flags & SA_SIGINFO) == 0 && action.sa_handler == handler;
+}
+
+std::string readFile(const std::filesystem::path& path)
+{
+    std::ifstream stream(path, std::ios::binary);
+    std::ostringstream text;
+    text << stream.rdbuf();
+    return text.str();
+}
+
+std::size_t countText(const std::string& haystack, const std::string& needle)
+{
+    std::size_t count = 0;
+    std::size_t at = 0;
+    while ((at = haystack.find(needle, at)) != std::string::npos)
+    {
+        ++count;
+        at += needle.size();
+    }
+    return count;
+}
+
+struct ChildResult
+{
+    bool timedOut = false;
+    int status = 0;
+};
+
+ChildResult waitForChild(pid_t child, int timeoutMs)
+{
+    const auto deadline = std::chrono::steady_clock::now()
+                        + std::chrono::milliseconds(timeoutMs);
+    int status = 0;
+    for (;;)
+    {
+        const pid_t waited = ::waitpid(child, &status, WNOHANG);
+        if (waited == child)
+            return { false, status };
+        if (waited < 0)
+        {
+            std::perror("waitpid");
+            return { false, -1 };
+        }
+        if (std::chrono::steady_clock::now() >= deadline)
+        {
+            ::kill(child, SIGKILL);
+            (void) ::waitpid(child, &status, 0);
+            return { true, status };
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+}
+
+bool expect(bool condition, const std::string& message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+using ModuleFunction = void (*)();
+
+struct Module
+{
+    void* handle = nullptr;
+    ModuleFunction install = nullptr;
+    ModuleFunction uninstall = nullptr;
+
+    bool open(const std::string& path)
+    {
+        handle = ::dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (handle == nullptr)
+        {
+            std::cerr << "dlopen failed: " << ::dlerror() << '\n';
+            return false;
+        }
+        install = reinterpret_cast<ModuleFunction>(::dlsym(handle, "crashlog_module_install"));
+        uninstall = reinterpret_cast<ModuleFunction>(::dlsym(handle, "crashlog_module_uninstall"));
+        return expect(install != nullptr && uninstall != nullptr, "module exports are present");
+    }
+
+    void close()
+    {
+        if (handle != nullptr)
+        {
+            (void) ::dlclose(handle);
+            handle = nullptr;
+        }
+    }
+};
+
+std::size_t mappedLines(const std::string& modulePath)
+{
+    std::ifstream maps("/proc/self/maps");
+    std::string line;
+    std::size_t count = 0;
+    const std::string canonical = std::filesystem::weakly_canonical(modulePath).string();
+    while (std::getline(maps, line))
+        if (line.find(canonical) != std::string::npos)
+            ++count;
+    return count;
+}
+
+const char* modulePath(const char* name)
+{
+    const char* const value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0')
+    {
+        std::cerr << "missing environment variable " << name << '\n';
+        std::exit(2);
+    }
+    return value;
+}
+
+bool testHostHandlerStillRuns(bool mutant)
+{
+    gHostCalls = 0;
+    setSimpleHandler(SIGABRT, &hostHandler);
+    DuskCrashLog::install("host-chain", "1");
+    if (mutant)
+        DuskCrashLog::detail::previousActions()[DuskCrashLog::detail::signalSlot(SIGABRT)].sa_handler = SIG_DFL;
+    ::raise(SIGABRT);
+    DuskCrashLog::uninstall("host-chain", "1");
+    return expect(gHostCalls.load() == 1, "the pre-existing host handler ran exactly once")
+        && expect(readFile(DuskCrashLog::getLogFile()).find("host-chain v1") != std::string::npos,
+                  "the Dusk handler logged before chaining");
+}
+
+bool testNoSigkill(bool mutant)
+{
+    const pid_t child = ::fork();
+    if (child == 0)
+    {
+        setSimpleHandler(SIGSEGV, &hostExit42);
+        DuskCrashLog::install("no-sigkill", "1");
+        if (mutant)
+            ::kill(::getpid(), SIGKILL);
+        ::raise(SIGSEGV);
+        ::_exit(90);
+    }
+    const ChildResult result = waitForChild(child, 2000);
+    return expect(!result.timedOut, "fault handling completed")
+        && expect(WIFEXITED(result.status) && WEXITSTATUS(result.status) == 42,
+                  "the host handler, not SIGKILL, chose the process exit");
+}
+
+bool testUninstallRestores(bool mutant)
+{
+    setSimpleHandler(SIGABRT, &hostHandler);
+    DuskCrashLog::install("restore", "1");
+    if (!mutant)
+        DuskCrashLog::uninstall("restore", "1");
+    const struct sigaction action = currentAction(SIGABRT);
+    return expect(sameSimpleHandler(action, &hostHandler),
+                  "last uninstall restored the previous disposition");
+}
+
+bool testChained(bool mutant)
+{
+    gHostCalls = 0;
+    setSimpleHandler(SIGABRT, &hostHandler);
+    Module first;
+    Module second;
+    if (!first.open(modulePath("CRASHLOG_TEST_MODULE_A"))
+        || !second.open(modulePath("CRASHLOG_TEST_MODULE_B")))
+        return false;
+    if (!mutant)
+        first.install();
+    second.install();
+    ::raise(SIGABRT);
+    const std::string log = readFile(DuskCrashLog::getLogFile());
+    bool ok = expect(gHostCalls.load() == 1, "the host terminus ran after the DSO chain")
+           && expect(countText(log, "Module A v1.0.0") == 1,
+                     "the first plugin binary logged exactly once")
+           && expect(countText(log, "Module B v1.0.0") == 1,
+                     "the second plugin binary logged exactly once");
+    second.uninstall();
+    if (!mutant)
+        first.uninstall();
+    second.close();
+    first.close();
+    return ok;
+}
+
+bool testRefcount(bool mutant)
+{
+    setSimpleHandler(SIGABRT, &hostHandler);
+    DuskCrashLog::install("refcount", "1");
+    if (!mutant)
+        DuskCrashLog::install("refcount", "1");
+    DuskCrashLog::uninstall("refcount", "1");
+    bool ok = expect(DuskCrashLog::detail::installCount() == 1,
+                     "one registration remains after the first uninstall")
+           && expect(isCrashHandler(currentAction(SIGABRT)),
+                     "the handler stays armed while one registration remains");
+    if (!mutant)
+        DuskCrashLog::uninstall("refcount", "1");
+    return ok;
+}
+
+bool testReentrant(bool mutant)
+{
+    const pid_t child = ::fork();
+    if (child == 0)
+    {
+        setSimpleHandler(SIGABRT, &hostExit42);
+        DuskCrashLog::install("reentrant", "1");
+        const std::uintptr_t me = DuskCrashLog::detail::currentThreadId();
+        if (DuskCrashLog::detail::enterHandler(me)
+            != DuskCrashLog::detail::HandlerEntry::Acquired)
+            ::_exit(91);
+        if (mutant)
+            DuskCrashLog::detail::leaveHandler(me);
+        ::raise(SIGABRT);
+        ::_exit(92);
+    }
+    const ChildResult result = waitForChild(child, 2000);
+    return expect(!result.timedOut, "recursive entry terminated promptly")
+        && expect(WIFSIGNALED(result.status) && WTERMSIG(result.status) == SIGABRT,
+                  "same-thread recursion restored the default instead of re-entering the host");
+}
+
+bool testSigIgnResumable(bool mutant)
+{
+    const pid_t child = ::fork();
+    if (child == 0)
+    {
+        setSimpleHandler(SIGABRT, SIG_IGN);
+        DuskCrashLog::install("sigign-resumable", "1");
+        if (mutant)
+            DuskCrashLog::detail::previousActions()[DuskCrashLog::detail::signalSlot(SIGABRT)].sa_handler = SIG_DFL;
+        ::raise(SIGABRT);
+        DuskCrashLog::uninstall("sigign-resumable", "1");
+        ::_exit(0);
+    }
+    const ChildResult result = waitForChild(child, 2000);
+    return expect(!result.timedOut, "ignored resumable signal returned promptly")
+        && expect(WIFEXITED(result.status) && WEXITSTATUS(result.status) == 0,
+                  "SIG_IGN was honoured for resumable SIGABRT");
+}
+
+bool testSigIgnBoundedNoSpin(bool mutant)
+{
+    const pid_t child = ::fork();
+    if (child == 0)
+    {
+        setSimpleHandler(SIGSEGV, SIG_IGN);
+        if (mutant)
+            setSimpleHandler(SIGSEGV, &returningHandler);
+        else
+            DuskCrashLog::install("sigign-fault", "1");
+        volatile int* const bad = reinterpret_cast<volatile int*>(0);
+        *bad = 7;
+        ::_exit(93);
+    }
+    const auto started = std::chrono::steady_clock::now();
+    const ChildResult result = waitForChild(child, 1500);
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started).count();
+    std::error_code ec;
+    const std::uintmax_t bytes = std::filesystem::file_size(DuskCrashLog::getLogFile(), ec);
+    const std::string log = readFile(DuskCrashLog::getLogFile());
+    std::cout << "MEASURE\tsig-ign-bounded-no-spin\telapsed-ms=" << elapsedMs
+              << "\tlog-bytes=" << (ec ? 0 : bytes)
+              << "\trecords=" << countText(log, "Dusk Audio crash log") << '\n';
+    return expect(!result.timedOut, "non-resumable SIG_IGN did not spin")
+        && expect(WIFSIGNALED(result.status) && WTERMSIG(result.status) == SIGSEGV,
+                  "non-resumable SIG_IGN fell through to SIG_DFL")
+        && expect(ec || bytes < 256 * 1024, "fault-loop output stayed bounded")
+        && expect(countText(log, "Dusk Audio crash log") <= 64,
+                  "the record cap was not exceeded");
+}
+
+bool testConcurrentThreads(bool mutant)
+{
+    constexpr int count = DuskCrashLog::detail::kMaxConcurrentHandlers;
+    std::atomic<int> ready { 0 };
+    std::atomic<int> entered { 0 };
+    std::atomic<int> acquired { 0 };
+    std::atomic<bool> go { false };
+    std::atomic<bool> release { false };
+    std::vector<std::thread> workers;
+    workers.reserve(count);
+    for (int i = 0; i < count; ++i)
+    {
+        workers.emplace_back([&]
+        {
+            ready.fetch_add(1, std::memory_order_relaxed);
+            while (!go.load(std::memory_order_acquire)) std::this_thread::yield();
+            const std::uintptr_t id = mutant ? 1 : DuskCrashLog::detail::currentThreadId();
+            const auto entry = DuskCrashLog::detail::enterHandler(id);
+            if (entry == DuskCrashLog::detail::HandlerEntry::Acquired)
+                acquired.fetch_add(1, std::memory_order_relaxed);
+            entered.fetch_add(1, std::memory_order_release);
+            while (!release.load(std::memory_order_acquire)) std::this_thread::yield();
+            if (entry == DuskCrashLog::detail::HandlerEntry::Acquired)
+                DuskCrashLog::detail::leaveHandler(id);
+        });
+    }
+    while (ready.load(std::memory_order_acquire) != count) std::this_thread::yield();
+    go.store(true, std::memory_order_release);
+    while (entered.load(std::memory_order_acquire) != count) std::this_thread::yield();
+    release.store(true, std::memory_order_release);
+    for (auto& worker : workers) worker.join();
+    if (!expect(acquired.load() == count,
+                "the fixed table gives each concurrent thread an independent slot"))
+        return false;
+
+    gHostCalls = 0;
+    setSimpleHandler(SIGABRT, &hostHandler);
+    DuskCrashLog::install("concurrent", "1");
+    ready.store(0);
+    go.store(false);
+    workers.clear();
+    for (int i = 0; i < count; ++i)
+    {
+        workers.emplace_back([&]
+        {
+            ready.fetch_add(1, std::memory_order_relaxed);
+            while (!go.load(std::memory_order_acquire)) std::this_thread::yield();
+            (void) ::pthread_kill(::pthread_self(), SIGABRT);
+        });
+    }
+    while (ready.load(std::memory_order_acquire) != count) std::this_thread::yield();
+    go.store(true, std::memory_order_release);
+    for (auto& worker : workers) worker.join();
+    DuskCrashLog::uninstall("concurrent", "1");
+    const std::string log = readFile(DuskCrashLog::getLogFile());
+    std::cout << "MEASURE\tconcurrent-threads\tacquired=" << acquired.load()
+              << "\thost-calls=" << gHostCalls.load()
+              << "\trecords=" << countText(log, "Dusk Audio crash log") << '\n';
+    return expect(gHostCalls.load() == count, "all concurrent faults reached the host handler")
+        && expect(countText(log, "Dusk Audio crash log") == count,
+                  "all concurrent faults produced bounded records");
+}
+
+bool testReinstallAfterPartialUninstall(bool mutant)
+{
+    gHostCalls = 0;
+    gUpperCalls = 0;
+    setSimpleHandler(SIGABRT, &hostHandler);
+    setSimpleHandler(SIGSYS, &hostHandler);
+    DuskCrashLog::install("partial-reinstall", "1");
+    setSiginfoHandler(SIGABRT, &upperHandler, &gUpperPrevious);
+    DuskCrashLog::uninstall("partial-reinstall", "1");
+
+    const int sysSlot = DuskCrashLog::detail::signalSlot(SIGSYS);
+    if (mutant)
+        DuskCrashLog::detail::installedForSignal()[sysSlot] = true;
+    DuskCrashLog::install("partial-reinstall", "1");
+
+    bool ok = expect(isCrashHandler(currentAction(SIGSYS)),
+                     "reinstall re-armed a signal restored by partial uninstall")
+           && expect(currentAction(SIGABRT).sa_sigaction == &upperHandler,
+                     "reinstall did not duplicate itself under the upper handler");
+    if (!ok)
+        return false;
+
+    ::raise(SIGABRT);
+    ::raise(SIGSYS);
+    ok = expect(gUpperCalls == 1, "the upper handler stayed on top")
+      && expect(gHostCalls.load() == 2, "both signal paths still reached the host");
+
+    (void) ::sigaction(SIGABRT, &gUpperPrevious, nullptr);
+    DuskCrashLog::uninstall("partial-reinstall", "1");
+    return ok;
+}
+
+bool testPartialUnlink(bool mutant)
+{
+    const std::string path = mutant ? modulePath("CRASHLOG_TEST_MODULE_NO_PIN")
+                                    : modulePath("CRASHLOG_TEST_MODULE_A");
+    bool ok = expect(mappedLines(path) == 0, "module starts unmapped");
+    {
+        Module control;
+        if (!control.open(path)) return false;
+        control.install();
+        control.uninstall();
+        control.close();
+    }
+    const std::size_t controlAfterClose = mappedLines(path);
+    ok = expect(controlAfterClose == 0,
+                "fully unlinked DPF module unloads (control measurement)") && ok;
+
+    gHostCalls = 0;
+    gUpperCalls = 0;
+    setSimpleHandler(SIGABRT, &hostHandler);
+    Module partial;
+    if (!partial.open(path)) return false;
+    partial.install();
+    setSiginfoHandler(SIGABRT, &upperHandler, &gUpperPrevious);
+    partial.uninstall();
+    const std::size_t beforeClose = mappedLines(path);
+    partial.close();
+    const std::size_t afterClose = mappedLines(path);
+    std::cout << "MEASURE\tpartial-unlink\tcontrol-after-close=" << controlAfterClose
+              << "\tpartial-before-close=" << beforeClose
+              << "\tpartial-after-close=" << afterClose << '\n';
+
+    ok = expect(beforeClose > 0, "partially linked module was mapped before dlclose") && ok;
+    ok = expect(afterClose > 0,
+                "partial unlink pinned the DPF module across dlclose") && ok;
+    ok = expect(currentAction(SIGABRT).sa_sigaction == &upperHandler,
+                "partial uninstall left the upper handler intact") && ok;
+    if (!ok)
+        return false;
+
+    ::raise(SIGABRT);
+    const std::string log = readFile(DuskCrashLog::getLogFile());
+    return expect(gUpperCalls == 1 && gHostCalls.load() == 1,
+                  "saved handler pointer remained callable and chained to the host")
+        && expect(log.find("Module A v1.0.0") != std::string::npos,
+                  "the pinned module still wrote its record");
+}
+
+bool testSiglongjmpRecovery(bool mutant)
+{
+    const pid_t child = ::fork();
+    if (child == 0)
+    {
+        gHostCalls = 0;
+        gJumped = 0;
+        setSimpleHandler(SIGABRT, &jumpHandler);
+        DuskCrashLog::install("siglongjmp", "1");
+        if (::sigsetjmp(gJumpBuffer, 1) == 0)
+            ::raise(SIGABRT);
+        if (gHostCalls.load() != 1)
+            ::_exit(94);
+        if (mutant)
+            (void) DuskCrashLog::detail::enterHandler(DuskCrashLog::detail::currentThreadId());
+        ::raise(SIGABRT);
+        DuskCrashLog::uninstall("siglongjmp", "1");
+        ::_exit(gHostCalls.load() == 2 ? 0 : 95);
+    }
+    const ChildResult result = waitForChild(child, 2000);
+    return expect(!result.timedOut, "siglongjmp recovery completed")
+        && expect(WIFEXITED(result.status) && WEXITSTATUS(result.status) == 0,
+                  "the guard slot was released before a non-returning host handler");
+}
+
+bool testFullRegistry(bool mutant)
+{
+    const int count = mutant ? DuskCrashLog::detail::kMaxPlugins - 1
+                             : DuskCrashLog::detail::kMaxPlugins;
+    for (int i = 0; i < count; ++i)
+        DuskCrashLog::install("Registry " + std::to_string(i), "1");
+    DuskCrashLog::install("Registry overflow", "1");
+    std::cout << "MEASURE\tfull-registry\tentry-count="
+              << DuskCrashLog::detail::entryCount().load()
+              << "\tcapacity=" << DuskCrashLog::detail::kMaxPlugins << '\n';
+
+    bool ok = expect(DuskCrashLog::detail::entryCount().load() == DuskCrashLog::detail::kMaxPlugins,
+                     "all fixed registry slots are usable")
+           && expect(std::string(DuskCrashLog::detail::entries()[15]) == "Registry 15 v1",
+                     "the sixteenth registry entry is complete");
+
+    const std::filesystem::path report = DuskCrashLog::getLogFolder() / "full-registry.txt";
+    const int fd = ::open(report.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0)
+        return expect(false, "full-registry report opened");
+    DuskCrashLog::detail::writeReport(fd, "signal: ", SIGABRT);
+    ::close(fd);
+    const std::string text = readFile(report);
+    ok = expect(countText(text, "  - Registry ") == DuskCrashLog::detail::kMaxPlugins,
+                "a full registry is emitted without truncation") && ok;
+    ok = expect(text.find("Registry overflow") == std::string::npos,
+                "overflow registration stays outside fixed storage") && ok;
+    for (int i = 0; i < count + 1; ++i)
+        DuskCrashLog::uninstall("", "");
+    return ok;
+}
+
+bool testScoped(bool mutant)
+{
+    setSimpleHandler(SIGABRT, &hostHandler);
+    bool armed = false;
+    if (mutant)
+    {
+        (void) new DuskCrashLog::ScopedRegistration("scoped", "1");
+        armed = isCrashHandler(currentAction(SIGABRT));
+    }
+    else
+    {
+        DuskCrashLog::ScopedRegistration registration("scoped", "1");
+        armed = isCrashHandler(currentAction(SIGABRT))
+             && DuskCrashLog::detail::installCount() == 1;
+    }
+    return expect(armed, "ScopedRegistration arms during its lifetime")
+        && expect(sameSimpleHandler(currentAction(SIGABRT), &hostHandler),
+                  "ScopedRegistration releases and restores on destruction")
+        && expect(DuskCrashLog::detail::installCount() == 0,
+                  "ScopedRegistration balances the refcount");
+}
+
+using TestFunction = bool (*)(bool);
+
+struct TestCase
+{
+    const char* name;
+    TestFunction function;
+};
+
+constexpr TestCase tests[] = {
+    { "host-handler-still-runs", &testHostHandlerStillRuns },
+    { "no-sigkill", &testNoSigkill },
+    { "uninstall-restores", &testUninstallRestores },
+    { "chained", &testChained },
+    { "refcount", &testRefcount },
+    { "reentrant", &testReentrant },
+    { "sig-ign-resumable", &testSigIgnResumable },
+    { "sig-ign-bounded-no-spin", &testSigIgnBoundedNoSpin },
+    { "concurrent-threads", &testConcurrentThreads },
+    { "reinstall-after-partial-uninstall", &testReinstallAfterPartialUninstall },
+    { "partial-unlink", &testPartialUnlink },
+    { "siglongjmp-recovery", &testSiglongjmpRecovery },
+    { "full-registry", &testFullRegistry },
+    { "scoped", &testScoped },
+};
+}
+
+int main(int argc, char** argv)
+{
+    std::string requested;
+    std::string home;
+    bool mutant = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        const std::string arg = argv[i];
+        if (arg == "--case" && i + 1 < argc)
+            requested = argv[++i];
+        else if (arg == "--home" && i + 1 < argc)
+            home = argv[++i];
+        else if (arg == "--mutant")
+            mutant = true;
+        else
+        {
+            std::cerr << "usage: CrashLogProbe --case NAME --home DIR [--mutant]\n";
+            return 2;
+        }
+    }
+    if (requested.empty() || home.empty())
+    {
+        std::cerr << "case and home are required\n";
+        return 2;
+    }
+    std::error_code ec;
+    std::filesystem::create_directories(home, ec);
+    if (ec || ::setenv("HOME", home.c_str(), 1) != 0)
+    {
+        std::cerr << "could not prepare isolated HOME\n";
+        return 2;
+    }
+    for (const TestCase& test : tests)
+    {
+        if (requested == test.name)
+        {
+            const bool passed = test.function(mutant);
+            std::cout << (passed ? "PASS" : "FAIL") << '\t' << test.name
+                      << '\t' << (mutant ? "mutant" : "correct") << '\n';
+            return passed ? 0 : 1;
+        }
+    }
+    std::cerr << "unknown case: " << requested << '\n';
+    return 2;
+}

--- a/plugins/shared-dpf/util/tests/run_crashlog_tests.sh
+++ b/plugins/shared-dpf/util/tests/run_crashlog_tests.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Build and run every CrashLog behaviour against the correct implementation,
+# then deliberately inject the corresponding defect and require that the same
+# assertion rejects it.
+
+set -euo pipefail
+
+if [[ $(uname -s) != Linux ]]; then
+    echo "CrashLog behavioral tests require Linux (/proc/self/maps and ELF dlopen semantics)." >&2
+    exit 2
+fi
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "CrashLog behavioral tests require Bash 4 or newer." >&2
+    exit 2
+fi
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UTIL_DIR=$(cd -- "$SCRIPT_DIR/.." && pwd)
+BUILD_DIR=${CRASHLOG_TEST_BUILD_DIR:-"$SCRIPT_DIR/build"}
+CXX=${CXX:-c++}
+
+for tool in "$CXX" perl timeout; do
+    command -v "$tool" >/dev/null || { echo "required tool not found: $tool" >&2; exit 2; }
+done
+
+mkdir -p "$BUILD_DIR" "$BUILD_DIR/runs" "$BUILD_DIR/mutant-no-pin"
+
+COMMON=( -std=c++17 -O2 -g -Wall -Wextra -Wpedantic -pthread )
+DSO_COMMON=( "${COMMON[@]}" -fPIC -fvisibility=hidden -fno-gnu-unique -shared )
+
+"$CXX" "${DSO_COMMON[@]}" -I"$UTIL_DIR" \
+    -DCRASHLOG_MODULE_NAME='"Module A"' \
+    -DCRASHLOG_MODULE_VERSION='"1.0.0"' \
+    "$SCRIPT_DIR/CrashLogModule.cpp" -ldl -o "$BUILD_DIR/libcrashlog_a.so"
+
+"$CXX" "${DSO_COMMON[@]}" -I"$UTIL_DIR" \
+    -DCRASHLOG_MODULE_NAME='"Module B"' \
+    -DCRASHLOG_MODULE_VERSION='"1.0.0"' \
+    "$SCRIPT_DIR/CrashLogModule.cpp" -ldl -o "$BUILD_DIR/libcrashlog_b.so"
+
+# Real source mutant for the DPF-only unload hazard: retain the partial-unlink
+# policy but remove the module pin. The probe must see the .so disappear.
+cp "$UTIL_DIR/CrashLog.hpp" "$BUILD_DIR/mutant-no-pin/CrashLog.hpp"
+perl -0pi -e 's/else\n\s*\(void\) detail::pinContainingModule\(\);/else\n            (void) 0;/' \
+    "$BUILD_DIR/mutant-no-pin/CrashLog.hpp"
+if grep -Fq '(void) detail::pinContainingModule();' \
+       "$BUILD_DIR/mutant-no-pin/CrashLog.hpp" \
+   || ! grep -Fq '(void) 0;' "$BUILD_DIR/mutant-no-pin/CrashLog.hpp"; then
+    echo "failed to create no-pin mutant" >&2
+    exit 2
+fi
+"$CXX" "${DSO_COMMON[@]}" -I"$BUILD_DIR/mutant-no-pin" \
+    -DCRASHLOG_MODULE_NAME='"Module A"' \
+    -DCRASHLOG_MODULE_VERSION='"1.0.0"' \
+    "$SCRIPT_DIR/CrashLogModule.cpp" -ldl -o "$BUILD_DIR/libcrashlog_no_pin.so"
+
+"$CXX" "${COMMON[@]}" "$SCRIPT_DIR/CrashLogProbe.cpp" -ldl \
+    -o "$BUILD_DIR/crashlog_probe"
+
+export CRASHLOG_TEST_MODULE_A="$BUILD_DIR/libcrashlog_a.so"
+export CRASHLOG_TEST_MODULE_B="$BUILD_DIR/libcrashlog_b.so"
+export CRASHLOG_TEST_MODULE_NO_PIN="$BUILD_DIR/libcrashlog_no_pin.so"
+
+CASES=(
+    host-handler-still-runs
+    no-sigkill
+    uninstall-restores
+    chained
+    refcount
+    reentrant
+    sig-ign-resumable
+    sig-ign-bounded-no-spin
+    concurrent-threads
+    reinstall-after-partial-uninstall
+    partial-unlink
+    siglongjmp-recovery
+    full-registry
+    scoped
+)
+
+declare -A MUTATION=(
+    [host-handler-still-runs]="replace saved host disposition with SIG_DFL"
+    [no-sigkill]="reintroduce kill(getpid(), SIGKILL)"
+    [uninstall-restores]="omit the final uninstall"
+    [chained]="omit the first DPF binary from the chain"
+    [refcount]="omit the second registration"
+    [reentrant]="clear the same-thread guard before recursive entry"
+    [sig-ign-resumable]="treat resumable SIG_IGN as SIG_DFL"
+    [sig-ign-bounded-no-spin]="return to a synchronous SIGSEGV instruction forever"
+    [concurrent-threads]="collapse all thread IDs to one global guard identity"
+    [reinstall-after-partial-uninstall]="falsely mark a restored signal as still installed"
+    [partial-unlink]="remove the DPF module pin from a copied header"
+    [siglongjmp-recovery]="leak the guard slot across siglongjmp"
+    [full-registry]="make only 15 of 16 fixed slots reachable"
+    [scoped]="leak the scoped registration instead of destroying it"
+)
+
+CORRECT_LOG="$BUILD_DIR/correct.tsv"
+MUTANT_LOG="$BUILD_DIR/mutants.tsv"
+: > "$CORRECT_LOG"
+: > "$MUTANT_LOG"
+
+correct_passed=0
+mutants_rejected=0
+
+for name in "${CASES[@]}"; do
+    run_home=$(mktemp -d "$BUILD_DIR/runs/correct-${name}.XXXXXX")
+    if timeout 15s "$BUILD_DIR/crashlog_probe" --case "$name" --home "$run_home" \
+        >>"$CORRECT_LOG" 2>&1; then
+        ((correct_passed += 1))
+        printf 'correct PASS\t%s\n' "$name"
+    else
+        status=$?
+        printf 'correct FAIL\t%s\tstatus=%s\n' "$name" "$status"
+        tail -20 "$CORRECT_LOG"
+    fi
+done
+
+for name in "${CASES[@]}"; do
+    run_home=$(mktemp -d "$BUILD_DIR/runs/mutant-${name}.XXXXXX")
+    printf '%s\t%s\t' "$name" "${MUTATION[$name]}" >>"$MUTANT_LOG"
+    if timeout 15s "$BUILD_DIR/crashlog_probe" --case "$name" --home "$run_home" --mutant \
+        >>"$MUTANT_LOG" 2>&1; then
+        printf 'mutant SURVIVED\t%s\n' "$name"
+    else
+        status=$?
+        ((mutants_rejected += 1))
+        printf 'mutant REJECTED\t%s\tstatus=%s\n' "$name" "$status"
+    fi
+done
+
+printf 'SUMMARY\tcorrect=%d/%d\tmutants-rejected=%d/%d\n' \
+    "$correct_passed" "${#CASES[@]}" "$mutants_rejected" "${#CASES[@]}"
+
+if (( correct_passed != ${#CASES[@]} || mutants_rejected != ${#CASES[@]} )); then
+    echo "correct log: $CORRECT_LOG" >&2
+    echo "mutant log:  $MUTANT_LOG" >&2
+    exit 1
+fi

--- a/plugins/sunset-circuits/dpf-plugin/MultiSynthPlugin.cpp
+++ b/plugins/sunset-circuits/dpf-plugin/MultiSynthPlugin.cpp
@@ -13,22 +13,11 @@
 #include "MultiSynthAccess.hpp"
 #include "MultiSynthDSP.hpp"
 #include "MultiSynthParams.hpp"
+#include "SunsetVersion.hpp"
+#include "util/CrashLog.hpp"
 
 #include <atomic>
 #include <cstring>
-
-// Version is injected by CMake (SC_VERSION_* compile defs from project(VERSION),
-// which is single-sourced through get_plugin_version). These fallbacks only apply
-// to an ad-hoc compile with no build definitions and keep getVersion() valid.
-#ifndef SC_VERSION_MAJOR
- #define SC_VERSION_MAJOR 1
-#endif
-#ifndef SC_VERSION_MINOR
- #define SC_VERSION_MINOR 0
-#endif
-#ifndef SC_VERSION_PATCH
- #define SC_VERSION_PATCH 0
-#endif
 
 START_NAMESPACE_DISTRHO
 
@@ -152,6 +141,8 @@ static bool detectBbtBeatIsQuarterNote() noexcept
 
 class MultiSynthPlugin : public Plugin
 {
+    DuskCrashLog::ScopedRegistration crashLog_ { "Sunset Circuits", SC_VERSION_STRING };
+
 public:
     MultiSynthPlugin()
         : Plugin(kParamCount, kNumFactoryPresets, 0)

--- a/plugins/sunset-circuits/dpf-plugin/MultiSynthUI.cpp
+++ b/plugins/sunset-circuits/dpf-plugin/MultiSynthUI.cpp
@@ -25,6 +25,8 @@
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
+#include "SunsetVersion.hpp"
+#include "util/CrashLog.hpp"
 
 #include <cfloat>
 #include <cmath>
@@ -33,12 +35,6 @@
 #include <cstring>
 #include <algorithm>
 #include <chrono>
-
-// Single-sourced from CMake project(VERSION) via SC_VERSION_STRING; fallback keeps
-// an ad-hoc compile (no build defs) valid. Shown in the nameplate hover tooltip.
-#ifndef SC_VERSION_STRING
- #define SC_VERSION_STRING "1.0.0"
-#endif
 
 START_NAMESPACE_DISTRHO
 
@@ -1243,6 +1239,8 @@ private:
             const ImVec2 np0 = P(14, 4), np1 = P(blockX1 + 6.0f, 50);
             ImGui::SetCursorScreenPos(np0);
             ImGui::InvisibleButton("nameplate", ImVec2(np1.x - np0.x, np1.y - np0.y));
+            if (ImGui::IsItemClicked())
+                DuskCrashLog::openLogFolder();
             // Full version (single-sourced from the git tag through CMake's
             // SC_VERSION_STRING, so it IS the build identity) plus the live
             // surface size and scale, which is the one other thing worth asking
@@ -1250,7 +1248,7 @@ private:
             // would make every rebuild a different binary and cost the release
             // builds their reproducibility for a line nobody can act on.
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_ForTooltip))
-                ImGui::SetTooltip("Sunset Circuits v%s\nDusk Audio\n%d x %d \xC2\xB7 scale %.2f",
+                ImGui::SetTooltip("Sunset Circuits v%s\nDusk Audio\n%d x %d \xC2\xB7 scale %.2f\nClick to open crash log folder",
                                   SC_VERSION_STRING, (int)getWidth(), (int)getHeight(), s);
         }
 

--- a/plugins/sunset-circuits/dpf-plugin/SunsetVersion.hpp
+++ b/plugins/sunset-circuits/dpf-plugin/SunsetVersion.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2026 Dusk Audio - GNU GPL v3.0 or later (see repository LICENSE).
+//
+// SunsetVersion.hpp - version shared by Sunset Circuits metadata, UI and
+// diagnostics. CMake supplies these values from project(... VERSION ...); the
+// fallbacks keep non-CMake source builds consistent.
+
+#pragma once
+
+#ifndef SC_VERSION_MAJOR
+ #define SC_VERSION_MAJOR 1
+#endif
+#ifndef SC_VERSION_MINOR
+ #define SC_VERSION_MINOR 0
+#endif
+#ifndef SC_VERSION_PATCH
+ #define SC_VERSION_PATCH 1
+#endif
+
+#ifndef SC_VERSION_STRING
+ #define SC_STRINGIFY_IMPL(value) #value
+ #define SC_STRINGIFY(value) SC_STRINGIFY_IMPL(value)
+ #define SC_VERSION_STRING \
+    SC_STRINGIFY(SC_VERSION_MAJOR) "." \
+    SC_STRINGIFY(SC_VERSION_MINOR) "." \
+    SC_STRINGIFY(SC_VERSION_PATCH)
+#endif

--- a/plugins/tape-echo/dpf-plugin/TapeEchoPlugin.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoPlugin.cpp
@@ -5,6 +5,7 @@
 #include "TapeEchoDSP.hpp"
 #include "TapeEchoParams.hpp"
 #include "TapeEchoVersion.hpp"
+#include "util/CrashLog.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -14,6 +15,8 @@ START_NAMESPACE_DISTRHO
 
 class TapeEchoPlugin : public Plugin
 {
+    DuskCrashLog::ScopedRegistration crashLog_ { "Tape Echo 2", TE2_VERSION_STRING };
+
 public:
     TapeEchoPlugin()
         : Plugin(kParamCount, kNumFactoryPresets, 0)

--- a/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/dpf-plugin/TapeEchoUI.cpp
@@ -14,6 +14,7 @@
 #include "DuskImGuiTextInput.hpp" // Windows host focus while typing values
 #include "DuskImGuiWidgets.hpp"   // shared DuskPanel: chrome knob, LED, text, value bubble
 #include "DuskSupportersOverlay.hpp" // shared DPF Patreon "Special Thanks" overlay
+#include "util/CrashLog.hpp"
 #include "TapeEchoFontRegular.inc"
 #include "TapeEchoFontSemiBold.inc"
 
@@ -115,6 +116,8 @@ public:
     TapeEchoUI()
         : UI(DISTRHO_UI_DEFAULT_WIDTH, DISTRHO_UI_DEFAULT_HEIGHT)
     {
+        supportersOverlay.setActionLink("Open crash log folder",
+                                        [] { DuskCrashLog::openLogFolder(); });
         for (uint32_t i = 0; i < kParamCount; ++i)
             values[i] = kTeParams[i].def;
         setGeometryConstraints((uint32_t)kDesignW, (uint32_t)kDesignH, true);
@@ -274,7 +277,7 @@ protected:
         if (showSupporters)
             duskdpf::drawSupportersOverlay(
                 panel, dl, kDesignW, kDesignH, showSupporters, "Tape Echo 2",
-                TE2_VERSION_STRING);
+                TE2_VERSION_STRING, &supportersOverlay);
 
         // Own resize grip, submitted LAST so it wins ImGui's hover race and
         // paints over everything. AUv2 hosts (Logic) never provide a window
@@ -1777,6 +1780,7 @@ private:
     };
 
     duskdpf::DuskPanel panel;
+    duskdpf::SupportersOverlay supportersOverlay;
     duskdpf::DuskImGuiTextInputFocus textInputFocus;
     duskdpf::CrispFontSet labelFonts;
     duskdpf::CrispFontSet regularFonts;


### PR DESCRIPTION
## Summary

- add a framework-free DPF crash logger that chains to host handlers and restores them on unload
- pin a DPF module only when a later handler prevents safe middle-of-chain unlinking
- add crash-log-folder actions to all five DPF plugin UIs
- register crash capture as the first derived member in all five DPF plugin classes
- add a reproducible 14-case behavior probe with 14 deliberate defect checks

Addresses #175.

## Verification

- behavior probe: 14/14 correct cases passed, 14/14 deliberate defects rejected
- rebuilt TapeMachine 2, Tape Echo 2, 4K EQ 2, Multi-Q 2, and Sunset Circuits in VST3, CLAP, and LV2 formats
- strict CLAP validation passed for all five with zero failures
- pluginval strictness 8 passed 21/21 groups for all five
- all 15 LV2 TTL files parsed and all five bundles were discovered in isolation
- Tape Echo CTest passed; Sunset Circuits full core gate suite passed
- inspected the built TapeMachine shared object and found no Dusk-owned handler calls to allocation, mutex, dynamic TLS, or C++ guard functions
- reviewed the complete diff twice, fixed every valid in-scope finding, and reran impacted gates
- GitHub CI passed all 16 Linux x64, Linux arm64, macOS, and Windows DPF build jobs plus Sunset Circuits Linux validation

## Known limits

- glibc and libgcc backtrace internals can reach loader locks and allocation paths; crash metadata is written before stack unwinding begins
- reliable stack-overflow capture still requires a host-provided alternate signal stack
- no destructive host crash injection was run on macOS or Windows
- the untouched JUCE CrashLog has the same POSIX handler-publication window and macOS `sigemptyset` qualifier defect found during this work; it needs a separate follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic crash-log capture for supported audio plugins.
  * Added “Open crash log folder” actions to plugin support and credits overlays.
  * Added a direct crash-log folder shortcut from the Sunset Circuits nameplate.
  * Improved overlay dismissal behavior when action links are available.
* **Bug Fixes**
  * Crash logs now include plugin identification and version information.
* **Tests**
  * Added comprehensive coverage for crash handling, signal behavior, registration, and log generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->