### PR TITLE
Centralize DuskVerb Nyquist clamps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,15 +330,16 @@ jobs:
             cmake --build build --config ${{ env.BUILD_TYPE }} -j$(nproc)
           fi
 
-      - name: DuskVerb stereo-image regression test
+      - name: DuskVerb regression tests
         # Only when DuskVerb is in scope: a bare/all build (empty target) or a
         # target list that includes DuskVerb. The build dir is configured for the
         # whole project, so the test target is always available to build here.
         if: ${{ needs.setup.outputs.plugin_target == '' || contains(needs.setup.outputs.plugin_target, 'DuskVerb') }}
         shell: bash
         run: |
-          cmake --build build --config ${{ env.BUILD_TYPE }} --target DuskVerbStereoImageTest -j$(nproc)
-          ctest --test-dir build -R DuskVerbStereoImage --output-on-failure --no-tests=error
+          cmake --build build --config ${{ env.BUILD_TYPE }} \
+            --target DuskVerbStereoImageTest DuskVerbNyquistClampTest -j"$(nproc)"
+          ctest --test-dir build -R '^DuskVerb' --output-on-failure --no-tests=error
 
       - name: Validate plugins
         shell: bash

--- a/plugins/DuskVerb/CMakeLists.txt
+++ b/plugins/DuskVerb/CMakeLists.txt
@@ -185,4 +185,31 @@ if(NOT CMAKE_CROSSCOMPILING)
     )
 
     add_test(NAME DuskVerbStereoImage COMMAND DuskVerbStereoImageTest)
+
+    # Issue #171 Nyquist-clamp regression: covers every migrated call site,
+    # compares helper/legacy bytes at standard rates, and exercises the real DSP types.
+    add_executable(DuskVerbNyquistClampTest
+        tests/test_nyquist_clamps.cpp
+        src/dsp/DattorroTank.cpp
+        src/dsp/DattorroPlateVintage.cpp
+        src/dsp/OctaveGEQDesign.cpp
+    )
+
+    target_include_directories(DuskVerbNyquistClampTest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/dsp
+    )
+
+    target_compile_features(DuskVerbNyquistClampTest PRIVATE cxx_std_17)
+
+    target_compile_definitions(DuskVerbNyquistClampTest PRIVATE
+        DUSKVERB_NYQUIST_TEST_HOOK=1
+    )
+
+    if(MSVC)
+        target_compile_options(DuskVerbNyquistClampTest PRIVATE /W4)
+    else()
+        target_compile_options(DuskVerbNyquistClampTest PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+
+    add_test(NAME DuskVerbNyquistClamp COMMAND DuskVerbNyquistClampTest)
 endif()

--- a/plugins/DuskVerb/src/dsp/DattorroPlateVintage.cpp
+++ b/plugins/DuskVerb/src/dsp/DattorroPlateVintage.cpp
@@ -44,7 +44,7 @@ void DattorroPlateVintage::prepare (double sampleRate, int maxBlockSize)
     // frontPredelayMs_ may exceed the tank pre-delay ring — saturate to its longest
     // representable delay so readAgo() can't (w-d)&mask wrap-alias to a shorter delay.
     frontPredelaySamp_ = std::min (frontPredelaySamp_, tankPreL_.mask);
-    erLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (frontLpHz_, 0.45f * sampleRate_) / sampleRate_);
+    erLpCoeff_ = 1.0f - std::exp (-6.283185307f * DspUtils::nyquistSafeHz (sampleRate_, frontLpHz_) / sampleRate_);
     erLpZL_ = erLpZR_ = 0.0f;
 
     // Post-main second-reflection tap ring (~300 ms headroom for a ~143 ms tap).
@@ -52,7 +52,7 @@ void DattorroPlateVintage::prepare (double sampleRate, int maxBlockSize)
     postMainL_.prepare (postMax); postMainR_.prepare (postMax);
     postMainDelayL_ = std::min (std::max (1, static_cast<int> (postMainMs_ * 0.001f * sampleRate_)), postMainL_.mask);
     postMainDelayR_ = std::min (std::max (1, static_cast<int> ((postMainMs_ + 9.0f) * 0.001f * sampleRate_)), postMainR_.mask);
-    postMainLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (postMainLpHz_, 0.45f * sampleRate_) / sampleRate_);
+    postMainLpCoeff_ = 1.0f - std::exp (-6.283185307f * DspUtils::nyquistSafeHz (sampleRate_, postMainLpHz_) / sampleRate_);
     postMainLpZL_ = postMainLpZR_ = 0.0f;
 
     // Dense early-field combs/allpasses + predelay (generous headroom).
@@ -69,7 +69,7 @@ void DattorroPlateVintage::prepare (double sampleRate, int maxBlockSize)
     dfPre_.prepare (static_cast<int> (0.30f * sampleRate_));   // up to 300 ms predelay
     dfApR_.prepare (static_cast<int> (kDfDecorrMs * 0.001f * sampleRate_) + 8);
     dfApRLen_ = std::max (1, static_cast<int> (kDfDecorrMs * 0.001f * sampleRate_));
-    dfLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (kDfLpHz, 0.45f * sampleRate_) / sampleRate_);
+    dfLpCoeff_ = 1.0f - std::exp (-6.283185307f * DspUtils::nyquistSafeHz (sampleRate_, kDfLpHz) / sampleRate_);
     dfLpZ_ = 0.0f;
     (void) rr;
 
@@ -286,7 +286,7 @@ void DattorroPlateVintage::setFrontLoad (float erGain, float predelayMs, float t
         // (w-d)&mask and silently alias to a SHORTER delay. Saturate to the longest
         // representable instead. (2026-06-23 review fix; latent — current callers stay small.)
         frontPredelaySamp_ = std::min (frontPredelaySamp_, tankPreL_.mask);
-        erLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (frontLpHz_, 0.45f * sampleRate_) / sampleRate_);
+        erLpCoeff_ = 1.0f - std::exp (-6.283185307f * DspUtils::nyquistSafeHz (sampleRate_, frontLpHz_) / sampleRate_);
     }
 }
 
@@ -300,7 +300,7 @@ void DattorroPlateVintage::setPostMainTap (float ms, float gain, float lpHz)
     {
         postMainDelayL_ = std::min (std::max (1, static_cast<int> (postMainMs_ * 0.001f * sampleRate_)), postMainL_.mask);
         postMainDelayR_ = std::min (std::max (1, static_cast<int> ((postMainMs_ + 9.0f) * 0.001f * sampleRate_)), postMainR_.mask);
-        postMainLpCoeff_ = 1.0f - std::exp (-6.283185307f * std::min (postMainLpHz_, 0.45f * sampleRate_) / sampleRate_);
+        postMainLpCoeff_ = 1.0f - std::exp (-6.283185307f * DspUtils::nyquistSafeHz (sampleRate_, postMainLpHz_) / sampleRate_);
     }
 }
 

--- a/plugins/DuskVerb/src/dsp/DattorroTank.cpp
+++ b/plugins/DuskVerb/src/dsp/DattorroTank.cpp
@@ -1057,7 +1057,8 @@ void DattorroTank::setModeNotch (float hz, float cutDb, float q)
     // compounds per pass, shortening the mode's T60 without a broadband dip.
     const float sr = static_cast<float> (sampleRate_);
     const float A  = std::pow (10.0f, std::clamp (cutDb, -12.0f, 0.0f) / 40.0f);
-    const float w0 = 6.283185307179586f * std::clamp (hz, 20.0f, 0.45f * sr) / sr;
+    const float w0 = 6.283185307179586f
+                   * DspUtils::nyquistSafeHz (sr, std::max (hz, 20.0f)) / sr;
     const float alpha = std::sin (w0) / (2.0f * mnQ_);
     const float cosw = std::cos (w0);
     const float a0 = 1.0f + alpha / A;

--- a/plugins/DuskVerb/src/dsp/DenseEarlyField.h
+++ b/plugins/DuskVerb/src/dsp/DenseEarlyField.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "DspUtils.h"
+
 #include <vector>
 #include <cmath>
 #include <algorithm>
@@ -35,7 +37,7 @@ public:
         apR_.prepare (static_cast<int> (kDecorrMs * 0.001f * sampleRate_) + 8);
         apRLen_ = std::max (1, static_cast<int> (kDecorrMs * 0.001f * sampleRate_));
         lpCoeff_ = 1.0f - std::exp (-6.283185307f
-                       * std::min (kLpHz, 0.45f * sampleRate_) / sampleRate_);
+                       * DspUtils::nyquistSafeHz (sampleRate_, kLpHz) / sampleRate_);
         prepared_ = true;
         setParams (gain_, predelayMs_, t60Ms_);   // (re)compute feedback + predelay
     }

--- a/plugins/DuskVerb/src/dsp/DenseHallReverb.h
+++ b/plugins/DuskVerb/src/dsp/DenseHallReverb.h
@@ -573,8 +573,8 @@ private:
             gHighB_ = std::clamp (std::pow (gMid, 1.0f / std::max (0.2f, trebMul_)), 0.0f, 0.999f);
         }
         // Tunable crossover one-pole coeffs (defaults 250 Hz / 3.5 kHz).
-        lCoeff_ = 1.0f - std::exp (-6.2831853f * std::min (lowX_,  sr_ * 0.45f) / sr_);
-        hCoeff_ = 1.0f - std::exp (-6.2831853f * std::min (highX_, sr_ * 0.45f) / sr_);
+        lCoeff_ = 1.0f - std::exp (-6.2831853f * DspUtils::nyquistSafeHz (sr_, lowX_) / sr_);
+        hCoeff_ = 1.0f - std::exp (-6.2831853f * DspUtils::nyquistSafeHz (sr_, highX_) / sr_);
 
         // Per-octave GEQ coeffs (fork #2). Each ISO octave's per-pass loop gain
         // gk = 10^(-3·meanLen/(Tk·sr)) realizes target T60 Tk over the uniform

--- a/plugins/DuskVerb/src/dsp/DspUtils.h
+++ b/plugins/DuskVerb/src/dsp/DspUtils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../../../shared-dpf/dsp/DuskFilters.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -17,6 +19,30 @@ static constexpr float kDenormalPrevention = 1.0e-15f;
 // linearly via `sampleRate / kBaseSampleRate`. The plugin runs correctly at
 // any host sample rate — this is the calibration anchor, not an assumption.
 static constexpr double kBaseSampleRate = 44100.0;
+
+// DuskVerb's one-pole/TPT designers historically used a tighter 0.45 * fs
+// ceiling than the shared RBJ designers. Keep that voicing, but delegate the
+// floor-first/ceiling-last ordering to the repository's single implementation.
+inline constexpr float kDesignFreqRatio = 0.45f;
+
+#if defined(DUSKVERB_NYQUIST_TEST_HOOK)
+inline unsigned int nyquistSafeHzCallCount = 0;
+
+inline void resetNyquistSafeHzCallCount() noexcept
+{
+    nyquistSafeHzCallCount = 0;
+}
+#endif
+
+inline float nyquistSafeHz (double sampleRate, float frequency) noexcept
+{
+#if defined(DUSKVERB_NYQUIST_TEST_HOOK)
+    ++nyquistSafeHzCallCount;
+#endif
+    return static_cast<float> (duskaudio::nyquistSafeDesignHzD (
+        sampleRate, static_cast<double> (frequency),
+        static_cast<double> (kDesignFreqRatio)));
+}
 
 // Returns the smallest power of 2 >= v. For v <= 1 returns 1.
 inline int nextPowerOf2 (int v)

--- a/plugins/DuskVerb/src/dsp/SustainBandLimiter.h
+++ b/plugins/DuskVerb/src/dsp/SustainBandLimiter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "DspUtils.h"
+
 #include <cmath>
 #include <algorithm>
 
@@ -165,7 +167,7 @@ struct SustainBandLimiter
             const float bw = std::max (hiHz - loHz, 1.0f);
             const float Q  = std::clamp (fc / bw, 0.20f, 8.0f);
             const float A  = std::pow (10.0f, -std::clamp (cutDb, 0.0f, 24.0f) / 40.0f);
-            const float w0 = 6.28318530718f * std::min (fc, 0.45f * sr) / sr;
+            const float w0 = 6.28318530718f * DspUtils::nyquistSafeHz (sr, fc) / sr;
             const float alpha = std::sin (w0) / (2.0f * Q);
             const float cosw  = std::cos (w0);
             const float a0    = 1.0f + alpha / A;

--- a/plugins/DuskVerb/src/dsp/VelvetTail.h
+++ b/plugins/DuskVerb/src/dsp/VelvetTail.h
@@ -136,7 +136,8 @@ private:
         }
         void lowpass (float fc, float sr)
         {
-            const float w = std::tan (3.14159265358979f * std::clamp (fc, 20.0f, 0.45f*sr) / sr);
+            const float w = std::tan (3.14159265358979f
+                                     * DspUtils::nyquistSafeHz (sr, std::max (fc, 20.0f)) / sr);
             const float k = 1.41421356f;
             const float nrm = 1.0f / (1.0f + k*w + w*w);
             b0 = w*w*nrm; b1 = 2.0f*b0; b2 = b0;

--- a/plugins/DuskVerb/tests/test_nyquist_clamps.cpp
+++ b/plugins/DuskVerb/tests/test_nyquist_clamps.cpp
@@ -1,0 +1,292 @@
+#include "../src/dsp/DattorroPlateVintage.h"
+#include "../src/dsp/DattorroTank.h"
+#include "../src/dsp/DenseEarlyField.h"
+#include "../src/dsp/DenseHallReverb.h"
+#include "../src/dsp/SustainBandLimiter.h"
+#include "../src/dsp/VelvetTail.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#if ! defined(DUSKVERB_NYQUIST_TEST_HOOK)
+#error "DuskVerbNyquistClampTest requires DUSKVERB_NYQUIST_TEST_HOOK"
+#endif
+
+namespace
+{
+constexpr int kBlockSize = 256;
+constexpr std::array<double, 6> kStandardRates {
+    44100.0, 48000.0, 88200.0, 96000.0, 176400.0, 192000.0
+};
+
+struct ClampCase
+{
+    const char* name;
+    float frequency;
+    bool hasTwentyHzFloor;
+};
+
+// One row per production call site. Repeated frequencies are intentional: the
+// regression is a wiring inventory as well as a numeric comparison.
+constexpr std::array<ClampCase, 11> kClampCases { {
+    { "DattorroPlate prepare front LP", 20000.0f, false },
+    { "DattorroPlate prepare post-main LP", 20000.0f, false },
+    { "DattorroPlate prepare dense-field LP", 12000.0f, false },
+    { "DattorroPlate live front LP", 20000.0f, false },
+    { "DattorroPlate live post-main LP", 20000.0f, false },
+    { "DattorroTank mode notch", 50000.0f, true },
+    { "DenseEarlyField LP", 12000.0f, false },
+    { "DenseHall low crossover", 2000.0f, false },
+    { "DenseHall high crossover", 14000.0f, false },
+    { "SustainBandLimiter peak cut", 18973.666f, false },
+    { "VelvetTail crossover", 2000.0f, true },
+} };
+
+int failures = 0;
+int callCountFailures = 0;
+
+void check (bool condition, const char* description)
+{
+    std::cout << (condition ? "[PASS] " : "[FAIL] ") << description << '\n';
+    if (! condition)
+        ++failures;
+}
+
+void testClampEquivalence()
+{
+    int mismatches = 0;
+    for (double sampleRate : kStandardRates)
+    {
+        const float sr = static_cast<float> (sampleRate);
+        for (const auto& clampCase : kClampCases)
+        {
+            const float requested = clampCase.hasTwentyHzFloor
+                                  ? std::max (clampCase.frequency, 20.0f)
+                                  : clampCase.frequency;
+            const float legacy = std::min (requested, 0.45f * sr);
+            const float shared = DspUtils::nyquistSafeHz (sampleRate, requested);
+            if (std::memcmp (&legacy, &shared, sizeof (float)) != 0)
+            {
+                std::cerr << "mismatch: " << clampCase.name << " @ "
+                          << sampleRate << " Hz\n";
+                ++mismatches;
+            }
+        }
+    }
+    check (mismatches == 0,
+           "all 11 call-site cases are byte-identical at six standard sample rates");
+
+    constexpr std::array<float, 5> kIrregularRates {
+        8000.125f, 44117.0f, 47999.5f, 123456.75f, 1000000.0f
+    };
+    int ceilingMismatches = 0;
+    for (float sampleRate : kIrregularRates)
+    {
+        const float legacy = 0.45f * sampleRate;
+        const float shared = DspUtils::nyquistSafeHz (
+            static_cast<double> (sampleRate), 1000000.0f);
+        if (std::memcmp (&legacy, &shared, sizeof (float)) != 0)
+            ++ceilingMismatches;
+    }
+    check (ceilingMismatches == 0,
+           "the promoted 0.45f ratio preserves arbitrary float-rate ceilings");
+
+    check (DspUtils::nyquistSafeHz (2.0, 20.0f) == 0.9f,
+           "shared ceiling wins after the preserved 20 Hz floor at a degenerate rate");
+}
+
+float nextNoise (std::uint32_t& state)
+{
+    state ^= state << 13;
+    state ^= state >> 17;
+    state ^= state << 5;
+    return static_cast<float> (static_cast<std::int32_t> (state)) / 2147483648.0f;
+}
+
+std::vector<float> makeInput (int sampleCount)
+{
+    std::vector<float> input (static_cast<std::size_t> (sampleCount), 0.0f);
+    std::uint32_t state = 0x12345678u;
+    for (int i = 0; i < std::min (sampleCount, 2048); ++i)
+        input[static_cast<std::size_t> (i)] = 0.2f * nextNoise (state);
+    return input;
+}
+
+void appendStereo (const std::vector<float>& left, const std::vector<float>& right,
+                   std::vector<float>& output)
+{
+    output.insert (output.end(), left.begin(), left.end());
+    output.insert (output.end(), right.begin(), right.end());
+}
+
+void appendDattorroPlate (double sampleRate, std::vector<float>& output)
+{
+    constexpr int sampleCount = 32768;
+    const auto input = makeInput (sampleCount);
+    std::vector<float> left (static_cast<std::size_t> (sampleCount), 0.0f);
+    std::vector<float> right (static_cast<std::size_t> (sampleCount), 0.0f);
+
+    DattorroPlateVintage plate;
+    plate.setFrontLoad (1.0f, 12.0f, 75.0f, 20000.0f);
+    plate.setPostMainTap (70.0f, 1.0f, 20000.0f);
+    plate.setDenseField (1.0f, 4.0f, 700.0f);
+    plate.prepare (sampleRate, kBlockSize);
+
+    // Exercise the two prepared-instance coefficient updates as well as the
+    // three designs in prepare(). Together these cover all five plate sites.
+    plate.setFrontLoad (1.0f, 12.0f, 75.0f, 20000.0f);
+    plate.setPostMainTap (70.0f, 1.0f, 20000.0f);
+
+    for (int offset = 0; offset < sampleCount; offset += kBlockSize)
+    {
+        const int count = std::min (kBlockSize, sampleCount - offset);
+        plate.process (input.data() + offset, input.data() + offset,
+                       left.data() + offset, right.data() + offset, count);
+    }
+    appendStereo (left, right, output);
+}
+
+void recordCallCount (unsigned int expected, const char* description)
+{
+    if (DspUtils::nyquistSafeHzCallCount != expected)
+    {
+        std::cerr << "call-count mismatch: " << description << " (expected "
+                  << expected << ", got " << DspUtils::nyquistSafeHzCallCount << ")\n";
+        ++callCountFailures;
+    }
+    DspUtils::resetNyquistSafeHzCallCount();
+}
+
+void appendDattorroTank (double sampleRate, std::vector<float>& output)
+{
+    constexpr int sampleCount = 32768;
+    const auto input = makeInput (sampleCount);
+    std::vector<float> left (static_cast<std::size_t> (sampleCount), 0.0f);
+    std::vector<float> right (static_cast<std::size_t> (sampleCount), 0.0f);
+
+    DattorroTank tank;
+    tank.prepare (sampleRate, kBlockSize);
+    tank.setModeNotch (50000.0f, -6.0f, 2.0f);
+    for (int offset = 0; offset < sampleCount; offset += kBlockSize)
+    {
+        const int count = std::min (kBlockSize, sampleCount - offset);
+        tank.process (input.data() + offset, input.data() + offset,
+                      left.data() + offset, right.data() + offset, count);
+    }
+    appendStereo (left, right, output);
+}
+
+void appendDenseEarlyField (double sampleRate, std::vector<float>& output)
+{
+    constexpr int sampleCount = 8192;
+    const auto input = makeInput (sampleCount);
+    std::vector<float> left (static_cast<std::size_t> (sampleCount), 0.0f);
+    std::vector<float> right (static_cast<std::size_t> (sampleCount), 0.0f);
+
+    DenseEarlyField field;
+    field.prepare (sampleRate);
+    field.setParams (1.0f, 0.0f, 700.0f);
+    for (int i = 0; i < sampleCount; ++i)
+        field.processSample (input[static_cast<std::size_t> (i)],
+                             left[static_cast<std::size_t> (i)],
+                             right[static_cast<std::size_t> (i)]);
+    appendStereo (left, right, output);
+}
+
+void appendDenseHall (double sampleRate, std::vector<float>& output)
+{
+    constexpr int sampleCount = 32768;
+    const auto input = makeInput (sampleCount);
+    std::vector<float> left (static_cast<std::size_t> (sampleCount), 0.0f);
+    std::vector<float> right (static_cast<std::size_t> (sampleCount), 0.0f);
+
+    DenseHallReverb hall;
+    hall.setCrossoverFreq (2000.0f);
+    hall.setHighCrossoverFreq (14000.0f);
+    hall.prepare (sampleRate, kBlockSize);
+    for (int offset = 0; offset < sampleCount; offset += kBlockSize)
+    {
+        const int count = std::min (kBlockSize, sampleCount - offset);
+        hall.process (input.data() + offset, input.data() + offset,
+                      left.data() + offset, right.data() + offset, count);
+    }
+    appendStereo (left, right, output);
+}
+
+void appendPeakCut (double sampleRate, std::vector<float>& output)
+{
+    constexpr int sampleCount = 2048;
+    const auto input = makeInput (sampleCount);
+    SustainBandLimiter::PeakCut cut;
+    cut.design (18000.0f, 20000.0f, 12.0f, sampleRate);
+    for (float sample : input)
+        output.push_back (cut.band (sample));
+}
+
+void appendVelvetTail (double sampleRate, std::vector<float>& output)
+{
+    constexpr int sampleCount = 8192;
+    const auto input = makeInput (sampleCount);
+    std::vector<float> left (static_cast<std::size_t> (sampleCount), 0.0f);
+    std::vector<float> right (static_cast<std::size_t> (sampleCount), 0.0f);
+
+    VelvetTail tail;
+    tail.prepare (sampleRate, kBlockSize);
+    tail.process (input.data(), input.data(), left.data(), right.data(), sampleCount);
+    appendStereo (left, right, output);
+}
+
+std::vector<float> renderAllSites()
+{
+    std::vector<float> output;
+    DspUtils::resetNyquistSafeHzCallCount();
+    for (double sampleRate : kStandardRates)
+    {
+        appendDattorroPlate (sampleRate, output);
+        recordCallCount (5, "DattorroPlate");
+        appendDattorroTank (sampleRate, output);
+        recordCallCount (1, "DattorroTank");
+        appendDenseEarlyField (sampleRate, output);
+        recordCallCount (1, "DenseEarlyField");
+        appendDenseHall (sampleRate, output);
+        recordCallCount (2, "DenseHall");
+        appendPeakCut (sampleRate, output);
+        recordCallCount (1, "SustainBandLimiter");
+        appendVelvetTail (sampleRate, output);
+        recordCallCount (3, "VelvetTail");
+    }
+    return output;
+}
+} // namespace
+
+int main (int argc, char** argv)
+{
+    testClampEquivalence();
+    const auto output = renderAllSites();
+    check (callCountFailures == 0,
+           "all 11 production sites route their designs through the shared alias");
+    check (! output.empty(), "focused render produced output");
+    check (std::all_of (output.begin(), output.end(),
+                        [] (float sample) { return std::isfinite (sample); }),
+           "focused render is finite at every standard sample rate");
+    check (std::any_of (output.begin(), output.end(),
+                        [] (float sample) { return sample != 0.0f; }),
+           "focused render exercises non-silent filter responses");
+
+    if (argc == 2)
+    {
+        std::ofstream stream (argv[1], std::ios::binary);
+        stream.write (reinterpret_cast<const char*> (output.data()),
+                      static_cast<std::streamsize> (output.size() * sizeof (float)));
+        check (stream.good(), "focused render bytes written");
+    }
+
+    return failures == 0 ? 0 : 1;
+}

--- a/plugins/shared-dpf/dsp/DuskFilters.hpp
+++ b/plugins/shared-dpf/dsp/DuskFilters.hpp
@@ -63,19 +63,18 @@ constexpr float kDuskPi    = 3.14159265358979323846f;
 // tighter than this ceiling as part of the voicing (TapeMachine's recordHeadCutoff
 // and biasFilter, TapeEcho's 0.45*fs sites). Everything else relies on this.
 //
-// The three NAMED clamp helpers in the tree now all delegate to
+// The four NAMED clamp helpers in the tree now all delegate to
 // nyquistSafeDesignHzD below at their own ceiling, rather than re-implementing
 // the comparison: TapeMachine 2's nyquistSafeHz, TapeEcho's
-// safeBiquadFrequency, and the JUCE TapeMachine v1's nyquistSafeHz are thin
-// aliases. Do not add a fourth implementation; alias this one.
+// safeBiquadFrequency, the JUCE TapeMachine v1's nyquistSafeHz, and DuskVerb's
+// DspUtils::nyquistSafeHz are thin aliases. Do not add another implementation;
+// alias this one.
 //
-// NOT yet covered, so do not read the above as "every clamp in the repo":
-// DuskVerb (a JUCE plugin that does not compile this header) still clamps
-// inline at roughly thirty sites, as std::min(fc, 0.45f * sr) or
-// std::clamp(fc, 20.0f, 0.45f * sr) -- ceiling-only, in float, and mostly
-// without the 1 Hz floor. Those are one-pole/TPT coefficients rather than RBJ
-// biquads, so the failure mode differs, but they are the remaining divergent
-// copies. Changing the ceiling here does NOT change them.
+// The eleven DuskVerb one-pole/TPT sites targeted by its clamp migration use
+// that 0.45 alias. Two keep an explicit 20 Hz floor ahead of the shared guard
+// because that floor is part of their existing filter contract. This is not a
+// claim that every DuskVerb float cap was migrated: its fixed 17 kHz FDN
+// anti-alias cap and its tighter 0.49 design caps are outside that migration.
 //
 // WHAT THE CEILING BUYS, AND WHAT IT DOES NOT. It trades divergence for a corner
 // parked just under Nyquist. At the ceiling the poles sit at |z| ~ 0.999, which


### PR DESCRIPTION
Addresses #171.

## Summary
- route all 11 targeted DuskVerb filter-design clamps through the shared Nyquist primitive
- preserve the existing 0.45 ceiling and the two explicit 20 Hz floors
- add focused regression coverage and run it in the existing DuskVerb CI step

## Validation
- standard-rate before and after renders are byte-identical across all affected DSP types
- focused mutation checks reject a changed ratio and a reverted production call site
- DuskVerb VST3 and LV2 builds pass
- both DuskVerb CTests pass
- plugin validation passes 9 of 9 checks, including pluginval strictness 1, 5, 7, and 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved frequency handling across DuskVerb’s filters and reverb stages, especially at unusual or high sample rates.
  - Preserved minimum frequency limits while preventing unsafe cutoff values near the Nyquist frequency.
  - Helps maintain stable, finite, and audible output across supported configurations.

- **Tests**
  - Added comprehensive regression coverage for frequency clamping and affected audio-processing paths.
  - Expanded automated Linux build testing for DuskVerb.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->