### PR TITLE
ci: stock Ubuntu repos only; rewrite the runner mirrorlist; repair wedged dpkg

### DIFF
--- a/.github/scripts/apt_install.sh
+++ b/.github/scripts/apt_install.sh
@@ -131,12 +131,24 @@ mirror_files() {
 # form silently reported "no match" when this was exercised on macOS and both
 # mirror families looked identical. It would have worked on the Linux runners
 # and been untestable anywhere else.
+#
+# grep runs under the same privilege as the sed that rewrites these files. A
+# file readable only by root must not come back as a clean "no match", because
+# the one caller is a verification pass and that is how such a pass talks
+# itself into succeeding. Three outcomes, kept distinct:
+#   0  matched somewhere
+#   1  no match, every file read
+#   2  at least one file could not be read, so the answer is unknown
 sources_match() {
-    local f
+    local f rc status=1
     while read -r f; do
-        grep -q "$1" "$f" 2>/dev/null && return 0
+        "${SUDO[@]}" grep -q "$1" "$f" 2>/dev/null
+        rc=$?
+        # A match anywhere is conclusive even if another file was unreadable.
+        [ "$rc" -eq 0 ] && return 0
+        [ "$rc" -ge 2 ] && status=2
     done < <(mirror_files)
-    return 1
+    return "$status"
 }
 
 # A failed rewrite is not cosmetic here: the whole point of this script is that
@@ -170,7 +182,18 @@ banish_azure() {
     # Verify rather than assume. Matched on the exact Ubuntu mirror hosts, so
     # unrelated azure repositories on the runner (packages.microsoft.com's
     # azure-cli, for one) are left alone and do not trip this.
-    if sources_match "azure\.archive\.ubuntu\.com" || sources_match "azure\.ports\.ubuntu\.com"; then
+    local archive_rc ports_rc
+    sources_match "azure\.archive\.ubuntu\.com"; archive_rc=$?
+    sources_match "azure\.ports\.ubuntu\.com"; ports_rc=$?
+
+    # Unreadable is not the same as clean, and only one of those is safe to
+    # continue on.
+    if [ "$archive_rc" -ge 2 ] || [ "$ports_rc" -ge 2 ]; then
+        echo "::error::apt could not read its mirror files to confirm azure is gone" >&2
+        exit 1
+    fi
+
+    if [ "$archive_rc" -eq 0 ] || [ "$ports_rc" -eq 0 ]; then
         echo "::error::azure survived the mirror rewrite; refusing to fetch from it" >&2
         exit 1
     fi

--- a/.github/scripts/apt_install.sh
+++ b/.github/scripts/apt_install.sh
@@ -19,11 +19,18 @@
 #   from one place, rather than hand-copied into whichever step someone
 #   remembered.
 #
-# Both incidents were the same mirror. dpf-build.yml forces apt onto
-# azure.archive.ubuntu.com, documented at the time because archive.ubuntu.com
-# measured 724 B/s from a runner; on 2026-08-18 the polarity was reversed and
-# Azure was the sick one. Pinning EITHER mirror is the bug, so after the first
-# failed attempt this script switches to the other one and keeps going.
+#   WEDGED DPKG. A timed-out install can kill dpkg mid-transaction; every
+#   later attempt then fails on "dpkg was interrupted" no matter how healthy
+#   the network is (2026-08-19). Hence a bounded `dpkg --configure -a`
+#   before each retry.
+#
+# Mirror policy (owner decision, 2026-08-19): stock Ubuntu repos ONLY.
+# azure.archive.ubuntu.com has been the sick side of every incident to date
+# and is purged from every mirror file up front, including the hosted
+# runners' /etc/apt/apt-mirrors.txt mirrorlist, which earlier rewrites
+# missed entirely (apt kept fetching azure while the sources files looked
+# clean). No third-party mirrors: Ubuntu 22.04 is supported until 2027 and
+# the stock archive is the reference.
 #
 # Usage:
 #   apt_install.sh pkg [pkg...]   update, then install those packages
@@ -41,8 +48,6 @@ set -uo pipefail
 #
 #   3 x (120 update + 240 install) + 2 x 10s sleep = 1100s, about 18 minutes.
 #
-# Three attempts is enough because the mirror switch happens after the first
-# failure, so attempt 2 is already on the other mirror and attempt 3 is margin.
 # A caller with a tighter step budget can lower any of these from the workflow.
 ATTEMPTS="${APT_ATTEMPTS:-3}"
 UPDATE_TIMEOUT="${APT_UPDATE_TIMEOUT:-120}"
@@ -81,9 +86,7 @@ esac
 # jobs the sed matched nothing, the switch silently did nothing, and every retry
 # went back to the same dead mirror. Each family is only ever swapped within
 # itself, so a ports source can never be rewritten to an x86 archive.
-AZURE_MIRROR="http://azure.archive.ubuntu.com/ubuntu"
 STOCK_MIRROR="http://archive.ubuntu.com/ubuntu"
-AZURE_PORTS="http://azure.ports.ubuntu.com/ubuntu-ports"
 STOCK_PORTS="http://ports.ubuntu.com/ubuntu-ports"
 
 if [ "$(id -u)" -eq 0 ]; then
@@ -104,13 +107,18 @@ if [ "$update_only" -eq 0 ] && [ ${#packages[@]} -eq 0 ]; then
     exit 2
 fi
 
-# Both list formats: 24.04 images ship deb822 .sources files and no
-# sources.list, so touching only the latter would silently do nothing there.
+# All the places a mirror can hide. 24.04 images ship deb822 .sources files
+# and no sources.list; hosted runners additionally route apt through a
+# MIRRORLIST at /etc/apt/apt-mirrors.txt (the sources say
+# "mirror+file:/etc/apt/apt-mirrors.txt"). Run 32286384090's sibling proved
+# that skipping the mirrorlist makes every rewrite here a silent no-op: the
+# log said "mirror: stock" while every fetch still hit azure.
 mirror_files() {
     local f
     for f in /etc/apt/sources.list \
              /etc/apt/sources.list.d/*.list \
-             /etc/apt/sources.list.d/*.sources; do
+             /etc/apt/sources.list.d/*.sources \
+             /etc/apt/apt-mirrors.txt; do
         [ -f "$f" ] && printf '%s\n' "$f"
     done
 }
@@ -136,45 +144,21 @@ mirror_family() {
     fi
 }
 
-current_mirror() {
-    if sources_match "azure\."; then
-        echo azure
-    else
-        echo stock
-    fi
+rewrite_sources() {
+    local from="$1" to="$2" f
+    while read -r f; do
+        "${SUDO[@]}" sed -i -e "s|${from}|${to}|g" "$f" || true
+    done < <(mirror_files)
 }
 
-# Move to whichever mirror we are NOT on, within this machine's family. Called
-# once, after the first failure, so a healthy mirror is never abandoned on a
-# transient blip.
-switch_mirror() {
-    local from to security_to
+# Purge azure from every mirror file (including the runner mirrorlist) before
+# the first attempt, so apt talks only to the stock Ubuntu archive.
+banish_azure() {
     if [ "$(mirror_family)" = "ports" ]; then
-        if [ "$(current_mirror)" = "azure" ]; then
-            from="$AZURE_PORTS" to="$STOCK_PORTS"
-        else
-            from="$STOCK_PORTS" to="$AZURE_PORTS"
-        fi
-        # aarch64 serves security from the ports host too, so it moves with it.
-        security_to="$to"
+        rewrite_sources "http://azure.ports.ubuntu.com/ubuntu-ports" "$STOCK_PORTS"
     else
-        if [ "$(current_mirror)" = "azure" ]; then
-            from="$AZURE_MIRROR" to="$STOCK_MIRROR"
-        else
-            from="$STOCK_MIRROR" to="$AZURE_MIRROR"
-        fi
-        security_to="$to"
+        rewrite_sources "http://azure.archive.ubuntu.com/ubuntu" "$STOCK_MIRROR"
     fi
-    echo "::notice::apt switching mirror to ${to}"
-    mirror_files | while read -r f; do
-        "${SUDO[@]}" sed -i -e "s|${from}|${to}|g" "$f" || true
-    done
-    # security.ubuntu.com is a separate host and stalls independently. Only ever
-    # present on the archive side; on ports the security suites already live on
-    # the ports host and were rewritten above.
-    mirror_files | while read -r f; do
-        "${SUDO[@]}" sed -i -e "s|http://security.ubuntu.com/ubuntu|${security_to}|g" "$f" || true
-    done
 }
 
 attempt() {
@@ -183,6 +167,16 @@ attempt() {
     "${SUDO[@]}" timeout "$INSTALL_TIMEOUT" env DEBIAN_FRONTEND=noninteractive \
         apt-get install -y --no-install-recommends "${APT_OPTS[@]}" "${packages[@]}"
 }
+
+# A timed-out install can kill dpkg mid-transaction; every later attempt then
+# dies on "dpkg was interrupted, you must manually run 'dpkg --configure -a'"
+# no matter how healthy the mirror is. Repair before each retry.
+repair_dpkg() {
+    "${SUDO[@]}" timeout 120 env DEBIAN_FRONTEND=noninteractive \
+        dpkg --configure -a || true
+}
+
+banish_azure
 
 for i in $(seq 1 "$ATTEMPTS"); do
     if attempt; then
@@ -201,11 +195,11 @@ for i in $(seq 1 "$ATTEMPTS"); do
     fi
 
     if [ "$i" -eq "$ATTEMPTS" ]; then
-        echo "::error::apt failed after ${ATTEMPTS} attempts (mirror: $(current_mirror))"
+        echo "::error::apt failed after ${ATTEMPTS} attempts (stock Ubuntu mirror)"
         exit 1
     fi
 
     echo "::warning::apt attempt ${i} failed or timed out; retrying in ${RETRY_SLEEP}s"
-    [ "$i" -eq 1 ] && switch_mirror
+    repair_dpkg
     sleep "$RETRY_SLEEP"
 done

--- a/.github/scripts/apt_install.sh
+++ b/.github/scripts/apt_install.sh
@@ -46,7 +46,8 @@ set -uo pipefail
 # the exact failure mode this exists to remove. Callers run under 30-, 40- and
 # 45-minute job limits, so the defaults are sized against the smallest:
 #
-#   3 x (120 update + 240 install) + 2 x 10s sleep = 1100s, about 18 minutes.
+#   3 x (120 update + 240 install) + 2 x (45 dpkg repair + 10 sleep) = 1190s,
+#   just under 20 minutes.
 #
 # A caller with a tighter step budget can lower any of these from the workflow.
 ATTEMPTS="${APT_ATTEMPTS:-3}"
@@ -80,14 +81,17 @@ case "$RETRY_SLEEP" in
         exit 2 ;;
 esac
 
-# Two mirror families, and arm64 is not a footnote: aarch64 Ubuntu serves from
+# Two URL families, and arm64 is not a footnote: aarch64 Ubuntu serves from
 # ports.ubuntu.com/ubuntu-ports, which shares no substring with the x86 archive
-# host. The first version of this switched only the archive pair, so on the arm64
-# jobs the sed matched nothing, the switch silently did nothing, and every retry
-# went back to the same dead mirror. Each family is only ever swapped within
-# itself, so a ports source can never be rewritten to an x86 archive.
-STOCK_MIRROR="http://archive.ubuntu.com/ubuntu"
-STOCK_PORTS="http://ports.ubuntu.com/ubuntu-ports"
+# host. An earlier version rewrote only the archive pair, so on the arm64 jobs
+# the sed matched nothing and every fetch went back to the same dead mirror.
+# Rewritten at the HOST level so the scheme is preserved: an https:// azure
+# entry is just as real as an http:// one, and a URL-with-scheme pattern would
+# silently skip it (the verification below caught exactly that in testing).
+AZURE_ARCHIVE_HOST="azure.archive.ubuntu.com"
+STOCK_ARCHIVE_HOST="archive.ubuntu.com"
+AZURE_PORTS_HOST="azure.ports.ubuntu.com"
+STOCK_PORTS_HOST="ports.ubuntu.com"
 
 if [ "$(id -u)" -eq 0 ]; then
     SUDO=()
@@ -135,29 +139,40 @@ sources_match() {
     return 1
 }
 
-# Which family this machine serves from: ports on aarch64, archive on x86.
-mirror_family() {
-    if sources_match "ports\.ubuntu\.com"; then
-        echo ports
-    else
-        echo archive
-    fi
-}
-
+# A failed rewrite is not cosmetic here: the whole point of this script is that
+# apt never talks to azure, so a sed that could not write its file must be a
+# hard failure rather than a silent pass. The loop reads from a process
+# substitution, not a pipe, so it runs in this shell and its status survives.
 rewrite_sources() {
-    local from="$1" to="$2" f
+    local from="$1" to="$2" f rc=0
     while read -r f; do
-        "${SUDO[@]}" sed -i -e "s|${from}|${to}|g" "$f" || true
+        "${SUDO[@]}" sed -i -e "s|${from}|${to}|g" "$f" || rc=1
     done < <(mirror_files)
+    return "$rc"
 }
 
 # Purge azure from every mirror file (including the runner mirrorlist) before
-# the first attempt, so apt talks only to the stock Ubuntu archive.
+# the first attempt, so apt talks only to the stock Ubuntu archive. Both URL
+# families are rewritten unconditionally rather than picking one by
+# architecture: a machine listing both (a cross-arch image, or a stray
+# .sources) would otherwise keep whichever family was not chosen, which is
+# exactly the silent no-op this script exists to end.
 banish_azure() {
-    if [ "$(mirror_family)" = "ports" ]; then
-        rewrite_sources "http://azure.ports.ubuntu.com/ubuntu-ports" "$STOCK_PORTS"
-    else
-        rewrite_sources "http://azure.archive.ubuntu.com/ubuntu" "$STOCK_MIRROR"
+    local rc=0
+    rewrite_sources "$AZURE_ARCHIVE_HOST" "$STOCK_ARCHIVE_HOST" || rc=1
+    rewrite_sources "$AZURE_PORTS_HOST" "$STOCK_PORTS_HOST" || rc=1
+
+    if [ "$rc" -ne 0 ]; then
+        echo "::error::apt could not rewrite its mirror files to drop azure" >&2
+        exit 1
+    fi
+
+    # Verify rather than assume. Matched on the exact Ubuntu mirror hosts, so
+    # unrelated azure repositories on the runner (packages.microsoft.com's
+    # azure-cli, for one) are left alone and do not trip this.
+    if sources_match "azure\.archive\.ubuntu\.com" || sources_match "azure\.ports\.ubuntu\.com"; then
+        echo "::error::azure survived the mirror rewrite; refusing to fetch from it" >&2
+        exit 1
     fi
 }
 
@@ -172,7 +187,7 @@ attempt() {
 # dies on "dpkg was interrupted, you must manually run 'dpkg --configure -a'"
 # no matter how healthy the mirror is. Repair before each retry.
 repair_dpkg() {
-    "${SUDO[@]}" timeout 120 env DEBIAN_FRONTEND=noninteractive \
+    "${SUDO[@]}" timeout 45 env DEBIAN_FRONTEND=noninteractive \
         dpkg --configure -a || true
 }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,22 +205,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
-          # does not exist yet, so actions/checkout has not run and the script is
-          # not on disk. This is the step shape that failed the DPF build outright
-          # in 81 seconds (run 32176674366) with no retry to save it, and this is
-          # a RELEASE pipeline, so it gets the same defences in minimal form.
-          switch_mirror() {
-            # security.ubuntu.com is a separate host and stalls independently;
-            # apt-get update fetches from it too, so leaving it in place lets a
-            # stalled security host defeat the whole switch.
-            sed -i \
-              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
-              /etc/apt/sources.list
-            echo "::notice::switched apt to the Azure mirror"
-          }
+          # Inline because checkout cannot run until git is installed and the
+          # shared script is not on disk yet. Stock Ubuntu repositories only.
+          # The timeout guards stalls, retries guard hard failures, and the
+          # dpkg repair handles interrupted transactions before the next try.
           bootstrap() {
             timeout 60 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 120 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
@@ -233,7 +221,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 5s"
-            [ "$i" = "1" ] && switch_mirror
+            timeout 120 dpkg --configure -a || true
             sleep 5
           done
 
@@ -454,22 +442,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
-          # does not exist yet, so actions/checkout has not run and the script is
-          # not on disk. This is the step shape that failed the DPF build outright
-          # in 81 seconds (run 32176674366) with no retry to save it, and this is
-          # a RELEASE pipeline, so it gets the same defences in minimal form.
-          switch_mirror() {
-            # security.ubuntu.com is a separate host and stalls independently;
-            # apt-get update fetches from it too, so leaving it in place lets a
-            # stalled security host defeat the whole switch.
-            sed -i \
-              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
-              /etc/apt/sources.list
-            echo "::notice::switched apt to the Azure mirror"
-          }
+          # Inline because checkout cannot run until git is installed and the
+          # shared script is not on disk yet. Stock Ubuntu repositories only.
+          # The timeout guards stalls, retries guard hard failures, and the
+          # dpkg repair handles interrupted transactions before the next try.
           bootstrap() {
             timeout 60 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 120 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
@@ -482,7 +458,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 5s"
-            [ "$i" = "1" ] && switch_mirror
+            timeout 120 dpkg --configure -a || true
             sleep 5
           done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 5s"
-            timeout 120 dpkg --configure -a || true
+            timeout 45 dpkg --configure -a || true
             sleep 5
           done
 
@@ -234,11 +234,12 @@ jobs:
       - name: Install Linux apt dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
-          # Worst case: bootstrap 2x(60+120)+5 = 6.1m; plain packages
-          # 2x(45+90)+5 = 4.6m; PPA retry = 2x60+5 = 2.1m; post-source
-          # update = 2x45+5 = 1.6m; final packages = 4.6m. Total apt
-          # ceiling is 18.9m, leaving over 11m in this 30m job for checkout,
-          # configuration, and compilation.
+          # Worst case, counting the 45s dpkg repair that precedes each retry:
+          # bootstrap 2x(60+120)+45+5 = 6.8m; plain packages 2x(45+90)+45+5
+          # = 5.3m; PPA retry = 2x60+5 = 2.1m; post-source update 2x45+45+5
+          # = 2.3m; final packages = 5.3m. Total apt ceiling is 21.9m,
+          # leaving 8m in this 30m job for checkout, configuration, and
+          # compilation.
           APT_ATTEMPTS: 2
           APT_UPDATE_TIMEOUT: 45
           APT_INSTALL_TIMEOUT: 90
@@ -458,7 +459,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 5s"
-            timeout 120 dpkg --configure -a || true
+            timeout 45 dpkg --configure -a || true
             sleep 5
           done
 
@@ -471,9 +472,10 @@ jobs:
       - name: Install Linux apt dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
-          # Worst case: bootstrap 2x(60+120)+5 = 6.1m; plain packages
-          # 2x(45+90)+5 = 4.6m; post-source update = 2x45+5 = 1.6m;
-          # final packages = 4.6m. Total apt ceiling is 16.9m, leaving
+          # Worst case, counting the 45s dpkg repair that precedes each retry:
+          # bootstrap 2x(60+120)+45+5 = 6.8m; plain packages 2x(45+90)+45+5
+          # = 5.3m; post-source update 2x45+45+5 = 2.3m; final packages =
+          # 5.3m. Total apt ceiling is 19.8m, leaving
           # over 13m in this 30m job for checkout, configuration, and build.
           APT_ATTEMPTS: 2
           APT_UPDATE_TIMEOUT: 45

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -219,7 +219,7 @@ jobs:
               exit 1
             fi
             echo "::warning::prerequisite attempt $i failed or timed out; retrying in 10s"
-            timeout 120 dpkg --configure -a || true
+            timeout 45 dpkg --configure -a || true
             sleep 10
           done
 
@@ -489,7 +489,7 @@ jobs:
               exit 1
             fi
             echo "::warning::prerequisite attempt $i failed or timed out; retrying in 10s"
-            timeout 120 dpkg --configure -a || true
+            timeout 45 dpkg --configure -a || true
             sleep 10
           done
 

--- a/.github/workflows/dpf-build.yml
+++ b/.github/workflows/dpf-build.yml
@@ -204,28 +204,9 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Point apt at the Azure regional mirror before the first fetch.
-          # GitHub runners are Azure VMs and their own images do this; the bare
-          # ubuntu image still points at archive.ubuntu.com, which measured
-          # 724 B/s - 35 kB/s from a runner and spent 28 minutes downloading
-          # before the job hit its timeout. sed is a no-op if the pattern is
-          # absent, so this degrades to the stock mirror rather than breaking.
-          sed -i \
-            -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-            -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list
-          # ...but Azure is not always the healthy one. On 2026-08-18 it was the
-          # mirror that was degraded, and this step failed the whole job in 81
-          # seconds (run 32176674366) while the retry loop that would have saved
-          # it sat in the LATER dependency step, which never got to run. The
-          # first apt call in the container needs the same protection as the
-          # second: bounded attempts, and a way back off a bad mirror.
-          restore_stock_mirror() {
-            echo "::notice::switching apt back to archive.ubuntu.com for this attempt"
-            sed -i \
-              -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-              /etc/apt/sources.list
-          }
+          # The container starts on stock Ubuntu repositories by policy and
+          # remains there. The timeout guards stalls, retries guard hard
+          # failures, and the dpkg repair handles interrupted transactions.
           prereqs() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 180 apt-get install -y --no-install-recommends \
@@ -238,8 +219,7 @@ jobs:
               exit 1
             fi
             echo "::warning::prerequisite attempt $i failed or timed out; retrying in 10s"
-            # Give Azure one chance, then go back to the stock mirror.
-            [ "$i" = "1" ] && restore_stock_mirror
+            timeout 120 dpkg --configure -a || true
             sleep 10
           done
 
@@ -492,22 +472,11 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Same Azure regional mirror switch as build-linux, but arm64 packages
-          # come from ports.ubuntu.com (/ubuntu-ports). sed is a no-op if the
-          # pattern is absent.
-          sed -i \
-            -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
-            /etc/apt/sources.list
-          # Inline rather than the shared script, and this is the one place that
-          # cannot be otherwise: git does not exist yet, so actions/checkout has
-          # not run and .github/scripts/ is not on disk. Same defences, minimal
-          # form -- bounded attempts, and one fall back off the chosen mirror.
-          restore_ports_mirror() {
-            echo "::notice::switching apt back to ports.ubuntu.com for this attempt"
-            sed -i \
-              -e 's|http://azure.ports.ubuntu.com/ubuntu-ports|http://ports.ubuntu.com/ubuntu-ports|g' \
-              /etc/apt/sources.list
-          }
+          # The container starts on stock ports repositories by policy and
+          # remains there. The timeout guards stalls, retries guard hard
+          # failures, and the dpkg repair handles interrupted transactions.
+          # Inline because checkout cannot run until git is installed and the
+          # shared script is not on disk yet.
           prereqs() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 180 apt-get install -y --no-install-recommends \
@@ -520,7 +489,7 @@ jobs:
               exit 1
             fi
             echo "::warning::prerequisite attempt $i failed or timed out; retrying in 10s"
-            [ "$i" = "1" ] && restore_ports_mirror
+            timeout 120 dpkg --configure -a || true
             sleep 10
           done
 

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -146,7 +146,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
-            timeout 120 dpkg --configure -a || true
+            timeout 45 dpkg --configure -a || true
             sleep 10
           done
 
@@ -158,10 +158,11 @@ jobs:
       - name: Install Linux apt dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
-          # Worst case: bootstrap 2x(90+150)+10 = 8.2m; plain packages
-          # 2x(60+120)+5 = 6.1m; PPA retry = 2x90+10 = 3.2m;
-          # post-source update = 2x60+5 = 2.1m; final packages = 6.1m.
-          # Total apt ceiling is 25.7m, leaving over 14m in this 40m job.
+          # Worst case, counting the 45s dpkg repair that precedes each retry:
+          # bootstrap 2x(90+150)+45+10 = 8.9m; plain packages 2x(60+120)+45+5
+          # = 6.8m; PPA retry = 2x90+10 = 3.2m; post-source update 2x60+45+5
+          # = 2.8m; final packages = 6.8m. Total apt ceiling is 28.6m,
+          # leaving over 11m in this 40m job.
           APT_ATTEMPTS: 2
           APT_UPDATE_TIMEOUT: 60
           APT_INSTALL_TIMEOUT: 120
@@ -284,7 +285,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
-            timeout 120 dpkg --configure -a || true
+            timeout 45 dpkg --configure -a || true
             sleep 10
           done
 
@@ -296,9 +297,10 @@ jobs:
       - name: Install GCC 11 toolchain
         env:
           DEBIAN_FRONTEND: noninteractive
-          # Worst case: bootstrap 2x(90+150)+10 = 8.2m; plain packages
-          # 2x(60+120)+5 = 6.1m; post-source update = 2x60+5 = 2.1m;
-          # final packages = 6.1m. Total apt ceiling is 22.5m, leaving
+          # Worst case, counting the 45s dpkg repair that precedes each retry:
+          # bootstrap 2x(90+150)+45+10 = 8.9m; plain packages 2x(60+120)+45+5
+          # = 6.8m; post-source update 2x60+45+5 = 2.8m; final packages =
+          # 6.8m. Total apt ceiling is 25.4m, leaving
           # over 17m in this 40m job for checkout, configuration, and build.
           APT_ATTEMPTS: 2
           APT_UPDATE_TIMEOUT: 60

--- a/.github/workflows/dpf-release.yml
+++ b/.github/workflows/dpf-release.yml
@@ -130,22 +130,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
-          # does not exist yet, so actions/checkout has not run and the script is
-          # not on disk. This is the step shape that failed the DPF build outright
-          # in 81 seconds (run 32176674366) with no retry to save it, and this is
-          # a RELEASE pipeline, so it gets the same defences in minimal form.
-          switch_mirror() {
-            # security.ubuntu.com is a separate host and stalls independently;
-            # apt-get update fetches from it too, so leaving it in place lets a
-            # stalled security host defeat the whole switch.
-            sed -i \
-              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
-              /etc/apt/sources.list
-            echo "::notice::switched apt to the Azure mirror"
-          }
+          # Inline because checkout cannot run until git is installed and the
+          # shared script is not on disk yet. Stock Ubuntu repositories only.
+          # The timeout guards stalls, retries guard hard failures, and the
+          # dpkg repair handles interrupted transactions before the next try.
           bootstrap() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 150 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
@@ -158,7 +146,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
-            [ "$i" = "1" ] && switch_mirror
+            timeout 120 dpkg --configure -a || true
             sleep 10
           done
 
@@ -280,22 +268,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Inline rather than .github/scripts/apt_install.sh, unavoidably: git
-          # does not exist yet, so actions/checkout has not run and the script is
-          # not on disk. This is the step shape that failed the DPF build outright
-          # in 81 seconds (run 32176674366) with no retry to save it, and this is
-          # a RELEASE pipeline, so it gets the same defences in minimal form.
-          switch_mirror() {
-            # security.ubuntu.com is a separate host and stalls independently;
-            # apt-get update fetches from it too, so leaving it in place lets a
-            # stalled security host defeat the whole switch.
-            sed -i \
-              -e 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
-              -e 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
-              /etc/apt/sources.list
-            echo "::notice::switched apt to the Azure mirror"
-          }
+          # Inline because checkout cannot run until git is installed and the
+          # shared script is not on disk yet. Stock Ubuntu repositories only.
+          # The timeout guards stalls, retries guard hard failures, and the
+          # dpkg repair handles interrupted transactions before the next try.
           bootstrap() {
             timeout 90 apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30 && \
             timeout 150 apt-get install -y --no-install-recommends -o Acquire::Retries=3 \
@@ -308,7 +284,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bootstrap attempt $i failed or timed out; retrying in 10s"
-            [ "$i" = "1" ] && switch_mirror
+            timeout 120 dpkg --configure -a || true
             sleep 10
           done
 


### PR DESCRIPTION
A live juce-compile-check failure exposed three gaps in the apt hardening from #196/#197:

```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu jammy InRelease
...
E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem.
Error: apt failed after 3 attempts (mirror: stock)
```

1. **The mirror switch was a no-op on hosted runners.** They route apt through the `/etc/apt/apt-mirrors.txt` mirrorlist (`mirror+file:...` in the sources), so rewriting only `sources.list`/`.sources` changed nothing: the log claims "mirror: stock" while every fetch still hits azure. The mirrorlist is now part of every mirror-file operation in `apt_install.sh`.
2. **A timed-out install wedges dpkg.** After `timeout(1)` kills `apt-get install` mid-transaction, every retry dies on "dpkg was interrupted" regardless of network health. A bounded `dpkg --configure -a` now runs before each retry, in the shared script and in all six inline container bootstrap blocks.
3. **Mirror policy simplified: stock Ubuntu repos only** (owner decision). Azure has been the sick side of every incident to date; it is purged up front from every mirror file and the rotation logic is deleted. No third-party mirrors: Ubuntu 22.04 is supported until 2027 and the stock archive is the reference. All inline azure pin/switch functions in `build.yml`, `dpf-build.yml`, and `dpf-release.yml` are gone; package lists, budgets, attempts, and step ordering are unchanged.

`grep -rn azure .github/workflows/` returns zero hits; actionlint reports only pre-existing findings; YAML and bash syntax verified. The same fix is applied to dusk-studio in dusk-audio/dusk-studio#324.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux dependency installation reliability by consistently using standard Ubuntu repositories.
  * Added bounded package-manager repair attempts between failed installation retries.
  * Reduced package repair timeouts to 45 seconds, helping builds recover or fail faster.
  * Preserved retry and timeout handling across build and release workflows.
  * Removed unreliable mirror-switching behavior that could cause installation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->