### PR TITLE
ci: route every post-checkout apt call through apt_install.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
           bootstrap() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-              git ca-certificates software-properties-common
+              git ca-certificates
           }
           for i in 1 2 3; do
             bootstrap && break
@@ -237,6 +237,11 @@ jobs:
             sleep 10
           done
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Install GCC 11 toolchain
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -245,11 +250,17 @@ jobs:
           # compat, where gcc-11 is NOT in the base repos — it needs the
           # ubuntu-toolchain-r/test PPA. That PPA add is occasionally flaky
           # (launchpad resolution stalls), which failed past release builds, so
-          # wrap it in a timeout + retry rather than dropping it.
-          add_toolchain() { timeout 120 add-apt-repository -y ppa:ubuntu-toolchain-r/test && timeout 180 apt-get update; }
-          add_toolchain || { echo "PPA attempt 1 failed; retry in 15s"; sleep 15; add_toolchain; } \
-                        || { echo "PPA attempt 2 failed; retry in 30s"; sleep 30; add_toolchain; }
-          apt-get install -y gcc-11 g++-11
+          # The shared script is available after checkout. The PPA command is
+          # the only apt operation it cannot own, so bound it and retry once.
+          .github/scripts/apt_install.sh software-properties-common
+          for i in 1 2; do
+            timeout 120 add-apt-repository -y ppa:ubuntu-toolchain-r/test && break
+            [ "$i" = "2" ] && exit 1
+            echo "PPA attempt 1 failed; retrying in 15s"
+            sleep 15
+          done
+          .github/scripts/apt_install.sh --update-only
+          .github/scripts/apt_install.sh gcc-11 g++-11
           # Set GCC 11 as default for all compiler symlinks
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
@@ -263,17 +274,11 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           # Install CMake 3.28 from Kitware's APT repo (JUCE 8 requires 3.22+)
-          apt-get install -y wget
+          .github/scripts/apt_install.sh wget
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-          apt-get update
-          apt-get install -y cmake
+          .github/scripts/apt_install.sh cmake
           cmake --version
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Apply refreshed supporters list
         # Always use the header refreshed once in the setup job. download-artifact errors if the
@@ -493,7 +498,7 @@ jobs:
           bootstrap() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-              git ca-certificates software-properties-common
+              git ca-certificates
           }
           for i in 1 2 3; do
             bootstrap && break
@@ -506,13 +511,17 @@ jobs:
             sleep 10
           done
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Install GCC 11 toolchain
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
           # Ubuntu 22.04 ships GCC 11 natively — no PPA needed
-          apt-get update
-          apt-get install -y gcc-11 g++-11
+          .github/scripts/apt_install.sh gcc-11 g++-11
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
           update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-11 100
@@ -524,17 +533,11 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          apt-get install -y wget gpg
+          .github/scripts/apt_install.sh wget gpg
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-          apt-get update
-          apt-get install -y cmake
+          .github/scripts/apt_install.sh cmake
           cmake --version
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Apply refreshed supporters list
         # Always use the header refreshed once in the setup job. download-artifact errors if the

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -149,7 +149,7 @@ jobs:
           bootstrap() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-              git ca-certificates software-properties-common wget gpg
+              git ca-certificates
           }
           for i in 1 2 3; do
             bootstrap && break
@@ -162,16 +162,26 @@ jobs:
             sleep 10
           done
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Install GCC 11 toolchain
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # gcc-11 is not in focal's base repos; the toolchain PPA add is
-          # occasionally flaky, so retry (mirrors build.yml).
-          add_toolchain() { timeout 120 add-apt-repository -y ppa:ubuntu-toolchain-r/test && timeout 180 apt-get update; }
-          add_toolchain || { echo "PPA attempt 1 failed; retry in 15s"; sleep 15; add_toolchain; } \
-                        || { echo "PPA attempt 2 failed; retry in 30s"; sleep 30; add_toolchain; }
-          apt-get install -y gcc-11 g++-11
+          # The shared script is available after checkout. The PPA command is
+          # the only apt operation it cannot own, so bound it and retry once.
+          .github/scripts/apt_install.sh software-properties-common
+          for i in 1 2; do
+            timeout 120 add-apt-repository -y ppa:ubuntu-toolchain-r/test && break
+            [ "$i" = "2" ] && exit 1
+            echo "PPA attempt 1 failed; retrying in 15s"
+            sleep 15
+          done
+          .github/scripts/apt_install.sh --update-only
+          .github/scripts/apt_install.sh gcc-11 g++-11
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
           update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-11 100
@@ -182,21 +192,16 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          .github/scripts/apt_install.sh wget gpg
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-          apt-get update
-          apt-get install -y --no-install-recommends \
+          .github/scripts/apt_install.sh \
             cmake ninja-build pkg-config zip unzip \
             libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev \
             libx11-dev libxext-dev libxrandr-dev libxinerama-dev libxcursor-dev \
             libdbus-1-dev
           cmake --version
           ninja --version
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Checkout DPF
         uses: actions/checkout@v4
@@ -294,7 +299,7 @@ jobs:
           bootstrap() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 180 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
-              git ca-certificates software-properties-common wget gpg
+              git ca-certificates
           }
           for i in 1 2 3; do
             bootstrap && break
@@ -307,12 +312,17 @@ jobs:
             sleep 10
           done
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Install GCC 11 toolchain
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
           # Ubuntu 22.04 ships gcc-11 natively — no PPA needed.
-          apt-get install -y gcc-11 g++-11
+          .github/scripts/apt_install.sh gcc-11 g++-11
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
           update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-11 100
@@ -323,21 +333,16 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          .github/scripts/apt_install.sh wget gpg
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-          apt-get update
-          apt-get install -y --no-install-recommends \
+          .github/scripts/apt_install.sh \
             cmake ninja-build pkg-config zip unzip \
             libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev \
             libx11-dev libxext-dev libxrandr-dev libxinerama-dev libxcursor-dev \
             libdbus-1-dev
           cmake --version
           ninja --version
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Checkout DPF
         uses: actions/checkout@v4


### PR DESCRIPTION
Finishes the fleet-wide apt hardening started in #191.

The shared `apt_install.sh` front end (per-invocation timeout, three attempts, automatic azure/stock mirror switch, package presence verification) was only wired into some steps. The GCC-11, CMake, wget, gpg, and PPA-refresh installs in `build.yml` and `dpf-release.yml` still called `apt-get` raw, several with no timeout at all. Any of those could stall on a dead mirror until the 30-75 minute job timeout killed the job as "cancelled" with nothing to read; that is where the hour-long builds came from.

Changes:
- `build.yml`, `dpf-release.yml`: every post-checkout apt call goes through `.github/scripts/apt_install.sh`. Checkout now runs directly after the minimal git/ca-certificates bootstrap so the script is available to the toolchain steps.
- `add-apt-repository` (the one apt operation the script cannot own) is bounded by `timeout 120` with one retry; its list refresh uses `apt_install.sh --update-only`.
- Pre-checkout bootstrap blocks keep their inline timeout + retry + mirror-switch defenses and now install only `git` and `ca-certificates`; `software-properties-common` moved after checkout.
- `dpf-build.yml` unchanged: its two pre-checkout blocks already carry bounded calls with mirror fallback.

Verified with actionlint (remaining findings are pre-existing: SC2129 style at build.yml:55, `softprops/action-gh-release@v1` age warnings) and YAML parse on both changed files.

Worst-case apt time per job is now bounded at roughly 18 minutes per the script's budget, instead of the job timeout. Flagged, not changed: the Kitware key wget, manual-PDF curl, pluginval downloads, recursive submodule checkout, and the release git clone are still unbounded network operations; separate concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Linux x86_64 and ARM64 build and release workflows.
  - Standardized package installation and repository setup across build jobs.
  - Added bounded retries for GCC toolchain setup to improve reliability.
  - Ensured required repository content is available before installing build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->