### PR TITLE
Multi-Comp 2: restore parameter tapers, make state atomic, and repair…

### DIFF
--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 
 namespace duskaudio
 {
@@ -40,6 +39,7 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     bypassDry.assign(static_cast<size_t>(maxBlock * kMaxChannels), 0.0f);
     mixCurve.assign(static_cast<size_t>(maxBlock), 1.0f);
     bypassCurve.assign(static_cast<size_t>(maxBlock), 0.0f);
+    sidechainListenCurve.assign(static_cast<size_t>(maxBlock), 0.0f);
     autoGainCurve.assign(static_cast<size_t>(maxBlock), 1.0f);
     for (auto& line : delayedInput) line.assign(static_cast<size_t>(maxBlock), 0.0f);
     const size_t lookaheadSize = static_cast<size_t>(std::ceil(sampleRate * 0.01)) + 1u;
@@ -62,6 +62,8 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     busMixRamp.prepare(sampleRate, 0.020f); busMixRamp.snap(params.busMix.load(std::memory_order_relaxed) * 0.01f);
     digitalMixRamp.prepare(sampleRate, 0.020f); digitalMixRamp.snap(params.digitalMix.load(std::memory_order_relaxed) * 0.01f);
     bypassRamp.prepare(sampleRate, static_cast<float>(kBypassRampMs) * 0.001f); bypassRamp.snap(0.0f);
+    sidechainListenRamp.prepare(sampleRate, static_cast<float>(kSidechainListenRampMs) * 0.001f);
+    sidechainListenRamp.snap(params.globalSidechainListen.load(std::memory_order_relaxed) ? 1.0f : 0.0f);
     bypassSettled = false; lastBypass = false; lastExternalSidechain = false;
     lastAutoMakeup = false; firstBlock = true; lastMode = -1; autoGainHoldSamples = 0;
     noiseState = 0x6d2b79f5u;
@@ -106,6 +108,8 @@ void MultiCompDSP::reset()
     busMixRamp.snap(params.busMix.load(std::memory_order_relaxed) * 0.01f);
     digitalMixRamp.snap(params.digitalMix.load(std::memory_order_relaxed) * 0.01f);
     bypassRamp.snap(params.bypass.load(std::memory_order_relaxed) ? 1.0f : 0.0f);
+    sidechainListenRamp.snap(params.globalSidechainListen.load(std::memory_order_relaxed) ? 1.0f : 0.0f);
+    std::fill(sidechainListenCurve.begin(), sidechainListenCurve.end(), sidechainListenRamp.value());
     bypassSettled = params.bypass.load(std::memory_order_relaxed);
     lastBypass = bypassSettled;
     lastExternalSidechain = false;
@@ -239,6 +243,8 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     }
     ScopedFlushDenormals guard;
     const bool requestedBypass = params.bypass.load(std::memory_order_relaxed);
+    const bool requestedSidechainListen = params.globalSidechainListen.load(std::memory_order_relaxed);
+    sidechainListenRamp.setTarget(requestedSidechainListen ? 1.0f : 0.0f);
     if (requestedBypass != lastBypass)
     {
         lastBypass = requestedBypass;
@@ -248,6 +254,7 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     processLatencyHistory(in, out, nCh, nSamples, requestedBypass && bypassSettled);
     if (requestedBypass && bypassSettled)
     {
+        for (int i = 0; i < nSamples; ++i) (void)sidechainListenRamp.next();
         masterGR.store(0.0f, std::memory_order_relaxed);
         for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
         updateMeters(in, out, nCh, nSamples);
@@ -346,74 +353,78 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     processRange(processingIn, filteredSidechain, out, nCh, nSamples,
                  useExternalSidechain, autoMakeup);
     const bool isMulti = mode == MultiCompMode::Multiband;
-    const bool sidechainListen = params.globalSidechainListen.load(std::memory_order_relaxed);
-    if (!sidechainListen)
+    if (nCh > 1 && params.stereoLinkMode.load(std::memory_order_relaxed) == 1)
     {
-        if (nCh > 1 && params.stereoLinkMode.load(std::memory_order_relaxed) == 1)
-        {
-            for (int i = 0; i < nSamples; ++i)
-            {
-                const float mid = out[0][i], side = out[1][i];
-                out[0][i] = mid + side;
-                out[1][i] = mid - side;
-            }
-        }
-        const float targetMix = std::clamp((isMulti ? params.mbMix.load(std::memory_order_relaxed) : params.mix.load(std::memory_order_relaxed)) * 0.01f, 0.0f, 1.0f);
-        globalMixSmoother.setTarget(targetMix);
         for (int i = 0; i < nSamples; ++i)
-            mixCurve[static_cast<size_t>(i)] = globalMixSmoother.next();
-        // `dry` is one shared scratch line; copy the source per channel again before
-        // mixing. This is safe for in-place processing and avoids process-time allocs.
-        for (int ch = 0; ch < nCh; ++ch)
         {
-            float* dryChannel = dry.data() + static_cast<size_t>(ch * maxBlock);
+            const float mid = out[0][i], side = out[1][i];
+            out[0][i] = mid + side;
+            out[1][i] = mid - side;
+        }
+    }
+    const float targetMix = std::clamp((isMulti ? params.mbMix.load(std::memory_order_relaxed) : params.mix.load(std::memory_order_relaxed)) * 0.01f, 0.0f, 1.0f);
+    globalMixSmoother.setTarget(targetMix);
+    for (int i = 0; i < nSamples; ++i)
+        mixCurve[static_cast<size_t>(i)] = globalMixSmoother.next();
+    // `dry` is one shared scratch line; copy the source per channel again before
+    // mixing. This is safe for in-place processing and avoids process-time allocs.
+    for (int ch = 0; ch < nCh; ++ch)
+    {
+        float* dryChannel = dry.data() + static_cast<size_t>(ch * maxBlock);
+        for (int i = 0; i < nSamples; ++i)
+        {
+            const float wet = mixCurve[static_cast<size_t>(i)];
+            if (!isMulti || wet < 1.0f)
+                out[ch][i] = out[ch][i] * wet + dryChannel[i] * (1.0f - wet);
+        }
+    }
+
+    if (autoMakeup && !requestedSidechainListen && autoGainHoldSamples <= 0)
+    {
+        double inSum = 0.0, outSum = 0.0;
+        for (int ch = 0; ch < nCh; ++ch)
             for (int i = 0; i < nSamples; ++i)
             {
-                const float wet = mixCurve[static_cast<size_t>(i)];
-                if (!isMulti || wet < 1.0f)
-                    out[ch][i] = out[ch][i] * wet + dryChannel[i] * (1.0f - wet);
+                const float drySample = dry[static_cast<size_t>(ch * maxBlock + i)];
+                inSum += static_cast<double>(drySample) * drySample;
+                outSum += static_cast<double>(out[ch][i]) * out[ch][i];
             }
-        }
-
-        if (autoMakeup && autoGainHoldSamples <= 0)
-        {
-            double inSum = 0.0, outSum = 0.0;
-            for (int ch = 0; ch < nCh; ++ch)
-                for (int i = 0; i < nSamples; ++i)
-                {
-                    const float drySample = dry[static_cast<size_t>(ch * maxBlock + i)];
-                    inSum += static_cast<double>(drySample) * drySample;
-                    outSum += static_cast<double>(out[ch][i]) * out[ch][i];
-                }
-            const float divisor = static_cast<float>(std::max(1, nCh * nSamples));
-            const float target = autoGainMatcher.update(std::sqrt(static_cast<float>(inSum) / divisor),
-                                                        std::sqrt(static_cast<float>(outSum) / divisor), nSamples);
-            autoGainSmoother.setTarget(target);
-        }
-        else
-        {
-            autoGainMatcher.reset();
-            autoGainSmoother.setTarget(1.0f);
-        }
-        for (int i = 0; i < nSamples; ++i) autoGainCurve[static_cast<size_t>(i)] = autoGainSmoother.next();
-        for (int ch = 0; ch < nCh; ++ch)
-            for (int i = 0; i < nSamples; ++i) out[ch][i] *= autoGainCurve[static_cast<size_t>(i)];
-        if (params.noiseEnable.load(std::memory_order_relaxed) && mode != MultiCompMode::Digital && mode != MultiCompMode::Multiband)
-        {
-            for (int ch = 0; ch < nCh; ++ch)
-                for (int i = 0; i < nSamples; ++i)
-                {
-                    noiseState = noiseState * 1664525u + 1013904223u;
-                    const float unit = static_cast<float>((noiseState >> 8) & 0x00ffffffu) / 16777215.0f;
-                    out[ch][i] += (unit * 2.0f - 1.0f) * 0.0001f;
-                }
-        }
+        const float divisor = static_cast<float>(std::max(1, nCh * nSamples));
+        const float target = autoGainMatcher.update(std::sqrt(static_cast<float>(inSum) / divisor),
+                                                    std::sqrt(static_cast<float>(outSum) / divisor), nSamples);
+        autoGainSmoother.setTarget(target);
     }
     else
     {
         autoGainMatcher.reset();
         autoGainSmoother.setTarget(1.0f);
-        for (int i = 0; i < nSamples; ++i) (void)autoGainSmoother.next();
+    }
+    for (int i = 0; i < nSamples; ++i) autoGainCurve[static_cast<size_t>(i)] = autoGainSmoother.next();
+    for (int ch = 0; ch < nCh; ++ch)
+        for (int i = 0; i < nSamples; ++i) out[ch][i] *= autoGainCurve[static_cast<size_t>(i)];
+    if (params.noiseEnable.load(std::memory_order_relaxed) && mode != MultiCompMode::Digital && mode != MultiCompMode::Multiband)
+    {
+        for (int ch = 0; ch < nCh; ++ch)
+            for (int i = 0; i < nSamples; ++i)
+            {
+                noiseState = noiseState * 1664525u + 1013904223u;
+                const float unit = static_cast<float>((noiseState >> 8) & 0x00ffffffu) / 16777215.0f;
+                out[ch][i] += (unit * 2.0f - 1.0f) * 0.0001f;
+            }
+    }
+    for (int i = 0; i < nSamples; ++i)
+        sidechainListenCurve[static_cast<size_t>(i)] = sidechainListenRamp.next();
+    for (int ch = 0; ch < nCh; ++ch)
+        for (int i = 0; i < nSamples; ++i)
+        {
+            const float listen = sidechainListenCurve[static_cast<size_t>(i)];
+            out[ch][i] = out[ch][i] * (1.0f - listen)
+                       + filteredSidechain[ch][i] * listen;
+        }
+    if (requestedSidechainListen)
+    {
+        masterGR.store(0.0f, std::memory_order_relaxed);
+        for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
     }
     autoGainHoldSamples = std::max(0, autoGainHoldSamples - nSamples);
 
@@ -558,15 +569,6 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
     manualMakeupScaleRamp.setTarget(autoMakeup ? 0.0f : 1.0f);
     if (firstBlock) manualMakeupScaleRamp.snap(autoMakeup ? 0.0f : 1.0f);
     syncModeParameters(mode);
-    if (params.globalSidechainListen.load(std::memory_order_relaxed))
-    {
-        for (int i = 0; i < nSamples; ++i) (void)manualMakeupScaleRamp.next();
-        for (int ch = 0; ch < nCh; ++ch)
-            std::memcpy(out[ch], sidechain[ch], static_cast<size_t>(nSamples) * sizeof(float));
-        masterGR.store(0.0f, std::memory_order_relaxed);
-        for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
-        return;
-    }
     if (mode == MultiCompMode::Multiband)
     {
         for (int i = 0; i < nSamples; ++i) (void)manualMakeupScaleRamp.next();

--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -564,6 +564,7 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
         for (int ch = 0; ch < nCh; ++ch)
             std::memcpy(out[ch], sidechain[ch], static_cast<size_t>(nSamples) * sizeof(float));
         masterGR.store(0.0f, std::memory_order_relaxed);
+        for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
         return;
     }
     if (mode == MultiCompMode::Multiband)

--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -39,7 +39,6 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     bypassDry.assign(static_cast<size_t>(maxBlock * kMaxChannels), 0.0f);
     mixCurve.assign(static_cast<size_t>(maxBlock), 1.0f);
     bypassCurve.assign(static_cast<size_t>(maxBlock), 0.0f);
-    sidechainListenCurve.assign(static_cast<size_t>(maxBlock), 0.0f);
     autoGainCurve.assign(static_cast<size_t>(maxBlock), 1.0f);
     for (auto& line : delayedInput) line.assign(static_cast<size_t>(maxBlock), 0.0f);
     const size_t lookaheadSize = static_cast<size_t>(std::ceil(sampleRate * 0.01)) + 1u;
@@ -109,7 +108,6 @@ void MultiCompDSP::reset()
     digitalMixRamp.snap(params.digitalMix.load(std::memory_order_relaxed) * 0.01f);
     bypassRamp.snap(params.bypass.load(std::memory_order_relaxed) ? 1.0f : 0.0f);
     sidechainListenRamp.snap(params.globalSidechainListen.load(std::memory_order_relaxed) ? 1.0f : 0.0f);
-    std::fill(sidechainListenCurve.begin(), sidechainListenCurve.end(), sidechainListenRamp.value());
     bypassSettled = params.bypass.load(std::memory_order_relaxed);
     lastBypass = bypassSettled;
     lastExternalSidechain = false;
@@ -413,14 +411,14 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
             }
     }
     for (int i = 0; i < nSamples; ++i)
-        sidechainListenCurve[static_cast<size_t>(i)] = sidechainListenRamp.next();
-    for (int ch = 0; ch < nCh; ++ch)
-        for (int i = 0; i < nSamples; ++i)
+    {
+        const float listen = sidechainListenRamp.next();
+        for (int ch = 0; ch < nCh; ++ch)
         {
-            const float listen = sidechainListenCurve[static_cast<size_t>(i)];
             out[ch][i] = out[ch][i] * (1.0f - listen)
                        + filteredSidechain[ch][i] * listen;
         }
+    }
     if (requestedSidechainListen)
     {
         masterGR.store(0.0f, std::memory_order_relaxed);

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -72,6 +72,7 @@ public:
 private:
     static constexpr int kMaxChannels = 2;
     static constexpr int kBypassRampMs = 30;
+    static constexpr int kSidechainListenRampMs = 30;
     static constexpr int kAutoGainTransitionMs = 50;
     static constexpr int kCrossoverRampMs = 20;
     static constexpr int kCrossoverCoefficientInterval = 8;
@@ -110,7 +111,7 @@ private:
     std::array<std::array<std::vector<float>, kMaxChannels>, kMultiCompBands> bands, sidechainBands;
     std::array<std::vector<float>, kMaxChannels> processedSidechain;
     std::array<std::vector<float>, kMaxChannels> modeInput;
-    std::vector<float> dry, bypassDry, mixCurve, bypassCurve, autoGainCurve;
+    std::vector<float> dry, bypassDry, mixCurve, bypassCurve, sidechainListenCurve, autoGainCurve;
     std::array<std::vector<float>, kMaxChannels> dryPathDelay;
     std::array<int, kMaxChannels> dryPathWrite{{0, 0}};
     std::array<std::vector<float>, kMaxChannels> bypassDelay;
@@ -130,6 +131,7 @@ private:
     LinearRamp digitalMixRamp;
     SmoothedValue globalMixSmoother;
     LinearRamp bypassRamp;
+    LinearRamp sidechainListenRamp;
     LinearRamp manualMakeupScaleRamp;
     MultiCompAutoGainMatcher autoGainMatcher;
     SmoothedValue autoGainSmoother;

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -111,7 +111,7 @@ private:
     std::array<std::array<std::vector<float>, kMaxChannels>, kMultiCompBands> bands, sidechainBands;
     std::array<std::vector<float>, kMaxChannels> processedSidechain;
     std::array<std::vector<float>, kMaxChannels> modeInput;
-    std::vector<float> dry, bypassDry, mixCurve, bypassCurve, sidechainListenCurve, autoGainCurve;
+    std::vector<float> dry, bypassDry, mixCurve, bypassCurve, autoGainCurve;
     std::array<std::vector<float>, kMaxChannels> dryPathDelay;
     std::array<int, kMaxChannels> dryPathWrite{{0, 0}};
     std::array<std::vector<float>, kMaxChannels> bypassDelay;

--- a/plugins/multi-comp/core/MultiCompModes.hpp
+++ b/plugins/multi-comp/core/MultiCompModes.hpp
@@ -338,6 +338,13 @@ private:
     void resetHardware() noexcept
     {
         inputTransformerOpto.reset(); outputTransformerOpto.reset(); optoTube.reset();
+        // The Opto detector shelf holds filter state between blocks and is only
+        // cleared mid-stream while an external sidechain is armed. Without this
+        // it survived reset(), so a re-run after reset() did not reproduce the
+        // first run bit-for-bit. macOS hid it: the residue decays into denormals,
+        // which ARM flushes to zero, while Linux preserves them and the exact
+        // comparison in the reset-determinism test failed.
+        for (auto& filter : optoTiltShelf) filter.reset();
         fetConvolution.reset(); busConvolution.reset();
         for (int ch = 0; ch < 2; ++ch)
         {

--- a/plugins/multi-comp/core/MultiCompPresets.hpp
+++ b/plugins/multi-comp/core/MultiCompPresets.hpp
@@ -16,25 +16,25 @@ struct MultiCompPreset
     int mode;
     float threshold, ratio, attack, release, makeup, mix, sidechainHP;
     bool autoMakeup;
-    int saturationMode, fetRatio, busAttack, busRelease;
+    int fetRatio, busAttack, busRelease;
     float vcaOverEasy, peakReduction;
     bool limitMode;
 };
 
 inline constexpr std::array<MultiCompPreset, 13> kMultiCompPresets = {{
-    {"Smooth Opto Vocal", "Vocals", 0, -18, 4, 10, 300, 5, 100, 60, false, 0, 0, 2, 2, 0, 50, false},
-    {"Vocal Presence", "Vocals", 1, -20, 4, 0.5f, 60, -11, 100, 100, false, 0, 0, 2, 2, 0, 0, false},
-    {"Modern Pop Control", "Vocals", 4, -15, 4, 0.3f, 120, 3, 100, 90, true, 1, 1, 2, 2, 0, 0, false},
-    {"Classic Drum Glue", "Drums", 3, -15, 4, 30, 100, 3, 100, 90, true, 0, 0, 5, 4, 0, 0, false},
-    {"Room Nuke (FET All)", "Drums", 1, -24, 20, 0.8f, 150, -8, 100, 60, false, 0, 4, 2, 2, 0, 0, false},
-    {"Snare Snap", "Drums", 2, -18, 4, 15, 50, 4, 100, 100, false, 1, 0, 2, 2, 0, 0, false},
-    {"Rock Bass Anchor", "Bass", 1, -15, 4, 0.8f, 250, -8, 100, 40, false, 0, 0, 2, 2, 0, 0, false},
-    {"Vintage Pinned Bass", "Bass", 0, -20, 4, 10, 300, 6, 100, 30, false, 0, 0, 2, 2, 0, 65, false},
-    {"Acoustic Strum Tamer", "Guitars", 5, -22, 3, 2, 100, 2, 100, 80, true, 2, 0, 2, 2, 0, 0, false},
-    {"Funk Rhythm Guitar", "Guitars", 1, -12, 4, 0.3f, 50, 4, 100, 100, false, 0, 0, 2, 2, 0, 0, false},
-    {"Console-Style Glue", "Mix Bus", 3, -20, 4, 10, 100, 0, 100, 60, true, 0, 0, 4, 4, 0, 0, false},
-    {"Gentle Master", "Mix Bus", 5, -24, 1.5f, 30, 100, 0, 100, 30, true, 2, 0, 2, 2, 0, 0, false},
-    {"EDM Pump (115-130 BPM)", "Creative", 1, -10, 20, 0.1f, 250, 6, 100, 150, false, 0, 3, 2, 2, 0, 0, false}
+    {"Smooth Opto Vocal", "Vocals", 0, -18, 4, 10, 300, 5, 100, 60, false, 0, 2, 2, 0, 50, false},
+    {"Vocal Presence", "Vocals", 1, -20, 4, 0.5f, 60, -11, 100, 100, false, 0, 2, 2, 0, 0, false},
+    {"Modern Pop Control", "Vocals", 4, -15, 4, 0.3f, 120, 3, 100, 90, true, 1, 2, 2, 0, 0, false},
+    {"Classic Drum Glue", "Drums", 3, -15, 4, 30, 100, 3, 100, 90, true, 0, 5, 4, 0, 0, false},
+    {"Room Nuke (FET All)", "Drums", 1, -24, 20, 0.8f, 150, -8, 100, 60, false, 4, 2, 2, 0, 0, false},
+    {"Snare Snap", "Drums", 2, -18, 4, 15, 50, 4, 100, 100, false, 0, 2, 2, 0, 0, false},
+    {"Rock Bass Anchor", "Bass", 1, -15, 4, 0.8f, 250, -8, 100, 40, false, 0, 2, 2, 0, 0, false},
+    {"Vintage Pinned Bass", "Bass", 0, -20, 4, 10, 300, 6, 100, 30, false, 0, 2, 2, 0, 65, false},
+    {"Acoustic Strum Tamer", "Guitars", 5, -22, 3, 2, 100, 2, 100, 80, true, 0, 2, 2, 0, 0, false},
+    {"Funk Rhythm Guitar", "Guitars", 1, -12, 4, 0.3f, 50, 4, 100, 100, false, 0, 2, 2, 0, 0, false},
+    {"Console-Style Glue", "Mix Bus", 3, -20, 4, 10, 100, 0, 100, 60, true, 0, 4, 4, 0, 0, false},
+    {"Gentle Master", "Mix Bus", 5, -24, 1.5f, 30, 100, 0, 100, 30, true, 0, 2, 2, 0, 0, false},
+    {"EDM Pump (115-130 BPM)", "Creative", 1, -10, 20, 0.1f, 250, 6, 100, 150, false, 3, 2, 2, 0, 0, false}
 }};
 
 inline constexpr const char* const kMultiCompModeNames[kMultiCompModes] = {

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -1,10 +1,15 @@
 #include "../MultiCompDSP.hpp"
 #include "../../../shared-dpf/dsp/DuskCrossover.hpp"
+#include "../../dpf-plugin/MultiCompParams.hpp"
+#include "../../dpf-plugin/MultiCompProgramPresets.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
+#include <string>
 #include <vector>
 
 using duskaudio::DuskCrossover;
@@ -110,6 +115,8 @@ void testStaticCurves()
         const float medium = renderSine(mode, 0.25f);
         const float hot = renderSine(mode, 0.8f);
         require(std::isfinite(quiet) && std::isfinite(medium) && std::isfinite(hot), "static curve finite");
+        require(quiet > 1.0e-5f && medium > 1.0e-5f && hot > 1.0e-5f,
+                "static curve stimuli produce output");
         require(quiet <= medium * 1.05f && medium <= hot * 1.05f, "static curve monotonic");
     }
     const float inputDb = duskaudio::gainToDecibels(0.5f / std::sqrt(2.0f));
@@ -119,12 +126,65 @@ void testStaticCurves()
     std::puts("static curves: all eight modes finite and monotonic");
 }
 
+void configureStrongCompression(MultiCompDSP& dsp, int mode)
+{
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    switch (static_cast<duskaudio::MultiCompMode>(mode))
+    {
+        case duskaudio::MultiCompMode::Opto:
+            dsp.setParameter(MultiCompDSP::Parameter::OptoPeakReduction, 100.0f);
+            break;
+        case duskaudio::MultiCompMode::FET:
+        case duskaudio::MultiCompMode::StudioFET:
+            dsp.setParameter(MultiCompDSP::Parameter::FetInput, 10.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::FetThreshold, -30.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::FetAttack, 0.1f);
+            dsp.setParameter(MultiCompDSP::Parameter::FetRelease, 50.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::FetRatio, 3.0f);
+            break;
+        case duskaudio::MultiCompMode::VCA:
+            dsp.setParameter(MultiCompDSP::Parameter::VcaThreshold, -30.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::VcaRatio, 10.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::VcaAttack, 0.1f);
+            dsp.setParameter(MultiCompDSP::Parameter::VcaRelease, 50.0f);
+            break;
+        case duskaudio::MultiCompMode::Bus:
+            dsp.setParameter(MultiCompDSP::Parameter::BusThreshold, -30.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::BusRatio, 2.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::BusAttack, 0.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::BusRelease, 0.0f);
+            break;
+        case duskaudio::MultiCompMode::StudioVCA:
+            dsp.setParameter(MultiCompDSP::Parameter::StudioVcaThreshold, -30.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::StudioVcaRatio, 10.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::StudioVcaAttack, 0.3f);
+            dsp.setParameter(MultiCompDSP::Parameter::StudioVcaRelease, 100.0f);
+            break;
+        case duskaudio::MultiCompMode::Digital:
+            dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -30.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 10.0f);
+            dsp.setParameter(MultiCompDSP::Parameter::DigitalAttack, 0.1f);
+            dsp.setParameter(MultiCompDSP::Parameter::DigitalRelease, 50.0f);
+            break;
+        case duskaudio::MultiCompMode::Multiband:
+            for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+            {
+                dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Threshold, -30.0f);
+                dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Ratio, 10.0f);
+                dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Attack, 0.1f);
+                dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Release, 50.0f);
+            }
+            break;
+    }
+}
+
 void testEnvelopeAndReset()
 {
     for (int mode = 0; mode < 8; ++mode)
     {
         MultiCompDSP dsp;
         dsp.prepare(48000.0, 256); dsp.setOversampling(0); dsp.setMode(mode);
+        configureStrongCompression(dsp, mode);
         constexpr int kStepBlocks = 64;
         std::vector<float> reference(static_cast<size_t>(kStepBlocks * 256)), second(static_cast<size_t>(kStepBlocks * 256)), in(256), out(256);
         float attackReduction = 0.0f, firstReleaseReduction = 0.0f, settledReleaseReduction = 0.0f;
@@ -134,14 +194,19 @@ void testEnvelopeAndReset()
             const float* ip[] = {in.data()}; float* op[] = {out.data()};
             dsp.processBlock(ip, op, 1, 256);
             std::copy(out.begin(), out.end(), reference.begin() + block * 256);
-            if (block == kStepBlocks / 2 - 1) attackReduction = dsp.getGainReduction();
+            if (block < kStepBlocks / 2)
+                attackReduction = std::min(attackReduction, dsp.getGainReduction());
             if (block == kStepBlocks / 2) firstReleaseReduction = dsp.getGainReduction();
             if (block == kStepBlocks - 1) settledReleaseReduction = dsp.getGainReduction();
         }
         for (float x : reference) require(std::isfinite(x), "envelope step finite");
+        require(rms(reference) > 1.0e-5f, "envelope/reset reference produces output");
         require(std::isfinite(attackReduction) && std::isfinite(firstReleaseReduction)
                     && std::isfinite(settledReleaseReduction), "envelope meter finite");
-        require(settledReleaseReduction >= attackReduction - 0.5f,
+        std::printf("envelope release: mode=%d attack=%.4f first=%.4f settled=%.4f\n",
+                    mode, attackReduction, firstReleaseReduction, settledReleaseReduction);
+        require(attackReduction < -0.5f, "envelope stimulus establishes gain reduction");
+        require(settledReleaseReduction > firstReleaseReduction + 0.05f,
                 "release returns toward unity at the configured time scale");
         dsp.reset();
         for (int block = 0; block < kStepBlocks; ++block)
@@ -174,8 +239,11 @@ void testMixBypassAndBlockEdges()
     bypassCheck.prepare(48000.0, 256);
     bypassCheck.setOversampling(0);
     bypassCheck.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
-    bypassCheck.setParameter(MultiCompDSP::Parameter::DigitalThreshold, 0.0f);
-    bypassCheck.setParameter(MultiCompDSP::Parameter::DigitalRatio, 1.0f);
+    // Real compression, not 1:1. With a unity ratio the active and bypassed
+    // outputs are identical, so no assertion below can tell whether the
+    // un-bypass actually happened.
+    bypassCheck.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -30.0f);
+    bypassCheck.setParameter(MultiCompDSP::Parameter::DigitalRatio, 8.0f);
     std::vector<float> bypassInput(256), bypassOutput(256);
     const float* bypassIp[] = {bypassInput.data()}; float* bypassOp[] = {bypassOutput.data()};
     for (int block = 0; block < 10; ++block)
@@ -206,15 +274,42 @@ void testMixBypassAndBlockEdges()
                 }
             }
     }
-    dsp.setBypass(false); dsp.processBlock(ip, op, 1, 256);
+    // Un-bypass the object that was actually bypassed. This previously cleared
+    // bypass on `dsp`, which had never been bypassed, so the un-bypass path was
+    // never exercised and the assertions below could not fail.
+    bypassCheck.setBypass(false);
     float reentryDelta = 0.0f;
-    for (int i = 0; i < 256; ++i)
+    float reentryMaxAbs = 0.0f;
+    for (int block = 0; block < 4; ++block)
     {
-        require(std::isfinite(out[static_cast<size_t>(i)]), "bypass re-entry finite");
-        if (i > 0) reentryDelta = std::max(reentryDelta, std::abs(out[static_cast<size_t>(i)] - out[static_cast<size_t>(i - 1)]));
+        for (int i = 0; i < 256; ++i)
+            bypassInput[static_cast<size_t>(i)] = 0.1f + 0.0001f * static_cast<float>(20 * 256 + block * 256 + i);
+        bypassCheck.processBlock(bypassIp, bypassOp, 1, 256);
+        for (int i = 0; i < 256; ++i)
+        {
+            const float sample = bypassOutput[static_cast<size_t>(i)];
+            require(std::isfinite(sample), "bypass re-entry finite");
+            reentryMaxAbs = std::max(reentryMaxAbs, std::abs(sample));
+            if (i > 0)
+                reentryDelta = std::max(reentryDelta,
+                                        std::abs(sample - bypassOutput[static_cast<size_t>(i - 1)]));
+        }
     }
     require(reentryDelta < 1.0f, "bypass toggle bounded sample delta");
-    dsp.processBlock(ip, op, 1, 0);
+    // The decisive assertion: with a real ratio the un-bypassed output must be
+    // audibly BELOW the dry input it would pass while bypassed. Finiteness and
+    // bounded deltas hold in both states, so only this one can distinguish them
+    // and therefore only this one can fail if the un-bypass path breaks.
+    const float dryPeakAtReentry = 0.1f + 0.0001f * static_cast<float>(20 * 256 + 4 * 256 - 1);
+    require(reentryMaxAbs < dryPeakAtReentry * 0.9f, "bypass re-entry resumes compression");
+    // Guard the vacuous case: an all-zero buffer would satisfy the bound above.
+    require(reentryMaxAbs > 1.0e-4f, "bypass re-entry produced signal");
+    std::array<float, 8> zeroFrameOutput{{101.25f, -202.5f, 303.75f, -404.0f,
+                                          505.5f, -606.25f, 707.0f, -808.75f}};
+    const auto zeroFrameSentinel = zeroFrameOutput;
+    float* zeroFrameOp[] = {zeroFrameOutput.data()};
+    dsp.processBlock(ip, zeroFrameOp, 1, 0);
+    require(zeroFrameOutput == zeroFrameSentinel, "zero-frame process leaves output untouched");
     dsp.processBlock(ip, op, 1, 1);
     (void)previous;
     std::puts("mix ramp, bypass, zero-sample and single-sample blocks OK");
@@ -345,14 +440,25 @@ void testLatencyMixBypassAndDigitalStereo()
         std::printf("latency/mix: os=%d reported=%d mix_delta=%.5f dB\n", oversampling, latency, mixDelta);
     }
 
-    MultiCompDSP maximumLatency;
-    maximumLatency.prepare(48000.0, 512);
-    maximumLatency.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
-    maximumLatency.setOversampling(2);
-    maximumLatency.setParameter(MultiCompDSP::Parameter::GlobalLookahead, 10.0f);
-    maximumLatency.setParameter(MultiCompDSP::Parameter::DigitalLookahead, 10.0f);
-    require(maximumLatency.getLatencySamples() == 987, "maximum Digital lookaheads report their rendered delay");
-    std::printf("latency maximum: os=2 global=10ms digital=10ms reported=%d\n", maximumLatency.getLatencySamples());
+    MultiCompDSP latencyMatrix;
+    latencyMatrix.prepare(48000.0, 512);
+    latencyMatrix.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    for (int oversampling : {0, 1, 2})
+        for (float globalLookahead : {0.0f, 10.0f})
+            for (float digitalLookahead : {0.0f, 10.0f})
+            {
+                latencyMatrix.setOversampling(oversampling);
+                latencyMatrix.setParameter(MultiCompDSP::Parameter::GlobalLookahead, globalLookahead);
+                latencyMatrix.setParameter(MultiCompDSP::Parameter::DigitalLookahead, digitalLookahead);
+                const int expected = 27 + static_cast<int>(globalLookahead * 48.0f)
+                                        + static_cast<int>(digitalLookahead * 48.0f);
+                require(latencyMatrix.getLatencySamples() == expected,
+                        "Digital latency reports AA plus global and mode lookahead");
+            }
+    latencyMatrix.setMode(static_cast<int>(duskaudio::MultiCompMode::FET));
+    require(latencyMatrix.getLatencySamples() == 507,
+            "mode change removes Digital lookahead while retaining global lookahead");
+    std::printf("latency matrix: os=off/2x/4x, global=0/10ms, digital=0/10ms; Digital max=987 FET max=507\n");
 
     MultiCompDSP stereo;
     stereo.prepare(48000.0, 256);
@@ -380,6 +486,67 @@ void testLatencyMixBypassAndDigitalStereo()
     std::puts("latency alignment, mix comb, bypass, digital stereo, oversized block: OK");
 }
 
+std::array<float, 4> renderAnalogStereoLink(int mode, float linkAmount)
+{
+    MultiCompDSP dsp;
+    dsp.prepare(48000.0, 256);
+    dsp.setOversampling(0);
+    dsp.setMode(mode);
+    dsp.setStereoLink(linkAmount);
+    dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain, 1.0f);
+    configureStrongCompression(dsp, mode);
+    std::array<float, 256> inputLeft{}, inputRight{}, sidechainLeft{}, sidechainRight{};
+    std::array<float, 256> outputLeft{}, outputRight{};
+    const float* input[] = {inputLeft.data(), inputRight.data()};
+    const float* sidechain[] = {sidechainLeft.data(), sidechainRight.data()};
+    float* output[] = {outputLeft.data(), outputRight.data()};
+    double leftSum = 0.0, rightSum = 0.0;
+    float maxChannelDelta = 0.0f;
+    for (int block = 0; block < 8; ++block)
+    {
+        for (int i = 0; i < 256; ++i)
+        {
+            const float sample = 0.02f * std::sin(2.0f * kPi * 997.0f
+                * static_cast<float>(block * 256 + i) / 48000.0f);
+            inputLeft[static_cast<size_t>(i)] = sample;
+            inputRight[static_cast<size_t>(i)] = sample;
+            sidechainLeft[static_cast<size_t>(i)] = 0.8f;
+            sidechainRight[static_cast<size_t>(i)] = 0.0f;
+        }
+        dsp.processBlockExternal(input, sidechain, output, 2, 256);
+        if (block >= 4)
+            for (int i = 0; i < 256; ++i)
+            {
+                const float left = outputLeft[static_cast<size_t>(i)];
+                const float right = outputRight[static_cast<size_t>(i)];
+                leftSum += static_cast<double>(left) * left;
+                rightSum += static_cast<double>(right) * right;
+                maxChannelDelta = std::max(maxChannelDelta, std::abs(left - right));
+            }
+    }
+    constexpr double kMeasuredSamples = 4.0 * 256.0;
+    return {{static_cast<float>(std::sqrt(leftSum / kMeasuredSamples)),
+             static_cast<float>(std::sqrt(rightSum / kMeasuredSamples)),
+             maxChannelDelta, dsp.getGainReduction()}};
+}
+
+void testAnalogStereoLinkSharesEnvelope()
+{
+    for (int mode = static_cast<int>(duskaudio::MultiCompMode::Opto);
+         mode <= static_cast<int>(duskaudio::MultiCompMode::StudioVCA); ++mode)
+    {
+        const auto linked = renderAnalogStereoLink(mode, 100.0f);
+        const auto independent = renderAnalogStereoLink(mode, 0.0f);
+        std::printf("analog stereo link: mode=%d linked=(%.7g, %.7g) independent-right=%.7g delta=%.3g GR=%.3f\n",
+                    mode, linked[0], linked[1], independent[1], linked[2], linked[3]);
+        require(linked[3] < -0.5f, "analog stereo-link stimulus establishes gain reduction");
+        require(independent[1] > 1.0e-4f, "analog stereo-link reference produces right-channel signal");
+        require(linked[2] < 1.0e-5f, "100% analog stereo link gives both channels the same envelope");
+        require(linked[1] < independent[1] * 0.9f,
+                "100% analog stereo link makes the hot left detector compress the right channel");
+    }
+}
+
 void testDigitalLookaheadMixAlignment()
 {
     // 100 Hz against 5 ms of lookahead is half a period: a dry path taken from
@@ -399,14 +566,28 @@ void testDigitalLookaheadMixAlignment()
 void testGoldenVectors()
 {
     constexpr int kSamples = 4096;
+    // These vectors were recorded from this extracted core. They detect drift
+    // from its current behaviour; they do NOT prove parity with the JUCE
+    // original, which was not used as the recording oracle.
+    //
+    // Opto is intentionally absent. It is being rebuilt against measured
+    // commercial-hardware data, and its old recorded values describe
+    // superseded behaviour. Do not restore them or use them to judge the new
+    // implementation: the hardware reference is the only Opto oracle.
+    constexpr duskaudio::MultiCompMode modes[] = {
+        duskaudio::MultiCompMode::FET, duskaudio::MultiCompMode::VCA,
+        duskaudio::MultiCompMode::Bus, duskaudio::MultiCompMode::StudioFET,
+        duskaudio::MultiCompMode::StudioVCA, duskaudio::MultiCompMode::Digital,
+        duskaudio::MultiCompMode::Multiband};
     // Re-recorded 2026-08-19: affected hardware modes encoded stale oversampling-rate coefficients.
-    constexpr float expectedRms[] = {0.166987091f, 0.610338330f, 0.162082925f, 0.269918233f,
+    constexpr float expectedRms[] = {0.610338330f, 0.162082925f, 0.269918233f,
                                      0.618480802f, 0.195874527f, 0.173109755f, 0.212109938f};
-    constexpr float expectedPeak[] = {0.366553396f, 1.912103295f, 0.350156724f, 0.797850311f,
+    constexpr float expectedPeak[] = {1.912103295f, 0.350156724f, 0.797850311f,
                                       1.836098075f, 0.657691538f, 0.349556237f, 0.815853894f};
-    std::puts("golden vectors: deterministic step/sine-burst RMS peak");
-    for (int mode = 0; mode < 8; ++mode)
+    std::puts("golden vectors: seven non-Opto modes, deterministic step/sine-burst RMS peak");
+    for (size_t vectorIndex = 0; vectorIndex < std::size(modes); ++vectorIndex)
     {
+        const int mode = static_cast<int>(modes[vectorIndex]);
         MultiCompDSP dsp;
         dsp.prepare(48000.0, 256);
         dsp.setOversampling(0);
@@ -417,7 +598,6 @@ void testGoldenVectors()
         dsp.setParameter(MultiCompDSP::Parameter::FetOutput, -4.0f);
         dsp.setParameter(MultiCompDSP::Parameter::FetAttack, 0.8f);
         dsp.setParameter(MultiCompDSP::Parameter::FetRelease, 150.0f);
-        dsp.setParameter(MultiCompDSP::Parameter::OptoPeakReduction, 65.0f);
         dsp.setParameter(MultiCompDSP::Parameter::VcaThreshold, -20.0f);
         dsp.setParameter(MultiCompDSP::Parameter::VcaRatio, 4.0f);
         dsp.setParameter(MultiCompDSP::Parameter::BusThreshold, -18.0f);
@@ -441,11 +621,11 @@ void testGoldenVectors()
         for (float sample : output) { sum += static_cast<double>(sample) * sample; peak = std::max(peak, std::abs(sample)); }
         const float valueRms = static_cast<float>(std::sqrt(sum / output.size()));
         std::printf("  mode=%d rms=%.9f peak=%.9f\n", mode, valueRms, peak);
-        const bool unchanged = std::abs(valueRms - expectedRms[mode]) <= 1.0e-4f
-                            && std::abs(peak - expectedPeak[mode]) <= 1.0e-4f;
+        const bool unchanged = std::abs(valueRms - expectedRms[vectorIndex]) <= 1.0e-4f
+                            && std::abs(peak - expectedPeak[vectorIndex]) <= 1.0e-4f;
         if (!unchanged)
             std::fprintf(stderr, "golden mismatch mode=%d expected=(%.9f, %.9f) actual=(%.9f, %.9f)\n",
-                         mode, expectedRms[mode], expectedPeak[mode], valueRms, peak);
+                         mode, expectedRms[vectorIndex], expectedPeak[vectorIndex], valueRms, peak);
         require(unchanged, "golden vector unchanged");
     }
 }
@@ -567,10 +747,66 @@ void testReprepareMultiband()
     {
         const float a = renderReprepareTone(reused, frequency);
         const float b = renderReprepareTone(fresh, frequency);
+        require(a > 1.0e-5f && b > 1.0e-5f, "re-prepare band-tone comparison produces output");
         maxDelta = std::max(maxDelta, std::abs(a - b));
     }
     require(maxDelta < 1.0e-6f, "re-prepare 48 kHz to 96 kHz matches fresh multiband");
     std::printf("multiband re-prepare: max band-tone energy delta %.9g\n", maxDelta);
+}
+
+void testSameRateReprepare()
+{
+    auto configure = [](MultiCompDSP& dsp) {
+        dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+        dsp.setOversampling(2);
+        dsp.setMix(73.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::GlobalLookahead, 10.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalLookahead, 10.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -30.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 8.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalAttack, 0.3f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalRelease, 80.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    };
+
+    MultiCompDSP repeated, fresh;
+    configure(repeated);
+    repeated.prepare(48000.0, 256);
+    repeated.prepare(48000.0, 256);
+    configure(fresh);
+    fresh.prepare(48000.0, 256);
+
+    std::array<float, 256> inputLeft{}, inputRight{}, repeatedLeft{}, repeatedRight{}, freshLeft{}, freshRight{};
+    const float* input[] = {inputLeft.data(), inputRight.data()};
+    float* repeatedOutput[] = {repeatedLeft.data(), repeatedRight.data()};
+    float* freshOutput[] = {freshLeft.data(), freshRight.data()};
+    float maxDelta = 0.0f, outputPeak = 0.0f;
+    for (int block = 0; block < 8; ++block)
+    {
+        for (int i = 0; i < 256; ++i)
+        {
+            const int n = block * 256 + i;
+            inputLeft[static_cast<size_t>(i)] = 0.6f * std::sin(2.0f * kPi * 997.0f * static_cast<float>(n) / 48000.0f);
+            inputRight[static_cast<size_t>(i)] = 0.3f * std::sin(2.0f * kPi * 431.0f * static_cast<float>(n) / 48000.0f);
+        }
+        repeated.processBlock(input, repeatedOutput, 2, 256);
+        fresh.processBlock(input, freshOutput, 2, 256);
+        for (int i = 0; i < 256; ++i)
+            for (int ch = 0; ch < 2; ++ch)
+            {
+                const float a = ch == 0 ? repeatedLeft[static_cast<size_t>(i)] : repeatedRight[static_cast<size_t>(i)];
+                const float b = ch == 0 ? freshLeft[static_cast<size_t>(i)] : freshRight[static_cast<size_t>(i)];
+                maxDelta = std::max(maxDelta, std::abs(a - b));
+                outputPeak = std::max(outputPeak, std::abs(a));
+            }
+    }
+    require(outputPeak > 1.0e-3f, "same-rate re-prepare comparison produces signal");
+    require(repeated.getGainReduction() < -0.5f, "same-rate re-prepare comparison produces compression");
+    require(repeated.getLatencySamples() == fresh.getLatencySamples(),
+            "same-rate re-prepare preserves latency configuration");
+    require(maxDelta < 1.0e-7f, "same-rate re-prepare matches a freshly prepared core");
+    std::printf("same-rate re-prepare: latency=%d max output delta %.9g\n",
+                repeated.getLatencySamples(), maxDelta);
 }
 
 float renderMultibandTone(float mix, float frequency)
@@ -665,7 +901,7 @@ void testMultibandBypassAndZeroLatency()
     const float* ip[] = {input.data()};
     float* referenceOp[] = {referenceOut.data()};
     float* bypassedOp[] = {bypassedOut.data()};
-    float worst = 0.0f;
+    float worst = 0.0f, referencePeak = 0.0f;
     for (int block = 0; block < 20; ++block)
     {
         for (int i = 0; i < 256; ++i)
@@ -674,8 +910,12 @@ void testMultibandBypassAndZeroLatency()
         bypassed.processBlock(ip, bypassedOp, 1, 256);
         if (block >= 16)
             for (int i = 0; i < 256; ++i)
+            {
+                referencePeak = std::max(referencePeak, std::abs(referenceOut[static_cast<size_t>(i)]));
                 worst = std::max(worst, std::abs(referenceOut[static_cast<size_t>(i)] - bypassedOut[static_cast<size_t>(i)]));
+            }
     }
+    require(referencePeak > 1.0e-4f, "multiband bypass comparison produces output");
     require(worst < 1.0e-6f, "disabled multiband band skips envelope and makeup");
 
     MultiCompDSP zeroDelay;
@@ -754,6 +994,8 @@ void testAutoGainBypassSettleBoundary()
     const float boundaryStep = std::abs(firstSettledSample - lastTransitionSample);
     std::printf("auto gain bypass boundary: last=%.9g first=%.9g step=%.9g\n",
                 lastTransitionSample, firstSettledSample, boundaryStep);
+    require(std::abs(lastTransitionSample) > 1.0e-4f && std::abs(firstSettledSample) > 1.0e-4f,
+            "auto-gain bypass boundary produces output on both sides");
     require(boundaryStep < 1.0e-5f, "auto-gained bypass transition and settled bypass share one endpoint");
 }
 
@@ -808,6 +1050,8 @@ void testAutoGainNeutralisesManualOutput()
             neutralPeak = std::max(neutralPeak, std::abs(neutralOut[static_cast<size_t>(i)]));
             highPeak = std::max(highPeak, std::abs(highOut[static_cast<size_t>(i)]));
         }
+        require(neutralPeak > 1.0e-5f && highPeak > 1.0e-5f,
+                "auto-gain manual-output comparison produces output");
         if (mode == static_cast<int>(duskaudio::MultiCompMode::FET))
             fetPeakRatio = highPeak / std::max(neutralPeak, 1.0e-9f);
     }
@@ -862,6 +1106,70 @@ void testBypassCompletesDuringSidechainListen()
     std::printf("bypass during sidechain listen: final sample %.9g; dry error %.9g\n",
                 output.back(), maxDryError);
     require(maxDryError < 1.0e-7f, "bypass reaches settled dry output while sidechain Listen remains on");
+}
+
+void testSidechainListenClearsGainReductionMeters()
+{
+    MultiCompDSP dsp;
+    dsp.prepare(48000.0, 256);
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Multiband));
+    configureStrongCompression(dsp, static_cast<int>(duskaudio::MultiCompMode::Multiband));
+    std::array<float, 256> input{}, output{};
+    input.fill(0.8f);
+    const float* ip[] = {input.data()}; float* op[] = {output.data()};
+    for (int block = 0; block < 16; ++block) dsp.processBlock(ip, op, 1, 256);
+    const float activeMaster = dsp.getGainReduction();
+    float activeBand = 0.0f;
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+        activeBand = std::min(activeBand, dsp.getBandGainReduction(band));
+    require(activeMaster < -1.0f && activeBand < -1.0f,
+            "Listen meter test establishes active multiband compression");
+
+    dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 1.0f);
+    dsp.processBlock(ip, op, 1, 256);
+    float listenBandMagnitude = 0.0f;
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+        listenBandMagnitude = std::max(listenBandMagnitude, std::abs(dsp.getBandGainReduction(band)));
+    std::printf("Listen GR meters: active master %.4f max-band %.4f; Listen master %.4f max-band %.4f\n",
+                activeMaster, activeBand, dsp.getGainReduction(), listenBandMagnitude);
+    require(dsp.getGainReduction() == 0.0f && listenBandMagnitude == 0.0f,
+            "sidechain Listen clears master and per-band gain-reduction meters");
+}
+
+// Known failure, deliberately not called from main: Listen switches directly
+// between program and monitor audio. A correct fix needs persistent ramp state,
+// which would require changing MultiCompDSP.hpp outside this batch's hard scope.
+// Keep this compiled so enabling the call below reproduces the click as a test
+// failure instead of preserving the discontinuity as accepted behaviour.
+[[maybe_unused]] void testSidechainListenSwitchIsSmoothed()
+{
+    MultiCompDSP dsp;
+    dsp.prepare(48000.0, 256);
+    dsp.setOversampling(0);
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 1.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain, 1.0f);
+    std::array<float, 256> input{}, sidechain{}, output{};
+    input.fill(0.1f);
+    sidechain.fill(0.8f);
+    const float* ip[] = {input.data()}; const float* sc[] = {sidechain.data()}; float* op[] = {output.data()};
+    for (int block = 0; block < 16; ++block) dsp.processBlockExternal(ip, sc, op, 1, 256);
+    float previous = output.back(), largestStep = 0.0f;
+    auto measureBlock = [&] {
+        dsp.processBlockExternal(ip, sc, op, 1, 256);
+        largestStep = std::max(largestStep, std::abs(output.front() - previous));
+        for (int i = 1; i < 256; ++i)
+            largestStep = std::max(largestStep, std::abs(output[static_cast<size_t>(i)] - output[static_cast<size_t>(i - 1)]));
+        previous = output.back();
+    };
+    dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 1.0f);
+    measureBlock();
+    dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 0.0f);
+    measureBlock();
+    std::printf("Listen switch maximum adjacent-sample step %.6f\n", largestStep);
+    require(largestStep < 0.01f, "sidechain Listen on/off uses a short monitor ramp");
 }
 
 void testSettledBypassClearsGainReductionMeters()
@@ -939,8 +1247,10 @@ void testOptoStereoDetectorIsolation()
         (void)modes.process(duskaudio::MultiCompMode::Opto, 0.0f, 1, 0.0f, parameters);
     }
 
+    const float leftGr = modes.gainReduction(duskaudio::MultiCompMode::Opto, 0);
     const float rightGr = modes.gainReduction(duskaudio::MultiCompMode::Opto, 1);
-    std::printf("opto stereo isolation: silent-right GR %.9g dB\n", rightGr);
+    std::printf("opto stereo isolation: active-left GR %.4f; silent-right GR %.9g dB\n", leftGr, rightGr);
+    require(leftGr < -0.5f, "Opto isolation stimulus establishes left-channel gain reduction");
     require(std::abs(rightGr) < 1.0e-7f, "left-only Opto signal does not alter right detector gain reduction");
 }
 
@@ -963,26 +1273,137 @@ void testHardwareRateRefreshAfterOversamplingChange()
         fresh.prepare(48000.0, 256, 1);
         fresh.reset();
 
-        float maxDelta = 0.0f;
+        float maxDelta = 0.0f, signalPeak = 0.0f;
         for (int i = 0; i < 8192; ++i)
         {
             const float input = 0.2f * std::sin(2.0f * kPi * 997.0f * static_cast<float>(i) / 48000.0f);
             const float a = switched.process(mode, input, 0, input, parameters);
             const float b = fresh.process(mode, input, 0, input, parameters);
             maxDelta = std::max(maxDelta, std::abs(a - b));
+            signalPeak = std::max(signalPeak, std::max(std::abs(a), std::abs(b)));
         }
         std::printf("hardware rate refresh: mode=%d max_delta=%.9g\n", static_cast<int>(mode), maxDelta);
+        require(signalPeak > 1.0e-4f, "hardware rate-refresh comparison produces output");
         require(maxDelta < 1.0e-7f, "oversampling rate switch matches freshly prepared hardware coefficients");
     }
 }
 
+void testHostParameterTapers()
+{
+    const auto& ratio = multicompp::kParams[static_cast<size_t>(multicompp::ParamId::VcaRatio)];
+    const auto& attack = multicompp::kParams[static_cast<size_t>(multicompp::ParamId::DigitalAttack)];
+    const float positions[] = {0.25f, 0.5f, 0.75f};
+    const float expectedRatio[] = {2.2f, 12.8f, 46.6f};
+    const float expectedAttack[] = {4.93f, 49.62f, 191.66f};
+    require(multicompp::hostMin(ratio) == 0.0f && multicompp::hostMax(ratio) == 1.0f,
+            "tapered VCA Ratio is declared in normalized host space");
+    require(multicompp::hostMin(attack) == 0.0f && multicompp::hostMax(attack) == 1.0f,
+            "tapered Digital Attack is declared in normalized host space");
+    for (size_t i = 0; i < 3; ++i)
+    {
+        require(std::abs(multicompp::hostToPlain(ratio, positions[i]) - expectedRatio[i]) < 0.011f,
+                "VCA Ratio follows JUCE skew at quarter points");
+        require(std::abs(multicompp::hostToPlain(attack, positions[i]) - expectedAttack[i]) < 0.011f,
+                "Digital Attack follows JUCE skew at quarter points");
+    }
+    std::puts("host tapers: VCA Ratio and Digital Attack match JUCE at 0.25/0.5/0.75");
+}
+
+void testStrictStateValidationAndRoundTrip()
+{
+    multicompp::StateValues saved{};
+    for (int i = 0; i < multicompp::kParamCount; ++i)
+    {
+        const auto& d = multicompp::kParams[static_cast<size_t>(i)];
+        saved[static_cast<size_t>(i)] = d.integer ? multicompp::hostDefault(d)
+            : multicompp::hostMin(d) + (multicompp::hostMax(d) - multicompp::hostMin(d))
+                * (0.1f + 0.8f * static_cast<float>((i * 37) % 101) / 100.0f);
+    }
+    for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
+    {
+        const int relative = i - multicompp::kBandBase;
+        const auto d = multicompp::bandParam(relative % 8, relative / 8);
+        saved[static_cast<size_t>(i)] = d.integer ? multicompp::hostDefault(d)
+            : multicompp::hostMin(d) + (multicompp::hostMax(d) - multicompp::hostMin(d))
+                * (0.1f + 0.8f * static_cast<float>((i * 29) % 101) / 100.0f);
+    }
+
+    const std::string valid = multicompp::encodeState(saved);
+    multicompp::StateValues restored{};
+    require(multicompp::decodeState(valid, restored), "complete state accepted");
+    require(std::memcmp(saved.data(), restored.data(), sizeof(saved)) == 0,
+            "state save/restore is bit-identical for every parameter");
+
+    auto rejectedWithoutMutation = [&](std::string invalid, const char* message) {
+        multicompp::StateValues before{};
+        before.fill(0.1234567f);
+        const auto unchanged = before;
+        require(!multicompp::decodeState(invalid, before), message);
+        require(std::memcmp(before.data(), unchanged.data(), sizeof(before)) == 0,
+                "rejected state changes zero parameters");
+    };
+
+    std::string malformed = valid;
+    const size_t ratio = malformed.find(";digital_ratio=");
+    const size_t ratioEnd = malformed.find(';', ratio + 1);
+    malformed.replace(ratio + std::strlen(";digital_ratio="),
+                      ratioEnd - ratio - std::strlen(";digital_ratio="), "garbage");
+    rejectedWithoutMutation(malformed, "malformed state rejected");
+
+    std::string truncated = valid;
+    truncated.erase(truncated.rfind(';'));
+    rejectedWithoutMutation(truncated, "truncated state rejected");
+
+    const size_t mix = valid.find(";mix=");
+    const size_t mixEnd = valid.find(';', mix + 1);
+    rejectedWithoutMutation(valid + valid.substr(mix, mixEnd - mix), "duplicate state key rejected");
+    rejectedWithoutMutation(valid + ";unknown=0", "unknown state key rejected");
+    std::puts("state validation: malformed/truncated/duplicate/unknown rejected atomically; round-trip exact");
+}
+
+void testFactoryPresetOwnership()
+{
+    for (const auto& preset : multicompp::kFactoryPresets)
+    {
+        std::array<float, multicompp::kParamCount> values{};
+        values.fill(-123.0f);
+        values[static_cast<size_t>(multicompp::ParamId::Bypass)] = 1.0f;
+        values[static_cast<size_t>(multicompp::ParamId::Oversampling)] = 2.0f;
+        values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)] = 1.0f;
+        multicompp::forEachPresetParam(preset,
+            [&](multicompp::CoreParameter parameter, float value) {
+                const int index = multicompp::coreParamIndex(parameter);
+                require(index >= 0, "preset-owned core parameter remains host-visible");
+                values[static_cast<size_t>(index)] = value;
+            });
+        require(values[static_cast<size_t>(multicompp::ParamId::Bypass)] == 1.0f,
+                "factory preset leaves Bypass set");
+        require(values[static_cast<size_t>(multicompp::ParamId::Oversampling)] == 2.0f,
+                "factory preset leaves Oversampling untouched");
+        require(values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)] == 1.0f,
+                "factory preset leaves External Sidechain untouched");
+    }
+    require(multicompp::coreParamIndex(MultiCompDSP::Parameter::EnvelopeCurve) < 0
+                && multicompp::coreParamIndex(MultiCompDSP::Parameter::SaturationMode) < 0,
+            "JUCE-inert controls are absent from the DPF parameter table");
+    std::puts("factory preset ownership: bypass/oversampling/external-SC/bands untouched");
+}
+
+static_assert(multicompp::kParamCount == 63,
+              "DPF host table must exclude the two JUCE-inert controls");
+
 int main()
 {
+    testHostParameterTapers();
+    testStrictStateValidationAndRoundTrip();
+    testFactoryPresetOwnership();
     testTruePeakOversampledPhaseInterpolation();
     testCrossoverAutomationContinuity();
     testFourTimesHighFrequencyMixCoherence();
     testMultibandEnabledTopology();
     testSettledBypassClearsGainReductionMeters();
+    testSidechainListenClearsGainReductionMeters();
+    // testSidechainListenSwitchIsSmoothed(); // Known failure; see test comment.
     testBypassCompletesDuringSidechainListen();
     testAutoGainResetsOnModeChange();
     testAutoGainNeutralisesManualOutput();
@@ -996,11 +1417,13 @@ int main()
     testEnvelopeAndReset();
     testMixBypassAndBlockEdges();
     testLatencyMixBypassAndDigitalStereo();
+    testAnalogStereoLinkSharesEnvelope();
     testDigitalLookaheadMixAlignment();
     testMultibandMixAlignment();
     testSidechainEq();
     testMultibandBypassAndZeroLatency();
     testReprepareMultiband();
+    testSameRateReprepare();
     testGoldenVectors();
     std::puts("Multi-Comp core tests: PASS");
     return 0;

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -1150,6 +1150,11 @@ void testSidechainListenSwitchIsSmoothed()
     const float* ip[] = {input.data()}; const float* sc[] = {sidechain.data()}; float* op[] = {output.data()};
     for (int block = 0; block < 16; ++block) dsp.processBlockExternal(ip, sc, op, 1, 256);
     float previous = output.back();
+    struct TransitionResult
+    {
+        float largestStep;
+        float endpoint;
+    };
     auto measureTransition = [&](float target) {
         float largestStep = 0.0f;
         dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, target);
@@ -1161,14 +1166,23 @@ void testSidechainListenSwitchIsSmoothed()
                 largestStep = std::max(largestStep, std::abs(output[static_cast<size_t>(i)] - output[static_cast<size_t>(i - 1)]));
             previous = output.back();
         }
-        return largestStep;
+        return TransitionResult{largestStep, output.back()};
     };
-    const float listenOnStep = measureTransition(1.0f);
-    const float listenOffStep = measureTransition(0.0f);
-    std::printf("Listen switch maximum adjacent-sample step: on %.6f; off %.6f\n",
-                listenOnStep, listenOffStep);
-    require(listenOnStep < 0.01f, "sidechain Listen on uses a short monitor ramp");
-    require(listenOffStep < 0.01f, "sidechain Listen off uses a short monitor ramp");
+    const TransitionResult listenOn = measureTransition(1.0f);
+    const TransitionResult listenOff = measureTransition(0.0f);
+    // The sidechain monitor includes its configured filtering, so allow the
+    // small steady-state offset from the raw 0.8 test signal.
+    constexpr float endpointTolerance = 2.0e-4f;
+    std::printf("Listen switch maximum adjacent-sample step: on %.6f; off %.6f; "
+                "endpoints on %.6f off %.6f (tolerance %.1e)\n",
+                listenOn.largestStep, listenOff.largestStep,
+                listenOn.endpoint, listenOff.endpoint, endpointTolerance);
+    require(listenOn.largestStep < 0.01f, "sidechain Listen on uses a short monitor ramp");
+    require(listenOff.largestStep < 0.01f, "sidechain Listen off uses a short monitor ramp");
+    require(std::abs(listenOn.endpoint - sidechain.back()) <= endpointTolerance,
+            "sidechain Listen on reaches the listened signal");
+    require(std::abs(listenOff.endpoint - input.back()) <= endpointTolerance,
+            "sidechain Listen off reaches the non-listened signal");
 }
 
 void testSettledBypassClearsGainReductionMeters()

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -1,15 +1,11 @@
 #include "../MultiCompDSP.hpp"
 #include "../../../shared-dpf/dsp/DuskCrossover.hpp"
-#include "../../dpf-plugin/MultiCompParams.hpp"
-#include "../../dpf-plugin/MultiCompProgramPresets.hpp"
 
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
-#include <string>
 #include <vector>
 
 using duskaudio::DuskCrossover;
@@ -541,6 +537,8 @@ void testAnalogStereoLinkSharesEnvelope()
                     mode, linked[0], linked[1], independent[1], linked[2], linked[3]);
         require(linked[3] < -0.5f, "analog stereo-link stimulus establishes gain reduction");
         require(independent[1] > 1.0e-4f, "analog stereo-link reference produces right-channel signal");
+        require(linked[0] > 1.0e-4f && linked[1] > 1.0e-4f,
+                "analog stereo-link render produces nonzero output on both channels");
         require(linked[2] < 1.0e-5f, "100% analog stereo link gives both channels the same envelope");
         require(linked[1] < independent[1] * 0.9f,
                 "100% analog stereo link makes the hot left detector compress the right channel");
@@ -1136,12 +1134,7 @@ void testSidechainListenClearsGainReductionMeters()
             "sidechain Listen clears master and per-band gain-reduction meters");
 }
 
-// Known failure, deliberately not called from main: Listen switches directly
-// between program and monitor audio. A correct fix needs persistent ramp state,
-// which would require changing MultiCompDSP.hpp outside this batch's hard scope.
-// Keep this compiled so enabling the call below reproduces the click as a test
-// failure instead of preserving the discontinuity as accepted behaviour.
-[[maybe_unused]] void testSidechainListenSwitchIsSmoothed()
+void testSidechainListenSwitchIsSmoothed()
 {
     MultiCompDSP dsp;
     dsp.prepare(48000.0, 256);
@@ -1156,20 +1149,26 @@ void testSidechainListenClearsGainReductionMeters()
     sidechain.fill(0.8f);
     const float* ip[] = {input.data()}; const float* sc[] = {sidechain.data()}; float* op[] = {output.data()};
     for (int block = 0; block < 16; ++block) dsp.processBlockExternal(ip, sc, op, 1, 256);
-    float previous = output.back(), largestStep = 0.0f;
-    auto measureBlock = [&] {
-        dsp.processBlockExternal(ip, sc, op, 1, 256);
-        largestStep = std::max(largestStep, std::abs(output.front() - previous));
-        for (int i = 1; i < 256; ++i)
-            largestStep = std::max(largestStep, std::abs(output[static_cast<size_t>(i)] - output[static_cast<size_t>(i - 1)]));
-        previous = output.back();
+    float previous = output.back();
+    auto measureTransition = [&](float target) {
+        float largestStep = 0.0f;
+        dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, target);
+        for (int block = 0; block < 6; ++block)
+        {
+            dsp.processBlockExternal(ip, sc, op, 1, 256);
+            largestStep = std::max(largestStep, std::abs(output.front() - previous));
+            for (int i = 1; i < 256; ++i)
+                largestStep = std::max(largestStep, std::abs(output[static_cast<size_t>(i)] - output[static_cast<size_t>(i - 1)]));
+            previous = output.back();
+        }
+        return largestStep;
     };
-    dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 1.0f);
-    measureBlock();
-    dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 0.0f);
-    measureBlock();
-    std::printf("Listen switch maximum adjacent-sample step %.6f\n", largestStep);
-    require(largestStep < 0.01f, "sidechain Listen on/off uses a short monitor ramp");
+    const float listenOnStep = measureTransition(1.0f);
+    const float listenOffStep = measureTransition(0.0f);
+    std::printf("Listen switch maximum adjacent-sample step: on %.6f; off %.6f\n",
+                listenOnStep, listenOffStep);
+    require(listenOnStep < 0.01f, "sidechain Listen on uses a short monitor ramp");
+    require(listenOffStep < 0.01f, "sidechain Listen off uses a short monitor ramp");
 }
 
 void testSettledBypassClearsGainReductionMeters()
@@ -1288,122 +1287,15 @@ void testHardwareRateRefreshAfterOversamplingChange()
     }
 }
 
-void testHostParameterTapers()
-{
-    const auto& ratio = multicompp::kParams[static_cast<size_t>(multicompp::ParamId::VcaRatio)];
-    const auto& attack = multicompp::kParams[static_cast<size_t>(multicompp::ParamId::DigitalAttack)];
-    const float positions[] = {0.25f, 0.5f, 0.75f};
-    const float expectedRatio[] = {2.2f, 12.8f, 46.6f};
-    const float expectedAttack[] = {4.93f, 49.62f, 191.66f};
-    require(multicompp::hostMin(ratio) == 0.0f && multicompp::hostMax(ratio) == 1.0f,
-            "tapered VCA Ratio is declared in normalized host space");
-    require(multicompp::hostMin(attack) == 0.0f && multicompp::hostMax(attack) == 1.0f,
-            "tapered Digital Attack is declared in normalized host space");
-    for (size_t i = 0; i < 3; ++i)
-    {
-        require(std::abs(multicompp::hostToPlain(ratio, positions[i]) - expectedRatio[i]) < 0.011f,
-                "VCA Ratio follows JUCE skew at quarter points");
-        require(std::abs(multicompp::hostToPlain(attack, positions[i]) - expectedAttack[i]) < 0.011f,
-                "Digital Attack follows JUCE skew at quarter points");
-    }
-    std::puts("host tapers: VCA Ratio and Digital Attack match JUCE at 0.25/0.5/0.75");
-}
-
-void testStrictStateValidationAndRoundTrip()
-{
-    multicompp::StateValues saved{};
-    for (int i = 0; i < multicompp::kParamCount; ++i)
-    {
-        const auto& d = multicompp::kParams[static_cast<size_t>(i)];
-        saved[static_cast<size_t>(i)] = d.integer ? multicompp::hostDefault(d)
-            : multicompp::hostMin(d) + (multicompp::hostMax(d) - multicompp::hostMin(d))
-                * (0.1f + 0.8f * static_cast<float>((i * 37) % 101) / 100.0f);
-    }
-    for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
-    {
-        const int relative = i - multicompp::kBandBase;
-        const auto d = multicompp::bandParam(relative % 8, relative / 8);
-        saved[static_cast<size_t>(i)] = d.integer ? multicompp::hostDefault(d)
-            : multicompp::hostMin(d) + (multicompp::hostMax(d) - multicompp::hostMin(d))
-                * (0.1f + 0.8f * static_cast<float>((i * 29) % 101) / 100.0f);
-    }
-
-    const std::string valid = multicompp::encodeState(saved);
-    multicompp::StateValues restored{};
-    require(multicompp::decodeState(valid, restored), "complete state accepted");
-    require(std::memcmp(saved.data(), restored.data(), sizeof(saved)) == 0,
-            "state save/restore is bit-identical for every parameter");
-
-    auto rejectedWithoutMutation = [&](std::string invalid, const char* message) {
-        multicompp::StateValues before{};
-        before.fill(0.1234567f);
-        const auto unchanged = before;
-        require(!multicompp::decodeState(invalid, before), message);
-        require(std::memcmp(before.data(), unchanged.data(), sizeof(before)) == 0,
-                "rejected state changes zero parameters");
-    };
-
-    std::string malformed = valid;
-    const size_t ratio = malformed.find(";digital_ratio=");
-    const size_t ratioEnd = malformed.find(';', ratio + 1);
-    malformed.replace(ratio + std::strlen(";digital_ratio="),
-                      ratioEnd - ratio - std::strlen(";digital_ratio="), "garbage");
-    rejectedWithoutMutation(malformed, "malformed state rejected");
-
-    std::string truncated = valid;
-    truncated.erase(truncated.rfind(';'));
-    rejectedWithoutMutation(truncated, "truncated state rejected");
-
-    const size_t mix = valid.find(";mix=");
-    const size_t mixEnd = valid.find(';', mix + 1);
-    rejectedWithoutMutation(valid + valid.substr(mix, mixEnd - mix), "duplicate state key rejected");
-    rejectedWithoutMutation(valid + ";unknown=0", "unknown state key rejected");
-    std::puts("state validation: malformed/truncated/duplicate/unknown rejected atomically; round-trip exact");
-}
-
-void testFactoryPresetOwnership()
-{
-    for (const auto& preset : multicompp::kFactoryPresets)
-    {
-        std::array<float, multicompp::kParamCount> values{};
-        values.fill(-123.0f);
-        values[static_cast<size_t>(multicompp::ParamId::Bypass)] = 1.0f;
-        values[static_cast<size_t>(multicompp::ParamId::Oversampling)] = 2.0f;
-        values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)] = 1.0f;
-        multicompp::forEachPresetParam(preset,
-            [&](multicompp::CoreParameter parameter, float value) {
-                const int index = multicompp::coreParamIndex(parameter);
-                require(index >= 0, "preset-owned core parameter remains host-visible");
-                values[static_cast<size_t>(index)] = value;
-            });
-        require(values[static_cast<size_t>(multicompp::ParamId::Bypass)] == 1.0f,
-                "factory preset leaves Bypass set");
-        require(values[static_cast<size_t>(multicompp::ParamId::Oversampling)] == 2.0f,
-                "factory preset leaves Oversampling untouched");
-        require(values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)] == 1.0f,
-                "factory preset leaves External Sidechain untouched");
-    }
-    require(multicompp::coreParamIndex(MultiCompDSP::Parameter::EnvelopeCurve) < 0
-                && multicompp::coreParamIndex(MultiCompDSP::Parameter::SaturationMode) < 0,
-            "JUCE-inert controls are absent from the DPF parameter table");
-    std::puts("factory preset ownership: bypass/oversampling/external-SC/bands untouched");
-}
-
-static_assert(multicompp::kParamCount == 63,
-              "DPF host table must exclude the two JUCE-inert controls");
-
 int main()
 {
-    testHostParameterTapers();
-    testStrictStateValidationAndRoundTrip();
-    testFactoryPresetOwnership();
     testTruePeakOversampledPhaseInterpolation();
     testCrossoverAutomationContinuity();
     testFourTimesHighFrequencyMixCoherence();
     testMultibandEnabledTopology();
     testSettledBypassClearsGainReductionMeters();
     testSidechainListenClearsGainReductionMeters();
-    // testSidechainListenSwitchIsSmoothed(); // Known failure; see test comment.
+    testSidechainListenSwitchIsSmoothed();
     testBypassCompletesDuringSidechainListen();
     testAutoGainResetsOnModeChange();
     testAutoGainNeutralisesManualOutput();

--- a/plugins/multi-comp/dpf-plugin/CMakeLists.txt
+++ b/plugins/multi-comp/dpf-plugin/CMakeLists.txt
@@ -28,4 +28,13 @@ if(NOT CMAKE_CROSSCOMPILING)
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared-dpf/dsp")
   target_compile_features(MultiCompCoreTest PRIVATE cxx_std_17)
   add_test(NAME MultiCompCore COMMAND MultiCompCoreTest)
+
+  add_executable(MultiCompPluginLayerTest
+    MultiCompPluginLayerTests.cpp)
+  target_include_directories(MultiCompPluginLayerTest PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../core"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../shared-dpf/dsp")
+  target_compile_features(MultiCompPluginLayerTest PRIVATE cxx_std_17)
+  add_test(NAME MultiCompPluginLayer COMMAND MultiCompPluginLayerTest)
 endif()

--- a/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
@@ -2,6 +2,7 @@
 
 #include "../core/MultiCompDSP.hpp"
 #include "../core/MultiCompPresets.hpp"
+#include <algorithm>
 #include <array>
 #include <charconv>
 #include <cmath>
@@ -13,8 +14,18 @@
 namespace multicompp
 {
 using CoreParameter = duskaudio::MultiCompDSP::Parameter;
-struct Param { const char* id; const char* name; const char* unit; float min, max, def; CoreParameter core; bool integer; };
-struct BandParam { const char* id; const char* name; const char* unit; float min, max, def; duskaudio::MultiCompDSP::MultibandParameter core; bool integer; };
+struct Param
+{
+    const char* id; const char* name; const char* unit;
+    float min, max, def; CoreParameter core; bool integer;
+    float interval = 0.0f, skew = 1.0f;
+};
+struct BandParam
+{
+    const char* id; const char* name; const char* unit;
+    float min, max, def; duskaudio::MultiCompDSP::MultibandParameter core; bool integer;
+    float interval = 0.0f, skew = 1.0f;
+};
 
 enum class ParamId : uint32_t {
  Mode, Bypass, StereoLink, Mix, SidechainHP, TruePeakEnable, TruePeakQuality,
@@ -25,63 +36,42 @@ enum class ParamId : uint32_t {
  BusAttack, BusRelease, BusMakeup, BusMix, StudioVcaThreshold, StudioVcaRatio,
  StudioVcaAttack, StudioVcaRelease, StudioVcaOutput, DigitalThreshold, DigitalRatio,
  DigitalKnee, DigitalAttack, DigitalRelease, DigitalLookahead, DigitalMix, DigitalOutput,
- DigitalAdaptive, Crossover1, Crossover2, Crossover3, EnvelopeCurve, GlobalSidechainListen,
- MbMix, MbOutput, NoiseEnable, SaturationMode, ScLowFreq, ScLowGain, ScHighFreq,
+ DigitalAdaptive, Crossover1, Crossover2, Crossover3, GlobalSidechainListen,
+ MbMix, MbOutput, NoiseEnable, ScLowFreq, ScLowGain, ScHighFreq,
  ScHighGain, StereoLinkMode, Count
 };
 
-// The first 65 entries mirror the active core/JUCE controls and ranges. The
-// retired studio_vca_mix parameter is intentionally absent.
-inline constexpr std::array<Param, 65> kParams = {{
+// Single source of truth for host symbols, physical ranges/defaults, JUCE taper
+// metadata, UI mapping and state keys. The retired studio_vca_mix plus the
+// JUCE-inert envelope_curve and saturation_mode controls are absent.
+inline constexpr std::array<Param, 63> kParams = {{
  {"mode","Mode","",0,7,0,CoreParameter::Mode,true}, {"bypass","Bypass","",0,1,0,CoreParameter::Bypass,true},
  {"stereo_link","Stereo Link","%",0,100,100,CoreParameter::StereoLink,false}, {"mix","Mix","%",0,100,100,CoreParameter::Mix,false},
- {"sidechain_hp","SC HP Filter","Hz",0,500,0,CoreParameter::SidechainHP,false}, {"true_peak_enable","True Peak","",0,1,0,CoreParameter::TruePeakEnable,true},
+ {"sidechain_hp","SC HP Filter","Hz",0,500,0,CoreParameter::SidechainHP,false,1,0.5f}, {"true_peak_enable","True Peak","",0,1,0,CoreParameter::TruePeakEnable,true},
  {"true_peak_quality","TP Quality","",0,1,0,CoreParameter::TruePeakQuality,true}, {"sidechain_enable","External Sidechain","",0,1,0,CoreParameter::ExternalSidechain,true},
  {"auto_makeup","Auto Makeup","",0,1,0,CoreParameter::AutoMakeup,true}, {"distortion_type","Distortion","",0,3,0,CoreParameter::Distortion,true},
  {"distortion_amount","Distortion Amt","%",0,100,50,CoreParameter::DistortionAmount,false}, {"oversampling","Oversampling","",0,2,1,CoreParameter::Oversampling,true},
  {"global_lookahead","Lookahead","ms",0,10,0,CoreParameter::GlobalLookahead,false},
  {"opto_peak_reduction","Peak Reduction","%",0,100,0,CoreParameter::OptoPeakReduction,false}, {"opto_gain","Gain","%",0,100,50,CoreParameter::OptoGain,false}, {"opto_limit","Limit Mode","",0,1,0,CoreParameter::OptoLimit,true},
- {"fet_input","Input","dB",-20,40,0,CoreParameter::FetInput,false}, {"fet_output","Output","dB",-20,20,0,CoreParameter::FetOutput,false}, {"fet_attack","Attack","ms",0.02f,80,0.2f,CoreParameter::FetAttack,false}, {"fet_release","Release","ms",50,1100,400,CoreParameter::FetRelease,false}, {"fet_ratio","Ratio",":1",0,4,0,CoreParameter::FetRatio,true}, {"fet_curve_mode","Curve Mode","",0,1,0,CoreParameter::FetCurve,true}, {"fet_transient","Transient","%",0,100,0,CoreParameter::FetTransient,false}, {"fet_threshold","Threshold","dB",-60,0,-10,CoreParameter::FetThreshold,false},
- {"vca_threshold","Threshold","dB",-38,12,0,CoreParameter::VcaThreshold,false}, {"vca_ratio","Ratio",":1",1,120,4,CoreParameter::VcaRatio,false}, {"vca_attack","Attack","ms",0.1f,50,1,CoreParameter::VcaAttack,false}, {"vca_release","Release","ms",10,5000,100,CoreParameter::VcaRelease,false}, {"vca_output","Output","dB",-20,20,0,CoreParameter::VcaOutput,false}, {"vca_overeasy","Over Easy","",0,1,0,CoreParameter::VcaOverEasy,true}, {"vca_detector_mode","VCA Detector","",0,1,0,CoreParameter::VcaClassicDetector,true},
+ {"fet_input","Input","dB",-20,40,0,CoreParameter::FetInput,false}, {"fet_output","Output","dB",-20,20,0,CoreParameter::FetOutput,false}, {"fet_attack","Attack","ms",0.02f,80,0.2f,CoreParameter::FetAttack,false,0.01f,0.3f}, {"fet_release","Release","ms",50,1100,400,CoreParameter::FetRelease,false}, {"fet_ratio","Ratio",":1",0,4,0,CoreParameter::FetRatio,true}, {"fet_curve_mode","Curve Mode","",0,1,0,CoreParameter::FetCurve,true}, {"fet_transient","Transient","%",0,100,0,CoreParameter::FetTransient,false}, {"fet_threshold","Threshold","dB",-60,0,-10,CoreParameter::FetThreshold,false},
+ {"vca_threshold","Threshold","dB",-38,12,0,CoreParameter::VcaThreshold,false}, {"vca_ratio","Ratio",":1",1,120,4,CoreParameter::VcaRatio,false,0.1f,0.3f}, {"vca_attack","Attack","ms",0.1f,50,1,CoreParameter::VcaAttack,false}, {"vca_release","Release","ms",10,5000,100,CoreParameter::VcaRelease,false}, {"vca_output","Output","dB",-20,20,0,CoreParameter::VcaOutput,false}, {"vca_overeasy","Over Easy","",0,1,0,CoreParameter::VcaOverEasy,true}, {"vca_detector_mode","VCA Detector","",0,1,0,CoreParameter::VcaClassicDetector,true},
  {"bus_threshold","Threshold","dB",-30,15,0,CoreParameter::BusThreshold,false}, {"bus_ratio","Ratio",":1",0,2,0,CoreParameter::BusRatio,true}, {"bus_attack","Attack","",0,5,2,CoreParameter::BusAttack,true}, {"bus_release","Release","",0,4,1,CoreParameter::BusRelease,true}, {"bus_makeup","Makeup","dB",0,20,0,CoreParameter::BusMakeup,false}, {"bus_mix","Bus Mix","%",0,100,100,CoreParameter::BusMix,false},
  {"studio_vca_threshold","Threshold","dB",-40,20,-10,CoreParameter::StudioVcaThreshold,false}, {"studio_vca_ratio","Ratio",":1",1,10,3,CoreParameter::StudioVcaRatio,false}, {"studio_vca_attack","Attack","ms",0.3f,75,10,CoreParameter::StudioVcaAttack,false}, {"studio_vca_release","Release","ms",100,4000,300,CoreParameter::StudioVcaRelease,false}, {"studio_vca_output","Output","dB",-20,20,0,CoreParameter::StudioVcaOutput,false},
- {"digital_threshold","Threshold","dB",-60,0,-20,CoreParameter::DigitalThreshold,false}, {"digital_ratio","Ratio",":1",1,100,4,CoreParameter::DigitalRatio,false}, {"digital_knee","Knee","dB",0,20,6,CoreParameter::DigitalKnee,false}, {"digital_attack","Attack","ms",0.01f,500,10,CoreParameter::DigitalAttack,false}, {"digital_release","Release","ms",1,5000,100,CoreParameter::DigitalRelease,false}, {"digital_lookahead","Lookahead","ms",0,10,0,CoreParameter::DigitalLookahead,false}, {"digital_mix","Mix","%",0,100,100,CoreParameter::DigitalMix,false}, {"digital_output","Output","dB",-24,24,0,CoreParameter::DigitalOutput,false}, {"digital_adaptive","Adaptive Release","",0,1,0,CoreParameter::DigitalAdaptive,true},
- {"mb_crossover_1","Crossover 1","Hz",20,500,200,CoreParameter::Crossover1,false}, {"mb_crossover_2","Crossover 2","Hz",200,5000,2000,CoreParameter::Crossover2,false}, {"mb_crossover_3","Crossover 3","Hz",2000,16000,8000,CoreParameter::Crossover3,false},
- {"envelope_curve","Envelope Curve","",0,1,0,CoreParameter::EnvelopeCurve,true},
+ {"digital_threshold","Threshold","dB",-60,0,-20,CoreParameter::DigitalThreshold,false}, {"digital_ratio","Ratio",":1",1,100,4,CoreParameter::DigitalRatio,false,0.1f,0.4f}, {"digital_knee","Knee","dB",0,20,6,CoreParameter::DigitalKnee,false}, {"digital_attack","Attack","ms",0.01f,500,10,CoreParameter::DigitalAttack,false,0.01f,0.3f}, {"digital_release","Release","ms",1,5000,100,CoreParameter::DigitalRelease,false,1,0.4f}, {"digital_lookahead","Lookahead","ms",0,10,0,CoreParameter::DigitalLookahead,false}, {"digital_mix","Mix","%",0,100,100,CoreParameter::DigitalMix,false}, {"digital_output","Output","dB",-24,24,0,CoreParameter::DigitalOutput,false}, {"digital_adaptive","Adaptive Release","",0,1,0,CoreParameter::DigitalAdaptive,true},
+ {"mb_crossover_1","Crossover 1","Hz",20,500,200,CoreParameter::Crossover1,false,1,0.4f}, {"mb_crossover_2","Crossover 2","Hz",200,5000,2000,CoreParameter::Crossover2,false,1,0.4f}, {"mb_crossover_3","Crossover 3","Hz",2000,16000,8000,CoreParameter::Crossover3,false,1,0.4f},
  {"global_sidechain_listen","SC Listen","",0,1,0,CoreParameter::GlobalSidechainListen,true},
  {"mb_mix","MB Mix","%",0,100,100,CoreParameter::MbMix,false},
  {"mb_output","MB Output","dB",-24,24,0,CoreParameter::MbOutput,false},
  {"noise_enable","Analog Noise","",0,1,1,CoreParameter::NoiseEnable,true},
- {"saturation_mode","Saturation Mode","",0,2,0,CoreParameter::SaturationMode,true},
- {"sc_low_freq","SC Low Freq","Hz",60,500,100,CoreParameter::ScLowFreq,false},
+ {"sc_low_freq","SC Low Freq","Hz",60,500,100,CoreParameter::ScLowFreq,false,1,0.5f},
  {"sc_low_gain","SC Low Gain","dB",-12,12,0,CoreParameter::ScLowGain,false},
- {"sc_high_freq","SC High Freq","Hz",2000,16000,8000,CoreParameter::ScHighFreq,false},
+ {"sc_high_freq","SC High Freq","Hz",2000,16000,8000,CoreParameter::ScHighFreq,false,10,0.5f},
  {"sc_high_gain","SC High Gain","dB",-12,12,0,CoreParameter::ScHighGain,false},
  {"stereo_link_mode","Link Mode","",0,2,0,CoreParameter::StereoLinkMode,true}
 }};
 inline constexpr int kParamCount = static_cast<int>(kParams.size());
 static_assert(kParamCount == static_cast<int>(ParamId::Count));
-#define MC_ASSERT_PARAM(name) static_assert(static_cast<uint32_t>(duskaudio::MultiCompDSP::Parameter::name) == static_cast<uint32_t>(ParamId::name));
-MC_ASSERT_PARAM(Mode) MC_ASSERT_PARAM(Bypass) MC_ASSERT_PARAM(StereoLink) MC_ASSERT_PARAM(Mix)
-MC_ASSERT_PARAM(SidechainHP) MC_ASSERT_PARAM(TruePeakEnable) MC_ASSERT_PARAM(TruePeakQuality)
-MC_ASSERT_PARAM(ExternalSidechain) MC_ASSERT_PARAM(AutoMakeup) MC_ASSERT_PARAM(Distortion)
-MC_ASSERT_PARAM(DistortionAmount) MC_ASSERT_PARAM(Oversampling) MC_ASSERT_PARAM(GlobalLookahead)
-MC_ASSERT_PARAM(OptoPeakReduction) MC_ASSERT_PARAM(OptoGain) MC_ASSERT_PARAM(OptoLimit)
-MC_ASSERT_PARAM(FetInput) MC_ASSERT_PARAM(FetOutput) MC_ASSERT_PARAM(FetAttack) MC_ASSERT_PARAM(FetRelease)
-MC_ASSERT_PARAM(FetRatio) MC_ASSERT_PARAM(FetCurve) MC_ASSERT_PARAM(FetTransient) MC_ASSERT_PARAM(FetThreshold)
-MC_ASSERT_PARAM(VcaThreshold) MC_ASSERT_PARAM(VcaRatio) MC_ASSERT_PARAM(VcaAttack) MC_ASSERT_PARAM(VcaRelease)
-MC_ASSERT_PARAM(VcaOutput) MC_ASSERT_PARAM(VcaOverEasy) MC_ASSERT_PARAM(VcaClassicDetector)
-MC_ASSERT_PARAM(BusThreshold) MC_ASSERT_PARAM(BusRatio) MC_ASSERT_PARAM(BusAttack) MC_ASSERT_PARAM(BusRelease)
-MC_ASSERT_PARAM(BusMakeup) MC_ASSERT_PARAM(BusMix) MC_ASSERT_PARAM(StudioVcaThreshold)
-MC_ASSERT_PARAM(StudioVcaRatio) MC_ASSERT_PARAM(StudioVcaAttack) MC_ASSERT_PARAM(StudioVcaRelease)
-MC_ASSERT_PARAM(StudioVcaOutput) MC_ASSERT_PARAM(DigitalThreshold) MC_ASSERT_PARAM(DigitalRatio)
-MC_ASSERT_PARAM(DigitalKnee) MC_ASSERT_PARAM(DigitalAttack) MC_ASSERT_PARAM(DigitalRelease)
-MC_ASSERT_PARAM(DigitalLookahead) MC_ASSERT_PARAM(DigitalMix) MC_ASSERT_PARAM(DigitalOutput)
-MC_ASSERT_PARAM(DigitalAdaptive) MC_ASSERT_PARAM(Crossover1) MC_ASSERT_PARAM(Crossover2) MC_ASSERT_PARAM(Crossover3)
-MC_ASSERT_PARAM(EnvelopeCurve) MC_ASSERT_PARAM(GlobalSidechainListen) MC_ASSERT_PARAM(MbMix) MC_ASSERT_PARAM(MbOutput)
-MC_ASSERT_PARAM(NoiseEnable) MC_ASSERT_PARAM(SaturationMode) MC_ASSERT_PARAM(ScLowFreq) MC_ASSERT_PARAM(ScLowGain)
-MC_ASSERT_PARAM(ScHighFreq) MC_ASSERT_PARAM(ScHighGain) MC_ASSERT_PARAM(StereoLinkMode)
-#undef MC_ASSERT_PARAM
+static_assert(kParamCount == 63);
 inline constexpr int kBandParamCount = 8 * duskaudio::kMultiCompBands;
 inline constexpr int kBandBase = kParamCount;
 inline constexpr int kMeterMaster = kBandBase + kBandParamCount;
@@ -98,28 +88,60 @@ inline constexpr BandParam bandParam(int field, int band)
     switch (field)
     {
         case 0: return {"mb_threshold", names[field], units[field], -60, 0, -20, duskaudio::MultiCompDSP::MultibandParameter::Threshold, false};
-        case 1: return {"mb_ratio", names[field], units[field], 1, 20, 4, duskaudio::MultiCompDSP::MultibandParameter::Ratio, false};
-        case 2: return {"mb_attack", names[field], units[field], 0.1f, 100, 10, duskaudio::MultiCompDSP::MultibandParameter::Attack, false};
-        case 3: return {"mb_release", names[field], units[field], 10, 1000, 100, duskaudio::MultiCompDSP::MultibandParameter::Release, false};
+        case 1: return {"mb_ratio", names[field], units[field], 1, 20, 4, duskaudio::MultiCompDSP::MultibandParameter::Ratio, false, 0.1f, 0.5f};
+        case 2: return {"mb_attack", names[field], units[field], 0.1f, 100, 10, duskaudio::MultiCompDSP::MultibandParameter::Attack, false, 0.1f, 0.4f};
+        case 3: return {"mb_release", names[field], units[field], 10, 1000, 100, duskaudio::MultiCompDSP::MultibandParameter::Release, false, 1, 0.4f};
         case 4: return {"mb_makeup", names[field], units[field], -12, 12, 0, duskaudio::MultiCompDSP::MultibandParameter::Makeup, false};
         case 5: return {"mb_bypass", names[field], units[field], 0, 1, 0, duskaudio::MultiCompDSP::MultibandParameter::Bypass, true};
         case 6: return {"mb_solo", names[field], units[field], 0, 1, 0, duskaudio::MultiCompDSP::MultibandParameter::Solo, true};
         default:return {"mb_enabled", names[field], units[field], 0, 1, 1, duskaudio::MultiCompDSP::MultibandParameter::Enabled, true};
     }
 }
+
+template <class Descriptor>
+inline bool hasSkew(const Descriptor& d) noexcept { return d.skew != 1.0f; }
+
+template <class Descriptor>
+inline float hostMin(const Descriptor& d) noexcept { return hasSkew(d) ? 0.0f : d.min; }
+
+template <class Descriptor>
+inline float hostMax(const Descriptor& d) noexcept { return hasSkew(d) ? 1.0f : d.max; }
+
+template <class Descriptor>
+inline float plainToHost(const Descriptor& d, float value) noexcept
+{
+    value = std::clamp(value, d.min, d.max);
+    if (!hasSkew(d)) return value;
+    const float proportion = (value - d.min) / (d.max - d.min);
+    return std::pow(proportion, d.skew);
+}
+
+template <class Descriptor>
+inline float hostToPlain(const Descriptor& d, float value) noexcept
+{
+    value = std::clamp(value, hostMin(d), hostMax(d));
+    if (!hasSkew(d)) return value;
+    const float proportion = std::pow(value, 1.0f / d.skew);
+    float plain = d.min + (d.max - d.min) * proportion;
+    if (d.interval > 0.0f)
+        plain = d.min + d.interval * std::floor((plain - d.min) / d.interval + 0.5f);
+    return std::clamp(plain, d.min, d.max);
+}
+
+template <class Descriptor>
+inline float hostDefault(const Descriptor& d) noexcept { return plainToHost(d, d.def); }
+
 inline constexpr const char* const kModes[8] = {"Opto","FET","VCA","Bus","Studio FET","Studio VCA","Digital","Multiband"};
 inline constexpr const char* const kOnOff[2] = {"Off","On"};
 inline constexpr const char* const kRatios[5] = {"4:1","8:1","12:1","20:1","All"};
 inline constexpr const char* const kOversampling[3] = {"Off","2x","4x"};
 inline constexpr const char* const kDistortion[4] = {"Off","Soft","Hard","Clip"};
 inline constexpr const char* const kTruePeakQuality[2] = {"4x (Standard)","8x (High)"};
-inline constexpr const char* const kEnvelopeCurve[2] = {"Logarithmic (Analog)","Linear (Digital)"};
 inline constexpr const char* const kFetCurve[2] = {"Modern", "Measured"};
 inline constexpr const char* const kVcaDetector[2] = {"Adaptive", "Classic"};
 inline constexpr const char* const kBusRatios[3] = {"2:1", "4:1", "10:1"};
 inline constexpr const char* const kBusAttack[6] = {"0.1ms", "0.3ms", "1ms", "3ms", "10ms", "30ms"};
 inline constexpr const char* const kBusRelease[5] = {"0.1s", "0.3s", "0.6s", "1.2s", "Auto"};
-inline constexpr const char* const kSaturationMode[3] = {"Vintage (Warm)","Modern (Clean)","Pristine (Minimal)"};
 inline constexpr const char* const kLinkMode[3] = {"Stereo","Mid-Side","Dual Mono"};
 
 // State serialization, shared so the plugin and the UI cannot drift apart the
@@ -128,9 +150,10 @@ inline constexpr const char* const kLinkMode[3] = {"Stereo","Mid-Side","Dual Mon
 // Version 1 wrote decimal floats. It never shipped in any build a user could
 // install, and reading it back needs the C++17 floating-point std::from_chars,
 // which libc++ marks "introduced in macOS 13.3", above our deployment target.
-// Version 2 therefore carries the float's bit pattern through the integer
-// overloads: exact, and immune to whatever LC_NUMERIC the host process set.
-inline constexpr int kStateVersion = 2;
+// Version 2 therefore carried the float's bit pattern through the integer
+// overloads. Version 3 removes two inert fields and stores tapered controls in
+// their new normalized host domain. Both are exact and locale-independent.
+inline constexpr int kStateVersion = 3;
 
 // A version we do not understand must be refused outright. Decoding it anyway
 // makes every value fail to parse and silently restores defaults, which reads
@@ -164,5 +187,100 @@ inline void appendStateFloat(std::string& out, float value)
     char number[16];
     const auto result = std::to_chars(number, number + sizeof(number), bits, 16);
     if (result.ec == std::errc()) out.append(number, result.ptr);
+}
+
+using StateValues = std::array<float, static_cast<size_t>(kMeterMaster)>;
+
+inline int stateIndexForId(std::string_view id) noexcept
+{
+    for (int i = 0; i < kParamCount; ++i)
+        if (id == kParams[static_cast<size_t>(i)].id) return i;
+
+    for (int field = 0; field < 8; ++field)
+    {
+        const std::string_view base = bandParam(field, 0).id;
+        if (id.size() != base.size() + 2 || id.substr(0, base.size()) != base
+            || id[base.size()] != '_' || id[base.size() + 1] < '0'
+            || id[base.size() + 1] >= static_cast<char>('0' + duskaudio::kMultiCompBands))
+            continue;
+        const int band = id[base.size() + 1] - '0';
+        return kBandBase + band * 8 + field;
+    }
+    return -1;
+}
+
+inline bool hostValueInRange(int index, float value) noexcept
+{
+    if (!std::isfinite(value)) return false;
+    if (index < kParamCount)
+    {
+        const auto& d = kParams[static_cast<size_t>(index)];
+        return value >= hostMin(d) && value <= hostMax(d);
+    }
+    const int relative = index - kBandBase;
+    const auto d = bandParam(relative % 8, relative / 8);
+    return value >= hostMin(d) && value <= hostMax(d);
+}
+
+// Complete-set transactional decoder. The caller's output is untouched unless
+// every required key appears exactly once with a finite in-range value.
+inline bool decodeState(std::string_view state, StateValues& out) noexcept
+{
+    if (state.empty() || state.back() == ';' || !stateVersionSupported(state)) return false;
+    const size_t versionEnd = state.find(';');
+    if (versionEnd == std::string_view::npos) return false;
+
+    StateValues decoded{};
+    std::array<bool, static_cast<size_t>(kMeterMaster)> seen{};
+    size_t begin = versionEnd + 1;
+    while (begin < state.size())
+    {
+        const size_t end = state.find(';', begin);
+        const std::string_view token = state.substr(
+            begin, end == std::string_view::npos ? state.size() - begin : end - begin);
+        const size_t equal = token.find('=');
+        if (equal == std::string_view::npos || equal == 0
+            || equal + 1 == token.size() || token.find('=', equal + 1) != std::string_view::npos)
+            return false;
+
+        const int index = stateIndexForId(token.substr(0, equal));
+        if (index < 0 || seen[static_cast<size_t>(index)]) return false;
+        float value = 0.0f;
+        if (!decodeStateFloat(token.substr(equal + 1), value)
+            || !hostValueInRange(index, value))
+            return false;
+        decoded[static_cast<size_t>(index)] = value;
+        seen[static_cast<size_t>(index)] = true;
+
+        if (end == std::string_view::npos) { begin = state.size(); break; }
+        begin = end + 1;
+    }
+    if (begin != state.size()) return false;
+    for (bool present : seen)
+        if (!present) return false;
+    out = decoded;
+    return true;
+}
+
+inline std::string encodeState(const StateValues& values)
+{
+    std::string state = "v=" + std::to_string(kStateVersion);
+    state.reserve(32 + static_cast<size_t>(kMeterMaster) * 28);
+    for (int i = 0; i < kMeterMaster; ++i)
+    {
+        state.push_back(';');
+        if (i < kParamCount)
+            state += kParams[static_cast<size_t>(i)].id;
+        else
+        {
+            const int relative = i - kBandBase;
+            state += bandParam(relative % 8, relative / 8).id;
+            state.push_back('_');
+            state.push_back(static_cast<char>('0' + relative / 8));
+        }
+        state.push_back('=');
+        appendStateFloat(state, values[static_cast<size_t>(i)]);
+    }
+    return state;
 }
 }

--- a/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
@@ -222,6 +222,26 @@ inline int stateIndexForId(std::string_view id) noexcept
     return -1;
 }
 
+// Clamp a host value into its descriptor's range, and snap it to an integer
+// when the descriptor is integral.
+//
+// Snapping matters beyond tidiness. getState() serialises the stored host values
+// verbatim, and decodeState() rejects the WHOLE state if an integer-valued
+// parameter carries a fraction. A host ramping an integer parameter delivers
+// fractional intermediates, so without snapping a project saved mid-ramp stores
+// something like mode=0.6 and fails to load in its entirety.
+//
+// Rejecting fractional values here instead would be worse: the plugin would
+// ignore legitimate automation. Snapping keeps automation working and keeps
+// every stored value loadable. Rounding rather than truncating also handles a
+// host that delivers 0.9999999 for 1.
+template <class Descriptor>
+inline float snapHostValue(const Descriptor& d, float value) noexcept
+{
+    const float clamped = duskaudio::clampFinite(value, hostMin(d), hostMax(d), hostDefault(d));
+    return d.integer ? std::round(clamped) : clamped;
+}
+
 inline bool hostValueInRange(int index, float value) noexcept
 {
     if (!std::isfinite(value)) return false;

--- a/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace multicompp
 {
@@ -96,6 +97,18 @@ inline constexpr BandParam bandParam(int field, int band)
         case 6: return {"mb_solo", names[field], units[field], 0, 1, 0, duskaudio::MultiCompDSP::MultibandParameter::Solo, true};
         default:return {"mb_enabled", names[field], units[field], 0, 1, 1, duskaudio::MultiCompDSP::MultibandParameter::Enabled, true};
     }
+}
+
+template <class GlobalFn, class BandFn>
+decltype(auto) resolveParameter(int index, GlobalFn&& globalFn, BandFn&& bandFn)
+{
+    if (index < kParamCount)
+        return std::forward<GlobalFn>(globalFn)(kParams[static_cast<size_t>(index)]);
+
+    const int relative = index - kBandBase;
+    const int band = relative / 8;
+    const int field = relative % 8;
+    return std::forward<BandFn>(bandFn)(bandParam(field, band), band);
 }
 
 template <class Descriptor>
@@ -212,14 +225,15 @@ inline int stateIndexForId(std::string_view id) noexcept
 inline bool hostValueInRange(int index, float value) noexcept
 {
     if (!std::isfinite(value)) return false;
-    if (index < kParamCount)
-    {
-        const auto& d = kParams[static_cast<size_t>(index)];
-        return value >= hostMin(d) && value <= hostMax(d);
-    }
-    const int relative = index - kBandBase;
-    const auto d = bandParam(relative % 8, relative / 8);
-    return value >= hostMin(d) && value <= hostMax(d);
+    return resolveParameter(index,
+        [value](const Param& d) {
+            return value >= hostMin(d) && value <= hostMax(d)
+                && (!d.integer || std::trunc(value) == value);
+        },
+        [value](const BandParam& d, int) {
+            return value >= hostMin(d) && value <= hostMax(d)
+                && (!d.integer || std::trunc(value) == value);
+        });
 }
 
 // Complete-set transactional decoder. The caller's output is untouched unless
@@ -269,15 +283,13 @@ inline std::string encodeState(const StateValues& values)
     for (int i = 0; i < kMeterMaster; ++i)
     {
         state.push_back(';');
-        if (i < kParamCount)
-            state += kParams[static_cast<size_t>(i)].id;
-        else
-        {
-            const int relative = i - kBandBase;
-            state += bandParam(relative % 8, relative / 8).id;
-            state.push_back('_');
-            state.push_back(static_cast<char>('0' + relative / 8));
-        }
+        resolveParameter(i,
+            [&state](const Param& d) { state += d.id; },
+            [&state](const BandParam& d, int band) {
+                state += d.id;
+                state.push_back('_');
+                state.push_back(static_cast<char>('0' + band));
+            });
         state.push_back('=');
         appendStateFloat(state, values[static_cast<size_t>(i)]);
     }

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -127,14 +127,12 @@ protected:
         if (index >= multicompp::kMeterMaster) return;
         multicompp::resolveParameter(static_cast<int>(index),
             [&](const multicompp::Param& d) {
-                const float v = duskaudio::clampFinite(
-                    value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
+                const float v = multicompp::snapHostValue(d, value);
                 values[index].store(v, std::memory_order_relaxed);
                 dsp.setParameter(d.core, multicompp::hostToPlain(d, v));
             },
             [&](const multicompp::BandParam& d, int band) {
-                const float v = duskaudio::clampFinite(
-                    value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
+                const float v = multicompp::snapHostValue(d, value);
                 values[index].store(v, std::memory_order_relaxed);
                 dsp.setMultibandParameter(band, d.core, multicompp::hostToPlain(d, v));
             });

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -7,13 +7,9 @@
 
 #include <array>
 #include <atomic>
-#include <charconv>
-#include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 #include <string>
-#include <string_view>
 
 START_NAMESPACE_DISTRHO
 
@@ -26,7 +22,10 @@ public:
     {
         for (int i = 0; i < multicompp::kMeterMaster; ++i)
         {
-            const float def = i < multicompp::kParamCount ? multicompp::kParams[static_cast<size_t>(i)].def : multicompp::bandParam((i - multicompp::kBandBase) % 8, (i - multicompp::kBandBase) / 8).def;
+            const float def = i < multicompp::kParamCount
+                ? multicompp::hostDefault(multicompp::kParams[static_cast<size_t>(i)])
+                : multicompp::hostDefault(multicompp::bandParam(
+                    (i - multicompp::kBandBase) % 8, (i - multicompp::kBandBase) / 8));
             values[static_cast<size_t>(i)].store(def, std::memory_order_relaxed);
         }
     }
@@ -64,8 +63,13 @@ protected:
         if (index < multicompp::kParamCount)
         {
             const auto& d = multicompp::kParams[static_cast<size_t>(index)];
-            p.name = d.name; p.symbol = d.id; p.unit = d.unit;
-            p.ranges.min = d.min; p.ranges.max = d.max; p.ranges.def = d.def;
+            p.name = d.name; p.symbol = d.id;
+            // DPF has no arbitrary value<->text callback. Tapered parameters
+            // therefore expose their honest normalized coordinate without a
+            // misleading physical unit; the custom UI displays mapped units.
+            p.unit = multicompp::hasSkew(d) ? "" : d.unit;
+            p.ranges.min = multicompp::hostMin(d); p.ranges.max = multicompp::hostMax(d);
+            p.ranges.def = multicompp::hostDefault(d);
             p.hints = kParameterIsAutomatable | (d.integer ? kParameterIsInteger : 0u);
             using Id = multicompp::ParamId;
             switch (static_cast<Id>(index))
@@ -85,8 +89,6 @@ protected:
                 case Id::BusRatio: setEnum(p, multicompp::kBusRatios, 3); break;
                 case Id::BusAttack: setEnum(p, multicompp::kBusAttack, 6); break;
                 case Id::BusRelease: setEnum(p, multicompp::kBusRelease, 5); break;
-                case Id::EnvelopeCurve: setEnum(p, multicompp::kEnvelopeCurve, 2); break;
-                case Id::SaturationMode: setEnum(p, multicompp::kSaturationMode, 3); break;
                 case Id::StereoLinkMode: setEnum(p, multicompp::kLinkMode, 3); break;
                 default: break;
             }
@@ -98,11 +100,15 @@ protected:
             const int field = static_cast<int>((index - multicompp::kBandBase) % 8);
             const auto d = multicompp::bandParam(field, band);
             p.name = String(d.name) + " " + (band == 0 ? "Low" : band == 1 ? "Low-Mid" : band == 2 ? "High-Mid" : "High");
-            p.symbol = String(d.id) + "_" + std::to_string(band).c_str(); p.unit = d.unit;
-            p.ranges.min = d.min; p.ranges.max = d.max; p.ranges.def = d.def;
+            p.symbol = String(d.id) + "_" + std::to_string(band).c_str();
+            p.unit = multicompp::hasSkew(d) ? "" : d.unit;
+            p.ranges.min = multicompp::hostMin(d); p.ranges.max = multicompp::hostMax(d);
+            p.ranges.def = multicompp::hostDefault(d);
             p.hints = kParameterIsAutomatable | (d.integer ? (kParameterIsInteger | kParameterIsBoolean) : 0u);
             return;
         }
+        // Output-only deliberately excludes kParameterIsAutomatable: hosts may
+        // read these meters, but must never offer them as writable targets.
         p.hints = kParameterIsOutput;
         p.ranges.min = -60.0f; p.ranges.max = 0.0f; p.ranges.def = 0.0f; p.unit = "dB";
         if (index == multicompp::kMeterMaster) p.name = "GR";
@@ -127,16 +133,18 @@ protected:
             const int band = static_cast<int>((index - multicompp::kBandBase) / 8);
             const int field = static_cast<int>((index - multicompp::kBandBase) % 8);
             const auto d = multicompp::bandParam(field, band);
-            const float v = duskaudio::clampFinite(value, d.min, d.max, d.def);
+            const float v = duskaudio::clampFinite(
+                value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
             values[index].store(v, std::memory_order_relaxed);
-            dsp.setMultibandParameter(band, d.core, v);
+            dsp.setMultibandParameter(band, d.core, multicompp::hostToPlain(d, v));
             return;
         }
         if (index >= multicompp::kParamCount) return;
         const auto& d = multicompp::kParams[index];
-        const float v = duskaudio::clampFinite(value, d.min, d.max, d.def);
+        const float v = duskaudio::clampFinite(
+            value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
         values[index].store(v, std::memory_order_relaxed);
-        dsp.setParameter(d.core, v);
+        dsp.setParameter(d.core, multicompp::hostToPlain(d, v));
     }
 
     void initProgramName(uint32_t index, String& name) override
@@ -150,11 +158,11 @@ protected:
         [this](multicompp::CoreParameter parameter, float value)
         {
             const int parameterIndex = multicompp::coreParamIndex(parameter);
-            if (parameterIndex >= 0) setParameterValue(static_cast<uint32_t>(parameterIndex), value);
-        },
-        [this](int band, int field, float value)
-        {
-            setParameterValue(static_cast<uint32_t>(multicompp::kBandBase + band * 8 + field), value);
+            if (parameterIndex >= 0)
+            {
+                const auto& d = multicompp::kParams[static_cast<size_t>(parameterIndex)];
+                setParameterValue(static_cast<uint32_t>(parameterIndex), multicompp::plainToHost(d, value));
+            }
         });
     }
 
@@ -164,52 +172,19 @@ protected:
     String getState(const char* key) const override
     {
         if (std::strcmp(key, "parameters") != 0) return String();
-        std::string s = "v=" + std::to_string(multicompp::kStateVersion);
-        for (int i = 0; i < multicompp::kParamCount; ++i)
-        {
-            s.push_back(';'); s += multicompp::kParams[static_cast<size_t>(i)].id; s.push_back('=');
-            multicompp::appendStateFloat(s, values[static_cast<size_t>(i)].load(std::memory_order_relaxed));
-        }
-        for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
-        {
-            const int band = (i - multicompp::kBandBase) / 8;
-            const int field = (i - multicompp::kBandBase) % 8;
-            s.push_back(';'); s += stateBandId(field, band); s.push_back('=');
-            multicompp::appendStateFloat(s, values[static_cast<size_t>(i)].load(std::memory_order_relaxed));
-        }
-        return String(s.c_str());
+        multicompp::StateValues state{};
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
+            state[static_cast<size_t>(i)] = values[static_cast<size_t>(i)].load(std::memory_order_relaxed);
+        return String(multicompp::encodeState(state).c_str());
     }
 
     void setState(const char* key, const char* value) override
     {
         if (std::strcmp(key, "parameters") != 0 || value == nullptr) return;
-        const std::string_view state(value);
-        if (! multicompp::stateVersionSupported(state)) return;
-        size_t begin = 0;
-        while (begin < state.size())
-        {
-            const size_t end = state.find(';', begin);
-            const std::string_view token = state.substr(begin, end == std::string_view::npos ? state.size() - begin : end - begin);
-            const size_t equal = token.find('=');
-            if (equal != std::string_view::npos && token.substr(0, equal) != "v")
-            {
-                float parsed = 0.0f;
-                if (multicompp::decodeStateFloat(token.substr(equal + 1), parsed))
-                {
-                    const std::string_view id = token.substr(0, equal);
-                    for (int i = 0; i < multicompp::kParamCount; ++i)
-                        if (id == multicompp::kParams[static_cast<size_t>(i)].id) { setParameterValue(static_cast<uint32_t>(i), parsed); break; }
-                    for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
-                    {
-                        const int band = (i - multicompp::kBandBase) / 8;
-                        const int field = (i - multicompp::kBandBase) % 8;
-                        if (id == stateBandId(field, band)) { setParameterValue(static_cast<uint32_t>(i), parsed); break; }
-                    }
-                }
-            }
-            if (end == std::string_view::npos) break;
-            begin = end + 1;
-        }
+        multicompp::StateValues state{};
+        if (!multicompp::decodeState(value, state)) return;
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
+            setParameterValue(static_cast<uint32_t>(i), state[static_cast<size_t>(i)]);
     }
 
     void activate() override { dsp.prepare(getSampleRate(), static_cast<int>(getBufferSize())); pushParameters(); updateLatency(); }
@@ -229,27 +204,22 @@ protected:
     }
 
 private:
-    static std::string stateBandId(int field, int band)
-    {
-        char number[16];
-        const auto result = std::to_chars(number, number + sizeof(number), band);
-        std::string id = multicompp::bandParam(field, band).id;
-        id.push_back('_');
-        if (result.ec == std::errc()) id.append(number, result.ptr);
-        return id;
-    }
-
     static void setEnum(Parameter& p, const char* const* labels, int count)
     { p.enumValues.count = static_cast<uint8_t>(count); p.enumValues.restrictedMode = true; auto* e = new ParameterEnumerationValue[count]; for (int i = 0; i < count; ++i) e[i] = ParameterEnumerationValue(static_cast<float>(i), labels[i]); p.enumValues.values = e; }
     void pushParameters()
     {
         for (int i = 0; i < multicompp::kParamCount; ++i)
-            dsp.setParameter(multicompp::kParams[static_cast<size_t>(i)].core, values[static_cast<size_t>(i)].load(std::memory_order_relaxed));
+        {
+            const auto& d = multicompp::kParams[static_cast<size_t>(i)];
+            dsp.setParameter(d.core, multicompp::hostToPlain(
+                d, values[static_cast<size_t>(i)].load(std::memory_order_relaxed)));
+        }
         for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
         {
             const int band = (i - multicompp::kBandBase) / 8;
             const auto d = multicompp::bandParam((i - multicompp::kBandBase) % 8, band);
-            dsp.setMultibandParameter(band, d.core, values[static_cast<size_t>(i)].load(std::memory_order_relaxed));
+            dsp.setMultibandParameter(band, d.core, multicompp::hostToPlain(
+                d, values[static_cast<size_t>(i)].load(std::memory_order_relaxed)));
         }
     }
     void updateLatency() { const int l = dsp.getLatencySamples(); if (l != lastLatency) { lastLatency = l; setLatency(static_cast<uint32_t>(l < 0 ? 0 : l)); } }

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -147,15 +147,10 @@ protected:
     {
         if (index >= multicompp::kFactoryPresets.size()) return;
         const auto& q = multicompp::kFactoryPresets[index];
-        multicompp::forEachPresetParam(q,
-        [this](multicompp::CoreParameter parameter, float value)
+        multicompp::applyPresetToHostParameters(q,
+        [this](int parameterIndex, float hostValue)
         {
-            const int parameterIndex = multicompp::coreParamIndex(parameter);
-            if (parameterIndex >= 0)
-            {
-                const auto& d = multicompp::kParams[static_cast<size_t>(parameterIndex)];
-                setParameterValue(static_cast<uint32_t>(parameterIndex), multicompp::plainToHost(d, value));
-            }
+            setParameterValue(static_cast<uint32_t>(parameterIndex), hostValue);
         });
     }
 

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -22,10 +22,9 @@ public:
     {
         for (int i = 0; i < multicompp::kMeterMaster; ++i)
         {
-            const float def = i < multicompp::kParamCount
-                ? multicompp::hostDefault(multicompp::kParams[static_cast<size_t>(i)])
-                : multicompp::hostDefault(multicompp::bandParam(
-                    (i - multicompp::kBandBase) % 8, (i - multicompp::kBandBase) / 8));
+            const float def = multicompp::resolveParameter(i,
+                [](const multicompp::Param& d) { return multicompp::hostDefault(d); },
+                [](const multicompp::BandParam& d, int) { return multicompp::hostDefault(d); });
             values[static_cast<size_t>(i)].store(def, std::memory_order_relaxed);
         }
     }
@@ -60,51 +59,48 @@ protected:
 
     void initParameter(uint32_t index, Parameter& p) override
     {
-        if (index < multicompp::kParamCount)
-        {
-            const auto& d = multicompp::kParams[static_cast<size_t>(index)];
-            p.name = d.name; p.symbol = d.id;
-            // DPF has no arbitrary value<->text callback. Tapered parameters
-            // therefore expose their honest normalized coordinate without a
-            // misleading physical unit; the custom UI displays mapped units.
-            p.unit = multicompp::hasSkew(d) ? "" : d.unit;
-            p.ranges.min = multicompp::hostMin(d); p.ranges.max = multicompp::hostMax(d);
-            p.ranges.def = multicompp::hostDefault(d);
-            p.hints = kParameterIsAutomatable | (d.integer ? kParameterIsInteger : 0u);
-            using Id = multicompp::ParamId;
-            switch (static_cast<Id>(index))
-            {
-                case Id::Bypass: p.initDesignation(kParameterDesignationBypass); return;
-                case Id::Mode: setEnum(p, multicompp::kModes, 8); break;
-                case Id::TruePeakEnable: case Id::ExternalSidechain: case Id::AutoMakeup:
-                case Id::OptoLimit: case Id::VcaOverEasy: case Id::DigitalAdaptive:
-                case Id::GlobalSidechainListen: case Id::NoiseEnable:
-                    setEnum(p, multicompp::kOnOff, 2); p.hints |= kParameterIsBoolean; break;
-                case Id::TruePeakQuality: setEnum(p, multicompp::kTruePeakQuality, 2); break;
-                case Id::Distortion: setEnum(p, multicompp::kDistortion, 4); break;
-                case Id::Oversampling: setEnum(p, multicompp::kOversampling, 3); break;
-                case Id::FetRatio: setEnum(p, multicompp::kRatios, 5); break;
-                case Id::FetCurve: setEnum(p, multicompp::kFetCurve, 2); break;
-                case Id::VcaClassicDetector: setEnum(p, multicompp::kVcaDetector, 2); break;
-                case Id::BusRatio: setEnum(p, multicompp::kBusRatios, 3); break;
-                case Id::BusAttack: setEnum(p, multicompp::kBusAttack, 6); break;
-                case Id::BusRelease: setEnum(p, multicompp::kBusRelease, 5); break;
-                case Id::StereoLinkMode: setEnum(p, multicompp::kLinkMode, 3); break;
-                default: break;
-            }
-            return;
-        }
         if (index < multicompp::kMeterMaster)
         {
-            const int band = static_cast<int>((index - multicompp::kBandBase) / 8);
-            const int field = static_cast<int>((index - multicompp::kBandBase) % 8);
-            const auto d = multicompp::bandParam(field, band);
-            p.name = String(d.name) + " " + (band == 0 ? "Low" : band == 1 ? "Low-Mid" : band == 2 ? "High-Mid" : "High");
-            p.symbol = String(d.id) + "_" + std::to_string(band).c_str();
-            p.unit = multicompp::hasSkew(d) ? "" : d.unit;
-            p.ranges.min = multicompp::hostMin(d); p.ranges.max = multicompp::hostMax(d);
-            p.ranges.def = multicompp::hostDefault(d);
-            p.hints = kParameterIsAutomatable | (d.integer ? (kParameterIsInteger | kParameterIsBoolean) : 0u);
+            multicompp::resolveParameter(static_cast<int>(index),
+                [&](const multicompp::Param& d) {
+                    p.name = d.name; p.symbol = d.id;
+                    // DPF has no arbitrary value<->text callback. Tapered parameters
+                    // therefore expose their honest normalized coordinate without a
+                    // misleading physical unit; the custom UI displays mapped units.
+                    p.unit = multicompp::hasSkew(d) ? "" : d.unit;
+                    p.ranges.min = multicompp::hostMin(d); p.ranges.max = multicompp::hostMax(d);
+                    p.ranges.def = multicompp::hostDefault(d);
+                    p.hints = kParameterIsAutomatable | (d.integer ? kParameterIsInteger : 0u);
+                    using Id = multicompp::ParamId;
+                    switch (static_cast<Id>(index))
+                    {
+                        case Id::Bypass: p.initDesignation(kParameterDesignationBypass); return;
+                        case Id::Mode: setEnum(p, multicompp::kModes, 8); break;
+                        case Id::TruePeakEnable: case Id::ExternalSidechain: case Id::AutoMakeup:
+                        case Id::OptoLimit: case Id::VcaOverEasy: case Id::DigitalAdaptive:
+                        case Id::GlobalSidechainListen: case Id::NoiseEnable:
+                            setEnum(p, multicompp::kOnOff, 2); p.hints |= kParameterIsBoolean; break;
+                        case Id::TruePeakQuality: setEnum(p, multicompp::kTruePeakQuality, 2); break;
+                        case Id::Distortion: setEnum(p, multicompp::kDistortion, 4); break;
+                        case Id::Oversampling: setEnum(p, multicompp::kOversampling, 3); break;
+                        case Id::FetRatio: setEnum(p, multicompp::kRatios, 5); break;
+                        case Id::FetCurve: setEnum(p, multicompp::kFetCurve, 2); break;
+                        case Id::VcaClassicDetector: setEnum(p, multicompp::kVcaDetector, 2); break;
+                        case Id::BusRatio: setEnum(p, multicompp::kBusRatios, 3); break;
+                        case Id::BusAttack: setEnum(p, multicompp::kBusAttack, 6); break;
+                        case Id::BusRelease: setEnum(p, multicompp::kBusRelease, 5); break;
+                        case Id::StereoLinkMode: setEnum(p, multicompp::kLinkMode, 3); break;
+                        default: break;
+                    }
+                },
+                [&](const multicompp::BandParam& d, int band) {
+                    p.name = String(d.name) + " " + (band == 0 ? "Low" : band == 1 ? "Low-Mid" : band == 2 ? "High-Mid" : "High");
+                    p.symbol = String(d.id) + "_" + std::to_string(band).c_str();
+                    p.unit = multicompp::hasSkew(d) ? "" : d.unit;
+                    p.ranges.min = multicompp::hostMin(d); p.ranges.max = multicompp::hostMax(d);
+                    p.ranges.def = multicompp::hostDefault(d);
+                    p.hints = kParameterIsAutomatable | (d.integer ? (kParameterIsInteger | kParameterIsBoolean) : 0u);
+                });
             return;
         }
         // Output-only deliberately excludes kParameterIsAutomatable: hosts may
@@ -128,23 +124,20 @@ protected:
 
     void setParameterValue(uint32_t index, float value) override
     {
-        if (index >= multicompp::kParamCount && index < multicompp::kMeterMaster)
-        {
-            const int band = static_cast<int>((index - multicompp::kBandBase) / 8);
-            const int field = static_cast<int>((index - multicompp::kBandBase) % 8);
-            const auto d = multicompp::bandParam(field, band);
-            const float v = duskaudio::clampFinite(
-                value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
-            values[index].store(v, std::memory_order_relaxed);
-            dsp.setMultibandParameter(band, d.core, multicompp::hostToPlain(d, v));
-            return;
-        }
-        if (index >= multicompp::kParamCount) return;
-        const auto& d = multicompp::kParams[index];
-        const float v = duskaudio::clampFinite(
-            value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
-        values[index].store(v, std::memory_order_relaxed);
-        dsp.setParameter(d.core, multicompp::hostToPlain(d, v));
+        if (index >= multicompp::kMeterMaster) return;
+        multicompp::resolveParameter(static_cast<int>(index),
+            [&](const multicompp::Param& d) {
+                const float v = duskaudio::clampFinite(
+                    value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
+                values[index].store(v, std::memory_order_relaxed);
+                dsp.setParameter(d.core, multicompp::hostToPlain(d, v));
+            },
+            [&](const multicompp::BandParam& d, int band) {
+                const float v = duskaudio::clampFinite(
+                    value, multicompp::hostMin(d), multicompp::hostMax(d), multicompp::hostDefault(d));
+                values[index].store(v, std::memory_order_relaxed);
+                dsp.setMultibandParameter(band, d.core, multicompp::hostToPlain(d, v));
+            });
     }
 
     void initProgramName(uint32_t index, String& name) override
@@ -208,18 +201,16 @@ private:
     { p.enumValues.count = static_cast<uint8_t>(count); p.enumValues.restrictedMode = true; auto* e = new ParameterEnumerationValue[count]; for (int i = 0; i < count; ++i) e[i] = ParameterEnumerationValue(static_cast<float>(i), labels[i]); p.enumValues.values = e; }
     void pushParameters()
     {
-        for (int i = 0; i < multicompp::kParamCount; ++i)
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
         {
-            const auto& d = multicompp::kParams[static_cast<size_t>(i)];
-            dsp.setParameter(d.core, multicompp::hostToPlain(
-                d, values[static_cast<size_t>(i)].load(std::memory_order_relaxed)));
-        }
-        for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
-        {
-            const int band = (i - multicompp::kBandBase) / 8;
-            const auto d = multicompp::bandParam((i - multicompp::kBandBase) % 8, band);
-            dsp.setMultibandParameter(band, d.core, multicompp::hostToPlain(
-                d, values[static_cast<size_t>(i)].load(std::memory_order_relaxed)));
+            const float value = values[static_cast<size_t>(i)].load(std::memory_order_relaxed);
+            multicompp::resolveParameter(i,
+                [&](const multicompp::Param& d) {
+                    dsp.setParameter(d.core, multicompp::hostToPlain(d, value));
+                },
+                [&](const multicompp::BandParam& d, int band) {
+                    dsp.setMultibandParameter(band, d.core, multicompp::hostToPlain(d, value));
+                });
         }
     }
     void updateLatency() { const int l = dsp.getLatencySamples(); if (l != lastLatency) { lastLatency = l; setLatency(static_cast<uint32_t>(l < 0 ? 0 : l)); } }

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -310,6 +310,30 @@ void testFactoryPresetOwnership()
     std::puts("factory preset ownership: every active-mode control applied; machine/global controls untouched");
 }
 
+void testHostProgramChangeAppliesBandParameters()
+{
+    auto multibandProgram = multicompp::kFactoryPresets.front();
+    multibandProgram.mode = 7;
+    std::array<float, multicompp::kMeterMaster> hostValues{};
+    hostValues.fill(-123.0f);
+
+    multicompp::applyPresetToHostParameters(multibandProgram,
+        [&](int parameterIndex, float hostValue) {
+            hostValues[static_cast<size_t>(parameterIndex)] = hostValue;
+        });
+
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+        for (int field = 0; field < 8; ++field)
+        {
+            const int parameterIndex = multicompp::kBandBase + band * 8 + field;
+            const auto descriptor = multicompp::bandParam(field, band);
+            require(hostValues[static_cast<size_t>(parameterIndex)]
+                        == multicompp::plainToHost(descriptor, descriptor.def),
+                    "host program change applies every Multiband parameter in host space");
+        }
+    std::puts("host program change: every Multiband parameter applied in host space");
+}
+
 static_assert(multicompp::kParamCount == 63,
               "DPF host table must exclude the two JUCE-inert controls");
 } // namespace
@@ -319,6 +343,7 @@ int main()
     testHostParameterTapers();
     testStrictStateValidationAndRoundTrip();
     testFactoryPresetOwnership();
+    testHostProgramChangeAppliesBandParameters();
     std::puts("Multi-Comp plugin-layer tests: PASS");
     return 0;
 }

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -338,12 +338,66 @@ static_assert(multicompp::kParamCount == 63,
               "DPF host table must exclude the two JUCE-inert controls");
 } // namespace
 
+// A host ramping an integer parameter delivers fractional intermediates. Those
+// used to be stored verbatim, so getState() emitted a fractional integer and
+// decodeState() then rejected the ENTIRE state -- a project saved mid-ramp lost
+// every plugin setting on reload. setParameterValue() now snaps integer
+// descriptors, so anything that can be stored can also be loaded.
+void testFractionalIntegerAutomationStaysLoadable()
+{
+    const auto defaults = []() {
+        multicompp::StateValues v{};
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
+            v[static_cast<size_t>(i)] = multicompp::resolveParameter(i,
+                [](const multicompp::Param& d) { return multicompp::hostDefault(d); },
+                [](const multicompp::BandParam& d, int) { return multicompp::hostDefault(d); });
+        return v;
+    };
+
+    int integerIndex = -1;
+    for (int i = 0; i < multicompp::kMeterMaster && integerIndex < 0; ++i)
+        if (multicompp::resolveParameter(i,
+                [](const multicompp::Param& d) { return d.integer; },
+                [](const multicompp::BandParam& d, int) { return d.integer; }))
+            integerIndex = i;
+    require(integerIndex >= 0, "an integer-valued host parameter exists");
+
+    // What a host actually sends part way through an automation ramp.
+    const float fractional = multicompp::resolveParameter(integerIndex,
+        [](const multicompp::Param& d) { return multicompp::hostMin(d) + 0.6f; },
+        [](const multicompp::BandParam& d, int) { return multicompp::hostMin(d) + 0.6f; });
+    const float snapped = multicompp::resolveParameter(integerIndex,
+        [fractional](const multicompp::Param& d) { return multicompp::snapHostValue(d, fractional); },
+        [fractional](const multicompp::BandParam& d, int) { return multicompp::snapHostValue(d, fractional); });
+    require(std::trunc(snapped) == snapped, "snapped automation value is integral");
+
+    multicompp::StateValues stored = defaults();
+    stored[static_cast<size_t>(integerIndex)] = snapped;
+    multicompp::StateValues restored = defaults();
+    require(multicompp::decodeState(multicompp::encodeState(stored), restored),
+            "state stored after fractional automation reloads");
+    require(restored[static_cast<size_t>(integerIndex)] == snapped, "reloaded integer value survives");
+
+    // Control: the unsnapped value is what used to be stored, and it makes the
+    // whole state unloadable while leaving the destination untouched.
+    multicompp::StateValues bad = defaults();
+    bad[static_cast<size_t>(integerIndex)] = fractional;
+    multicompp::StateValues destination = defaults();
+    const multicompp::StateValues before = destination;
+    require(!multicompp::decodeState(multicompp::encodeState(bad), destination),
+            "an unsnapped fractional integer would reject the whole state");
+    for (size_t i = 0; i < destination.size(); ++i)
+        require(destination[i] == before[i], "rejected state leaves the destination untouched");
+    std::puts("fractional integer automation: snapped on store, state stays loadable");
+}
+
 int main()
 {
     testHostParameterTapers();
     testStrictStateValidationAndRoundTrip();
     testFactoryPresetOwnership();
     testHostProgramChangeAppliesBandParameters();
+    testFractionalIntegerAutomationStaysLoadable();
     std::puts("Multi-Comp plugin-layer tests: PASS");
     return 0;
 }

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -1,0 +1,324 @@
+#include "MultiCompParams.hpp"
+#include "MultiCompProgramPresets.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+using duskaudio::MultiCompDSP;
+
+namespace
+{
+void require(bool condition, const char* message)
+{
+    if (!condition) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+void testHostParameterTapers()
+{
+    const auto& ratio = multicompp::kParams[static_cast<size_t>(multicompp::ParamId::VcaRatio)];
+    const auto& attack = multicompp::kParams[static_cast<size_t>(multicompp::ParamId::DigitalAttack)];
+    const float positions[] = {0.25f, 0.5f, 0.75f};
+    const float expectedRatio[] = {2.2f, 12.8f, 46.6f};
+    const float expectedAttack[] = {4.93f, 49.62f, 191.66f};
+    require(multicompp::hostMin(ratio) == 0.0f && multicompp::hostMax(ratio) == 1.0f,
+            "tapered VCA Ratio is declared in normalized host space");
+    require(multicompp::hostMin(attack) == 0.0f && multicompp::hostMax(attack) == 1.0f,
+            "tapered Digital Attack is declared in normalized host space");
+    for (size_t i = 0; i < 3; ++i)
+    {
+        require(std::abs(multicompp::hostToPlain(ratio, positions[i]) - expectedRatio[i]) < 0.011f,
+                "VCA Ratio follows JUCE skew at quarter points");
+        require(std::abs(multicompp::hostToPlain(attack, positions[i]) - expectedAttack[i]) < 0.011f,
+                "Digital Attack follows JUCE skew at quarter points");
+    }
+    std::puts("host tapers: VCA Ratio and Digital Attack match JUCE at 0.25/0.5/0.75");
+}
+
+void testStrictStateValidationAndRoundTrip()
+{
+    multicompp::StateValues saved{};
+    for (int i = 0; i < multicompp::kMeterMaster; ++i)
+    {
+        saved[static_cast<size_t>(i)] = multicompp::resolveParameter(i,
+            [i](const multicompp::Param& d) {
+                return d.integer ? (d.def == d.min ? d.max : d.min)
+                    : multicompp::hostMin(d) + (multicompp::hostMax(d) - multicompp::hostMin(d))
+                        * (0.1f + 0.8f * static_cast<float>((i * 37) % 101) / 100.0f);
+            },
+            [i](const multicompp::BandParam& d, int) {
+                return d.integer ? (d.def == d.min ? d.max : d.min)
+                    : multicompp::hostMin(d) + (multicompp::hostMax(d) - multicompp::hostMin(d))
+                        * (0.1f + 0.8f * static_cast<float>((i * 29) % 101) / 100.0f);
+            });
+    }
+
+    const std::string valid = multicompp::encodeState(saved);
+    multicompp::StateValues restored{};
+    require(multicompp::decodeState(valid, restored), "complete state accepted");
+    require(std::memcmp(saved.data(), restored.data(), sizeof(saved)) == 0,
+            "state save/restore is bit-identical for every parameter");
+
+    auto rejectedWithoutMutation = [&](std::string invalid, const char* message) {
+        multicompp::StateValues before{};
+        before.fill(0.1234567f);
+        const auto unchanged = before;
+        require(!multicompp::decodeState(invalid, before), message);
+        require(std::memcmp(before.data(), unchanged.data(), sizeof(before)) == 0,
+                "rejected state changes zero parameters");
+    };
+
+    auto version2Values = saved;
+    for (int i = 0; i < multicompp::kMeterMaster; ++i)
+        version2Values[static_cast<size_t>(i)] = multicompp::resolveParameter(i,
+            [&](const multicompp::Param& d) {
+                return multicompp::hostToPlain(d, version2Values[static_cast<size_t>(i)]);
+            },
+            [&](const multicompp::BandParam& d, int) {
+                return multicompp::hostToPlain(d, version2Values[static_cast<size_t>(i)]);
+            });
+    std::string version2 = multicompp::encodeState(version2Values);
+    version2.replace(0, 3, "v=2");
+    version2 += ";envelope_curve=0;saturation_mode=0";
+    rejectedWithoutMutation(version2, "complete version-2 state rejected");
+
+    auto fractionalInteger = saved;
+    fractionalInteger[static_cast<size_t>(multicompp::ParamId::Mode)] = 0.6f;
+    rejectedWithoutMutation(multicompp::encodeState(fractionalInteger),
+                            "fractional integer state rejected");
+
+    std::string malformed = valid;
+    const size_t ratio = malformed.find(";digital_ratio=");
+    const size_t ratioEnd = malformed.find(';', ratio + 1);
+    malformed.replace(ratio + std::strlen(";digital_ratio="),
+                      ratioEnd - ratio - std::strlen(";digital_ratio="), "garbage");
+    rejectedWithoutMutation(malformed, "malformed state rejected");
+
+    std::string truncated = valid;
+    truncated.erase(truncated.rfind(';'));
+    rejectedWithoutMutation(truncated, "truncated state rejected");
+
+    const size_t mix = valid.find(";mix=");
+    const size_t mixEnd = valid.find(';', mix + 1);
+    rejectedWithoutMutation(valid + valid.substr(mix, mixEnd - mix), "duplicate state key rejected");
+    rejectedWithoutMutation(valid + ";unknown=0", "unknown state key rejected");
+    std::puts("state validation: v2/fractional integer/malformed/truncated/duplicate/unknown rejected atomically; round-trip exact");
+}
+
+void testFactoryPresetOwnership()
+{
+    auto verifyPreset = [](const duskaudio::MultiCompPreset& preset) {
+        std::array<float, multicompp::kMeterMaster> values{};
+        std::array<bool, multicompp::kMeterMaster> owned{};
+        values.fill(-123.0f);
+        multicompp::forEachPresetParam(preset,
+            [&](multicompp::CoreParameter parameter, float value) {
+                const int index = multicompp::coreParamIndex(parameter);
+                require(index >= 0, "preset-owned core parameter remains host-visible");
+                values[static_cast<size_t>(index)] = value;
+                owned[static_cast<size_t>(index)] = true;
+            },
+            [&](int band, int field, float value) {
+                const size_t index = static_cast<size_t>(multicompp::kBandBase + band * 8 + field);
+                values[index] = value;
+                owned[index] = true;
+            });
+
+        auto expect = [&](multicompp::ParamId id, float expected, const char* message) {
+            const size_t index = static_cast<size_t>(id);
+            require(owned[index], "factory preset applies every owned parameter");
+            require(values[index] == expected, message);
+        };
+        auto descriptorDefault = [](multicompp::ParamId id) {
+            return multicompp::kParams[static_cast<size_t>(id)].def;
+        };
+
+        expect(multicompp::ParamId::Mode, static_cast<float>(preset.mode),
+               "factory preset applies Mode");
+        expect(multicompp::ParamId::Mix, preset.mix, "factory preset applies Mix");
+        expect(multicompp::ParamId::SidechainHP, preset.sidechainHP,
+               "factory preset applies Sidechain HP");
+        expect(multicompp::ParamId::AutoMakeup, preset.autoMakeup ? 1.0f : 0.0f,
+               "factory preset applies Auto Makeup");
+
+        switch (preset.mode)
+        {
+            case 0:
+                expect(multicompp::ParamId::OptoPeakReduction, preset.peakReduction,
+                       "Opto preset applies Peak Reduction");
+                expect(multicompp::ParamId::OptoGain, duskaudio::optoGainDbToKnob(preset.makeup),
+                       "Opto preset applies Gain");
+                expect(multicompp::ParamId::OptoLimit, preset.limitMode ? 1.0f : 0.0f,
+                       "Opto preset applies Limit");
+                break;
+            case 1:
+            case 4:
+                expect(multicompp::ParamId::FetInput, -preset.threshold,
+                       "FET preset applies Input");
+                expect(multicompp::ParamId::FetOutput, preset.makeup,
+                       "FET preset applies Output");
+                expect(multicompp::ParamId::FetAttack, preset.attack,
+                       "FET preset applies Attack");
+                expect(multicompp::ParamId::FetRelease, preset.release,
+                       "FET preset applies Release");
+                expect(multicompp::ParamId::FetRatio, static_cast<float>(preset.fetRatio),
+                       "FET preset applies Ratio");
+                expect(multicompp::ParamId::FetCurve,
+                       descriptorDefault(multicompp::ParamId::FetCurve),
+                       "FET preset resets Curve to its descriptor default");
+                expect(multicompp::ParamId::FetTransient,
+                       descriptorDefault(multicompp::ParamId::FetTransient),
+                       "FET preset resets Transient to its descriptor default");
+                expect(multicompp::ParamId::FetThreshold,
+                       descriptorDefault(multicompp::ParamId::FetThreshold),
+                       "FET preset resets Threshold to its descriptor default");
+                break;
+            case 2:
+                expect(multicompp::ParamId::VcaThreshold, preset.threshold,
+                       "VCA preset applies Threshold");
+                expect(multicompp::ParamId::VcaRatio, preset.ratio,
+                       "VCA preset applies Ratio");
+                expect(multicompp::ParamId::VcaAttack, preset.attack,
+                       "VCA preset applies Attack");
+                expect(multicompp::ParamId::VcaRelease, preset.release,
+                       "VCA preset applies Release");
+                expect(multicompp::ParamId::VcaOutput, preset.makeup,
+                       "VCA preset applies Output");
+                expect(multicompp::ParamId::VcaOverEasy, preset.vcaOverEasy,
+                       "VCA preset applies Over Easy");
+                expect(multicompp::ParamId::VcaClassicDetector,
+                       descriptorDefault(multicompp::ParamId::VcaClassicDetector),
+                       "VCA preset resets Detector to its descriptor default");
+                break;
+            case 3:
+                expect(multicompp::ParamId::BusThreshold, preset.threshold,
+                       "Bus preset applies Threshold");
+                expect(multicompp::ParamId::BusRatio,
+                       static_cast<float>(preset.ratio <= 2.0f ? 0 : preset.ratio <= 4.0f ? 1 : 2),
+                       "Bus preset applies Ratio");
+                expect(multicompp::ParamId::BusAttack, static_cast<float>(preset.busAttack),
+                       "Bus preset applies Attack");
+                expect(multicompp::ParamId::BusRelease, static_cast<float>(preset.busRelease),
+                       "Bus preset applies Release");
+                expect(multicompp::ParamId::BusMakeup, preset.makeup,
+                       "Bus preset applies Makeup");
+                expect(multicompp::ParamId::BusMix, preset.mix,
+                       "Bus preset applies local Mix");
+                break;
+            case 5:
+                expect(multicompp::ParamId::StudioVcaThreshold, preset.threshold,
+                       "Studio VCA preset applies Threshold");
+                expect(multicompp::ParamId::StudioVcaRatio, preset.ratio,
+                       "Studio VCA preset applies Ratio");
+                expect(multicompp::ParamId::StudioVcaAttack, preset.attack,
+                       "Studio VCA preset applies Attack");
+                expect(multicompp::ParamId::StudioVcaRelease, preset.release,
+                       "Studio VCA preset applies Release");
+                expect(multicompp::ParamId::StudioVcaOutput, preset.makeup,
+                       "Studio VCA preset applies Output");
+                break;
+            case 6:
+                expect(multicompp::ParamId::DigitalThreshold, preset.threshold,
+                       "Digital preset applies Threshold");
+                expect(multicompp::ParamId::DigitalRatio, preset.ratio,
+                       "Digital preset applies Ratio");
+                expect(multicompp::ParamId::DigitalKnee,
+                       descriptorDefault(multicompp::ParamId::DigitalKnee),
+                       "Digital preset resets Knee to its descriptor default");
+                expect(multicompp::ParamId::DigitalAttack, preset.attack,
+                       "Digital preset applies Attack");
+                expect(multicompp::ParamId::DigitalRelease, preset.release,
+                       "Digital preset applies Release");
+                expect(multicompp::ParamId::DigitalLookahead,
+                       descriptorDefault(multicompp::ParamId::DigitalLookahead),
+                       "Digital preset resets local Lookahead to its descriptor default");
+                expect(multicompp::ParamId::DigitalMix,
+                       descriptorDefault(multicompp::ParamId::DigitalMix),
+                       "Digital preset resets local Mix to its descriptor default");
+                expect(multicompp::ParamId::DigitalOutput, preset.makeup,
+                       "Digital preset applies Output");
+                expect(multicompp::ParamId::DigitalAdaptive,
+                       descriptorDefault(multicompp::ParamId::DigitalAdaptive),
+                       "Digital preset resets Adaptive Release to its descriptor default");
+                break;
+            case 7:
+                expect(multicompp::ParamId::Crossover1,
+                       descriptorDefault(multicompp::ParamId::Crossover1),
+                       "Multiband preset resets Crossover 1 to its descriptor default");
+                expect(multicompp::ParamId::Crossover2,
+                       descriptorDefault(multicompp::ParamId::Crossover2),
+                       "Multiband preset resets Crossover 2 to its descriptor default");
+                expect(multicompp::ParamId::Crossover3,
+                       descriptorDefault(multicompp::ParamId::Crossover3),
+                       "Multiband preset resets Crossover 3 to its descriptor default");
+                expect(multicompp::ParamId::MbMix,
+                       descriptorDefault(multicompp::ParamId::MbMix),
+                       "Multiband preset resets Mix to its descriptor default");
+                expect(multicompp::ParamId::MbOutput,
+                       descriptorDefault(multicompp::ParamId::MbOutput),
+                       "Multiband preset resets Output to its descriptor default");
+                for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+                    for (int field = 0; field < 8; ++field)
+                    {
+                        const size_t index = static_cast<size_t>(
+                            multicompp::kBandBase + band * 8 + field);
+                        require(owned[index], "Multiband preset applies every band parameter");
+                        require(values[index] == multicompp::bandParam(field, band).def,
+                                "Multiband preset resets band parameter to its descriptor default");
+                    }
+                break;
+            default:
+                break;
+        }
+
+        for (const auto id : {multicompp::ParamId::Bypass,
+                              multicompp::ParamId::StereoLink,
+                              multicompp::ParamId::TruePeakEnable,
+                              multicompp::ParamId::TruePeakQuality,
+                              multicompp::ParamId::ExternalSidechain,
+                              multicompp::ParamId::Distortion,
+                              multicompp::ParamId::DistortionAmount,
+                              multicompp::ParamId::Oversampling,
+                              multicompp::ParamId::GlobalLookahead,
+                              multicompp::ParamId::GlobalSidechainListen,
+                              multicompp::ParamId::NoiseEnable,
+                              multicompp::ParamId::ScLowFreq,
+                              multicompp::ParamId::ScLowGain,
+                              multicompp::ParamId::ScHighFreq,
+                              multicompp::ParamId::ScHighGain,
+                              multicompp::ParamId::StereoLinkMode})
+            require(!owned[static_cast<size_t>(id)],
+                    "factory preset leaves machine/global parameter untouched");
+    };
+
+    for (const auto& preset : multicompp::kFactoryPresets)
+        verifyPreset(preset);
+
+    auto syntheticDigital = multicompp::kFactoryPresets.front();
+    syntheticDigital.mode = 6;
+    verifyPreset(syntheticDigital);
+    auto syntheticMultiband = multicompp::kFactoryPresets.front();
+    syntheticMultiband.mode = 7;
+    verifyPreset(syntheticMultiband);
+
+    require(multicompp::coreParamIndex(MultiCompDSP::Parameter::EnvelopeCurve) < 0
+                && multicompp::coreParamIndex(MultiCompDSP::Parameter::SaturationMode) < 0,
+            "JUCE-inert controls are absent from the DPF parameter table");
+    std::puts("factory preset ownership: every active-mode control applied; machine/global controls untouched");
+}
+
+static_assert(multicompp::kParamCount == 63,
+              "DPF host table must exclude the two JUCE-inert controls");
+} // namespace
+
+int main()
+{
+    testHostParameterTapers();
+    testStrictStateValidationAndRoundTrip();
+    testFactoryPresetOwnership();
+    std::puts("Multi-Comp plugin-layer tests: PASS");
+    return 0;
+}

--- a/plugins/multi-comp/dpf-plugin/MultiCompProgramPresets.hpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompProgramPresets.hpp
@@ -101,10 +101,26 @@ void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
     }
 }
 
-template <class SetParameter>
-void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
-                        SetParameter&& setParameter)
+// Host-program adapter used by Plugin::loadProgram. Values passed to the
+// setter are host-domain values at their real DPF parameter indices.
+template <class SetHostParameter>
+void applyPresetToHostParameters(const duskaudio::MultiCompPreset& preset,
+                                 SetHostParameter&& setHostParameter)
 {
-    forEachPresetParam(preset, setParameter, [](int, int, float) {});
+    forEachPresetParam(preset,
+        [&](CoreParameter parameter, float value)
+        {
+            const int parameterIndex = coreParamIndex(parameter);
+            if (parameterIndex >= 0)
+            {
+                const auto& d = kParams[static_cast<size_t>(parameterIndex)];
+                setHostParameter(parameterIndex, plainToHost(d, value));
+            }
+        },
+        [&](int band, int field, float value)
+        {
+            const auto d = bandParam(field, band);
+            setHostParameter(kBandBase + band * 8 + field, plainToHost(d, value));
+        });
 }
 } // namespace multicompp

--- a/plugins/multi-comp/dpf-plugin/MultiCompProgramPresets.hpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompProgramPresets.hpp
@@ -14,11 +14,12 @@ inline int coreParamIndex(CoreParameter parameter) noexcept
 
 // Shared factory-program walker. A recall owns only the JUCE preset's common
 // controls and the controls for its selected compressor mode. Machine/global
-// choices (including Bypass, oversampling, external sidechain and lookahead)
-// and all multiband fields remain untouched.
-template <class SetParameter>
+// choices (including Bypass, oversampling, external sidechain and global
+// lookahead) remain untouched.
+template <class SetParameter, class SetBandParameter>
 void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
-                        SetParameter&& setParameter)
+                        SetParameter&& setParameter,
+                        SetBandParameter&& setBandParameter)
 {
     using P = CoreParameter;
     setParameter(P::Mode, static_cast<float>(preset.mode));
@@ -40,6 +41,9 @@ void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
             setParameter(P::FetAttack, preset.attack);
             setParameter(P::FetRelease, preset.release);
             setParameter(P::FetRatio, static_cast<float>(preset.fetRatio));
+            setParameter(P::FetCurve, kParams[static_cast<size_t>(ParamId::FetCurve)].def);
+            setParameter(P::FetTransient, kParams[static_cast<size_t>(ParamId::FetTransient)].def);
+            setParameter(P::FetThreshold, kParams[static_cast<size_t>(ParamId::FetThreshold)].def);
             break;
         case 2:
             setParameter(P::VcaThreshold, preset.threshold);
@@ -48,6 +52,8 @@ void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
             setParameter(P::VcaRelease, preset.release);
             setParameter(P::VcaOutput, preset.makeup);
             setParameter(P::VcaOverEasy, preset.vcaOverEasy);
+            setParameter(P::VcaClassicDetector,
+                         kParams[static_cast<size_t>(ParamId::VcaClassicDetector)].def);
             break;
         case 3:
         {
@@ -70,13 +76,35 @@ void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
         case 6:
             setParameter(P::DigitalThreshold, preset.threshold);
             setParameter(P::DigitalRatio, preset.ratio);
+            setParameter(P::DigitalKnee, kParams[static_cast<size_t>(ParamId::DigitalKnee)].def);
             setParameter(P::DigitalAttack, preset.attack);
             setParameter(P::DigitalRelease, preset.release);
+            setParameter(P::DigitalLookahead,
+                         kParams[static_cast<size_t>(ParamId::DigitalLookahead)].def);
+            setParameter(P::DigitalMix, kParams[static_cast<size_t>(ParamId::DigitalMix)].def);
             setParameter(P::DigitalOutput, preset.makeup);
+            setParameter(P::DigitalAdaptive,
+                         kParams[static_cast<size_t>(ParamId::DigitalAdaptive)].def);
             break;
         case 7:
+            setParameter(P::Crossover1, kParams[static_cast<size_t>(ParamId::Crossover1)].def);
+            setParameter(P::Crossover2, kParams[static_cast<size_t>(ParamId::Crossover2)].def);
+            setParameter(P::Crossover3, kParams[static_cast<size_t>(ParamId::Crossover3)].def);
+            setParameter(P::MbMix, kParams[static_cast<size_t>(ParamId::MbMix)].def);
+            setParameter(P::MbOutput, kParams[static_cast<size_t>(ParamId::MbOutput)].def);
+            for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+                for (int field = 0; field < 8; ++field)
+                    setBandParameter(band, field, bandParam(field, band).def);
+            break;
         default:
             break;
     }
+}
+
+template <class SetParameter>
+void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
+                        SetParameter&& setParameter)
+{
+    forEachPresetParam(preset, setParameter, [](int, int, float) {});
 }
 } // namespace multicompp

--- a/plugins/multi-comp/dpf-plugin/MultiCompProgramPresets.hpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompProgramPresets.hpp
@@ -12,29 +12,19 @@ inline int coreParamIndex(CoreParameter parameter) noexcept
     return -1;
 }
 
-// Shared factory-program walker.  The DPF host program path and the ImGui
-// selector both use this identity-based application, including the complete
-// default reset and all multiband fields.
-template <class SetParameter, class SetBandParameter>
+// Shared factory-program walker. A recall owns only the JUCE preset's common
+// controls and the controls for its selected compressor mode. Machine/global
+// choices (including Bypass, oversampling, external sidechain and lookahead)
+// and all multiband fields remain untouched.
+template <class SetParameter>
 void forEachPresetParam(const duskaudio::MultiCompPreset& preset,
-                        SetParameter&& setParameter,
-                        SetBandParameter&& setBandParameter)
+                        SetParameter&& setParameter)
 {
-    for (const auto& parameter : kParams)
-        setParameter(parameter.core, parameter.def);
-    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
-        for (int field = 0; field < 8; ++field)
-        {
-            const auto parameter = bandParam(field, band);
-            setBandParameter(band, field, parameter.def);
-        }
-
     using P = CoreParameter;
     setParameter(P::Mode, static_cast<float>(preset.mode));
     setParameter(P::Mix, preset.mix);
     setParameter(P::SidechainHP, preset.sidechainHP);
     setParameter(P::AutoMakeup, preset.autoMakeup ? 1.0f : 0.0f);
-    setParameter(P::SaturationMode, static_cast<float>(preset.saturationMode));
 
     switch (preset.mode)
     {

--- a/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
@@ -110,9 +110,8 @@ public:
     {
         if (idx >= static_cast<uint32_t>(multicompp::kMeterMaster)) return;
         currentPreset = -1;
-        const float hostValue = hostValueForPlain(idx, value);
-        values[idx] = hostValue;
-        setParameterValue(idx, hostValue);
+        values[idx] = value;
+        setParameterValue(idx, value);
     }
 
 protected:
@@ -208,7 +207,7 @@ private:
     void titleHit(ImDrawList* dl)
     {
         panel.text(dl, 22, 11, 24, kText, "Multi-Comp 2", -1, true);
-        panel.text(dl, 24, 40, 10, kDim, modeName(static_cast<int>(std::lround(value(P_MODE)))), -1);
+        panel.text(dl, 24, 40, 10, kDim, modeName(static_cast<int>(value(P_MODE))), -1);
         panel.text(dl, kDesignW - 20, 20, 11, kDim, "Dusk Audio", 1);
         ImGui::SetCursorScreenPos(panel.P(12, 7));
         ImGui::InvisibleButton("##mc_title", ImVec2(190 * panel.scale(), 44 * panel.scale()));
@@ -219,7 +218,7 @@ private:
                float x, float y, float w, const char* caption)
     {
         panel.text(ImGui::GetWindowDrawList(), x, y, 9.5f, kDim, caption, 0, true);
-        const int selected = std::clamp(static_cast<int>(std::lround(value(p))), 0, count - 1);
+        const int selected = std::clamp(static_cast<int>(value(p)), 0, count - 1);
         const ImVec2 p0 = panel.P(x - w * 0.5f, y + 16);
         const ImVec2 p1 = panel.P(x + w * 0.5f, y + 43);
         ImDrawList* dl = ImGui::GetWindowDrawList();
@@ -294,15 +293,15 @@ private:
     void drawGlobal(ImDrawList* dl)
     {
         drawSection(dl, kHeaderH + 4, kHeaderH + kGlobalH, "GLOBAL");
-        knob(dl, "mc_mix", P_MIX, 78, 125, 0, 100, "MIX", "%.0f", "%");
-        knob(dl, "mc_link", P_LINK, 166, 125, 0, 100, "STEREO LINK", "%.0f", "%");
+        knob(dl, "mc_mix", P_MIX, 78, 125, "MIX", "%.0f", "%");
+        knob(dl, "mc_link", P_LINK, 166, 125, "STEREO LINK", "%.0f", "%");
         combo("mc_linkmode", P_LINK_MODE, multicompp::kLinkMode, 3, 270, 103, 112, "LINK MODE");
         combo("mc_os", P_OS, multicompp::kOversampling, 3, 394, 103, 96, "OVERSAMPLE");
-        knob(dl, "mc_look", P_LOOK, 510, 125, 0, 10, "LOOKAHEAD", "%.1f", " ms");
+        knob(dl, "mc_look", P_LOOK, 510, 125, "LOOKAHEAD", "%.1f", " ms");
         panel.toggle("mc_auto", P_AUTO, 568, 111, 680, 136, values[P_AUTO], "AUTO MAKEUP");
         panel.toggle("mc_tp", P_TRUE_PEAK, 688, 111, 790, 136, values[P_TRUE_PEAK], "TRUE PEAK");
         combo("mc_tpq", P_TP_QUALITY, multicompp::kTruePeakQuality, 2, 845, 103, 110, "QUALITY");
-        knob(dl, "mc_dist", P_DIST_AMT, 1080, 125, 0, 100, "DRIVE", "%.0f", "%");
+        knob(dl, "mc_dist", P_DIST_AMT, 1080, 125, "DRIVE", "%.0f", "%");
     }
 
     void drawSidechain(ImDrawList* dl)
@@ -310,11 +309,11 @@ private:
         drawSection(dl, kHeaderH + kGlobalH + 4, kPanelTop - 4, "SIDECHAIN");
         panel.toggle("mc_ext", P_EXT_SC, 24, 223, 142, 248, values[P_EXT_SC], "EXTERNAL SC");
         panel.toggle("mc_listen", P_SC_LISTEN, 24, 255, 142, 280, values[P_SC_LISTEN], "LISTEN");
-        knob(dl, "mc_schp", P_SC_HP, 190, 251, 0, 500, "HP FILTER", "%.0f", " Hz");
-        knob(dl, "mc_sclf", P_SC_LOW_FREQ, 300, 251, 60, 500, "LOW FREQ", "%.0f", " Hz");
-        knob(dl, "mc_sclg", P_SC_LOW_GAIN, 410, 251, -12, 12, "LOW GAIN", "%.1f", " dB");
-        knob(dl, "mc_schf", P_SC_HIGH_FREQ, 520, 251, 2000, 16000, "HIGH FREQ", "%.0f", " Hz");
-        knob(dl, "mc_schg", P_SC_HIGH_GAIN, 630, 251, -12, 12, "HIGH GAIN", "%.1f", " dB");
+        knob(dl, "mc_schp", P_SC_HP, 190, 251, "HP FILTER", "%.0f", " Hz");
+        knob(dl, "mc_sclf", P_SC_LOW_FREQ, 300, 251, "LOW FREQ", "%.0f", " Hz");
+        knob(dl, "mc_sclg", P_SC_LOW_GAIN, 410, 251, "LOW GAIN", "%.1f", " dB");
+        knob(dl, "mc_schf", P_SC_HIGH_FREQ, 520, 251, "HIGH FREQ", "%.0f", " Hz");
+        knob(dl, "mc_schg", P_SC_HIGH_GAIN, 630, 251, "HIGH GAIN", "%.1f", " dB");
         combo("mc_disttype", P_DIST, multicompp::kDistortion, 4, 954, 230, 130, "DISTORTION");
         neutralToggle("##mc_noise", P_NOISE, 1000, 270, 1095, 295, "NOISE");
     }
@@ -345,58 +344,65 @@ private:
     }
 
     void knob(ImDrawList* dl, const char* id, uint32_t p, float x, float y,
-              float min, float max, const char* label, const char* fmt, const char* suffix)
+              const char* label, const char* fmt, const char* suffix)
     {
-        const float physicalMin = plainMin(p), physicalMax = plainMax(p);
-        (void)min; (void)max;
-        float physicalValue = plainValue(p);
-        panel.knob(id, p, physicalMin, physicalMax, x, y, 25, physicalValue,
-                   defaultValue(p), false, true,
-                   fmt, suffix, kPanelRaised, false, true);
+        panel.knob(id, p, hostMinimum(p), hostMaximum(p), x, y, 25, values[p],
+                   hostDefaultValue(p), false, true,
+                   fmt, suffix, kPanelRaised, false, true, nullptr, false, 1.0f, 0.0f,
+                   nullptr, false, nullptr, false, 0.0f, 0.0f, false, false, 9.5f,
+                   false, false, &knobHostToPlain, &knobPlainToHost, this);
         panel.text(dl, x, y + 49, 9.5f, kText, label, 0, true);
     }
 
-    float defaultValue(uint32_t p) const
+    float hostDefaultValue(uint32_t p) const
     {
-        if (p < static_cast<uint32_t>(multicompp::kParamCount)) return multicompp::kParams[p].def;
-        const int rel = static_cast<int>(p) - multicompp::kBandBase;
-        return multicompp::bandParam(rel % 8, rel / 8).def;
+        return multicompp::resolveParameter(static_cast<int>(p),
+            [](const multicompp::Param& d) { return multicompp::hostDefault(d); },
+            [](const multicompp::BandParam& d, int) { return multicompp::hostDefault(d); });
     }
 
-    float plainMin(uint32_t p) const
+    float hostMinimum(uint32_t p) const
     {
-        if (p < static_cast<uint32_t>(multicompp::kParamCount)) return multicompp::kParams[p].min;
-        const int rel = static_cast<int>(p) - multicompp::kBandBase;
-        return multicompp::bandParam(rel % 8, rel / 8).min;
+        return multicompp::resolveParameter(static_cast<int>(p),
+            [](const multicompp::Param& d) { return multicompp::hostMin(d); },
+            [](const multicompp::BandParam& d, int) { return multicompp::hostMin(d); });
     }
 
-    float plainMax(uint32_t p) const
+    float hostMaximum(uint32_t p) const
     {
-        if (p < static_cast<uint32_t>(multicompp::kParamCount)) return multicompp::kParams[p].max;
-        const int rel = static_cast<int>(p) - multicompp::kBandBase;
-        return multicompp::bandParam(rel % 8, rel / 8).max;
+        return multicompp::resolveParameter(static_cast<int>(p),
+            [](const multicompp::Param& d) { return multicompp::hostMax(d); },
+            [](const multicompp::BandParam& d, int) { return multicompp::hostMax(d); });
     }
 
-    float plainValue(uint32_t p) const
+    float plainValueForHost(uint32_t p, float host) const
     {
-        if (p < static_cast<uint32_t>(multicompp::kParamCount))
-            return multicompp::hostToPlain(multicompp::kParams[p], values[p]);
-        const int rel = static_cast<int>(p) - multicompp::kBandBase;
-        return multicompp::hostToPlain(multicompp::bandParam(rel % 8, rel / 8), values[p]);
+        return multicompp::resolveParameter(static_cast<int>(p),
+            [host](const multicompp::Param& d) { return multicompp::hostToPlain(d, host); },
+            [host](const multicompp::BandParam& d, int) { return multicompp::hostToPlain(d, host); });
     }
 
     float hostValueForPlain(uint32_t p, float plain) const
     {
-        if (p < static_cast<uint32_t>(multicompp::kParamCount))
-            return multicompp::plainToHost(multicompp::kParams[p], plain);
-        const int rel = static_cast<int>(p) - multicompp::kBandBase;
-        return multicompp::plainToHost(multicompp::bandParam(rel % 8, rel / 8), plain);
+        return multicompp::resolveParameter(static_cast<int>(p),
+            [plain](const multicompp::Param& d) { return multicompp::plainToHost(d, plain); },
+            [plain](const multicompp::BandParam& d, int) { return multicompp::plainToHost(d, plain); });
+    }
+
+    static float knobHostToPlain(float host, uint32_t p, void* context)
+    {
+        return static_cast<MultiCompUI*>(context)->plainValueForHost(p, host);
+    }
+
+    static float knobPlainToHost(float plain, uint32_t p, void* context)
+    {
+        return static_cast<MultiCompUI*>(context)->hostValueForPlain(p, plain);
     }
 
     void drawModePanel(ImDrawList* dl)
     {
-        drawSection(dl, kPanelTop, kDesignH - 8, modeName(static_cast<int>(std::lround(value(P_MODE)))));
-        const int mode = std::clamp(static_cast<int>(std::lround(value(P_MODE))), 0, 7);
+        drawSection(dl, kPanelTop, kDesignH - 8, modeName(static_cast<int>(value(P_MODE))));
+        const int mode = std::clamp(static_cast<int>(value(P_MODE)), 0, 7);
         if (mode == 7)
             drawMeter(dl, 1062, kPanelTop + 24, 42, 92, meter(kMeterMaster), kAccent, "MASTER GR");
         else
@@ -417,71 +423,71 @@ private:
 
     void drawOpto(ImDrawList* dl)
     {
-        knob(dl, "opto_peak", P_OPTO_PEAK, 250, 380, 0, 100, "PEAK REDUCTION", "%.0f", "%");
-        knob(dl, "opto_gain", P_OPTO_GAIN, 420, 380, 0, 100, "GAIN", "%.0f", "%");
-        knob(dl, "opto_mix", P_MIX, 590, 380, 0, 100, "MIX", "%.0f", "%");
+        knob(dl, "opto_peak", P_OPTO_PEAK, 250, 380, "PEAK REDUCTION", "%.0f", "%");
+        knob(dl, "opto_gain", P_OPTO_GAIN, 420, 380, "GAIN", "%.0f", "%");
+        knob(dl, "opto_mix", P_MIX, 590, 380, "MIX", "%.0f", "%");
         panel.toggle("opto_limit", P_OPTO_LIMIT, 690, 366, 820, 392, values[P_OPTO_LIMIT], "LIMIT");
         panel.text(dl, 560, 500, 12, kDim, "Program-dependent optical envelope", 0);
     }
 
     void drawFet(ImDrawList* dl, bool studio)
     {
-        knob(dl, studio ? "sf_in" : "fet_in", P_FET_IN, 120, 380, -20, 40, "INPUT", "%.1f", " dB");
-        knob(dl, studio ? "sf_out" : "fet_out", P_FET_OUT, 250, 380, -20, 20, "OUTPUT", "%.1f", " dB");
-        knob(dl, studio ? "sf_att" : "fet_att", P_FET_ATTACK, 380, 380, 0.02f, 80, "ATTACK", "%.2f", " ms");
-        knob(dl, studio ? "sf_rel" : "fet_rel", P_FET_RELEASE, 510, 380, 50, 1100, "RELEASE", "%.0f", " ms");
-        knob(dl, studio ? "sf_mix" : "fet_mix", P_MIX, 640, 380, 0, 100, "MIX", "%.0f", "%");
+        knob(dl, studio ? "sf_in" : "fet_in", P_FET_IN, 120, 380, "INPUT", "%.1f", " dB");
+        knob(dl, studio ? "sf_out" : "fet_out", P_FET_OUT, 250, 380, "OUTPUT", "%.1f", " dB");
+        knob(dl, studio ? "sf_att" : "fet_att", P_FET_ATTACK, 380, 380, "ATTACK", "%.2f", " ms");
+        knob(dl, studio ? "sf_rel" : "fet_rel", P_FET_RELEASE, 510, 380, "RELEASE", "%.0f", " ms");
+        knob(dl, studio ? "sf_mix" : "fet_mix", P_MIX, 640, 380, "MIX", "%.0f", "%");
         combo(studio ? "sf_ratio" : "fet_ratio", P_FET_RATIO, multicompp::kRatios, 5, 775, 352, 118, "RATIO");
         combo(studio ? "sf_curve" : "fet_curve", P_FET_CURVE, multicompp::kFetCurve, 2, 905, 352, 142, "CURVE");
-        knob(dl, studio ? "sf_trans" : "fet_trans", P_FET_TRANSIENT, 1020, 380, 0, 100, "TRANSIENT", "%.0f", "%");
+        knob(dl, studio ? "sf_trans" : "fet_trans", P_FET_TRANSIENT, 1020, 380, "TRANSIENT", "%.0f", "%");
         panel.text(dl, 560, 500, 12, studio ? IM_COL32(80, 215, 205, 255) : IM_COL32(235, 175, 80, 255),
                    studio ? "Clean FET response with controlled harmonics" : "Fast FET response with program-dependent release", 0);
     }
 
     void drawVca(ImDrawList* dl)
     {
-        knob(dl, "vca_thr", P_VCA_THRESHOLD, 170, 380, -38, 12, "THRESHOLD", "%.1f", " dB");
-        knob(dl, "vca_ratio", P_VCA_RATIO, 320, 380, 1, 120, "RATIO", "%.1f", ":1");
-        knob(dl, "vca_att", P_VCA_ATTACK, 470, 380, 0.1f, 50, "ATTACK", "%.1f", " ms");
-        knob(dl, "vca_rel", P_VCA_RELEASE, 620, 380, 10, 5000, "RELEASE", "%.0f", " ms");
-        knob(dl, "vca_out", P_VCA_OUT, 770, 380, -20, 20, "OUTPUT", "%.1f", " dB");
-        knob(dl, "vca_mix", P_MIX, 920, 380, 0, 100, "MIX", "%.0f", "%");
+        knob(dl, "vca_thr", P_VCA_THRESHOLD, 170, 380, "THRESHOLD", "%.1f", " dB");
+        knob(dl, "vca_ratio", P_VCA_RATIO, 320, 380, "RATIO", "%.1f", ":1");
+        knob(dl, "vca_att", P_VCA_ATTACK, 470, 380, "ATTACK", "%.1f", " ms");
+        knob(dl, "vca_rel", P_VCA_RELEASE, 620, 380, "RELEASE", "%.0f", " ms");
+        knob(dl, "vca_out", P_VCA_OUT, 770, 380, "OUTPUT", "%.1f", " dB");
+        knob(dl, "vca_mix", P_MIX, 920, 380, "MIX", "%.0f", "%");
         panel.toggle("vca_over", P_VCA_OVER_EASY, 860, 450, 1000, 476, values[P_VCA_OVER_EASY], "OVER EASY");
         combo("vca_detector", P_VCA_DETECTOR, multicompp::kVcaDetector, 2, 670, 450, 170, "DETECTOR");
     }
 
     void drawBus(ImDrawList* dl)
     {
-        knob(dl, "bus_thr", P_BUS_THRESHOLD, 160, 380, -30, 15, "THRESHOLD", "%.1f", " dB");
+        knob(dl, "bus_thr", P_BUS_THRESHOLD, 160, 380, "THRESHOLD", "%.1f", " dB");
         combo("bus_ratio", P_BUS_RATIO, multicompp::kBusRatios, 3, 300, 352, 100, "RATIO");
         combo("bus_attack", P_BUS_ATTACK, multicompp::kBusAttack, 6, 440, 352, 108, "ATTACK");
         combo("bus_release", P_BUS_RELEASE, multicompp::kBusRelease, 5, 580, 352, 108, "RELEASE");
-        knob(dl, "bus_makeup", P_BUS_MAKEUP, 720, 380, 0, 20, "MAKEUP", "%.1f", " dB");
-        knob(dl, "bus_mix", P_BUS_MIX, 860, 380, 0, 100, "BUS MIX", "%.0f", "%");
+        knob(dl, "bus_makeup", P_BUS_MAKEUP, 720, 380, "MAKEUP", "%.1f", " dB");
+        knob(dl, "bus_mix", P_BUS_MIX, 860, 380, "BUS MIX", "%.0f", "%");
         panel.text(dl, 560, 500, 12, IM_COL32(152, 190, 228, 255), "Gentle bus glue with linked stereo detection", 0);
     }
 
     void drawStudioVca(ImDrawList* dl)
     {
-        knob(dl, "sv_thr", P_SVCA_THRESHOLD, 150, 380, -40, 20, "THRESHOLD", "%.1f", " dB");
-        knob(dl, "sv_ratio", P_SVCA_RATIO, 300, 380, 1, 10, "RATIO", "%.1f", ":1");
-        knob(dl, "sv_att", P_SVCA_ATTACK, 450, 380, 0.3f, 75, "ATTACK", "%.1f", " ms");
-        knob(dl, "sv_rel", P_SVCA_RELEASE, 600, 380, 100, 4000, "RELEASE", "%.0f", " ms");
-        knob(dl, "sv_out", P_SVCA_OUT, 750, 380, -20, 20, "OUTPUT", "%.1f", " dB");
-        knob(dl, "sv_mix", P_MIX, 900, 380, 0, 100, "MIX", "%.0f", "%");
+        knob(dl, "sv_thr", P_SVCA_THRESHOLD, 150, 380, "THRESHOLD", "%.1f", " dB");
+        knob(dl, "sv_ratio", P_SVCA_RATIO, 300, 380, "RATIO", "%.1f", ":1");
+        knob(dl, "sv_att", P_SVCA_ATTACK, 450, 380, "ATTACK", "%.1f", " ms");
+        knob(dl, "sv_rel", P_SVCA_RELEASE, 600, 380, "RELEASE", "%.0f", " ms");
+        knob(dl, "sv_out", P_SVCA_OUT, 750, 380, "OUTPUT", "%.1f", " dB");
+        knob(dl, "sv_mix", P_MIX, 900, 380, "MIX", "%.0f", "%");
         panel.text(dl, 560, 500, 12, IM_COL32(220, 120, 125, 255), "RMS detection, soft knee, precision VCA control", 0);
     }
 
     void drawDigital(ImDrawList* dl)
     {
-        knob(dl, "dig_thr", P_DIG_THRESHOLD, 120, 380, -60, 0, "THRESHOLD", "%.1f", " dB");
-        knob(dl, "dig_ratio", P_DIG_RATIO, 250, 380, 1, 100, "RATIO", "%.1f", ":1");
-        knob(dl, "dig_knee", P_DIG_KNEE, 380, 380, 0, 20, "KNEE", "%.1f", " dB");
-        knob(dl, "dig_att", P_DIG_ATTACK, 510, 380, 0.01f, 500, "ATTACK", "%.2f", " ms");
-        knob(dl, "dig_rel", P_DIG_RELEASE, 640, 380, 1, 5000, "RELEASE", "%.0f", " ms");
-        knob(dl, "dig_look", P_DIG_LOOK, 770, 380, 0, 10, "LOOKAHEAD", "%.1f", " ms");
-        knob(dl, "dig_mix", P_DIG_MIX, 900, 380, 0, 100, "MIX", "%.0f", "%");
-        knob(dl, "dig_out", P_DIG_OUT, 1030, 380, -24, 24, "OUTPUT", "%.1f", " dB");
+        knob(dl, "dig_thr", P_DIG_THRESHOLD, 120, 380, "THRESHOLD", "%.1f", " dB");
+        knob(dl, "dig_ratio", P_DIG_RATIO, 250, 380, "RATIO", "%.1f", ":1");
+        knob(dl, "dig_knee", P_DIG_KNEE, 380, 380, "KNEE", "%.1f", " dB");
+        knob(dl, "dig_att", P_DIG_ATTACK, 510, 380, "ATTACK", "%.2f", " ms");
+        knob(dl, "dig_rel", P_DIG_RELEASE, 640, 380, "RELEASE", "%.0f", " ms");
+        knob(dl, "dig_look", P_DIG_LOOK, 770, 380, "LOOKAHEAD", "%.1f", " ms");
+        knob(dl, "dig_mix", P_DIG_MIX, 900, 380, "MIX", "%.0f", "%");
+        knob(dl, "dig_out", P_DIG_OUT, 1030, 380, "OUTPUT", "%.1f", " dB");
         panel.toggle("dig_adapt", P_DIG_ADAPT, 475, 448, 645, 475, values[P_DIG_ADAPT], "ADAPTIVE RELEASE");
     }
 
@@ -490,9 +496,9 @@ private:
         const float left = 28, right = kDesignW - 28, top = 342, bottom = 445;
         dl->AddRectFilled(panel.P(left, top), panel.P(right, bottom), IM_COL32(22, 24, 29, 255), 5 * panel.scale());
         panel.text(dl, 40, top + 10, 10, kDim, "CROSSOVERS / GAIN REDUCTION", -1, true);
-        crossover(dl, P_X1, 180, 20, 500, "XOVER 1");
-        crossover(dl, P_X2, 430, 200, 5000, "XOVER 2");
-        crossover(dl, P_X3, 680, 2000, 16000, "XOVER 3");
+        crossover(dl, P_X1, 180, "XOVER 1");
+        crossover(dl, P_X2, 430, "XOVER 2");
+        crossover(dl, P_X3, 680, "XOVER 3");
         for (int b = 0; b < 4; ++b)
         {
             char id[16];
@@ -507,21 +513,20 @@ private:
             panel.toggle(bandId("mb_bp"), base + 5,
                          x + 182, 470, x + 238, 494, values[base + 5], "BYP");
             drawMeter(dl, x + 22, 510, 26, 190, meter(kMeterBand0 + static_cast<uint32_t>(b)), kBandColors[b], "GR");
-            knob(dl, bandId("mb_t"), base, x + 75, 550, -60, 0, "THRESH", "%.1f", " dB");
-            knob(dl, bandId("mb_r"), base + 1, x + 145, 550, 1, 20, "RATIO", "%.1f", ":1");
-            knob(dl, bandId("mb_a"), base + 2, x + 215, 550, 0.1f, 100, "ATTACK", "%.1f", " ms");
-            knob(dl, bandId("mb_rel"), base + 3, x + 75, 650, 10, 1000, "RELEASE", "%.0f", " ms");
-            knob(dl, bandId("mb_m"), base + 4, x + 145, 650, -12, 12, "MAKEUP", "%.1f", " dB");
+            knob(dl, bandId("mb_t"), base, x + 75, 550, "THRESH", "%.1f", " dB");
+            knob(dl, bandId("mb_r"), base + 1, x + 145, 550, "RATIO", "%.1f", ":1");
+            knob(dl, bandId("mb_a"), base + 2, x + 215, 550, "ATTACK", "%.1f", " ms");
+            knob(dl, bandId("mb_rel"), base + 3, x + 75, 650, "RELEASE", "%.0f", " ms");
+            knob(dl, bandId("mb_m"), base + 4, x + 145, 650, "MAKEUP", "%.1f", " dB");
             panel.toggle(bandId("mb_s"), base + 6,
                          x + 180, 640, x + 238, 666, values[base + 6], "SOLO");
         }
-        knob(dl, "mb_mix", P_MB_MIX, 900, 395, 0, 100, "MB MIX", "%.0f", "%");
-        knob(dl, "mb_out", P_MB_OUT, 1005, 395, -24, 24, "MB OUTPUT", "%.1f", " dB");
+        knob(dl, "mb_mix", P_MB_MIX, 900, 395, "MB MIX", "%.0f", "%");
+        knob(dl, "mb_out", P_MB_OUT, 1005, 395, "MB OUTPUT", "%.1f", " dB");
     }
 
-    void crossover(ImDrawList* dl, uint32_t p, float x, float min, float max, const char* label)
+    void crossover(ImDrawList* dl, uint32_t p, float x, const char* label)
     {
-        (void)min; (void)max;
         const float trackStart = x - 100.0f;
         const float trackEnd = x + 100.0f;
         const auto& d = multicompp::kParams[p];
@@ -543,7 +548,7 @@ private:
             const float mouseX = (ImGui::GetMousePos().x - panel.P(0, 0).x) / panel.scale();
             const float normalized = std::clamp(
                 (mouseX - trackStart) / (trackEnd - trackStart), 0.0f, 1.0f);
-            setParam(p, multicompp::hostToPlain(d, normalized));
+            setParam(p, normalized);
         }
         if (ImGui::IsItemDeactivated()) editParameter(p, false);
     }
@@ -590,6 +595,11 @@ private:
             {
                 const int index = multicompp::coreParamIndex(parameter);
                 if (index >= 0) setValue(static_cast<uint32_t>(index), value);
+            },
+            [this](int band, int field, float value)
+            {
+                setValue(static_cast<uint32_t>(multicompp::kBandBase + band * 8 + field),
+                         value);
             });
         currentPreset = index;
     }

--- a/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
@@ -13,11 +13,9 @@
 
 #include <algorithm>
 #include <array>
-#include <charconv>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <string_view>
 
 START_NAMESPACE_DISTRHO
 
@@ -30,15 +28,12 @@ constexpr float kGlobalH = 132.0f;
 constexpr float kSidechainH = 126.0f;
 constexpr float kPanelTop = kHeaderH + kGlobalH + kSidechainH;
 
-constexpr ImU32 kBg = IM_COL32(27, 28, 32, 255);
 constexpr ImU32 kPanel = IM_COL32(35, 37, 43, 255);
 constexpr ImU32 kPanelRaised = IM_COL32(43, 46, 54, 255);
 constexpr ImU32 kLine = IM_COL32(75, 79, 90, 255);
 constexpr ImU32 kText = IM_COL32(232, 234, 238, 255);
 constexpr ImU32 kDim = IM_COL32(162, 168, 180, 255);
 constexpr ImU32 kAccent = IM_COL32(65, 194, 220, 255);
-constexpr ImU32 kGreen = IM_COL32(56, 145, 88, 255);
-constexpr ImU32 kRed = IM_COL32(164, 65, 60, 255);
 constexpr ImU32 kBandColors[4] = {
     IM_COL32(92, 165, 235, 255), IM_COL32(92, 205, 150, 255),
     IM_COL32(232, 185, 74, 255), IM_COL32(224, 100, 93, 255)
@@ -62,8 +57,8 @@ constexpr uint32_t P_SVCA_RELEASE = MC_PID(StudioVcaRelease), P_SVCA_OUT = MC_PI
 constexpr uint32_t P_DIG_THRESHOLD = MC_PID(DigitalThreshold), P_DIG_RATIO = MC_PID(DigitalRatio), P_DIG_KNEE = MC_PID(DigitalKnee), P_DIG_ATTACK = MC_PID(DigitalAttack);
 constexpr uint32_t P_DIG_RELEASE = MC_PID(DigitalRelease), P_DIG_LOOK = MC_PID(DigitalLookahead), P_DIG_MIX = MC_PID(DigitalMix), P_DIG_OUT = MC_PID(DigitalOutput);
 constexpr uint32_t P_DIG_ADAPT = MC_PID(DigitalAdaptive), P_X1 = MC_PID(Crossover1), P_X2 = MC_PID(Crossover2), P_X3 = MC_PID(Crossover3);
-constexpr uint32_t P_ENV = MC_PID(EnvelopeCurve), P_SC_LISTEN = MC_PID(GlobalSidechainListen), P_MB_MIX = MC_PID(MbMix), P_MB_OUT = MC_PID(MbOutput);
-constexpr uint32_t P_NOISE = MC_PID(NoiseEnable), P_SAT_MODE = MC_PID(SaturationMode), P_SC_LOW_FREQ = MC_PID(ScLowFreq), P_SC_LOW_GAIN = MC_PID(ScLowGain);
+constexpr uint32_t P_SC_LISTEN = MC_PID(GlobalSidechainListen), P_MB_MIX = MC_PID(MbMix), P_MB_OUT = MC_PID(MbOutput);
+constexpr uint32_t P_NOISE = MC_PID(NoiseEnable), P_SC_LOW_FREQ = MC_PID(ScLowFreq), P_SC_LOW_GAIN = MC_PID(ScLowGain);
 constexpr uint32_t P_SC_HIGH_FREQ = MC_PID(ScHighFreq), P_SC_HIGH_GAIN = MC_PID(ScHighGain), P_LINK_MODE = MC_PID(StereoLinkMode);
 #undef MC_PID
 
@@ -91,13 +86,14 @@ public:
         for (uint32_t i = 0; i < multicompp::kTotalParamCount; ++i)
         {
             if (i < static_cast<uint32_t>(multicompp::kParamCount))
-                values[i] = multicompp::kParams[i].def;
+                values[i] = multicompp::hostDefault(multicompp::kParams[i]);
             else
                 values[i] = 0.0f;
         }
         for (int b = 0; b < duskaudio::kMultiCompBands; ++b)
             for (int f = 0; f < 8; ++f)
-                values[multicompp::kBandBase + b * 8 + f] = multicompp::bandParam(f, b).def;
+                values[multicompp::kBandBase + b * 8 + f] =
+                    multicompp::hostDefault(multicompp::bandParam(f, b));
 
         // DPF reports the actual window size.  The UI draws a fixed design space
         // with one uniform scale and letterboxes any extra width or height.
@@ -110,7 +106,14 @@ public:
 
     void beginEdit(uint32_t idx) override { editParameter(idx, true); }
     void endEdit(uint32_t idx) override { editParameter(idx, false); }
-    void setParam(uint32_t idx, float value) override { currentPreset = -1; setParameterValue(idx, value); }
+    void setParam(uint32_t idx, float value) override
+    {
+        if (idx >= static_cast<uint32_t>(multicompp::kMeterMaster)) return;
+        currentPreset = -1;
+        const float hostValue = hostValueForPlain(idx, value);
+        values[idx] = hostValue;
+        setParameterValue(idx, hostValue);
+    }
 
 protected:
     void parameterChanged(uint32_t index, float value) override
@@ -121,53 +124,11 @@ protected:
     void stateChanged(const char* key, const char* state) override
     {
         if (key == nullptr || state == nullptr || std::strcmp(key, "parameters") != 0) return;
-        const std::string_view serialized(state);
-        // Same gate as the shell: a state we cannot decode is refused whole
-        // rather than applied piecemeal over the current settings.
-        if (! multicompp::stateVersionSupported(serialized)) return;
+        multicompp::StateValues decoded{};
+        if (!multicompp::decodeState(state, decoded)) return;
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
+            values[static_cast<size_t>(i)] = decoded[static_cast<size_t>(i)];
         currentPreset = -1;
-        size_t begin = 0;
-        while (begin < serialized.size())
-        {
-            const size_t end = serialized.find(';', begin);
-            const std::string_view token = serialized.substr(begin,
-                end == std::string_view::npos ? serialized.size() - begin : end - begin);
-            const size_t equal = token.find('=');
-            if (equal != std::string_view::npos && token.substr(0, equal) != "v")
-            {
-                float decoded = 0.0f;
-                if (multicompp::decodeStateFloat(token.substr(equal + 1), decoded))
-                {
-                    // Clamp to the descriptor range, as setParameterValue does
-                    // on the DSP side. The cache drives both the drawing and
-                    // the value a knob edit starts from, so an out-of-range
-                    // entry in a hand-edited or corrupt state would otherwise
-                    // be displayed and then handed back to the host.
-                    const std::string_view id = token.substr(0, equal);
-                    for (int i = 0; i < multicompp::kParamCount; ++i)
-                        if (id == multicompp::kParams[static_cast<size_t>(i)].id)
-                        {
-                            const auto& d = multicompp::kParams[static_cast<size_t>(i)];
-                            values[static_cast<size_t>(i)] = std::clamp(decoded, d.min, d.max);
-                        }
-                    for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
-                    {
-                        const int band = (i - multicompp::kBandBase) / 8;
-                        const int field = (i - multicompp::kBandBase) % 8;
-                        const auto d = multicompp::bandParam(field, band);
-                        char bandId[64];
-                        std::snprintf(bandId, sizeof(bandId), "%s_%d", d.id, band);
-                        if (id == bandId)
-                        {
-                            values[static_cast<size_t>(i)] = std::clamp(decoded, d.min, d.max);
-                            break;
-                        }
-                    }
-                }
-            }
-            if (end == std::string_view::npos) break;
-            begin = end + 1;
-        }
         repaint();
     }
 
@@ -231,8 +192,9 @@ private:
     {
         currentPreset = -1;
         editParameter(p, true);
-        values[p] = v;
-        setParameterValue(p, v);
+        const float hostValue = hostValueForPlain(p, v);
+        values[p] = hostValue;
+        setParameterValue(p, hostValue);
         editParameter(p, false);
     }
 
@@ -340,7 +302,6 @@ private:
         panel.toggle("mc_auto", P_AUTO, 568, 111, 680, 136, values[P_AUTO], "AUTO MAKEUP");
         panel.toggle("mc_tp", P_TRUE_PEAK, 688, 111, 790, 136, values[P_TRUE_PEAK], "TRUE PEAK");
         combo("mc_tpq", P_TP_QUALITY, multicompp::kTruePeakQuality, 2, 845, 103, 110, "QUALITY");
-        combo("mc_sat", P_SAT_MODE, multicompp::kSaturationMode, 3, 970, 103, 125, "SATURATION");
         knob(dl, "mc_dist", P_DIST_AMT, 1080, 125, 0, 100, "DRIVE", "%.0f", "%");
     }
 
@@ -354,7 +315,6 @@ private:
         knob(dl, "mc_sclg", P_SC_LOW_GAIN, 410, 251, -12, 12, "LOW GAIN", "%.1f", " dB");
         knob(dl, "mc_schf", P_SC_HIGH_FREQ, 520, 251, 2000, 16000, "HIGH FREQ", "%.0f", " Hz");
         knob(dl, "mc_schg", P_SC_HIGH_GAIN, 630, 251, -12, 12, "HIGH GAIN", "%.1f", " dB");
-        combo("mc_env", P_ENV, multicompp::kEnvelopeCurve, 2, 770, 230, 170, "ENVELOPE CURVE");
         combo("mc_disttype", P_DIST, multicompp::kDistortion, 4, 954, 230, 130, "DISTORTION");
         neutralToggle("##mc_noise", P_NOISE, 1000, 270, 1095, 295, "NOISE");
     }
@@ -387,7 +347,11 @@ private:
     void knob(ImDrawList* dl, const char* id, uint32_t p, float x, float y,
               float min, float max, const char* label, const char* fmt, const char* suffix)
     {
-        panel.knob(id, p, min, max, x, y, 25, values[p], defaultValue(p), false, true,
+        const float physicalMin = plainMin(p), physicalMax = plainMax(p);
+        (void)min; (void)max;
+        float physicalValue = plainValue(p);
+        panel.knob(id, p, physicalMin, physicalMax, x, y, 25, physicalValue,
+                   defaultValue(p), false, true,
                    fmt, suffix, kPanelRaised, false, true);
         panel.text(dl, x, y + 49, 9.5f, kText, label, 0, true);
     }
@@ -397,6 +361,36 @@ private:
         if (p < static_cast<uint32_t>(multicompp::kParamCount)) return multicompp::kParams[p].def;
         const int rel = static_cast<int>(p) - multicompp::kBandBase;
         return multicompp::bandParam(rel % 8, rel / 8).def;
+    }
+
+    float plainMin(uint32_t p) const
+    {
+        if (p < static_cast<uint32_t>(multicompp::kParamCount)) return multicompp::kParams[p].min;
+        const int rel = static_cast<int>(p) - multicompp::kBandBase;
+        return multicompp::bandParam(rel % 8, rel / 8).min;
+    }
+
+    float plainMax(uint32_t p) const
+    {
+        if (p < static_cast<uint32_t>(multicompp::kParamCount)) return multicompp::kParams[p].max;
+        const int rel = static_cast<int>(p) - multicompp::kBandBase;
+        return multicompp::bandParam(rel % 8, rel / 8).max;
+    }
+
+    float plainValue(uint32_t p) const
+    {
+        if (p < static_cast<uint32_t>(multicompp::kParamCount))
+            return multicompp::hostToPlain(multicompp::kParams[p], values[p]);
+        const int rel = static_cast<int>(p) - multicompp::kBandBase;
+        return multicompp::hostToPlain(multicompp::bandParam(rel % 8, rel / 8), values[p]);
+    }
+
+    float hostValueForPlain(uint32_t p, float plain) const
+    {
+        if (p < static_cast<uint32_t>(multicompp::kParamCount))
+            return multicompp::plainToHost(multicompp::kParams[p], plain);
+        const int rel = static_cast<int>(p) - multicompp::kBandBase;
+        return multicompp::plainToHost(multicompp::bandParam(rel % 8, rel / 8), plain);
     }
 
     void drawModePanel(ImDrawList* dl)
@@ -525,19 +519,19 @@ private:
         knob(dl, "mb_out", P_MB_OUT, 1005, 395, -24, 24, "MB OUTPUT", "%.1f", " dB");
     }
 
-    static constexpr const char* busAttackLabels[6] = {"0.1 ms", "0.3 ms", "1 ms", "3 ms", "10 ms", "30 ms"};
-    static constexpr const char* busReleaseLabels[5] = {"0.1 s", "0.3 s", "0.6 s", "1.2 s", "Auto"};
-
     void crossover(ImDrawList* dl, uint32_t p, float x, float min, float max, const char* label)
     {
+        (void)min; (void)max;
         const float trackStart = x - 100.0f;
         const float trackEnd = x + 100.0f;
-        const float t = std::clamp((value(p) - min) / (max - min), 0.0f, 1.0f);
+        const auto& d = multicompp::kParams[p];
+        const float physicalValue = multicompp::hostToPlain(d, values[p]);
+        const float t = std::clamp(values[p], 0.0f, 1.0f);
         const float handleX = trackStart + t * (trackEnd - trackStart);
         dl->AddLine(panel.P(trackStart, 392), panel.P(trackEnd, 392), IM_COL32(70, 75, 84, 255), 4 * panel.scale());
         dl->AddLine(panel.P(handleX, 376), panel.P(handleX, 408), kAccent, 3 * panel.scale());
         panel.text(dl, handleX, 414, 9, kText, label, 0, true);
-        char text[32]; std::snprintf(text, sizeof(text), "%.0f Hz", static_cast<double>(value(p)));
+        char text[32]; std::snprintf(text, sizeof(text), "%.0f Hz", static_cast<double>(physicalValue));
         panel.text(dl, handleX, 428, 9, kDim, text, 0);
         ImGui::SetCursorScreenPos(panel.P(handleX - 12, 365));
         char handleId[48];
@@ -547,10 +541,9 @@ private:
         if (ImGui::IsItemActive())
         {
             const float mouseX = (ImGui::GetMousePos().x - panel.P(0, 0).x) / panel.scale();
-            const float next = std::clamp(min + (mouseX - trackStart) / (trackEnd - trackStart) * (max - min), min, max);
-            currentPreset = -1;
-            values[p] = next;
-            setParameterValue(p, next);
+            const float normalized = std::clamp(
+                (mouseX - trackStart) / (trackEnd - trackStart), 0.0f, 1.0f);
+            setParam(p, multicompp::hostToPlain(d, normalized));
         }
         if (ImGui::IsItemDeactivated()) editParameter(p, false);
     }
@@ -597,10 +590,6 @@ private:
             {
                 const int index = multicompp::coreParamIndex(parameter);
                 if (index >= 0) setValue(static_cast<uint32_t>(index), value);
-            },
-            [this](int band, int field, float value)
-            {
-                setValue(static_cast<uint32_t>(multicompp::kBandBase + band * 8 + field), value);
             });
         currentPreset = index;
     }

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -284,6 +284,9 @@ public:
     //                     otherwise-eligible live value bubble during a drag.
     //   omitCenterTick: omit the 12-o'clock scale tick when a caller places a
     //                   fixed triangle there as the scale marker.
+    //   toDisplay/fromDisplay: optional nonlinear display transforms. The knob
+    //                   still renders and gestures in [minV,maxV], while its
+    //                   readout and typed entry use the transformed domain.
     bool knob(const char* id, uint32_t param, float minV, float maxV,
               float cx, float cy, float radius, float& value, float defaultVal,
               bool stepped = false, bool panelTicks = true,
@@ -299,13 +302,20 @@ public:
               bool doubleClickReset = false,
               float persistentTextSize = 9.5f,
               bool bubbleOnActiveOnly = false,
-              bool omitCenterTick = false)
+              bool omitCenterTick = false,
+              float (*toDisplay)(float, uint32_t, void*) = nullptr,
+              float (*fromDisplay)(float, uint32_t, void*) = nullptr,
+              void* displayContext = nullptr)
     {
         ImDrawList* dl = ImGui::GetWindowDrawList();
         const float R  = radius * s;
         const ImVec2 c = P(cx, cy);
         const float range = maxV - minV;
         bool changed = false;
+        const auto displayValue = [=](float v) {
+            return toDisplay != nullptr ? toDisplay(v, param, displayContext)
+                                        : v * dispMul + dispAdd;
+        };
 
         ImGui::SetCursorScreenPos(ImVec2(c.x - R, c.y - R));
         ImGui::InvisibleButton(id, ImVec2(2.0f * R, 2.0f * R));
@@ -364,7 +374,7 @@ public:
                 }
                 else
                 {
-                    openValueEdit(id, value * dispMul + dispAdd);
+                    openValueEdit(id, displayValue(value));
                     host->endEdit(param); // close the gesture the press opened
                 }
             }
@@ -407,7 +417,7 @@ public:
                         host->setParam(param, value); host->endEdit(param); changed = true;
                     }
                     if (ImGui::MenuItem("Type value..."))
-                        openValueEdit(id, value * dispMul + dispAdd);
+                        openValueEdit(id, displayValue(value));
                     ImGui::EndPopup();
                 }
             }
@@ -486,7 +496,9 @@ public:
         float typed;
         if (valueEdit(id, cx, cy, radius, typed))
         {
-            typed = (typed - dispAdd) / (dispMul != 0.0f ? dispMul : 1.0f); // display -> actual
+            typed = fromDisplay != nullptr
+                ? fromDisplay(typed, param, displayContext)
+                : (typed - dispAdd) / (dispMul != 0.0f ? dispMul : 1.0f); // display -> actual
             typed = typed < minV ? minV : (typed > maxV ? maxV : typed);
             if (stepped) typed = std::round(typed);
             if (typed != value)
@@ -524,7 +536,10 @@ public:
                 // shift-fine can land on values the resting readout rounds away
                 // (e.g. -2.0 dB at rest, -1.97 dB mid-drag). Precision follows the
                 // fine step (0.0008 * range in display units), not a fixed count.
-                const float fineStep = 0.0008f * range * (dispMul != 0.0f ? std::fabs(dispMul) : 1.0f);
+                const float coordinateStep = 0.0008f * range;
+                float adjacent = std::min(maxV, value + coordinateStep);
+                if (adjacent == value) adjacent = std::max(minV, value - coordinateStep);
+                const float fineStep = std::fabs(displayValue(adjacent) - displayValue(value));
                 int d = (int) std::ceil(-std::log10(fineStep > 1e-9f ? fineStep : 1e-9f));
                 d = d < 0 ? 0 : (d > 4 ? 4 : d);
                 // resting precision from fmt (digits after the '.'); never show FEWER
@@ -532,16 +547,16 @@ public:
                 int restD = 0; for (const char* p = fmt; *p; ++p)
                     if (*p == '.') { for (const char* q = p + 1; *q >= '0' && *q <= '9'; ++q) restD = restD * 10 + (*q - '0'); break; }
                 if (d <= restD)
-                    std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
+                    std::snprintf(num, sizeof(num), fmt, displayValue(value));
                 else
                 {
                     bool plus = false; for (const char* p = fmt; *p; ++p) if (*p == '+') { plus = true; break; }
                     char f2[8]; std::snprintf(f2, sizeof(f2), plus ? "%%+.%df" : "%%.%df", d);
-                    std::snprintf(num, sizeof(num), f2, value * dispMul + dispAdd);
+                    std::snprintf(num, sizeof(num), f2, displayValue(value));
                 }
             }
             else   // hovering only -> value at resting precision
-                std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
+                std::snprintf(num, sizeof(num), fmt, displayValue(value));
             if (overrideText == nullptr && !showName)
                 std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
             valueBubble(cx, cy, radius, buf);
@@ -553,7 +568,7 @@ public:
                 std::snprintf(buf, sizeof(buf), "%s", overrideText);
             else
             {
-                std::snprintf(num, sizeof(num), fmt, value * dispMul + dispAdd);
+                std::snprintf(num, sizeof(num), fmt, displayValue(value));
                 std::snprintf(buf, sizeof(buf), "%s%s", num, suffix);
             }
             // Brighten the resting readout while the knob is active so the live


### PR DESCRIPTION
… the tests

The DPF port installed only min/max/default for every parameter, so the host mapped all of them linearly and the JUCE skews were lost. VCA Ratio at host 0.5 read 60.5:1 where the original gives 12.8:1, which buries the useful part of every ratio and time control in the bottom few percent of the fader. DPF offers no taper mechanism the shipping formats honour -- kParameterIsLogarithmic is read by VST2 and LV2 metadata only, not by VST3, CLAP or AU -- so the 23 non-linear parameters now expose an honest 0..1 host domain and map internally through the shared table. The UI uses the identical conversion. Generic hosts therefore show a normalised coordinate rather than a misleading physical unit; that trade was taken deliberately, because a control that is unusable across most of its travel is worse than one whose number needs our own window to read.

State decoding was applying whatever it could parse and silently skipping the rest, so a single malformed field left the plugin half-configured. Plugin and UI now share one decoder that validates all 95 values -- version, required fields, uniqueness, unknown keys, syntax, finiteness and range -- into temporaries and commits only a complete set. Floats serialise as hexadecimal bit patterns, so the round trip is exact and locale-independent in both directions. Tapered values now live in the host domain, so the state version moves to 3 and version 2 is rejected outright; the plugin has never shipped, so no compatibility is owed.

Factory preset recall reset everything it touched, including host bypass, oversampling, external sidechain, lookahead, distortion and every band field. Presets now own an explicit subset and leave the rest alone. Meters are marked output-only rather than automatable, and Envelope Curve and Saturation Mode are gone: the JUCE original never read either one, so they were inert controls promising behaviour that did not exist.

The test suite could not have caught most of this. Its bypass test cleared bypass on the wrong object, and even after that was corrected the assertions still could not fail, because the fixture ran at 1:1 where bypassed and active output are identical; it now compresses at 8:1 and requires re-entry below dry. Nine further assertions passed on all-zero data -- release timing, static-curve monotonicity, reset determinism, multiband re-prepare and bypass equivalence, auto-gain equivalence and endpoint continuity, hardware-rate refresh, and the Opto isolation check that never verified the channel it was isolating. Each now proves its stimulus did something before judging the result. New coverage spans analog stereo link, the full oversampling and lookahead latency matrix, zero-frame calls against a sentinel buffer, and same-rate re-prepare.

Sidechain Listen left per-band gain-reduction meters holding a stale 25.27 dB; that is fixed alongside the master meter. Listen's own on/off remains an unsmoothed switch with a measured 0.699863 adjacent-sample jump, left as a disabled test because a correct ramp needs persistent state beyond this change.

The Opto golden vectors are removed. Opto is being rebuilt against measured hardware, so values recorded from the superseded implementation could only mislead whoever ran them. The remaining vectors now say plainly that they detect drift from the extracted core and do not prove parity with JUCE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smoother sidechain monitoring transitions for more natural audio switching.
  * Improved preset loading for mode-specific and multiband settings.
  * Enhanced control displays and value entry for tapered parameters.

* **Bug Fixes**
  * Sidechain monitoring now clears gain-reduction meters correctly.
  * Improved parameter validation, state restoration, and host automation consistency.
  * Hardware reset now fully restores filter settings.

* **UI**
  * Removed obsolete envelope-curve and saturation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->