### PR TITLE
fix(Convolution Reverb): align attack/decay/filter-attack label and editor units

### DIFF
--- a/plugins/convolution-reverb/PluginEditor.cpp
+++ b/plugins/convolution-reverb/PluginEditor.cpp
@@ -993,11 +993,13 @@ void ConvolutionReverbEditor::updateValueLabels()
     mixValueLabel->setText(formatPercent(static_cast<float>(mixSlider->getValue())),
                             juce::dontSendNotification);
 
-    // Attack (0-1, display as 0-500ms)
-    float attackMs = static_cast<float>(attackSlider->getValue()) * 500.0f;
-    attackValueLabel->setText(formatTime(attackMs), juce::dontSendNotification);
+    // Attack (0-1): label must match type-in editor units (#176). Showing ms
+    // here while the editor speaks 0..1 made typing the label value clamp to max.
+    attackValueLabel->setText(juce::String(attackSlider->getValue(), 2),
+                              juce::dontSendNotification);
 
-    // Decay (0-1, display as percentage)
+    // Decay / filter attack: same 0..1 native range as MIX — paint % via
+    // parameter string functions so label and ValueEditor agree (#176).
     decayValueLabel->setText(formatPercent(static_cast<float>(decaySlider->getValue())),
                               juce::dontSendNotification);
 

--- a/plugins/convolution-reverb/PluginProcessor.cpp
+++ b/plugins/convolution-reverb/PluginProcessor.cpp
@@ -111,10 +111,14 @@ juce::AudioProcessorValueTreeState::ParameterLayout ConvolutionReverbProcessor::
         juce::NormalisableRange<float>(0.0f, 1.0f, 0.01f),
         0.0f));
 
+    // Decay is a 0..1 fraction painted as percent under the knob. Same pattern
+    // as MIX (#170): without string functions the type-in editor shows "0.50"
+    // while the label shows "50%", so typing the label clamps to max (#176).
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "decay", "Decay",
         juce::NormalisableRange<float>(0.0f, 1.0f, 0.01f),
-        1.0f));
+        1.0f,
+        fractionShownAsPercent()));
 
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "length", "Length",
@@ -238,7 +242,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout ConvolutionReverbProcessor::
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "filter_env_attack", "Filter Attack",
         juce::NormalisableRange<float>(0.0f, 1.0f, 0.01f),
-        0.3f));  // 30% of IR length for filter attack
+        0.3f,  // 30% of IR length for filter attack
+        fractionShownAsPercent()));
 
     // Stereo Mode
     params.push_back(std::make_unique<juce::AudioParameterChoice>(


### PR DESCRIPTION
## Summary

Convolution Reverb: the painted knob labels and the double-click type-in editors disagreed on units for three 0..1 parameters (#176; distinct from the MIX/LENGTH/OFFSET round-trip fixed in #170).

- `decay` / `filter_env_attack`: use the same `fractionShownAsPercent()` string functions as MIX so the editor speaks percent like the label (`50` ↔ `50%`), and commit stays correct.
- `attack`: cannot print milliseconds on the parameter without tripping `parseSmart`'s seconds-scale heuristic (max ≤ 60 + display ends in `ms` → typed `250 ms` becomes `0.25`). Align the painted label to the native 0..1 editor units instead.

LENGTH's IR-dependent seconds/percent split is left alone (called out separately in the issue).

Fixes #176

## Test plan

- [ ] Build Convolution Reverb; set attack/decay/filter attack to mid values
- [ ] Confirm decay / filter attack labels and type-in both show percent-scale numbers; commit unedited and type the label number
- [ ] Confirm attack label matches the type-in prefills (0..1); typing that value round-trips


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the convolution reverb decay control to display and accept percentage values consistently with other percentage-based settings.
  * No changes were made to the underlying reverb behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->