### PR TITLE
Convolution Reverb: unit-correct knob labels, plus two defects found verifying them

### DIFF
--- a/plugins/convolution-reverb/EnvelopeProcessor.h
+++ b/plugins/convolution-reverb/EnvelopeProcessor.h
@@ -92,13 +92,25 @@ public:
         }
     }
 
-    // Generate envelope curve for visualization
-    std::vector<float> getEnvelopeCurve(int numPoints) const
+    // Generate envelope curve for visualization.
+    //
+    // irLengthSeconds is the duration of the UNTRUNCATED IR and is required for
+    // the drawn curve to match what processIR() actually applies. The attack is a
+    // fixed wall-clock span (0..500 ms), so the FRACTION of the IR it occupies
+    // depends on how long that IR is: the same knob covers half of a 1 s IR and a
+    // tenth of a 5 s one. This used to pass a flat attack * 0.25f "scaled for
+    // visualization", which happens to be right only for a 2 s IR at full length
+    // and drew a visibly wrong envelope for everything else.
+    std::vector<float> getEnvelopeCurve(int numPoints, float irLengthSeconds) const
     {
         std::vector<float> curve(numPoints);
 
-        // Calculate normalized attack position
-        float attackNormalizedPos = attack * 0.5f / 5.0f; // Assuming max IR is ~5 seconds
+        // Mirror processIR(): the buffer is truncated to `length` first, and the
+        // attack is then measured as a fraction of what survives.
+        const float activeSeconds = irLengthSeconds * length;
+        const float attackFraction = activeSeconds > 0.0f
+                                   ? std::min(attack * 0.5f, activeSeconds) / activeSeconds
+                                   : 1.0f;
 
         for (int i = 0; i < numPoints; ++i)
         {
@@ -113,7 +125,7 @@ public:
             {
                 // Normalize position within the active length
                 float normalizedPos = position / length;
-                curve[i] = getEnvelopeValue(normalizedPos, attack * 0.25f); // Scaled for visualization
+                curve[i] = getEnvelopeValue(normalizedPos, attackFraction);
             }
         }
 

--- a/plugins/convolution-reverb/EnvelopeProcessor.h
+++ b/plugins/convolution-reverb/EnvelopeProcessor.h
@@ -55,6 +55,28 @@ public:
         return length * 100.0f;
     }
 
+    // Samples of an irNumSamples-long IR that survive processIR()'s length
+    // truncation. Mirrors it exactly, including the 64-sample floor and the fact
+    // that it only ever shrinks the buffer.
+    int getActiveSamples(int irNumSamples) const
+    {
+        if (irNumSamples <= 0)
+            return 0;
+        return std::min(std::max(64, static_cast<int>(irNumSamples * length)), irNumSamples);
+    }
+
+    // The same thing as a fraction of the untruncated IR. Every drawing that
+    // marks where the IR ends -- the envelope curve, the cutoff line, the shaded
+    // truncated region -- must use THIS and not `length`, or they disagree with
+    // each other and with the DSP once the 64-sample floor bites. With no IR
+    // there is no sample count to derive it from, so fall back to the knob.
+    float getActiveFraction(int irNumSamples) const
+    {
+        if (irNumSamples <= 0)
+            return length;
+        return static_cast<float>(getActiveSamples(irNumSamples)) / static_cast<float>(irNumSamples);
+    }
+
     // Process IR buffer in place
     void processIR(juce::AudioBuffer<float>& ir, double sampleRate) const
     {
@@ -110,20 +132,13 @@ public:
         // then measure the attack against whatever survived. Working in seconds
         // instead would drop the 64-sample floor and draw the wrong ramp for a
         // short IR at a small length.
-        int activeSamples = std::max(64, static_cast<int>(irNumSamples * length));
-        activeSamples = std::min(activeSamples, irNumSamples);
+        const int activeSamples = getActiveSamples(irNumSamples);
+        const float activeFraction = getActiveFraction(irNumSamples);
 
-        // The cutoff and the position normalisation below must both use the
-        // fraction that SURVIVES, not the raw length knob. Where the 64-sample
-        // floor raises the surviving buffer above numSamples * length, drawing
-        // against `length` would cut the curve early and compress the position
-        // axis relative to the buffer the DSP actually shaped. With no IR loaded
-        // there is no sample count to derive it from, so fall back to the knob.
-        const float activeFraction = irNumSamples > 0
-                                   ? static_cast<float>(activeSamples) / static_cast<float>(irNumSamples)
-                                   : length;
-
-        float attackFraction = 1.0f;
+        // Zero, not one: with no usable sample rate processIR() computes zero
+        // attack samples and applies NO fade, so the drawing must not paint one.
+        // An attackFraction of 1.0 would ramp the whole curve up from silence.
+        float attackFraction = 0.0f;
         if (activeSamples > 0 && irSampleRate > 0.0)
         {
             const int attackSamples = std::min(static_cast<int>(attack * 0.5f * irSampleRate),

--- a/plugins/convolution-reverb/EnvelopeProcessor.h
+++ b/plugins/convolution-reverb/EnvelopeProcessor.h
@@ -113,6 +113,16 @@ public:
         int activeSamples = std::max(64, static_cast<int>(irNumSamples * length));
         activeSamples = std::min(activeSamples, irNumSamples);
 
+        // The cutoff and the position normalisation below must both use the
+        // fraction that SURVIVES, not the raw length knob. Where the 64-sample
+        // floor raises the surviving buffer above numSamples * length, drawing
+        // against `length` would cut the curve early and compress the position
+        // axis relative to the buffer the DSP actually shaped. With no IR loaded
+        // there is no sample count to derive it from, so fall back to the knob.
+        const float activeFraction = irNumSamples > 0
+                                   ? static_cast<float>(activeSamples) / static_cast<float>(irNumSamples)
+                                   : length;
+
         float attackFraction = 1.0f;
         if (activeSamples > 0 && irSampleRate > 0.0)
         {
@@ -125,15 +135,15 @@ public:
         {
             float position = static_cast<float>(i) / static_cast<float>(numPoints - 1);
 
-            // Only show envelope up to the length cutoff
-            if (position > length)
+            // Only show envelope up to the effective length cutoff
+            if (position > activeFraction || activeFraction <= 0.0f)
             {
                 curve[i] = 0.0f;
             }
             else
             {
-                // Normalize position within the active length
-                float normalizedPos = position / length;
+                // Normalize position within the surviving length
+                float normalizedPos = position / activeFraction;
                 curve[i] = getEnvelopeValue(normalizedPos, attackFraction);
             }
         }

--- a/plugins/convolution-reverb/EnvelopeProcessor.h
+++ b/plugins/convolution-reverb/EnvelopeProcessor.h
@@ -94,23 +94,32 @@ public:
 
     // Generate envelope curve for visualization.
     //
-    // irLengthSeconds is the duration of the UNTRUNCATED IR and is required for
-    // the drawn curve to match what processIR() actually applies. The attack is a
-    // fixed wall-clock span (0..500 ms), so the FRACTION of the IR it occupies
-    // depends on how long that IR is: the same knob covers half of a 1 s IR and a
-    // tenth of a 5 s one. This used to pass a flat attack * 0.25f "scaled for
-    // visualization", which happens to be right only for a 2 s IR at full length
-    // and drew a visibly wrong envelope for everything else.
-    std::vector<float> getEnvelopeCurve(int numPoints, float irLengthSeconds) const
+    // Takes the UNTRUNCATED IR's sample count and rate because the drawn curve
+    // has to reproduce processIR()'s arithmetic, not approximate it. The attack
+    // is a fixed wall-clock span (0..500 ms), so the FRACTION of the IR it
+    // occupies depends on how long that IR is: the same knob covers half of a 1 s
+    // IR and a tenth of a 5 s one. This used to pass a flat attack * 0.25f
+    // "scaled for visualization", which happens to be right only for a 2 s IR at
+    // full length and drew a visibly wrong envelope for everything else.
+    std::vector<float> getEnvelopeCurve(int numPoints, int irNumSamples, double irSampleRate) const
     {
         std::vector<float> curve(numPoints);
 
-        // Mirror processIR(): the buffer is truncated to `length` first, and the
-        // attack is then measured as a fraction of what survives.
-        const float activeSeconds = irLengthSeconds * length;
-        const float attackFraction = activeSeconds > 0.0f
-                                   ? std::min(attack * 0.5f, activeSeconds) / activeSeconds
-                                   : 1.0f;
+        // Mirror processIR() step for step, in samples: truncate to `length`,
+        // floor the result at 64 samples, never extend past the original buffer,
+        // then measure the attack against whatever survived. Working in seconds
+        // instead would drop the 64-sample floor and draw the wrong ramp for a
+        // short IR at a small length.
+        int activeSamples = std::max(64, static_cast<int>(irNumSamples * length));
+        activeSamples = std::min(activeSamples, irNumSamples);
+
+        float attackFraction = 1.0f;
+        if (activeSamples > 0 && irSampleRate > 0.0)
+        {
+            const int attackSamples = std::min(static_cast<int>(attack * 0.5f * irSampleRate),
+                                               activeSamples);
+            attackFraction = static_cast<float>(attackSamples) / static_cast<float>(activeSamples);
+        }
 
         for (int i = 0; i < numPoints; ++i)
         {

--- a/plugins/convolution-reverb/IRWaveformDisplay.cpp
+++ b/plugins/convolution-reverb/IRWaveformDisplay.cpp
@@ -183,7 +183,7 @@ void IRWaveformDisplay::paint(juce::Graphics& g)
         tempEnvelope.setLength(lengthParam);
 
         int numPoints = static_cast<int>(envBounds.getWidth());
-        auto envelopeCurve = tempEnvelope.getEnvelopeCurve(numPoints, getIRLengthSeconds());
+        auto envelopeCurve = buildEnvelopeCurve(tempEnvelope, numPoints);
         int actualPoints = static_cast<int>(envelopeCurve.size());
 
         if (actualPoints > 0)
@@ -546,7 +546,7 @@ void IRWaveformDisplay::rebuildEnvelopePath()
     tempEnvelope.setDecay(decayParam);
     tempEnvelope.setLength(lengthParam);
 
-    auto envelopeCurve = tempEnvelope.getEnvelopeCurve(numPoints, getIRLengthSeconds());
+    auto envelopeCurve = buildEnvelopeCurve(tempEnvelope, numPoints);
     int actualPoints = static_cast<int>(envelopeCurve.size());
 
     if (actualPoints == 0)

--- a/plugins/convolution-reverb/IRWaveformDisplay.cpp
+++ b/plugins/convolution-reverb/IRWaveformDisplay.cpp
@@ -183,7 +183,7 @@ void IRWaveformDisplay::paint(juce::Graphics& g)
         tempEnvelope.setLength(lengthParam);
 
         int numPoints = static_cast<int>(envBounds.getWidth());
-        auto envelopeCurve = tempEnvelope.getEnvelopeCurve(numPoints);
+        auto envelopeCurve = tempEnvelope.getEnvelopeCurve(numPoints, getIRLengthSeconds());
         int actualPoints = static_cast<int>(envelopeCurve.size());
 
         if (actualPoints > 0)
@@ -546,7 +546,7 @@ void IRWaveformDisplay::rebuildEnvelopePath()
     tempEnvelope.setDecay(decayParam);
     tempEnvelope.setLength(lengthParam);
 
-    auto envelopeCurve = tempEnvelope.getEnvelopeCurve(numPoints);
+    auto envelopeCurve = tempEnvelope.getEnvelopeCurve(numPoints, getIRLengthSeconds());
     int actualPoints = static_cast<int>(envelopeCurve.size());
 
     if (actualPoints == 0)

--- a/plugins/convolution-reverb/IRWaveformDisplay.cpp
+++ b/plugins/convolution-reverb/IRWaveformDisplay.cpp
@@ -284,10 +284,12 @@ void IRWaveformDisplay::paint(juce::Graphics& g)
                    30, 12, juce::Justification::centredRight);
     }
 
-    // Draw length cutoff line
-    if (lengthParam < 1.0f)
+    // Draw length cutoff line. Uses the surviving fraction, not the raw knob, so
+    // the line and the shading land where the envelope curve actually ends.
+    const float cutoffFraction = activeLengthFraction();
+    if (cutoffFraction < 1.0f)
     {
-        float cutoffX = waveformBounds.getX() + waveformBounds.getWidth() * lengthParam;
+        float cutoffX = waveformBounds.getX() + waveformBounds.getWidth() * cutoffFraction;
         g.setColour(envelopeColour.withAlpha(0.7f));
         g.drawVerticalLine(static_cast<int>(cutoffX), waveformBounds.getY(), waveformBounds.getBottom());
 

--- a/plugins/convolution-reverb/IRWaveformDisplay.h
+++ b/plugins/convolution-reverb/IRWaveformDisplay.h
@@ -72,6 +72,15 @@ private:
     void drawModeToggle(juce::Graphics& g);
     float calculateEQResponse(float frequencyHz);
 
+    // Duration of the loaded IR before any length truncation. The envelope curve
+    // needs it because the attack is a wall-clock span, not a fraction of the IR.
+    float getIRLengthSeconds() const
+    {
+        if (irSampleRate <= 0.0 || irBuffer.getNumSamples() == 0)
+            return 0.0f;
+        return static_cast<float>(irBuffer.getNumSamples() / irSampleRate);
+    }
+
     // Display mode
     DisplayMode displayMode = DisplayMode::IRWaveform;
     juce::Rectangle<int> irToggleBounds;

--- a/plugins/convolution-reverb/IRWaveformDisplay.h
+++ b/plugins/convolution-reverb/IRWaveformDisplay.h
@@ -72,13 +72,12 @@ private:
     void drawModeToggle(juce::Graphics& g);
     float calculateEQResponse(float frequencyHz);
 
-    // Duration of the loaded IR before any length truncation. The envelope curve
-    // needs it because the attack is a wall-clock span, not a fraction of the IR.
-    float getIRLengthSeconds() const
+    // Envelope curve for the loaded IR. Forwards the untruncated sample count and
+    // rate so EnvelopeProcessor can reproduce processIR()'s arithmetic exactly --
+    // the attack is a wall-clock span, not a fraction of the IR.
+    std::vector<float> buildEnvelopeCurve(const EnvelopeProcessor& envelope, int numPoints) const
     {
-        if (irSampleRate <= 0.0 || irBuffer.getNumSamples() == 0)
-            return 0.0f;
-        return static_cast<float>(irBuffer.getNumSamples() / irSampleRate);
+        return envelope.getEnvelopeCurve(numPoints, irBuffer.getNumSamples(), irSampleRate);
     }
 
     // Display mode

--- a/plugins/convolution-reverb/IRWaveformDisplay.h
+++ b/plugins/convolution-reverb/IRWaveformDisplay.h
@@ -75,6 +75,17 @@ private:
     // Envelope curve for the loaded IR. Forwards the untruncated sample count and
     // rate so EnvelopeProcessor can reproduce processIR()'s arithmetic exactly --
     // the attack is a wall-clock span, not a fraction of the IR.
+    // Fraction of the loaded IR that survives the length knob, from the same
+    // helper the envelope curve uses. The cutoff line and the shaded truncated
+    // region are drawn from this rather than lengthParam so all three agree once
+    // processIR's 64-sample floor raises the surviving buffer above the knob.
+    float activeLengthFraction() const
+    {
+        EnvelopeProcessor envelope;
+        envelope.setLength(lengthParam);
+        return envelope.getActiveFraction(irBuffer.getNumSamples());
+    }
+
     std::vector<float> buildEnvelopeCurve(const EnvelopeProcessor& envelope, int numPoints) const
     {
         return envelope.getEnvelopeCurve(numPoints, irBuffer.getNumSamples(), irSampleRate);

--- a/plugins/convolution-reverb/PluginEditor.cpp
+++ b/plugins/convolution-reverb/PluginEditor.cpp
@@ -54,7 +54,7 @@ ConvolutionReverbEditor::ConvolutionReverbEditor(ConvolutionReverbProcessor& p)
     lengthLabel = std::make_unique<juce::Label>();
 
     setupSlider(*attackSlider, *attackLabel, "ATTACK");
-    setupSlider(*decaySlider, *decayLabel, "DECAY");
+    setupSlider(*decaySlider, *decayLabel, "DECAY", "%");
     setupSlider(*lengthSlider, *lengthLabel, "LENGTH", "%");
 
     reverseButton = std::make_unique<juce::ToggleButton>("REV");
@@ -207,7 +207,7 @@ ConvolutionReverbEditor::ConvolutionReverbEditor(ConvolutionReverbProcessor& p)
 
     setupSlider(*filterEnvInitSlider, *filterEnvInitLabel, "INIT", "Hz");
     setupSlider(*filterEnvEndSlider, *filterEnvEndLabel, "END", "Hz");
-    setupSlider(*filterEnvAttackSlider, *filterEnvAttackLabel, "F.ATK");
+    setupSlider(*filterEnvAttackSlider, *filterEnvAttackLabel, "F.ATK", "%");
 
     // Meters (stereo mode)
     inputMeter = std::make_unique<LEDMeter>();
@@ -993,9 +993,10 @@ void ConvolutionReverbEditor::updateValueLabels()
     mixValueLabel->setText(formatPercent(static_cast<float>(mixSlider->getValue())),
                             juce::dontSendNotification);
 
-    // Attack (0-1, display as 0-500ms)
-    float attackMs = static_cast<float>(attackSlider->getValue()) * 500.0f;
-    attackValueLabel->setText(formatTime(attackMs), juce::dontSendNotification);
+    // Attack (0-1): label must match type-in editor units (#176). Showing ms
+    // here while the editor speaks 0..1 made typing the label value clamp to max.
+    attackValueLabel->setText(juce::String(attackSlider->getValue(), 2),
+                              juce::dontSendNotification);
 
     // Decay (0-1, display as percentage)
     decayValueLabel->setText(formatPercent(static_cast<float>(decaySlider->getValue())),

--- a/plugins/convolution-reverb/PluginEditor.cpp
+++ b/plugins/convolution-reverb/PluginEditor.cpp
@@ -53,7 +53,7 @@ ConvolutionReverbEditor::ConvolutionReverbEditor(ConvolutionReverbProcessor& p)
     decayLabel = std::make_unique<juce::Label>();
     lengthLabel = std::make_unique<juce::Label>();
 
-    setupSlider(*attackSlider, *attackLabel, "ATTACK");
+    setupSlider(*attackSlider, *attackLabel, "ATTACK", "%");
     setupSlider(*decaySlider, *decayLabel, "DECAY", "%");
     setupSlider(*lengthSlider, *lengthLabel, "LENGTH", "%");
 
@@ -69,7 +69,7 @@ ConvolutionReverbEditor::ConvolutionReverbEditor(ConvolutionReverbProcessor& p)
     mixLabel = std::make_unique<juce::Label>();
 
     setupSlider(*preDelaySlider, *preDelayLabel, "PRE-DELAY", "ms");
-    setupSlider(*widthSlider, *widthLabel, "WIDTH");
+    setupSlider(*widthSlider, *widthLabel, "WIDTH", "%");
     setupSlider(*mixSlider, *mixLabel, "MIX", "%");
 
     // Filter controls
@@ -984,36 +984,37 @@ void ConvolutionReverbEditor::updateValueLabels()
     preDelayValueLabel->setText(formatTime(static_cast<float>(preDelaySlider->getValue())),
                                  juce::dontSendNotification);
 
-    // Width (0-200%, display as percentage)
-    float widthPercent = static_cast<float>(widthSlider->getValue()) * 100.0f;
-    widthValueLabel->setText(juce::String(static_cast<int>(widthPercent)) + "%",
+    // Width (0-2 native, display as 0-200%)
+    widthValueLabel->setText(formatPercent(static_cast<float>(widthSlider->getValue())),
                               juce::dontSendNotification);
 
     // Mix (0-100%)
     mixValueLabel->setText(formatPercent(static_cast<float>(mixSlider->getValue())),
                             juce::dontSendNotification);
 
-    // Attack (0-1): label must match type-in editor units (#176). Showing ms
-    // here while the editor speaks 0..1 made typing the label value clamp to max.
-    attackValueLabel->setText(juce::String(attackSlider->getValue(), 2),
+    // Attack (0-1, display as percentage of the 500 ms envelope span). The label
+    // must speak the same units as the type-in editor (#176): ValueEditor pre-fills
+    // from slider.getTextFromValue(), so a label in any other unit invites the user
+    // to type a number the parser will misread.
+    attackValueLabel->setText(formatPercent(static_cast<float>(attackSlider->getValue())),
                               juce::dontSendNotification);
 
     // Decay (0-1, display as percentage)
     decayValueLabel->setText(formatPercent(static_cast<float>(decaySlider->getValue())),
                               juce::dontSendNotification);
 
-    // Length (0-1, display as percentage or seconds based on IR)
+    // Length (0-1). The percentage leads and the resolved tail time follows in
+    // parentheses (#176). This label used to switch wholesale to seconds once an
+    // IR was loaded, while the parameter kept speaking percent: at a 5 s IR the
+    // knob read "3.8 s", and typing 3.8 into the editor wrote 0.038 -- a
+    // collapsed tail rather than a visible failure. Keeping percent first means
+    // the number nearest the knob is always the one the editor accepts.
     float lengthVal = static_cast<float>(lengthSlider->getValue());
     float irLengthSec = audioProcessor.getCurrentIRLengthSeconds();
+    juce::String lengthText = formatPercent(lengthVal);
     if (irLengthSec > 0.0f)
-    {
-        float actualLength = lengthVal * irLengthSec;
-        lengthValueLabel->setText(juce::String(actualLength, 1) + " s", juce::dontSendNotification);
-    }
-    else
-    {
-        lengthValueLabel->setText(formatPercent(lengthVal), juce::dontSendNotification);
-    }
+        lengthText += " (" + juce::String(lengthVal * irLengthSec, 1) + " s)";
+    lengthValueLabel->setText(lengthText, juce::dontSendNotification);
 
     // HPF (20-500 Hz)
     hpfValueLabel->setText(formatFrequency(static_cast<float>(hpfSlider->getValue())),

--- a/plugins/convolution-reverb/PluginProcessor.cpp
+++ b/plugins/convolution-reverb/PluginProcessor.cpp
@@ -106,10 +106,18 @@ juce::AudioProcessorValueTreeState::ParameterLayout ConvolutionReverbProcessor::
         juce::AudioParameterFloatAttributes().withLabel("ms")));
 
     // Envelope controls
+    // ATTACK is a 0..1 fraction of a fixed 500 ms envelope span, and it reads as
+    // a percentage rather than the milliseconds it actually drives (GH #176).
+    // Milliseconds are not available here: ValueEditor::parseSmart classifies any
+    // slider whose maximum is <= 60 and whose display ends in a time token as
+    // seconds-native, so a "250 ms" display would have a typed 250 come back as
+    // 0.25 -- half the intended value, silently. Percent keeps the round trip
+    // exact and matches DECAY and F.ATK, the other two envelope fractions.
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "attack", "Attack",
         juce::NormalisableRange<float>(0.0f, 1.0f, 0.01f),
-        0.0f));
+        0.0f,
+        fractionShownAsPercent()));
 
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "decay", "Decay",
@@ -127,11 +135,16 @@ juce::AudioProcessorValueTreeState::ParameterLayout ConvolutionReverbProcessor::
     params.push_back(std::make_unique<juce::AudioParameterBool>(
         "reverse", "Reverse", false));
 
-    // Stereo width
+    // Stereo width. Native 0..2 shown as 0..200 %, so the literal x100 in
+    // fractionShownAsPercent() is again the right scale (GH #176). The knob
+    // painted "150%" while its editor spoke 0..2, so typing the number on
+    // screen clamped to maximum width. percentNeedsScaling() still scales here:
+    // a native maximum of 2 is far below its 50 percent-native bar.
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "width", "Stereo Width",
         juce::NormalisableRange<float>(0.0f, 2.0f, 0.01f),
-        1.0f));
+        1.0f,
+        fractionShownAsPercent()));
 
     // Filters
     params.push_back(std::make_unique<juce::AudioParameterFloat>(

--- a/plugins/convolution-reverb/PluginProcessor.cpp
+++ b/plugins/convolution-reverb/PluginProcessor.cpp
@@ -114,7 +114,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout ConvolutionReverbProcessor::
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "decay", "Decay",
         juce::NormalisableRange<float>(0.0f, 1.0f, 0.01f),
-        1.0f));
+        1.0f,
+        fractionShownAsPercent()));
 
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "length", "Length",
@@ -238,7 +239,8 @@ juce::AudioProcessorValueTreeState::ParameterLayout ConvolutionReverbProcessor::
     params.push_back(std::make_unique<juce::AudioParameterFloat>(
         "filter_env_attack", "Filter Attack",
         juce::NormalisableRange<float>(0.0f, 1.0f, 0.01f),
-        0.3f));  // 30% of IR length for filter attack
+        0.3f,  // 30% of IR length for filter attack
+        fractionShownAsPercent()));
 
     // Stereo Mode
     params.push_back(std::make_unique<juce::AudioParameterChoice>(

--- a/plugins/shared-dpf/util/tests/CrashLogProbe.cpp
+++ b/plugins/shared-dpf/util/tests/CrashLogProbe.cpp
@@ -86,7 +86,9 @@ void setSimpleHandler(int sig, void (*handler)(int))
 {
     struct sigaction action {};
     action.sa_handler = handler;
-    ::sigemptyset(&action.sa_mask);
+    // Unqualified: Darwin defines sigemptyset as a function-like macro, so the
+    // "::" form expands to "::(*(&m) = 0, 0)" and will not parse.
+    sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
     if (::sigaction(sig, &action, nullptr) != 0)
     {
@@ -101,7 +103,7 @@ void setSiginfoHandler(int sig,
 {
     struct sigaction action {};
     action.sa_sigaction = handler;
-    ::sigemptyset(&action.sa_mask);
+    sigemptyset(&action.sa_mask);   // macro on Darwin; see setSimpleHandler
     action.sa_flags = SA_SIGINFO | SA_RESTART;
     if (::sigaction(sig, &action, previous) != 0)
     {

--- a/plugins/shared/CrashLog.h
+++ b/plugins/shared/CrashLog.h
@@ -594,7 +594,11 @@ namespace DuskCrashLog
         {
             struct sigaction dfl {};
             dfl.sa_handler = SIG_DFL;
-            ::sigemptyset (&dfl.sa_mask);
+            // Unqualified on purpose: Darwin's signal.h defines sigemptyset as a
+            // function-like macro, so "::sigemptyset (&m)" expands to
+            // "::(*(&m) = 0, 0)" and fails to parse. The neighbouring ::sigaction
+            // and ::raise are real functions and keep their qualifier.
+            sigemptyset (&dfl.sa_mask);
             dfl.sa_flags = 0;
             ::sigaction (sig, &dfl, nullptr);
             ::raise (sig);
@@ -857,7 +861,7 @@ namespace DuskCrashLog
 
         struct sigaction action {};
         action.sa_sigaction = &detail::crashHandler;
-        ::sigemptyset (&action.sa_mask);
+        sigemptyset (&action.sa_mask);   // macro on Darwin; see restoreDefaultAndReraise
         // SA_ONSTACK is opportunistic, NOT a stack-overflow guarantee: it only
         // does anything if an alternate stack already exists on the faulting
         // thread, and we deliberately do not install one. sigaltstack() is


### PR DESCRIPTION
Fixes the Convolution Reverb unit bugs from #176, plus two defects found while verifying them.

Closes #176

## 1. Knob labels and type-in editors now agree

`ValueEditor` pre-fills its editor from `slider.getTextFromValue()`, so a value label in different units invites the user to type a number the parser will misread.

| param | before | after |
|---|---|---|
| `attack` | label `0.50`, no unit | `50%` / editor `50.0 %` |
| `width` | label `150%`, editor spoke `1.50` -- typing 150 clamped to **maximum width** | `150%` / editor `150.0 %`, typed 150 gives 1.5 |
| `length` | label flipped to `3.8 s` with an IR loaded while the parameter kept percent -- typing 3.8 wrote **0.038** | `75% (3.8 s)`, percentage first |

`attack` and `width` now use `fractionShownAsPercent()`, the same parameter-side formatter `mix`, `decay`, `length`, `ir_offset` and `filter_env_attack` already share. Seven parameters, one unit contract.

**Why `attack` shows percent and not the milliseconds it drives:** `ValueEditor::parseSmart` classifies any slider whose maximum is <= 60 and whose display ends in a time token as seconds-native. A `250 ms` display would therefore make a typed `250` come back as 0.25 -- half value, silently. Milliseconds need option A from #176 (teaching `parseSmart` about display scale), which touches shared code used by seven plugins. Not worth it against a UI that #187 replaces.

Native ranges are unchanged, so saved sessions and existing automation are unaffected.

## 2. macOS builds were broken fleet-wide

`shared/CrashLog.h` called `::sigemptyset`. Darwin's `signal.h` defines it as a function-like macro, so that expands to `::(*(&m) = 0, 0)` and fails to parse. Every JUCE plugin includes this header, so nothing built on macOS since it landed in 3612e43. The same call in `shared-dpf/util/tests/CrashLogProbe.cpp` had the same defect.

**Linux CI cannot catch this.** `sigemptyset` is a real function on Linux, and `run_crashlog_tests.sh` hard-exits unless `uname -s` is Linux. The DPF original at `shared-dpf/util/CrashLog.hpp` always had the call unqualified; the `::` was introduced by the JUCE port.

Confirmed by control experiment: stashing the changes and rebuilding clean HEAD reproduces the identical two errors.

## 3. The envelope display did not match the DSP

`getEnvelopeCurve` passed a flat `attack * 0.25f` marked "scaled for visualization" while `processIR` applies `attackSamples / numSamples`. Since the attack is a fixed wall-clock span, the fraction of the IR it covers depends on IR length, and the two agreed only on a 2 s IR at full length:

| IR length | drawn | actually applied |
|---|---|---|
| 1 s | attack x 0.25 | attack x 0.5 -- half what was shown |
| 2 s | attack x 0.25 | attack x 0.25 |
| 5 s | attack x 0.25 | attack x 0.1 -- 2.5x what was shown |

The curve now takes the IR duration and mirrors `processIR` exactly. Display only; no audio path touched. The unused `attackNormalizedPos` the compiler flagged was the fossil of an earlier attempt at this.

## Verification

- All 11 JUCE AU targets build on macOS: ChordAnalyzer, ChordAnalyzerMIDI, ConvolutionReverb, DuskAmp, DuskVerb, FourKEQ, MultiComp, MultiQ, SpectrumAnalyzer, TapeEcho, TapeMachine.
- `CrashLogProbe.cpp` goes from 2 errors to clean under `clang++ -fsyntax-only`.
- Swept the repo for the rest of the qualified-POSIX-macro class (`setjmp`, `FD_ZERO`, `WIFEXITED`, `htonl`, `S_ISREG`, `va_start`): no further instances.
- **Not verified:** the type-in round trip in a live host. Traced by hand through `parseSmart` and `percentNeedsScaling` -- `width` (max 2.0) and `attack` (max 1.0) both sit under the 50 percent-native bar, so scaling applies and a typed 150/50 lands on 1.5/0.5.

## Note on the previous red CI

The five failing jobs on the earlier run (ConvolutionReverb, ChordAnalyzerMIDI, DuskVerb, FourKEQ, MultiQ) were all `cancelled` after hanging ~45 minutes on **Install Linux dependencies**, never reaching Configure or Build. `juce-compile-check.yml` runs a bare `apt-get update` with no mirror switch and no retry, unlike `dpf-build.yml`, which already hardens exactly this. Being addressed in a separate PR so this one stays scoped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated envelope attack, decay, stereo width, and filter attack controls to display percentages consistently.
  * Length labels now show normalized percentages and, when available, the corresponding duration in seconds.
  * Improved envelope visualization accuracy across impulse responses with different sample rates and lengths.

* **Bug Fixes**
  * Resolved a macOS compatibility issue affecting crash-log signal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->