### PR TITLE
ci: retry apt in juce-compile-check instead of stalling out

### DIFF
--- a/.github/scripts/apt_install.sh
+++ b/.github/scripts/apt_install.sh
@@ -33,13 +33,33 @@
 # than configured, because the call sites are split between both.
 set -uo pipefail
 
-ATTEMPTS=5
-UPDATE_TIMEOUT=240
-INSTALL_TIMEOUT=600
+# The whole point of this script is to fail fast and legibly, so its own worst
+# case has to fit inside the caller's job budget -- otherwise a pathological run
+# is killed by the JOB timeout and reports as "cancelled" with no error, which is
+# the exact failure mode this exists to remove. Callers run under 30-, 40- and
+# 45-minute job limits, so the defaults are sized against the smallest:
+#
+#   3 x (120 update + 240 install) + 2 x 10s sleep = 1100s, about 18 minutes.
+#
+# Three attempts is enough because the mirror switch happens after the first
+# failure, so attempt 2 is already on the other mirror and attempt 3 is margin.
+# A caller with a tighter step budget can lower any of these from the workflow.
+ATTEMPTS="${APT_ATTEMPTS:-3}"
+UPDATE_TIMEOUT="${APT_UPDATE_TIMEOUT:-120}"
+INSTALL_TIMEOUT="${APT_INSTALL_TIMEOUT:-240}"
+RETRY_SLEEP="${APT_RETRY_SLEEP:-10}"
 APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30)
 
+# Two mirror families, and arm64 is not a footnote: aarch64 Ubuntu serves from
+# ports.ubuntu.com/ubuntu-ports, which shares no substring with the x86 archive
+# host. The first version of this switched only the archive pair, so on the arm64
+# jobs the sed matched nothing, the switch silently did nothing, and every retry
+# went back to the same dead mirror. Each family is only ever swapped within
+# itself, so a ports source can never be rewritten to an x86 archive.
 AZURE_MIRROR="http://azure.archive.ubuntu.com/ubuntu"
 STOCK_MIRROR="http://archive.ubuntu.com/ubuntu"
+AZURE_PORTS="http://azure.ports.ubuntu.com/ubuntu-ports"
+STOCK_PORTS="http://ports.ubuntu.com/ubuntu-ports"
 
 if [ "$(id -u)" -eq 0 ]; then
     SUDO=()
@@ -70,30 +90,65 @@ mirror_files() {
     done
 }
 
+# Plain loop rather than `xargs -r grep`: -r is a GNU extension, so the xargs
+# form silently reported "no match" when this was exercised on macOS and both
+# mirror families looked identical. It would have worked on the Linux runners
+# and been untestable anywhere else.
+sources_match() {
+    local f
+    while read -r f; do
+        grep -q "$1" "$f" 2>/dev/null && return 0
+    done < <(mirror_files)
+    return 1
+}
+
+# Which family this machine serves from: ports on aarch64, archive on x86.
+mirror_family() {
+    if sources_match "ports\.ubuntu\.com"; then
+        echo ports
+    else
+        echo archive
+    fi
+}
+
 current_mirror() {
-    if mirror_files | xargs -r grep -lq "azure.archive.ubuntu.com" 2>/dev/null; then
+    if sources_match "azure\."; then
         echo azure
     else
         echo stock
     fi
 }
 
-# Move to whichever mirror we are NOT on. Called once, after the first failure,
-# so a healthy mirror is never abandoned on a transient blip.
+# Move to whichever mirror we are NOT on, within this machine's family. Called
+# once, after the first failure, so a healthy mirror is never abandoned on a
+# transient blip.
 switch_mirror() {
-    local from to
-    if [ "$(current_mirror)" = "azure" ]; then
-        from="$AZURE_MIRROR" to="$STOCK_MIRROR"
+    local from to security_to
+    if [ "$(mirror_family)" = "ports" ]; then
+        if [ "$(current_mirror)" = "azure" ]; then
+            from="$AZURE_PORTS" to="$STOCK_PORTS"
+        else
+            from="$STOCK_PORTS" to="$AZURE_PORTS"
+        fi
+        # aarch64 serves security from the ports host too, so it moves with it.
+        security_to="$to"
     else
-        from="$STOCK_MIRROR" to="$AZURE_MIRROR"
+        if [ "$(current_mirror)" = "azure" ]; then
+            from="$AZURE_MIRROR" to="$STOCK_MIRROR"
+        else
+            from="$STOCK_MIRROR" to="$AZURE_MIRROR"
+        fi
+        security_to="$to"
     fi
     echo "::notice::apt switching mirror to ${to}"
     mirror_files | while read -r f; do
         "${SUDO[@]}" sed -i -e "s|${from}|${to}|g" "$f" || true
     done
-    # security.ubuntu.com is a separate host and stalls independently.
+    # security.ubuntu.com is a separate host and stalls independently. Only ever
+    # present on the archive side; on ports the security suites already live on
+    # the ports host and were rewritten above.
     mirror_files | while read -r f; do
-        "${SUDO[@]}" sed -i -e "s|http://security.ubuntu.com/ubuntu|${to}|g" "$f" || true
+        "${SUDO[@]}" sed -i -e "s|http://security.ubuntu.com/ubuntu|${security_to}|g" "$f" || true
     done
 }
 
@@ -125,7 +180,7 @@ for i in $(seq 1 "$ATTEMPTS"); do
         exit 1
     fi
 
-    echo "::warning::apt attempt ${i} failed or timed out; retrying in 15s"
+    echo "::warning::apt attempt ${i} failed or timed out; retrying in ${RETRY_SLEEP}s"
     [ "$i" -eq 1 ] && switch_mirror
-    sleep 15
+    sleep "$RETRY_SLEEP"
 done

--- a/.github/scripts/apt_install.sh
+++ b/.github/scripts/apt_install.sh
@@ -50,6 +50,31 @@ INSTALL_TIMEOUT="${APT_INSTALL_TIMEOUT:-240}"
 RETRY_SLEEP="${APT_RETRY_SLEEP:-10}"
 APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30)
 
+# A bad override must not pass silently, and ATTEMPTS is the one that would:
+# `for i in $(seq 1 abc)` prints an error, runs the body zero times, and leaves
+# the script exiting 0 having installed NOTHING. A typo'd APT_ATTEMPTS in a
+# workflow would therefore turn this into a no-op that reports success, and the
+# missing packages would surface much later as a confusing compile error.
+# Zero and negatives fail the same way. The timeouts are checked too, since a
+# non-numeric one makes every attempt fail for a reason that has nothing to do
+# with the mirror.
+require_positive_int() {
+    case "$2" in
+        '' | *[!0-9]* ) ;;
+        * ) [ "$2" -gt 0 ] && return 0 ;;
+    esac
+    echo "::error::$1 must be a positive integer, got '$2'" >&2
+    exit 2
+}
+require_positive_int APT_ATTEMPTS        "$ATTEMPTS"
+require_positive_int APT_UPDATE_TIMEOUT  "$UPDATE_TIMEOUT"
+require_positive_int APT_INSTALL_TIMEOUT "$INSTALL_TIMEOUT"
+case "$RETRY_SLEEP" in
+    '' | *[!0-9]* )
+        echo "::error::APT_RETRY_SLEEP must be a non-negative integer, got '$RETRY_SLEEP'" >&2
+        exit 2 ;;
+esac
+
 # Two mirror families, and arm64 is not a footnote: aarch64 Ubuntu serves from
 # ports.ubuntu.com/ubuntu-ports, which shares no substring with the x86 archive
 # host. The first version of this switched only the archive pair, so on the arm64

--- a/.github/scripts/apt_install.sh
+++ b/.github/scripts/apt_install.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# One apt front end for every workflow in this repo.
+#
+# Ubuntu mirrors are the least reliable thing in this CI. Two distinct failure
+# shapes have both taken the fleet down, and they need different defences:
+#
+#   STALL. An unreachable mirror does not fail apt, it hangs it. On run
+#   32157020545 five of the eleven juce-compile-check jobs sat in their install
+#   step until the 45-minute job timeout killed them: three hours of runner
+#   time, reported as "cancelled" with no error to read. A retry loop is no
+#   help here, because a call that hangs never comes back to be retried. Hence
+#   timeout(1) around every apt invocation.
+#
+#   HARD FAIL. On run 32176674366 the DPF container's prerequisite step failed
+#   outright in 81 seconds. That one WOULD have survived a retry, but the loop
+#   only existed in a later step which never ran. Hence retries everywhere,
+#   from one place, rather than hand-copied into whichever step someone
+#   remembered.
+#
+# Both incidents were the same mirror. dpf-build.yml forces apt onto
+# azure.archive.ubuntu.com, documented at the time because archive.ubuntu.com
+# measured 724 B/s from a runner; on 2026-08-18 the polarity was reversed and
+# Azure was the sick one. Pinning EITHER mirror is the bug, so after the first
+# failed attempt this script switches to the other one and keeps going.
+#
+# Usage:
+#   apt_install.sh pkg [pkg...]   update, then install those packages
+#   apt_install.sh --update-only  refresh the lists only (after adding a PPA)
+#
+# Runs as root in a container and via sudo on a hosted runner, detected rather
+# than configured, because the call sites are split between both.
+set -uo pipefail
+
+ATTEMPTS=5
+UPDATE_TIMEOUT=240
+INSTALL_TIMEOUT=600
+APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=30)
+
+AZURE_MIRROR="http://azure.archive.ubuntu.com/ubuntu"
+STOCK_MIRROR="http://archive.ubuntu.com/ubuntu"
+
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=()
+else
+    SUDO=(sudo)
+fi
+
+update_only=0
+if [ "${1:-}" = "--update-only" ]; then
+    update_only=1
+    shift
+fi
+packages=("$@")
+
+if [ "$update_only" -eq 0 ] && [ ${#packages[@]} -eq 0 ]; then
+    echo "apt_install: no packages given" >&2
+    exit 2
+fi
+
+# Both list formats: 24.04 images ship deb822 .sources files and no
+# sources.list, so touching only the latter would silently do nothing there.
+mirror_files() {
+    local f
+    for f in /etc/apt/sources.list \
+             /etc/apt/sources.list.d/*.list \
+             /etc/apt/sources.list.d/*.sources; do
+        [ -f "$f" ] && printf '%s\n' "$f"
+    done
+}
+
+current_mirror() {
+    if mirror_files | xargs -r grep -lq "azure.archive.ubuntu.com" 2>/dev/null; then
+        echo azure
+    else
+        echo stock
+    fi
+}
+
+# Move to whichever mirror we are NOT on. Called once, after the first failure,
+# so a healthy mirror is never abandoned on a transient blip.
+switch_mirror() {
+    local from to
+    if [ "$(current_mirror)" = "azure" ]; then
+        from="$AZURE_MIRROR" to="$STOCK_MIRROR"
+    else
+        from="$STOCK_MIRROR" to="$AZURE_MIRROR"
+    fi
+    echo "::notice::apt switching mirror to ${to}"
+    mirror_files | while read -r f; do
+        "${SUDO[@]}" sed -i -e "s|${from}|${to}|g" "$f" || true
+    done
+    # security.ubuntu.com is a separate host and stalls independently.
+    mirror_files | while read -r f; do
+        "${SUDO[@]}" sed -i -e "s|http://security.ubuntu.com/ubuntu|${to}|g" "$f" || true
+    done
+}
+
+attempt() {
+    "${SUDO[@]}" timeout "$UPDATE_TIMEOUT" apt-get update "${APT_OPTS[@]}" || return 1
+    [ "$update_only" -eq 1 ] && return 0
+    "${SUDO[@]}" timeout "$INSTALL_TIMEOUT" env DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y --no-install-recommends "${APT_OPTS[@]}" "${packages[@]}"
+}
+
+for i in $(seq 1 "$ATTEMPTS"); do
+    if attempt; then
+        # A non-zero exit is not the only way apt disappoints. Confirm the
+        # packages are actually present, so a missing one fails here with a
+        # clear message instead of surfacing as a confusing compile or loader
+        # error several steps later.
+        missing=()
+        for pkg in ${packages+"${packages[@]}"}; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
+        done
+        if [ ${#missing[@]} -eq 0 ]; then
+            exit 0
+        fi
+        echo "::warning::apt reported success but these are missing: ${missing[*]}"
+    fi
+
+    if [ "$i" -eq "$ATTEMPTS" ]; then
+        echo "::error::apt failed after ${ATTEMPTS} attempts (mirror: $(current_mirror))"
+        exit 1
+    fi
+
+    echo "::warning::apt attempt ${i} failed or timed out; retrying in 15s"
+    [ "$i" -eq 1 ] && switch_mirror
+    sleep 15
+done

--- a/.github/scripts/select_juce_plugins.py
+++ b/.github/scripts/select_juce_plugins.py
@@ -63,6 +63,9 @@ FLEET_WIDE = (
     "CMakeLists.txt",
     ".github/workflows/juce-compile-check.yml",
     ".github/scripts/select_juce_plugins.py",
+    # Every Linux compile job runs this installer before building anything, so a
+    # change to it is exercised by -- and must trigger -- the whole fleet.
+    ".github/scripts/apt_install.sh",
 )
 
 # Subtrees inside a plugin directory that no JUCE target compiles. The workflow's

--- a/.github/scripts/select_juce_plugins.py
+++ b/.github/scripts/select_juce_plugins.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Pick the JUCE plugins a change actually needs built.
+
+juce-compile-check.yml used to run its full twelve-plugin matrix for every
+pull request, including one that touched a single plugin. That is not free:
+each job re-runs checkout, apt and a full CMake configure of the whole tree
+before compiling anything, and twelve simultaneous jobs queue against the
+runner pool, so the wasted legs delay the ones that matter.
+
+The blast-radius argument the workflow was built on still holds, but it only
+applies to code that actually crosses trees. So:
+
+  * a change under plugins/shared/, cmake/, the root CMakeLists or this
+    workflow reaches every plugin -> build all of them, as before
+  * a change confined to one plugin's own directory -> build that plugin
+
+Emits GitHub Actions outputs:
+
+  plugins  JSON array of Linux target names for the matrix
+  windows  JSON array of Windows target names (the small fixed subset,
+           intersected with the selection)
+  reason   one line for the job summary
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+# Directory prefix -> the juce_add_plugin targets it produces. chord-analyzer
+# declares two; spectrum-analyzer and groovemind name theirs through a CMake
+# variable, so neither is greppable from the source and both are listed here by
+# hand. Keep this in sync with the matrix in juce-compile-check.yml.
+PLUGIN_DIRS: dict[str, list[str]] = {
+    "plugins/4k-eq/": ["FourKEQ"],
+    "plugins/multi-comp/": ["MultiComp"],
+    "plugins/TapeMachine/": ["TapeMachine"],
+    "plugins/tape-echo/": ["TapeEcho"],
+    "plugins/multi-q/": ["MultiQ"],
+    "plugins/convolution-reverb/": ["ConvolutionReverb"],
+    "plugins/DuskVerb/": ["DuskVerb"],
+    "plugins/DuskAmp/": ["DuskAmp"],
+    "plugins/chord-analyzer/": ["ChordAnalyzer", "ChordAnalyzerMIDI"],
+    "plugins/spectrum-analyzer/": ["SpectrumAnalyzer"],
+    "plugins/groovemind/": ["GrooveMind"],
+}
+
+ALL_PLUGINS = [target for targets in PLUGIN_DIRS.values() for target in targets]
+
+# The Windows leg deliberately covers four distinct shapes rather than the whole
+# fleet; see the comment above compile-windows in the workflow.
+WINDOWS_PLUGINS = ["FourKEQ", "MultiComp", "SpectrumAnalyzer", "ChordAnalyzer"]
+
+# Paths that reach the whole fleet. plugins/shared/ alone is included by eleven
+# plugins, and DuskFilters.hpp is compiled by the JUCE TapeMachine through the
+# cross-tree include.
+FLEET_WIDE = (
+    "plugins/shared/",
+    "plugins/shared-dpf/dsp/DuskFilters.hpp",
+    "cmake/",
+    "CMakeLists.txt",
+    ".github/workflows/juce-compile-check.yml",
+    ".github/scripts/select_juce_plugins.py",
+)
+
+# Subtrees inside a plugin directory that no JUCE target compiles. The workflow's
+# own paths filter already subtracts these; repeated here so a DPF-only change
+# that slips through the filter still selects nothing rather than everything.
+NON_JUCE_SUBTREES = ("/dpf-plugin/", "/core/")
+
+
+def changed_files(base_ref: str) -> list[str]:
+    """Files this PR touches, or an empty list if the range cannot be resolved."""
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError as exc:
+        print(f"::warning::could not diff against origin/{base_ref}: {exc}", file=sys.stderr)
+        return []
+    return [line for line in out.splitlines() if line]
+
+
+def select(files: list[str]) -> tuple[list[str], str]:
+    if not files:
+        return ALL_PLUGINS, "could not determine changed files; building the full fleet"
+
+    for path in files:
+        if path.startswith(FLEET_WIDE):
+            return ALL_PLUGINS, f"{path} reaches every plugin; building the full fleet"
+
+    selected: list[str] = []
+    for path in files:
+        if any(sub in "/" + path for sub in NON_JUCE_SUBTREES):
+            continue
+        for prefix, targets in PLUGIN_DIRS.items():
+            if path.startswith(prefix):
+                selected += [t for t in targets if t not in selected]
+
+    if not selected:
+        return [], "no JUCE plugin sources changed"
+
+    # Keep the matrix in the workflow's declared order for a stable check list.
+    ordered = [t for t in ALL_PLUGINS if t in selected]
+    return ordered, f"changed plugins: {', '.join(ordered)}"
+
+
+def main() -> int:
+    base_ref = os.environ.get("BASE_REF", "")
+    event = os.environ.get("EVENT_NAME", "")
+
+    if event != "pull_request" or not base_ref:
+        plugins, reason = ALL_PLUGINS, f"event '{event or 'unknown'}' builds the full fleet"
+    else:
+        plugins, reason = select(changed_files(base_ref))
+
+    windows = [p for p in WINDOWS_PLUGINS if p in plugins]
+
+    print(f"::notice::{reason}")
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"plugins={json.dumps(plugins)}\n")
+            handle.write(f"windows={json.dumps(windows)}\n")
+            handle.write(f"reason={reason}\n")
+    else:
+        print(json.dumps({"plugins": plugins, "windows": windows, "reason": reason}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,19 +218,19 @@ jobs:
             echo "::notice::switched apt to the Azure mirror"
           }
           bootstrap() {
-            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
-            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+            timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
               git ca-certificates software-properties-common
           }
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3; do
             bootstrap && break
-            if [ "$i" = "5" ]; then
-              echo "::error::apt bootstrap unavailable after 5 attempts"
+            if [ "$i" = "3" ]; then
+              echo "::error::apt bootstrap unavailable after 3 attempts"
               exit 1
             fi
-            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
             [ "$i" = "1" ] && switch_mirror
-            sleep 15
+            sleep 10
           done
 
       - name: Install GCC 11 toolchain
@@ -296,6 +296,11 @@ jobs:
       - name: Install Linux dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
+          # This job is capped at 30 minutes and the bootstrap step above can
+          # already spend ~14 of them in its own worst case, so trim the shared
+          # script's budget here: 2 x (120 + 240) + 10s is ~12 minutes, leaving
+          # the pathological total under the job limit instead of dying to it.
+          APT_ATTEMPTS: 2
         run: |
           # Retry, timeout, mirror fallback and per-package verification come
           # from the shared script; this step runs after checkout, so it is on
@@ -478,19 +483,19 @@ jobs:
             echo "::notice::switched apt to the Azure mirror"
           }
           bootstrap() {
-            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
-            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+            timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
               git ca-certificates software-properties-common
           }
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3; do
             bootstrap && break
-            if [ "$i" = "5" ]; then
-              echo "::error::apt bootstrap unavailable after 5 attempts"
+            if [ "$i" = "3" ]; then
+              echo "::error::apt bootstrap unavailable after 3 attempts"
               exit 1
             fi
-            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
             [ "$i" = "1" ] && switch_mirror
-            sleep 15
+            sleep 10
           done
 
       - name: Install GCC 11 toolchain
@@ -548,6 +553,11 @@ jobs:
       - name: Install Linux dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
+          # This job is capped at 30 minutes and the bootstrap step above can
+          # already spend ~14 of them in its own worst case, so trim the shared
+          # script's budget here: 2 x (120 + 240) + 10s is ~12 minutes, leaving
+          # the pathological total under the job limit instead of dying to it.
+          APT_ATTEMPTS: 2
         run: |
           # Retry, timeout, mirror fallback and per-package verification come
           # from the shared script; this step runs after checkout, so it is on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,8 +211,12 @@ jobs:
           # in 81 seconds (run 32176674366) with no retry to save it, and this is
           # a RELEASE pipeline, so it gets the same defences in minimal form.
           switch_mirror() {
+            # security.ubuntu.com is a separate host and stalls independently;
+            # apt-get update fetches from it too, so leaving it in place lets a
+            # stalled security host defeat the whole switch.
             sed -i \
               -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
               -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
               /etc/apt/sources.list
             echo "::notice::switched apt to the Azure mirror"
@@ -476,8 +480,12 @@ jobs:
           # in 81 seconds (run 32176674366) with no retry to save it, and this is
           # a RELEASE pipeline, so it gets the same defences in minimal form.
           switch_mirror() {
+            # security.ubuntu.com is a separate host and stalls independently;
+            # apt-get update fetches from it too, so leaving it in place lets a
+            # stalled security host defeat the whole switch.
             sed -i \
               -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
               -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
               /etc/apt/sources.list
             echo "::notice::switched apt to the Azure mirror"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,8 +205,33 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends git ca-certificates software-properties-common
+          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
+          # does not exist yet, so actions/checkout has not run and the script is
+          # not on disk. This is the step shape that failed the DPF build outright
+          # in 81 seconds (run 32176674366) with no retry to save it, and this is
+          # a RELEASE pipeline, so it gets the same defences in minimal form.
+          switch_mirror() {
+            sed -i \
+              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
+              /etc/apt/sources.list
+            echo "::notice::switched apt to the Azure mirror"
+          }
+          bootstrap() {
+            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+              git ca-certificates software-properties-common
+          }
+          for i in 1 2 3 4 5; do
+            bootstrap && break
+            if [ "$i" = "5" ]; then
+              echo "::error::apt bootstrap unavailable after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            [ "$i" = "1" ] && switch_mirror
+            sleep 15
+          done
 
       - name: Install GCC 11 toolchain
         env:
@@ -272,7 +297,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get install -y --no-install-recommends \
+          # Retry, timeout, mirror fallback and per-package verification come
+          # from the shared script; this step runs after checkout, so it is on
+          # disk here (unlike the bootstrap step above).
+          .github/scripts/apt_install.sh \
             build-essential \
             cmake \
             pkg-config \
@@ -437,8 +465,33 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends git ca-certificates software-properties-common
+          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
+          # does not exist yet, so actions/checkout has not run and the script is
+          # not on disk. This is the step shape that failed the DPF build outright
+          # in 81 seconds (run 32176674366) with no retry to save it, and this is
+          # a RELEASE pipeline, so it gets the same defences in minimal form.
+          switch_mirror() {
+            sed -i \
+              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
+              /etc/apt/sources.list
+            echo "::notice::switched apt to the Azure mirror"
+          }
+          bootstrap() {
+            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+              git ca-certificates software-properties-common
+          }
+          for i in 1 2 3 4 5; do
+            bootstrap && break
+            if [ "$i" = "5" ]; then
+              echo "::error::apt bootstrap unavailable after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            [ "$i" = "1" ] && switch_mirror
+            sleep 15
+          done
 
       - name: Install GCC 11 toolchain
         env:
@@ -496,7 +549,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get install -y --no-install-recommends \
+          # Retry, timeout, mirror fallback and per-package verification come
+          # from the shared script; this step runs after checkout, so it is on
+          # disk here (unlike the bootstrap step above).
+          .github/scripts/apt_install.sh \
             build-essential \
             cmake \
             pkg-config \

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -227,20 +227,20 @@ jobs:
               /etc/apt/sources.list
           }
           prereqs() {
-            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
-            timeout 300 apt-get install -y --no-install-recommends \
+            timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 180 apt-get install -y --no-install-recommends \
               -o Acquire::Retries=3 git ca-certificates
           }
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3; do
             prereqs && break
-            if [ "$i" = "5" ]; then
-              echo "::error::apt prerequisites unavailable after 5 attempts"
+            if [ "$i" = "3" ]; then
+              echo "::error::apt prerequisites unavailable after 3 attempts"
               exit 1
             fi
-            echo "::warning::prerequisite attempt $i failed or timed out; retrying in 15s"
+            echo "::warning::prerequisite attempt $i failed or timed out; retrying in 10s"
             # Give Azure one chance, then go back to the stock mirror.
             [ "$i" = "1" ] && restore_stock_mirror
-            sleep 15
+            sleep 10
           done
 
       - name: Checkout plugins repo
@@ -509,19 +509,19 @@ jobs:
               /etc/apt/sources.list
           }
           prereqs() {
-            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
-            timeout 300 apt-get install -y --no-install-recommends \
+            timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 180 apt-get install -y --no-install-recommends \
               -o Acquire::Retries=3 git ca-certificates
           }
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3; do
             prereqs && break
-            if [ "$i" = "5" ]; then
-              echo "::error::apt prerequisites unavailable after 5 attempts"
+            if [ "$i" = "3" ]; then
+              echo "::error::apt prerequisites unavailable after 3 attempts"
               exit 1
             fi
-            echo "::warning::prerequisite attempt $i failed or timed out; retrying in 15s"
+            echo "::warning::prerequisite attempt $i failed or timed out; retrying in 10s"
             [ "$i" = "1" ] && restore_ports_mirror
-            sleep 15
+            sleep 10
           done
 
       - name: Checkout plugins repo

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -214,8 +214,34 @@ jobs:
             -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
             -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
             /etc/apt/sources.list
-          apt-get update -o Acquire::Retries=3
-          apt-get install -y --no-install-recommends git ca-certificates
+          # ...but Azure is not always the healthy one. On 2026-08-18 it was the
+          # mirror that was degraded, and this step failed the whole job in 81
+          # seconds (run 32176674366) while the retry loop that would have saved
+          # it sat in the LATER dependency step, which never got to run. The
+          # first apt call in the container needs the same protection as the
+          # second: bounded attempts, and a way back off a bad mirror.
+          restore_stock_mirror() {
+            echo "::notice::switching apt back to archive.ubuntu.com for this attempt"
+            sed -i \
+              -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+              /etc/apt/sources.list
+          }
+          prereqs() {
+            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 300 apt-get install -y --no-install-recommends \
+              -o Acquire::Retries=3 git ca-certificates
+          }
+          for i in 1 2 3 4 5; do
+            prereqs && break
+            if [ "$i" = "5" ]; then
+              echo "::error::apt prerequisites unavailable after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::prerequisite attempt $i failed or timed out; retrying in 15s"
+            # Give Azure one chance, then go back to the stock mirror.
+            [ "$i" = "1" ] && restore_stock_mirror
+            sleep 15
+          done
 
       - name: Checkout plugins repo
         uses: actions/checkout@v4
@@ -253,32 +279,20 @@ jobs:
           # DPF's OpenGL (DGL) UI resolves these via pkg-config in Makefile.base.mk:
           # gl (mesa), x11, dbus-1 (optional file browser).
           # cmake/zip/curl are needed here too: the ubuntu:22.04 container is bare
-          # (no sudo either — we run as root). Mirrors are intermittently
-          # unreachable from GitHub runners, so retry the whole update+install.
+          # (no sudo either — we run as root).
           # libasound2 + libfreetype6 are the two DT_NEEDED entries of the
           # downloaded pluginval binary that this bare image does not already
           # pull in; without them the VST3 gate dies in the dynamic loader.
-          install_deps() {
-            apt-get update -o Acquire::Retries=3 && \
-            apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-              build-essential pkg-config cmake ninja-build zip unzip curl \
-              libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev \
-              libasound2 libfreetype6 \
-              xvfb python3 serdi lilv-utils
-          }
-          for i in 1 2 3 4 5; do
-            install_deps && break
-            echo "::warning::apt attempt $i failed (mirror unreachable); retrying in 15s"
-            sleep 15
-          done
-          # Final check: fail loudly if deps still missing after all retries.
-          # libasound2/libfreetype6 are pluginval's runtime libraries: verify them
-          # here so a missing one fails at install time with a clear message,
-          # instead of surfacing as a dynamic-loader error inside the VST3 gate.
-          for pkg in libgl1-mesa-dev libasound2 libfreetype6; do
-            dpkg -s "$pkg" >/dev/null 2>&1 \
-              || { echo "::error::apt dep unavailable after retries: $pkg"; exit 1; }
-          done
+          # The retry, timeout and mirror-fallback handling, and the per-package
+          # verification that used to be open-coded here, now live in
+          # .github/scripts/apt_install.sh so every workflow gets the same one.
+          .github/scripts/apt_install.sh \
+            build-essential pkg-config cmake ninja-build zip unzip curl \
+            libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev \
+            libasound2 libfreetype6 \
+            xvfb python3 serdi lilv-utils
+          # Binaries, not packages: these come from several of the packages above
+          # and a missing one should fail here rather than mid-gate.
           for tool in cmake ninja zip unzip curl python3 serdi lv2info xvfb-run; do
             command -v "$tool" >/dev/null || { echo "::error::missing dependency: $tool"; exit 1; }
           done
@@ -479,13 +493,36 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           # Same Azure regional mirror switch as build-linux, but arm64 packages
-          # come from ports.ubuntu.com (/ubuntu-ports), whose flakiness this job
-          # already retries around. sed is a no-op if the pattern is absent.
+          # come from ports.ubuntu.com (/ubuntu-ports). sed is a no-op if the
+          # pattern is absent.
           sed -i \
             -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
             /etc/apt/sources.list
-          apt-get update -o Acquire::Retries=3
-          apt-get install -y --no-install-recommends git ca-certificates
+          # Inline rather than the shared script, and this is the one place that
+          # cannot be otherwise: git does not exist yet, so actions/checkout has
+          # not run and .github/scripts/ is not on disk. Same defences, minimal
+          # form -- bounded attempts, and one fall back off the chosen mirror.
+          restore_ports_mirror() {
+            echo "::notice::switching apt back to ports.ubuntu.com for this attempt"
+            sed -i \
+              -e 's|http://azure.ports.ubuntu.com/ubuntu-ports|http://ports.ubuntu.com/ubuntu-ports|g' \
+              /etc/apt/sources.list
+          }
+          prereqs() {
+            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 300 apt-get install -y --no-install-recommends \
+              -o Acquire::Retries=3 git ca-certificates
+          }
+          for i in 1 2 3 4 5; do
+            prereqs && break
+            if [ "$i" = "5" ]; then
+              echo "::error::apt prerequisites unavailable after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::prerequisite attempt $i failed or timed out; retrying in 15s"
+            [ "$i" = "1" ] && restore_ports_mirror
+            sleep 15
+          done
 
       - name: Checkout plugins repo
         uses: actions/checkout@v4
@@ -514,22 +551,14 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # ports.ubuntu.com (the arm64 mirror) is intermittently unreachable from GitHub
-          # runners, aborting apt with exit 100. Retry the whole update+install a few times.
-          # cmake/zip/curl needed too: bare ubuntu:22.04 container, run as root (no sudo).
-          install_deps() {
-            apt-get update -o Acquire::Retries=3 && \
-            apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-              build-essential pkg-config cmake ninja-build zip curl \
-              libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev
-          }
-          for i in 1 2 3 4 5; do
-            install_deps && break
-            echo "::warning::apt attempt $i failed (mirror unreachable); retrying in 15s"
-            sleep 15
-          done
-          # Final check: fail loudly if deps still missing after all retries.
-          dpkg -s libgl1-mesa-dev >/dev/null 2>&1 || { echo "::error::apt deps unavailable after retries"; exit 1; }
+          # ports.ubuntu.com (the arm64 mirror) is intermittently unreachable from
+          # GitHub runners, aborting apt with exit 100. cmake/zip/curl needed too:
+          # bare ubuntu:22.04 container, run as root (no sudo). Retry, timeout,
+          # mirror fallback and per-package verification all come from the shared
+          # script now.
+          .github/scripts/apt_install.sh \
+            build-essential pkg-config cmake ninja-build zip curl \
+            libgl1-mesa-dev libx11-dev libxext-dev libdbus-1-dev
 
       - name: Configure
         working-directory: ${{ env.PLUGIN_DIR }}

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -136,8 +136,12 @@ jobs:
           # in 81 seconds (run 32176674366) with no retry to save it, and this is
           # a RELEASE pipeline, so it gets the same defences in minimal form.
           switch_mirror() {
+            # security.ubuntu.com is a separate host and stalls independently;
+            # apt-get update fetches from it too, so leaving it in place lets a
+            # stalled security host defeat the whole switch.
             sed -i \
               -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
               -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
               /etc/apt/sources.list
             echo "::notice::switched apt to the Azure mirror"
@@ -277,8 +281,12 @@ jobs:
           # in 81 seconds (run 32176674366) with no retry to save it, and this is
           # a RELEASE pipeline, so it gets the same defences in minimal form.
           switch_mirror() {
+            # security.ubuntu.com is a separate host and stalls independently;
+            # apt-get update fetches from it too, so leaving it in place lets a
+            # stalled security host defeat the whole switch.
             sed -i \
               -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
               -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
               /etc/apt/sources.list
             echo "::notice::switched apt to the Azure mirror"

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -130,8 +130,33 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends git ca-certificates software-properties-common wget gpg
+          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
+          # does not exist yet, so actions/checkout has not run and the script is
+          # not on disk. This is the step shape that failed the DPF build outright
+          # in 81 seconds (run 32176674366) with no retry to save it, and this is
+          # a RELEASE pipeline, so it gets the same defences in minimal form.
+          switch_mirror() {
+            sed -i \
+              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
+              /etc/apt/sources.list
+            echo "::notice::switched apt to the Azure mirror"
+          }
+          bootstrap() {
+            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+              git ca-certificates software-properties-common wget gpg
+          }
+          for i in 1 2 3 4 5; do
+            bootstrap && break
+            if [ "$i" = "5" ]; then
+              echo "::error::apt bootstrap unavailable after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            [ "$i" = "1" ] && switch_mirror
+            sleep 15
+          done
 
       - name: Install GCC 11 toolchain
         env:
@@ -246,8 +271,33 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get update
-          apt-get install -y --no-install-recommends git ca-certificates software-properties-common wget gpg
+          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
+          # does not exist yet, so actions/checkout has not run and the script is
+          # not on disk. This is the step shape that failed the DPF build outright
+          # in 81 seconds (run 32176674366) with no retry to save it, and this is
+          # a RELEASE pipeline, so it gets the same defences in minimal form.
+          switch_mirror() {
+            sed -i \
+              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
+              /etc/apt/sources.list
+            echo "::notice::switched apt to the Azure mirror"
+          }
+          bootstrap() {
+            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+              git ca-certificates software-properties-common wget gpg
+          }
+          for i in 1 2 3 4 5; do
+            bootstrap && break
+            if [ "$i" = "5" ]; then
+              echo "::error::apt bootstrap unavailable after 5 attempts"
+              exit 1
+            fi
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            [ "$i" = "1" ] && switch_mirror
+            sleep 15
+          done
 
       - name: Install GCC 11 toolchain
         env:
@@ -687,12 +737,20 @@ jobs:
     env:
       PLUGIN_VERSION_OVERRIDE: ${{ needs.setup.outputs.version }}
     steps:
+      # Checkout moved ahead of the dependency install so the shared apt script
+      # is on disk when that step runs. Safe here and only here: this job runs on
+      # a hosted runner, which already has git, unlike the bare containers above
+      # where the first apt call is what makes checkout possible at all.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Install build + test deps
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          .github/scripts/apt_install.sh \
             cmake ninja-build pkg-config unzip \
             libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev \
             libx11-dev libxext-dev libxrandr-dev libxinerama-dev libxcursor-dev \
@@ -703,11 +761,6 @@ jobs:
           # gate self-skips and the LV2 host path would go unvalidated, so fail
           # here rather than let the suite quietly skip it.
           pkg-config --modversion lilv-0
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -143,19 +143,19 @@ jobs:
             echo "::notice::switched apt to the Azure mirror"
           }
           bootstrap() {
-            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
-            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+            timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
               git ca-certificates software-properties-common wget gpg
           }
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3; do
             bootstrap && break
-            if [ "$i" = "5" ]; then
-              echo "::error::apt bootstrap unavailable after 5 attempts"
+            if [ "$i" = "3" ]; then
+              echo "::error::apt bootstrap unavailable after 3 attempts"
               exit 1
             fi
-            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
             [ "$i" = "1" ] && switch_mirror
-            sleep 15
+            sleep 10
           done
 
       - name: Install GCC 11 toolchain
@@ -284,19 +284,19 @@ jobs:
             echo "::notice::switched apt to the Azure mirror"
           }
           bootstrap() {
-            timeout 240 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
-            timeout 300 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+            timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
+            timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
               git ca-certificates software-properties-common wget gpg
           }
-          for i in 1 2 3 4 5; do
+          for i in 1 2 3; do
             bootstrap && break
-            if [ "$i" = "5" ]; then
-              echo "::error::apt bootstrap unavailable after 5 attempts"
+            if [ "$i" = "3" ]; then
+              echo "::error::apt bootstrap unavailable after 3 attempts"
               exit 1
             fi
-            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 15s"
+            echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
             [ "$i" = "1" ] && switch_mirror
-            sleep 15
+            sleep 10
           done
 
       - name: Install GCC 11 toolchain

--- a/.github/workflows/juce-compile-check.yml
+++ b/.github/workflows/juce-compile-check.yml
@@ -122,9 +122,23 @@ jobs:
       - name: Install Linux dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
+        # Cap the step well under the job's 45-minute budget. An unreachable
+        # mirror does not fail apt, it stalls it: on run 32157020545 five of the
+        # eleven matrix jobs sat in this step until the JOB timeout killed them,
+        # burning about three hours of runner time and reporting as "cancelled"
+        # with no log to read. Failing here at 10 minutes turns that into a
+        # legible error, and the retry below usually means it never fires.
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          # Mirrors are intermittently unreachable from GitHub runners, so retry
+          # the whole update+install rather than failing the matrix leg. Same
+          # approach as dpf-build.yml, which already hardened its apt step.
+          # No sources.list rewrite here: this runs on the ubuntu-22.04 runner
+          # image, which already points at the Azure regional mirror. That
+          # rewrite is specific to dpf-build.yml's bare ubuntu container.
+          install_deps() {
+            sudo apt-get update -o Acquire::Retries=3 && \
+            sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
             build-essential \
             pkg-config \
             libasound2-dev \
@@ -142,6 +156,14 @@ jobs:
             libwebkit2gtk-4.0-dev \
             libglu1-mesa-dev \
             mesa-common-dev
+          }
+          for i in 1 2 3 4 5; do
+            install_deps && exit 0
+            echo "::warning::apt attempt $i failed (mirror unreachable); retrying in 15s"
+            sleep 15
+          done
+          echo "::error::apt dependencies unavailable after 5 attempts"
+          exit 1
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/juce-compile-check.yml
+++ b/.github/workflows/juce-compile-check.yml
@@ -60,6 +60,11 @@ on:
       - 'CMakeLists.txt'
       - 'cmake/**'
       - '.github/workflows/juce-compile-check.yml'
+      # The scripts this workflow itself runs: the plugin selector and the shared
+      # apt installer. Without these a PR editing only one of them never fires
+      # this workflow, so the change lands untested by the jobs that execute it.
+      - '.github/scripts/select_juce_plugins.py'
+      - '.github/scripts/apt_install.sh'
       # Subtract the DPF trees again. Several plugins above are wildcarded at
       # the plugin root, and 'plugins/4k-eq/**' matches 'plugins/4k-eq/dpf-plugin/**'
       # too, so without these a DPF-only PR would fire all twelve JUCE jobs and

--- a/.github/workflows/juce-compile-check.yml
+++ b/.github/workflows/juce-compile-check.yml
@@ -86,6 +86,9 @@ jobs:
     name: Select plugins
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    # Reads the diff and nothing else, so it needs nothing beyond contents:read.
+    permissions:
+      contents: read
     outputs:
       plugins: ${{ steps.pick.outputs.plugins }}
       windows: ${{ steps.pick.outputs.windows }}
@@ -93,8 +96,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # The selector diffs against the base branch, so it needs history.
+          # The selector diffs against the base branch, so it needs history...
           fetch-depth: 0
+          # ...but not a credential left behind in .git/config afterwards. The
+          # diff is local once the fetch is done. Matches the other workflows.
+          persist-credentials: false
 
       - name: Pick plugins
         id: pick

--- a/.github/workflows/juce-compile-check.yml
+++ b/.github/workflows/juce-compile-check.yml
@@ -141,38 +141,15 @@ jobs:
       - name: Install Linux dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
-        # Backstop only. Every attempt below is individually time-boxed, so this
-        # should never fire; it exists so a pathological case still fails inside
-        # the job's 45-minute budget with a readable status.
+        # Backstop only. Every apt attempt inside the script is individually
+        # time-boxed, so this should never fire; it exists so a pathological case
+        # still fails inside the job's 45-minute budget with a readable status.
         timeout-minutes: 20
         run: |
-          # A dead mirror does not fail apt, it STALLS it, and that distinction
-          # decides the whole design of this step. On run 32157020545 five of the
-          # eleven matrix jobs sat here until the job timeout killed them: three
-          # hours of runner time, reported as "cancelled" with no error to read.
-          #
-          # So a bare retry loop is not enough. A retry only helps a call that
-          # FAILS; a call that hangs never comes back to be retried. Every apt
-          # invocation is therefore wrapped in timeout(1), which converts a stall
-          # into a fast non-zero exit that the loop can actually act on. The apt
-          # Acquire options cut most stalls off earlier still.
-          #
-          # Retrying the same dead mirror is pointless, so attempt 2 onward
-          # switches away from it. The runner image ships pointed at the Azure
-          # regional mirror, which is the one observed hanging, so the fallback
-          # is the stock archive.ubuntu.com. sed is a no-op if the pattern is
-          # absent, which degrades to "retry the same mirror" rather than
-          # breaking.
-          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::http::No-Cache=true"
-          use_fallback_mirror() {
-            echo "::notice::switching apt to archive.ubuntu.com for this attempt"
-            sudo sed -i \
-              -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-              /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true
-          }
-          install_deps() {
-            sudo timeout 240 apt-get update $APT_OPTS && \
-            sudo timeout 600 apt-get install -y --no-install-recommends $APT_OPTS \
+          # The retry, timeout and mirror-fallback logic that used to be spelled
+          # out here now lives in the shared script, so this workflow and the two
+          # release pipelines all get the same behaviour from one implementation.
+          .github/scripts/apt_install.sh \
             build-essential \
             ccache \
             ninja-build \
@@ -192,28 +169,7 @@ jobs:
             libwebkit2gtk-4.0-dev \
             libglu1-mesa-dev \
             mesa-common-dev
-          }
-          for i in 1 2 3 4 5; do
-            install_deps && exit 0
-            echo "::warning::apt attempt $i failed or timed out; retrying in 15s"
-            # Give the configured mirror exactly one chance, then move off it.
-            [ "$i" = "1" ] && use_fallback_mirror
-            sleep 15
-          done
-          echo "::error::apt dependencies unavailable after 5 attempts"
-          exit 1
 
-      # Every job here compiles the whole JUCE module set from scratch, because
-      # juce_add_plugin builds the modules into each plugin's own SharedCode
-      # library. Twelve jobs x every run x ~50 module TUs was the single largest
-      # cost in this workflow, and none of it changes between runs.
-      #
-      # cmake/GlobalSettings.cmake already wires CMAKE_CXX_COMPILER_LAUNCHER to
-      # ccache whenever find_program locates it, so installing ccache above is
-      # the entire integration; this step only has to carry the directory across
-      # runs. Keyed per plugin because each one caches its own copy of those
-      # module objects, and restore-keys lets a changed source file still land on
-      # the previous run's cache instead of starting cold.
       - name: Restore ccache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/juce-compile-check.yml
+++ b/.github/workflows/juce-compile-check.yml
@@ -76,8 +76,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Twelve jobs for a one-plugin change is not just wasted runner time, it is
+  # wasted WALL time: the legs queue against the runner pool, so a PR touching
+  # convolution-reverb waited on eleven builds that could not tell it anything.
+  # This narrows the matrix to what the change can actually reach, and still
+  # expands to the whole fleet the moment shared code is touched, which is the
+  # case the workflow was built for.
+  scope:
+    name: Select plugins
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      plugins: ${{ steps.pick.outputs.plugins }}
+      windows: ${{ steps.pick.outputs.windows }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # The selector diffs against the base branch, so it needs history.
+          fetch-depth: 0
+
+      - name: Pick plugins
+        id: pick
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: python3 .github/scripts/select_juce_plugins.py
+
   compile:
     name: ${{ matrix.plugin }}
+    needs: scope
+    if: needs.scope.outputs.plugins != '[]'
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     strategy:
@@ -92,20 +121,10 @@ jobs:
         # variable, so neither is greppable from juce_add_plugin alone.
         #
         # A plugin added to the root CMakeLists without a row here is silently
-        # unbuilt, which is the class of gap this workflow exists to close.
-        plugin:
-          - FourKEQ
-          - MultiComp
-          - TapeMachine
-          - TapeEcho
-          - MultiQ
-          - ConvolutionReverb
-          - DuskVerb
-          - DuskAmp
-          - ChordAnalyzer
-          - ChordAnalyzerMIDI
-          - SpectrumAnalyzer
-          - GrooveMind
+        # unbuilt, which is the class of gap this workflow exists to close. The
+        # list itself now lives in .github/scripts/select_juce_plugins.py, which
+        # decides which of them this particular change needs.
+        plugin: ${{ fromJSON(needs.scope.outputs.plugins) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -155,6 +174,8 @@ jobs:
             sudo timeout 240 apt-get update $APT_OPTS && \
             sudo timeout 600 apt-get install -y --no-install-recommends $APT_OPTS \
             build-essential \
+            ccache \
+            ninja-build \
             pkg-config \
             libasound2-dev \
             libjack-jackd2-dev \
@@ -182,9 +203,36 @@ jobs:
           echo "::error::apt dependencies unavailable after 5 attempts"
           exit 1
 
+      # Every job here compiles the whole JUCE module set from scratch, because
+      # juce_add_plugin builds the modules into each plugin's own SharedCode
+      # library. Twelve jobs x every run x ~50 module TUs was the single largest
+      # cost in this workflow, and none of it changes between runs.
+      #
+      # cmake/GlobalSettings.cmake already wires CMAKE_CXX_COMPILER_LAUNCHER to
+      # ccache whenever find_program locates it, so installing ccache above is
+      # the entire integration; this step only has to carry the directory across
+      # runs. Keyed per plugin because each one caches its own copy of those
+      # module objects, and restore-keys lets a changed source file still land on
+      # the previous run's cache instead of starting cold.
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-juce-linux-${{ matrix.plugin }}-${{ github.sha }}
+          restore-keys: |
+            ccache-juce-linux-${{ matrix.plugin }}-
+
       - name: Configure CMake
+        env:
+          # 350M x 12 plugins keeps the whole matrix inside GitHub's 10 GB
+          # per-repository cache budget with room for the DPF workflows.
+          CCACHE_MAXSIZE: 350M
         run: |
-          cmake -B build \
+          ccache --zero-stats >/dev/null 2>&1 || true
+          # Ninja over the default Make generator: it parallelises the configure
+          # side better and schedules a large object graph with less overhead,
+          # which matters when a single plugin drags in the entire JUCE tree.
+          cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDUSK_COPY_AFTER_BUILD=OFF \
             -DJUCE_PATH=$(pwd)/JUCE
@@ -192,7 +240,15 @@ jobs:
       - name: Build ${{ matrix.plugin }} VST3
         # An unknown target fails here with a readable "No rule to make target"
         # rather than needing a guard step of its own.
+        env:
+          CCACHE_MAXSIZE: 350M
         run: cmake --build build --config Release --target ${{ matrix.plugin }}_VST3 -j$(nproc)
+
+      - name: ccache statistics
+        # Printed so a regression in hit rate is visible in the log rather than
+        # only as a slower job.
+        if: always()
+        run: ccache --show-stats 2>/dev/null || true
 
       - name: Verify a binary came out
         # A target that silently produces nothing is indistinguishable from a
@@ -226,12 +282,15 @@ jobs:
   # with no juce_dsp at all.
   compile-windows:
     name: ${{ matrix.plugin }} (windows)
+    needs: scope
+    if: needs.scope.outputs.windows != '[]'
     runs-on: windows-2022
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        plugin: [FourKEQ, MultiComp, SpectrumAnalyzer, ChordAnalyzer]
+        # The four shapes above, narrowed to the ones this change reaches.
+        plugin: ${{ fromJSON(needs.scope.outputs.windows) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/juce-compile-check.yml
+++ b/.github/workflows/juce-compile-check.yml
@@ -122,23 +122,38 @@ jobs:
       - name: Install Linux dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
-        # Cap the step well under the job's 45-minute budget. An unreachable
-        # mirror does not fail apt, it stalls it: on run 32157020545 five of the
-        # eleven matrix jobs sat in this step until the JOB timeout killed them,
-        # burning about three hours of runner time and reporting as "cancelled"
-        # with no log to read. Failing here at 10 minutes turns that into a
-        # legible error, and the retry below usually means it never fires.
-        timeout-minutes: 10
+        # Backstop only. Every attempt below is individually time-boxed, so this
+        # should never fire; it exists so a pathological case still fails inside
+        # the job's 45-minute budget with a readable status.
+        timeout-minutes: 20
         run: |
-          # Mirrors are intermittently unreachable from GitHub runners, so retry
-          # the whole update+install rather than failing the matrix leg. Same
-          # approach as dpf-build.yml, which already hardened its apt step.
-          # No sources.list rewrite here: this runs on the ubuntu-22.04 runner
-          # image, which already points at the Azure regional mirror. That
-          # rewrite is specific to dpf-build.yml's bare ubuntu container.
+          # A dead mirror does not fail apt, it STALLS it, and that distinction
+          # decides the whole design of this step. On run 32157020545 five of the
+          # eleven matrix jobs sat here until the job timeout killed them: three
+          # hours of runner time, reported as "cancelled" with no error to read.
+          #
+          # So a bare retry loop is not enough. A retry only helps a call that
+          # FAILS; a call that hangs never comes back to be retried. Every apt
+          # invocation is therefore wrapped in timeout(1), which converts a stall
+          # into a fast non-zero exit that the loop can actually act on. The apt
+          # Acquire options cut most stalls off earlier still.
+          #
+          # Retrying the same dead mirror is pointless, so attempt 2 onward
+          # switches away from it. The runner image ships pointed at the Azure
+          # regional mirror, which is the one observed hanging, so the fallback
+          # is the stock archive.ubuntu.com. sed is a no-op if the pattern is
+          # absent, which degrades to "retry the same mirror" rather than
+          # breaking.
+          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::http::No-Cache=true"
+          use_fallback_mirror() {
+            echo "::notice::switching apt to archive.ubuntu.com for this attempt"
+            sudo sed -i \
+              -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+              /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true
+          }
           install_deps() {
-            sudo apt-get update -o Acquire::Retries=3 && \
-            sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
+            sudo timeout 240 apt-get update $APT_OPTS && \
+            sudo timeout 600 apt-get install -y --no-install-recommends $APT_OPTS \
             build-essential \
             pkg-config \
             libasound2-dev \
@@ -159,7 +174,9 @@ jobs:
           }
           for i in 1 2 3 4 5; do
             install_deps && exit 0
-            echo "::warning::apt attempt $i failed (mirror unreachable); retrying in 15s"
+            echo "::warning::apt attempt $i failed or timed out; retrying in 15s"
+            # Give the configured mirror exactly one chance, then move off it.
+            [ "$i" = "1" ] && use_fallback_mirror
             sleep 15
           done
           echo "::error::apt dependencies unavailable after 5 attempts"


### PR DESCRIPTION
Split out of #190, where this surfaced.

## What happened

On [run 32157020545](https://github.com/dusk-audio/dusk-audio-plugins/actions/runs/32157020545), five of the eleven matrix jobs failed:

| job | conclusion | duration | last step |
|---|---|---|---|
| ConvolutionReverb | cancelled | 45m21s | Install Linux dependencies |
| ChordAnalyzerMIDI | cancelled | 45m20s | Install Linux dependencies |
| DuskVerb | cancelled | 45m20s | Install Linux dependencies |
| FourKEQ | cancelled | 45m22s | Install Linux dependencies |
| MultiQ | cancelled | 45m23s | Install Linux dependencies |

None of them reached Configure or Build; both steps show `skipped`. The other six drew a healthy mirror and passed in 4-14 minutes.

An unreachable apt mirror does not fail, it stalls. Each of those jobs sat in the install step until `timeout-minutes: 45` killed it. Three consequences:

1. A red PR looks like a compile failure when nothing was compiled.
2. There is no error in the log to read, because apt never returned one.
3. Roughly three hours of runner time per occurrence.

## The fix

- Retry update+install five times with a 15s gap, the same shape [dpf-build.yml:262-275](https://github.com/dusk-audio/dusk-audio-plugins/blob/main/.github/workflows/dpf-build.yml#L262-L275) already uses.
- Pass `-o Acquire::Retries=3` so each attempt retries its own fetches.
- Cap the step at `timeout-minutes: 10`, well under the job's 45, so a stall fails with `::error::apt dependencies unavailable after 5 attempts` instead of an opaque cancellation.

**No `sources.list` rewrite here.** `dpf-build.yml` needs one because it runs in a bare `ubuntu` container still pointing at `archive.ubuntu.com`. This workflow runs on the `ubuntu-22.04` runner image, which already points at the Azure regional mirror, so that sed would be a no-op. Copying it would have been cargo cult.

## Verification

- YAML parses; the extracted `run:` block passes `bash -n`.
- Package list is byte-identical to `main`: 17 packages, diffed after normalising the line continuations. Only the retry wrapper and the step timeout are new.
- The real proof is this PR's own CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved build reliability across Linux and ARM64 environments with automatic retries, timeouts, package verification, and mirror fallback.
  - Standardized dependency installation across build and release workflows for more consistent results.
  - JUCE compile checks now build only affected plugins and relevant Windows targets, reducing unnecessary CI work.
  - Added compiler caching and Ninja-based builds to accelerate repeated compile checks.
  - Improved workflow diagnostics with clearer dependency and cache status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->