### PR TITLE
Multi comp 2/review fixes part2

### DIFF
--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -60,6 +60,7 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     sidechainListenWrite = {{0, 0}};
     globalMixSmoother.prepare(sampleRate, 0.020f); globalMixSmoother.snap(params.mix.load(std::memory_order_relaxed) * 0.01f);
     autoGainMatcher.prepare(sampleRate);
+    resetAutoGainMeasurement();
     autoGainSmoother.prepare(sampleRate, static_cast<float>(kAutoGainTransitionMs) * 0.001f); autoGainSmoother.snap(1.0f);
     manualMakeupScaleRamp.prepare(sampleRate, static_cast<float>(kAutoGainTransitionMs) * 0.001f);
     manualMakeupScaleRamp.snap(params.autoMakeup.load(std::memory_order_relaxed) ? 0.0f : 1.0f);
@@ -111,6 +112,7 @@ void MultiCompDSP::reset()
     rebuildMultibandTopology(0x0f);
     globalMixSmoother.snap(params.mix.load(std::memory_order_relaxed) * 0.01f);
     autoGainMatcher.reset();
+    resetAutoGainMeasurement();
     autoGainSmoother.snap(1.0f);
     manualMakeupScaleRamp.snap(params.autoMakeup.load(std::memory_order_relaxed) ? 0.0f : 1.0f);
     busMixRamp.snap(params.busMix.load(std::memory_order_relaxed) * 0.01f);
@@ -272,16 +274,6 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         bypassSettled = false;
         bypassRamp.setTarget(requestedBypass ? 1.0f : 0.0f);
     }
-    processLatencyHistory(in, out, nCh, nSamples, blockLatency, requestedBypass && bypassSettled);
-    if (requestedBypass && bypassSettled)
-    {
-        for (int i = 0; i < nSamples; ++i) (void)sidechainListenRamp.next();
-        masterGR.store(0.0f, std::memory_order_relaxed);
-        for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
-        updateMeters(blockInputPeak, out, nCh, nSamples);
-        return;
-    }
-    const float* processingIn[kMaxChannels] = {in[0], nCh > 1 ? in[1] : in[0]};
     const bool useExternalSidechain = params.externalSidechain.load(std::memory_order_relaxed) && sidechain != nullptr;
     const float* filteredSidechain[kMaxChannels] = {processedSidechain[0].data(), processedSidechain[1].data()};
     const float sidechainHP = params.sidechainHP.load(std::memory_order_relaxed);
@@ -314,6 +306,17 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
             }
     }
     if (nCh == 1) filteredSidechain[1] = filteredSidechain[0];
+    processLatencyHistory(in, out, nCh, nSamples, blockLatency, requestedBypass && bypassSettled);
+    if (requestedBypass && bypassSettled)
+    {
+        processSidechainListenHistory(filteredSidechain, nCh, nSamples, blockLatency);
+        for (int i = 0; i < nSamples; ++i) (void)sidechainListenRamp.next();
+        masterGR.store(0.0f, std::memory_order_relaxed);
+        for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
+        updateMeters(blockInputPeak, out, nCh, nSamples);
+        return;
+    }
+    const float* processingIn[kMaxChannels] = {in[0], nCh > 1 ? in[1] : in[0]};
     const int globalLookaheadDelay = static_cast<int>(std::round(
         globalLookaheadMs * 0.001f * static_cast<float>(sampleRate)));
     prepareLookahead(in, processingIn, nCh, nSamples, globalLookaheadDelay);
@@ -351,6 +354,7 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
             autoGainHoldSamples = std::max(1, static_cast<int>(sampleRate * kAutoGainTransitionMs * 0.001));
         lastMode = modeIndex;
         autoGainMatcher.reset();
+        resetAutoGainMeasurement();
         autoGainSmoother.setTarget(1.0f);
     }
     if (useExternalSidechain != lastExternalSidechain)
@@ -359,6 +363,7 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         if (!firstBlock)
             autoGainHoldSamples = std::max(1, static_cast<int>(sampleRate * kAutoGainTransitionMs * 0.001));
         autoGainMatcher.reset();
+        resetAutoGainMeasurement();
         autoGainSmoother.setTarget(1.0f);
     }
     const bool autoMakeup = params.autoMakeup.load(std::memory_order_relaxed) && !useExternalSidechain;
@@ -368,6 +373,7 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         if (!firstBlock)
             autoGainHoldSamples = std::max(1, static_cast<int>(sampleRate * kAutoGainTransitionMs * 0.001));
         autoGainMatcher.reset();
+        resetAutoGainMeasurement();
         autoGainSmoother.setTarget(1.0f);
     }
     processRange(processingIn, filteredSidechain, out, nCh, nSamples,
@@ -399,22 +405,7 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     // lookaheads). Keep the monitor history running even while Listen is off so
     // either direction of the crossfade starts between time-aligned signals.
     const int listenDelay = blockLatency;
-    for (int ch = 0; ch < nCh; ++ch)
-    {
-        auto& line = sidechainListenDelay[static_cast<size_t>(ch)];
-        int& write = sidechainListenWrite[static_cast<size_t>(ch)];
-        const int size = static_cast<int>(line.size());
-        const int delay = std::clamp(listenDelay, 0, size - 1);
-        for (int i = 0; i < nSamples; ++i)
-        {
-            const int read = (write - delay + size) % size;
-            const float sample = filteredSidechain[ch][i];
-            line[static_cast<size_t>(write)] = sample;
-            processedSidechain[static_cast<size_t>(ch)][static_cast<size_t>(i)] =
-                delay > 0 ? line[static_cast<size_t>(read)] : sample;
-            write = (write + 1) % size;
-        }
-    }
+    processSidechainListenHistory(filteredSidechain, nCh, nSamples, listenDelay);
     for (int i = 0; i < nSamples; ++i)
         mixCurve[static_cast<size_t>(i)] = globalMixSmoother.next();
     // `dry` is one shared scratch line; copy the source per channel again before
@@ -430,27 +421,46 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         }
     }
 
-    if (autoMakeup && !requestedSidechainListen && autoGainHoldSamples <= 0)
-    {
-        double inSum = 0.0, outSum = 0.0;
-        for (int ch = 0; ch < nCh; ++ch)
-            for (int i = 0; i < nSamples; ++i)
-            {
-                const float drySample = dry[static_cast<size_t>(ch * maxBlock + i)];
-                inSum += static_cast<double>(drySample) * drySample;
-                outSum += static_cast<double>(out[ch][i]) * out[ch][i];
-            }
-        const float divisor = static_cast<float>(std::max(1, nCh * nSamples));
-        const float target = autoGainMatcher.update(std::sqrt(static_cast<float>(inSum) / divisor),
-                                                    std::sqrt(static_cast<float>(outSum) / divisor), nSamples);
-        autoGainSmoother.setTarget(target);
-    }
-    else
+    const bool measureAutoGain = autoMakeup && !requestedSidechainListen;
+    if (!measureAutoGain || autoGainHoldSamples > 0)
     {
         autoGainMatcher.reset();
+        resetAutoGainMeasurement();
         autoGainSmoother.setTarget(1.0f);
     }
-    for (int i = 0; i < nSamples; ++i) autoGainCurve[static_cast<size_t>(i)] = autoGainSmoother.next();
+    for (int i = 0; i < nSamples; ++i)
+    {
+        if (measureAutoGain)
+        {
+            if (autoGainHoldSamples <= 0)
+            {
+                double inPower = 0.0, outPower = 0.0;
+                for (int ch = 0; ch < nCh; ++ch)
+                {
+                    const float drySample = dry[static_cast<size_t>(ch * maxBlock + i)];
+                    inPower += static_cast<double>(drySample) * drySample;
+                    outPower += static_cast<double>(out[ch][i]) * out[ch][i];
+                }
+                const double channelDivisor = static_cast<double>(std::max(1, nCh));
+                // Carry one fixed measurement window across host calls. Target
+                // cadence then follows sample position, not buffer boundaries.
+                autoGainInputPower += inPower / channelDivisor;
+                autoGainOutputPower += outPower / channelDivisor;
+                if (++autoGainMeasurementCount == kAutoGainMeasurementWindow)
+                {
+                    const float sampleDivisor = static_cast<float>(autoGainMeasurementCount);
+                    const float target = autoGainMatcher.update(
+                        std::sqrt(static_cast<float>(autoGainInputPower) / sampleDivisor),
+                        std::sqrt(static_cast<float>(autoGainOutputPower) / sampleDivisor),
+                        autoGainMeasurementCount);
+                    autoGainSmoother.setTarget(target);
+                    resetAutoGainMeasurement();
+                }
+            }
+        }
+        autoGainCurve[static_cast<size_t>(i)] = autoGainSmoother.next();
+        if (autoGainHoldSamples > 0) --autoGainHoldSamples;
+    }
     for (int ch = 0; ch < nCh; ++ch)
         for (int i = 0; i < nSamples; ++i) out[ch][i] *= autoGainCurve[static_cast<size_t>(i)];
     if (params.noiseEnable.load(std::memory_order_relaxed) && mode != MultiCompMode::Digital && mode != MultiCompMode::Multiband)
@@ -477,8 +487,6 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         masterGR.store(0.0f, std::memory_order_relaxed);
         for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
     }
-    autoGainHoldSamples = std::max(0, autoGainHoldSamples - nSamples);
-
     // Bypass is the final gain-stage transition, so its 100% endpoint is the
     // same latency-aligned dry sample emitted by the settled-bypass fast path.
     for (int i = 0; i < nSamples; ++i)
@@ -518,6 +526,35 @@ void MultiCompDSP::processLatencyHistory(const float* const* in, float* const* o
         }
         bypassWrite = (bypassWrite + 1) % size;
     }
+}
+
+void MultiCompDSP::processSidechainListenHistory(const float* const* sidechain,
+                                                 int nCh, int nSamples,
+                                                 int delay) noexcept
+{
+    for (int ch = 0; ch < nCh; ++ch)
+    {
+        auto& line = sidechainListenDelay[static_cast<size_t>(ch)];
+        int& write = sidechainListenWrite[static_cast<size_t>(ch)];
+        const int size = static_cast<int>(line.size());
+        const int clampedDelay = std::clamp(delay, 0, size - 1);
+        for (int i = 0; i < nSamples; ++i)
+        {
+            const int read = (write - clampedDelay + size) % size;
+            const float sample = sidechain[ch][i];
+            line[static_cast<size_t>(write)] = sample;
+            processedSidechain[static_cast<size_t>(ch)][static_cast<size_t>(i)] =
+                clampedDelay > 0 ? line[static_cast<size_t>(read)] : sample;
+            write = (write + 1) % size;
+        }
+    }
+}
+
+void MultiCompDSP::resetAutoGainMeasurement() noexcept
+{
+    autoGainInputPower = 0.0;
+    autoGainOutputPower = 0.0;
+    autoGainMeasurementCount = 0;
 }
 
 void MultiCompDSP::prepareLookahead(const float* const* in,

--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -784,13 +784,26 @@ void MultiCompDSP::processMultiband(const float* const* input, const float* cons
     const float distortionAmount = std::clamp(params.distortionAmount.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f);
     std::array<float, kMultiCompBands> maxGr{{0, 0, 0, 0}};
     std::array<bool, kMultiCompBands> solos{};
+    std::array<bool, kMultiCompBands> bypassed{};
+    std::array<float, kMultiCompBands> thresholds{};
+    std::array<float, kMultiCompBands> ratios{};
+    std::array<float, kMultiCompBands> attacks{};
+    std::array<float, kMultiCompBands> releases{};
+    std::array<float, kMultiCompBands> makeupGains{};
     bool anySolo = false;
     for (int band = 0; band < kMultiCompBands; ++band)
     {
-        solos[static_cast<size_t>(band)] =
-            params.mbSolo[static_cast<size_t>(band)].load(std::memory_order_relaxed);
-        anySolo = anySolo || solos[static_cast<size_t>(band)];
+        const size_t bandIndex = static_cast<size_t>(band);
+        solos[bandIndex] = params.mbSolo[bandIndex].load(std::memory_order_relaxed);
+        bypassed[bandIndex] = params.mbBypass[bandIndex].load(std::memory_order_relaxed);
+        thresholds[bandIndex] = params.mbThreshold[bandIndex].load(std::memory_order_relaxed);
+        ratios[bandIndex] = std::max(1.0f, params.mbRatio[bandIndex].load(std::memory_order_relaxed));
+        attacks[bandIndex] = std::max(0.0001f, params.mbAttack[bandIndex].load(std::memory_order_relaxed) * 0.001f);
+        releases[bandIndex] = std::max(0.001f, params.mbRelease[bandIndex].load(std::memory_order_relaxed) * 0.001f);
+        makeupGains[bandIndex] = decibelsToGain(params.mbMakeup[bandIndex].load(std::memory_order_relaxed));
+        anySolo = anySolo || solos[bandIndex];
     }
+    const float mbOutputGain = decibelsToGain(params.mbOutput.load(std::memory_order_relaxed));
     for (int band = 0; band < kMultiCompBands; ++band)
         if ((activeBandMask & static_cast<std::uint8_t>(1u << band)) == 0)
             for (int ch = 0; ch < nCh; ++ch)
@@ -863,16 +876,16 @@ void MultiCompDSP::processMultiband(const float* const* input, const float* cons
                 envelope = 1.0f;
                 continue;
             }
-            if (params.mbBypass[bandIndex].load(std::memory_order_relaxed))
+            if (bypassed[bandIndex])
             {
                 envelope = 1.0f;
                 continue;
             }
-            const float threshold = params.mbThreshold[static_cast<size_t>(band)].load(std::memory_order_relaxed);
-            const float ratio = std::max(1.0f, params.mbRatio[static_cast<size_t>(band)].load(std::memory_order_relaxed));
-            const float attack = std::max(0.0001f, params.mbAttack[static_cast<size_t>(band)].load(std::memory_order_relaxed) * 0.001f);
-            const float release = std::max(0.001f, params.mbRelease[static_cast<size_t>(band)].load(std::memory_order_relaxed) * 0.001f);
-            const float makeupGain = decibelsToGain(params.mbMakeup[bandIndex].load(std::memory_order_relaxed));
+            const float threshold = thresholds[bandIndex];
+            const float ratio = ratios[bandIndex];
+            const float attack = attacks[bandIndex];
+            const float release = releases[bandIndex];
+            const float makeupGain = makeupGains[bandIndex];
             for (int i = 0; i < nSamples; ++i)
             {
                 const float own = sidechain != nullptr ? std::abs(sidechainBands[static_cast<size_t>(band)][static_cast<size_t>(ch)][static_cast<size_t>(i)]) : std::abs(bands[static_cast<size_t>(band)][static_cast<size_t>(ch)][static_cast<size_t>(i)]);
@@ -904,7 +917,6 @@ void MultiCompDSP::processMultiband(const float* const* input, const float* cons
                 maxGr[static_cast<size_t>(band)] = std::min(maxGr[static_cast<size_t>(band)], gainToDecibels(envelope));
             }
         }
-        const float mbOutputGain = decibelsToGain(params.mbOutput.load(std::memory_order_relaxed));
         for (int i = 0; i < nSamples; ++i)
         {
             float sum = 0.0f;

--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -53,6 +53,8 @@ void MultiCompDSP::prepare(double sr, int blockSize)
         + static_cast<int>(std::ceil(sampleRate * 0.02)) + 1));
     for (auto& line : bypassDelay) line.assign(bypassDelaySize, 0.0f);
     bypassWrite = 0;
+    for (auto& line : sidechainListenDelay) line.assign(bypassDelaySize, 0.0f);
+    sidechainListenWrite = {{0, 0}};
     globalMixSmoother.prepare(sampleRate, 0.020f); globalMixSmoother.snap(params.mix.load(std::memory_order_relaxed) * 0.01f);
     autoGainMatcher.prepare(sampleRate);
     autoGainSmoother.prepare(sampleRate, static_cast<float>(kAutoGainTransitionMs) * 0.001f); autoGainSmoother.snap(1.0f);
@@ -97,6 +99,8 @@ void MultiCompDSP::reset()
     dryPathWrite = {{0, 0}};
     for (auto& line : bypassDelay) std::fill(line.begin(), line.end(), 0.0f);
     bypassWrite = 0;
+    for (auto& line : sidechainListenDelay) std::fill(line.begin(), line.end(), 0.0f);
+    sidechainListenWrite = {{0, 0}};
     multibandEnvelopes.fill(1.0f);
     activeBandMask = 0;
     rebuildMultibandTopology(0x0f);
@@ -240,6 +244,14 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         return;
     }
     ScopedFlushDenormals guard;
+    float blockInputPeak = 0.0f;
+    for (int ch = 0; ch < nCh; ++ch)
+        for (int i = 0; i < nSamples; ++i)
+            blockInputPeak = std::max(blockInputPeak, std::abs(in[ch][i]));
+    const MultiCompMode mode = static_cast<MultiCompMode>(
+        std::clamp(params.mode.load(std::memory_order_relaxed), 0, 7));
+    const int linkMode = std::clamp(params.stereoLinkMode.load(std::memory_order_relaxed), 0, 2);
+    const int blockLatency = latencySamplesForMode(mode);
     const bool requestedBypass = params.bypass.load(std::memory_order_relaxed);
     const bool requestedSidechainListen = params.globalSidechainListen.load(std::memory_order_relaxed);
     sidechainListenRamp.setTarget(requestedSidechainListen ? 1.0f : 0.0f);
@@ -249,13 +261,13 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         bypassSettled = false;
         bypassRamp.setTarget(requestedBypass ? 1.0f : 0.0f);
     }
-    processLatencyHistory(in, out, nCh, nSamples, requestedBypass && bypassSettled);
+    processLatencyHistory(in, out, nCh, nSamples, blockLatency, requestedBypass && bypassSettled);
     if (requestedBypass && bypassSettled)
     {
         for (int i = 0; i < nSamples; ++i) (void)sidechainListenRamp.next();
         masterGR.store(0.0f, std::memory_order_relaxed);
         for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
-        updateMeters(in, out, nCh, nSamples);
+        updateMeters(blockInputPeak, out, nCh, nSamples);
         return;
     }
     const float* processingIn[kMaxChannels] = {in[0], nCh > 1 ? in[1] : in[0]};
@@ -292,11 +304,10 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     }
     if (nCh == 1) filteredSidechain[1] = filteredSidechain[0];
     prepareLookahead(in, processingIn, nCh, nSamples);
-    const MultiCompMode inputMode = static_cast<MultiCompMode>(std::clamp(params.mode.load(std::memory_order_relaxed), 0, 7));
-    const int digitalDryDelay = inputMode == MultiCompMode::Digital
+    const int digitalDryDelay = mode == MultiCompMode::Digital
         ? static_cast<int>(std::round(std::clamp(params.digitalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f)
                                       * 0.001f * static_cast<float>(sampleRate))) : 0;
-    const int dryDelay = inputMode == MultiCompMode::Multiband ? 0 : antiAliasLatency + digitalDryDelay;
+    const int dryDelay = mode == MultiCompMode::Multiband ? 0 : antiAliasLatency + digitalDryDelay;
     for (int ch = 0; ch < nCh; ++ch)
     {
         auto& line = dryPathDelay[static_cast<size_t>(ch)];
@@ -311,7 +322,7 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
             write = (write + 1) % size;
         }
     }
-    if (nCh > 1 && params.stereoLinkMode.load(std::memory_order_relaxed) == 1)
+    if (nCh > 1 && linkMode == 1)
     {
         for (int i = 0; i < nSamples; ++i)
         {
@@ -321,7 +332,6 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         processingIn[0] = modeInput[0].data();
         processingIn[1] = modeInput[1].data();
     }
-    const MultiCompMode mode = inputMode;
     const int modeIndex = static_cast<int>(mode);
     if (modeIndex != lastMode)
     {
@@ -349,19 +359,49 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         autoGainSmoother.setTarget(1.0f);
     }
     processRange(processingIn, filteredSidechain, out, nCh, nSamples,
-                 useExternalSidechain, autoMakeup);
+                 useExternalSidechain, autoMakeup, mode, linkMode);
     const bool isMulti = mode == MultiCompMode::Multiband;
-    if (nCh > 1 && params.stereoLinkMode.load(std::memory_order_relaxed) == 1)
+    if (nCh > 1 && linkMode == 1)
     {
         for (int i = 0; i < nSamples; ++i)
         {
             const float mid = out[0][i], side = out[1][i];
             out[0][i] = mid + side;
             out[1][i] = mid - side;
+            if (isMulti)
+            {
+                // Keep the crossover-rotated split sum, but put it in the same
+                // L/R domain as the decoded wet path before mixing/matching.
+                const size_t leftIndex = static_cast<size_t>(i);
+                const size_t rightIndex = static_cast<size_t>(maxBlock + i);
+                const float dryMid = dry[leftIndex], drySide = dry[rightIndex];
+                dry[leftIndex] = dryMid + drySide;
+                dry[rightIndex] = dryMid - drySide;
+            }
         }
     }
     const float targetMix = std::clamp((isMulti ? params.mbMix.load(std::memory_order_relaxed) : params.mix.load(std::memory_order_relaxed)) * 0.01f, 0.0f, 1.0f);
     globalMixSmoother.setTarget(targetMix);
+    // The processed output carries the full reported latency (AA plus both
+    // lookaheads). Keep the monitor history running even while Listen is off so
+    // either direction of the crossfade starts between time-aligned signals.
+    const int listenDelay = blockLatency;
+    for (int ch = 0; ch < nCh; ++ch)
+    {
+        auto& line = sidechainListenDelay[static_cast<size_t>(ch)];
+        int& write = sidechainListenWrite[static_cast<size_t>(ch)];
+        const int size = static_cast<int>(line.size());
+        const int delay = std::clamp(listenDelay, 0, size - 1);
+        for (int i = 0; i < nSamples; ++i)
+        {
+            const int read = (write - delay + size) % size;
+            const float sample = filteredSidechain[ch][i];
+            line[static_cast<size_t>(write)] = sample;
+            processedSidechain[static_cast<size_t>(ch)][static_cast<size_t>(i)] =
+                delay > 0 ? line[static_cast<size_t>(read)] : sample;
+            write = (write + 1) % size;
+        }
+    }
     for (int i = 0; i < nSamples; ++i)
         mixCurve[static_cast<size_t>(i)] = globalMixSmoother.next();
     // `dry` is one shared scratch line; copy the source per channel again before
@@ -443,14 +483,14 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         }
     }
     if (requestedBypass && bypassRamp.value() >= 1.0f) bypassSettled = true;
-    updateMeters(in, out, nCh, nSamples);
+    updateMeters(blockInputPeak, out, nCh, nSamples);
     firstBlock = false;
 }
 
 void MultiCompDSP::processLatencyHistory(const float* const* in, float* const* out,
-                                         int nCh, int nSamples, bool emit) noexcept
+                                         int nCh, int nSamples, int delay, bool emit) noexcept
 {
-    const int delay = std::clamp(getLatencySamples(), 0, static_cast<int>(bypassDelay[0].size()) - 1);
+    delay = std::clamp(delay, 0, static_cast<int>(bypassDelay[0].size()) - 1);
     const int size = static_cast<int>(bypassDelay[0].size());
     for (int i = 0; i < nSamples; ++i)
     {
@@ -554,11 +594,10 @@ void MultiCompDSP::syncModeParameters(MultiCompMode mode) noexcept
 
 void MultiCompDSP::processRange(const float* const* in, const float* const* sidechain,
                                 float* const* out, int nCh, int nSamples,
-                                bool external, bool autoMakeup)
+                                bool external, bool autoMakeup,
+                                MultiCompMode mode, int linkMode)
 {
-    const MultiCompMode mode = static_cast<MultiCompMode>(std::clamp(params.mode.load(std::memory_order_relaxed), 0, 7));
     const int actualOs = params.oversampling.load(std::memory_order_relaxed) == 2 ? 4 : (params.oversampling.load(std::memory_order_relaxed) == 1 ? 2 : 1);
-    const int linkMode = std::clamp(params.stereoLinkMode.load(std::memory_order_relaxed), 0, 2);
     const float linkAmount = std::clamp(params.stereoLink.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f);
     const auto distortionType = static_cast<DistortionType>(std::clamp(params.distortion.load(std::memory_order_relaxed), 0, 3));
     const float distortionAmount = std::clamp(params.distortionAmount.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f);
@@ -658,6 +697,7 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
     }
     const float gr = std::min(modes.gainReduction(mode, 0), nCh > 1 ? modes.gainReduction(mode, 1) : modes.gainReduction(mode, 0));
     masterGR.store(gr, std::memory_order_relaxed);
+    for (auto& meter : bandGR) meter.store(0.0f, std::memory_order_relaxed);
 }
 
 void MultiCompDSP::processMultiband(const float* const* input, const float* const* sidechain,
@@ -929,10 +969,12 @@ void MultiCompDSP::rebuildMultibandTopology(std::uint8_t mask) noexcept
             }
 }
 
-void MultiCompDSP::updateMeters(const float* const* in, float* const* out, int nCh, int nSamples)
+void MultiCompDSP::updateMeters(float inPeak, float* const* out, int nCh, int nSamples)
 {
-    float inPeak = 0.0f, outPeak = 0.0f;
-    for (int ch = 0; ch < nCh; ++ch) for (int i = 0; i < nSamples; ++i) { inPeak = std::max(inPeak, std::abs(in[ch][i])); outPeak = std::max(outPeak, std::abs(out[ch][i])); }
+    float outPeak = 0.0f;
+    for (int ch = 0; ch < nCh; ++ch)
+        for (int i = 0; i < nSamples; ++i)
+            outPeak = std::max(outPeak, std::abs(out[ch][i]));
     inputLevel.store(inPeak > 1.0e-5f ? gainToDecibels(inPeak) : -60.0f, std::memory_order_relaxed);
     outputLevel.store(outPeak > 1.0e-5f ? gainToDecibels(outPeak) : -60.0f, std::memory_order_relaxed);
 }
@@ -940,6 +982,11 @@ void MultiCompDSP::updateMeters(const float* const* in, float* const* out, int n
 int MultiCompDSP::getLatencySamples() const noexcept
 {
     const auto mode = static_cast<MultiCompMode>(std::clamp(params.mode.load(std::memory_order_relaxed), 0, 7));
+    return latencySamplesForMode(mode);
+}
+
+int MultiCompDSP::latencySamplesForMode(MultiCompMode mode) const noexcept
+{
     const int lookahead = static_cast<int>(std::round(std::clamp(params.globalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f) * 0.001f * static_cast<float>(sampleRate)));
     const int digital = mode == MultiCompMode::Digital ? static_cast<int>(std::round(std::clamp(params.digitalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f) * 0.001f * static_cast<float>(sampleRate))) : 0;
     // JUCE keeps PDC constant at the maximum anti-alias group delay.  The

--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -20,8 +20,9 @@ void MultiCompDSP::prepare(double sr, int blockSize)
 {
     sampleRate = std::isfinite(sr) && sr > 0.0 ? sr : 48000.0;
     maxBlock = std::max(1, blockSize);
-    const int initialOversampling = params.oversampling.load(std::memory_order_relaxed) == 2 ? 4
-                                  : params.oversampling.load(std::memory_order_relaxed) == 1 ? 2 : 1;
+    const int oversamplingSetting = params.oversampling.load(std::memory_order_relaxed);
+    const int initialOversampling = oversamplingSetting == 2 ? 4
+                                  : oversamplingSetting == 1 ? 2 : 1;
     modes.prepare(sampleRate, maxBlock, initialOversampling);
     truePeakDetector.prepare();
     truePeakDetector.setQuality(MultiCompTruePeakDetector::Quality::Standard4x);
@@ -44,6 +45,8 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     const size_t lookaheadSize = static_cast<size_t>(std::ceil(sampleRate * 0.01)) + 1u;
     for (auto& line : globalLookahead) line.assign(lookaheadSize, 0.0f);
     globalLookaheadWrite = {{0, 0}};
+    previousOversampledSidechain = {{0.0f, 0.0f}};
+    previousOversampledSidechainValid = {{false, false}};
     const size_t dryDelaySize = static_cast<size_t>(std::max(1, antiAliasLatency + static_cast<int>(std::ceil(sampleRate * 0.01)) + 1));
     for (auto& line : dryPathDelay) line.assign(dryDelaySize, 0.0f);
     dryPathWrite = {{0, 0}};
@@ -95,6 +98,8 @@ void MultiCompDSP::reset()
     for (auto& line : delayedInput) std::fill(line.begin(), line.end(), 0.0f);
     for (auto& line : globalLookahead) std::fill(line.begin(), line.end(), 0.0f);
     globalLookaheadWrite = {{0, 0}};
+    previousOversampledSidechain = {{0.0f, 0.0f}};
+    previousOversampledSidechainValid = {{false, false}};
     for (auto& line : dryPathDelay) std::fill(line.begin(), line.end(), 0.0f);
     dryPathWrite = {{0, 0}};
     for (auto& line : bypassDelay) std::fill(line.begin(), line.end(), 0.0f);
@@ -251,7 +256,13 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     const MultiCompMode mode = static_cast<MultiCompMode>(
         std::clamp(params.mode.load(std::memory_order_relaxed), 0, 7));
     const int linkMode = std::clamp(params.stereoLinkMode.load(std::memory_order_relaxed), 0, 2);
-    const int blockLatency = latencySamplesForMode(mode);
+    const int oversamplingSetting = params.oversampling.load(std::memory_order_relaxed);
+    const int actualOversampling = oversamplingSetting == 2 ? 4 : oversamplingSetting == 1 ? 2 : 1;
+    const float globalLookaheadMs = std::clamp(
+        params.globalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f);
+    const float digitalLookaheadMs = std::clamp(
+        params.digitalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f);
+    const int blockLatency = latencySamplesForMode(mode, globalLookaheadMs, digitalLookaheadMs);
     const bool requestedBypass = params.bypass.load(std::memory_order_relaxed);
     const bool requestedSidechainListen = params.globalSidechainListen.load(std::memory_order_relaxed);
     sidechainListenRamp.setTarget(requestedSidechainListen ? 1.0f : 0.0f);
@@ -303,10 +314,11 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
             }
     }
     if (nCh == 1) filteredSidechain[1] = filteredSidechain[0];
-    prepareLookahead(in, processingIn, nCh, nSamples);
+    const int globalLookaheadDelay = static_cast<int>(std::round(
+        globalLookaheadMs * 0.001f * static_cast<float>(sampleRate)));
+    prepareLookahead(in, processingIn, nCh, nSamples, globalLookaheadDelay);
     const int digitalDryDelay = mode == MultiCompMode::Digital
-        ? static_cast<int>(std::round(std::clamp(params.digitalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f)
-                                      * 0.001f * static_cast<float>(sampleRate))) : 0;
+        ? static_cast<int>(std::round(digitalLookaheadMs * 0.001f * static_cast<float>(sampleRate))) : 0;
     const int dryDelay = mode == MultiCompMode::Multiband ? 0 : antiAliasLatency + digitalDryDelay;
     for (int ch = 0; ch < nCh; ++ch)
     {
@@ -359,7 +371,8 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
         autoGainSmoother.setTarget(1.0f);
     }
     processRange(processingIn, filteredSidechain, out, nCh, nSamples,
-                 useExternalSidechain, autoMakeup, mode, linkMode);
+                 useExternalSidechain, autoMakeup, mode, linkMode,
+                 actualOversampling, digitalLookaheadMs);
     const bool isMulti = mode == MultiCompMode::Multiband;
     if (nCh > 1 && linkMode == 1)
     {
@@ -509,11 +522,8 @@ void MultiCompDSP::processLatencyHistory(const float* const* in, float* const* o
 
 void MultiCompDSP::prepareLookahead(const float* const* in,
                                     const float* (&processingIn)[kMaxChannels],
-                                    int nCh, int nSamples)
+                                    int nCh, int nSamples, int delay)
 {
-    const int delay = static_cast<int>(std::round(std::clamp(
-        params.globalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f)
-        * 0.001f * static_cast<float>(sampleRate)));
     if (globalLookahead[0].empty()) return;
 
     const int size = static_cast<int>(globalLookahead[0].size());
@@ -534,7 +544,7 @@ void MultiCompDSP::prepareLookahead(const float* const* in,
     }
 }
 
-void MultiCompDSP::syncModeParameters(MultiCompMode mode) noexcept
+void MultiCompDSP::syncModeParameters(MultiCompMode mode, float digitalLookaheadMs) noexcept
 {
     switch (mode)
     {
@@ -583,7 +593,7 @@ void MultiCompDSP::syncModeParameters(MultiCompMode mode) noexcept
             copyParameter(modeParams.digitalKnee, params.digitalKnee);
             copyParameter(modeParams.digitalAttack, params.digitalAttack);
             copyParameter(modeParams.digitalRelease, params.digitalRelease);
-            copyParameter(modeParams.digitalLookahead, params.digitalLookahead);
+            modeParams.digitalLookahead.store(digitalLookaheadMs, std::memory_order_relaxed);
             copyParameter(modeParams.digitalOutput, params.digitalOutput);
             copyParameter(modeParams.digitalAdaptive, params.digitalAdaptive);
             break;
@@ -595,9 +605,9 @@ void MultiCompDSP::syncModeParameters(MultiCompMode mode) noexcept
 void MultiCompDSP::processRange(const float* const* in, const float* const* sidechain,
                                 float* const* out, int nCh, int nSamples,
                                 bool external, bool autoMakeup,
-                                MultiCompMode mode, int linkMode)
+                                MultiCompMode mode, int linkMode, int actualOs,
+                                float digitalLookaheadMs)
 {
-    const int actualOs = params.oversampling.load(std::memory_order_relaxed) == 2 ? 4 : (params.oversampling.load(std::memory_order_relaxed) == 1 ? 2 : 1);
     const float linkAmount = std::clamp(params.stereoLink.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f);
     const auto distortionType = static_cast<DistortionType>(std::clamp(params.distortion.load(std::memory_order_relaxed), 0, 3));
     const float distortionAmount = std::clamp(params.distortionAmount.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f);
@@ -605,9 +615,10 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
     modes.setRate(sampleRate, actualOs);
     manualMakeupScaleRamp.setTarget(autoMakeup ? 0.0f : 1.0f);
     if (firstBlock) manualMakeupScaleRamp.snap(autoMakeup ? 0.0f : 1.0f);
-    syncModeParameters(mode);
+    syncModeParameters(mode, digitalLookaheadMs);
     if (mode == MultiCompMode::Multiband)
     {
+        previousOversampledSidechainValid = {{false, false}};
         for (int i = 0; i < nSamples; ++i) (void)manualMakeupScaleRamp.next();
         processMultiband(in, external ? sidechain : nullptr, out, nCh, nSamples);
         return;
@@ -657,25 +668,16 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
             const float midSideSc = ch == 0 ? (sc0 + sc1) * 0.5f : (sc0 - sc1) * 0.5f;
             const float sc = link ? std::abs(ownSc) * (1.0f - linkAmount) + scLevel * linkAmount
                                   : linkMode == 1 ? midSideSc : ownSc;
-            // JUCE pre-interpolates the already-filtered sidechain to the
-            // oversampled rate before entering each mode.  The native-rate
-            // detector value above is retained for the non-oversampled path;
-            // for the oversampled path, derive the next native detector value
-            // and linearly interpolate it at the same phase positions as the
-            // Dusk halfband callback (0, 1/2, or 1/4 steps).
-            float nextSc = sc;
-            if (actualOs > 1 && i + 1 < nSamples)
+            // Interpolate causally from the previous native detector sample to
+            // this one.  The carried endpoint makes the same detector curve
+            // independent of where the host divides blocks.
+            const size_t channelIndex = static_cast<size_t>(ch);
+            if (!previousOversampledSidechainValid[channelIndex])
             {
-                const float next0 = sidechain != nullptr ? sidechain[0][i + 1] : in[0][i + 1];
-                const float next1 = sidechain != nullptr ? sidechain[std::min(1, nCh - 1)][i + 1] : in[std::min(1, nCh - 1)][i + 1];
-                const float nextLevel = std::max(std::abs(next0), std::abs(next1));
-                const float nextOwn = ch == 0 ? next0 : next1;
-                const float nextInput = link ? std::abs(nextOwn) * (1.0f - linkAmount) + nextLevel * linkAmount
-                                             : linkMode == 1 ? (ch == 0 ? (next0 + next1) * 0.5f
-                                                                         : (next0 - next1) * 0.5f)
-                                                             : nextOwn;
-                nextSc = nextInput;
+                previousOversampledSidechain[channelIndex] = sc;
+                previousOversampledSidechainValid[channelIndex] = true;
             }
+            const float previousSc = previousOversampledSidechain[channelIndex];
             const float localMix = mode == MultiCompMode::Digital ? localDigitalMix : localBusMix;
             if (actualOs == 1)
             {
@@ -688,11 +690,12 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
             {
                 int osPhase = 0;
                 out[ch][i] = oversamplers[ch].processSample(input, [&](float sample) noexcept {
-                    const float osSc = interpolateOversampledSidechain(sc, nextSc, osPhase++, actualOs);
+                    const float osSc = interpolateOversampledSidechain(previousSc, sc, osPhase++, actualOs);
                     return applyCoreDistortion(modes.process(mode, sample, ch, osSc, modeParams, localMix, external),
                                                distortionType, distortionAmount);
                 });
             }
+            previousOversampledSidechain[channelIndex] = sc;
         }
     }
     const float gr = std::min(modes.gainReduction(mode, 0), nCh > 1 ? modes.gainReduction(mode, 1) : modes.gainReduction(mode, 0));
@@ -743,9 +746,14 @@ void MultiCompDSP::processMultiband(const float* const* input, const float* cons
     const auto distortionType = static_cast<DistortionType>(std::clamp(params.distortion.load(std::memory_order_relaxed), 0, 3));
     const float distortionAmount = std::clamp(params.distortionAmount.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f);
     std::array<float, kMultiCompBands> maxGr{{0, 0, 0, 0}};
+    std::array<bool, kMultiCompBands> solos{};
     bool anySolo = false;
     for (int band = 0; band < kMultiCompBands; ++band)
-        anySolo = anySolo || params.mbSolo[static_cast<size_t>(band)].load(std::memory_order_relaxed);
+    {
+        solos[static_cast<size_t>(band)] =
+            params.mbSolo[static_cast<size_t>(band)].load(std::memory_order_relaxed);
+        anySolo = anySolo || solos[static_cast<size_t>(band)];
+    }
     for (int band = 0; band < kMultiCompBands; ++band)
         if ((activeBandMask & static_cast<std::uint8_t>(1u << band)) == 0)
             for (int ch = 0; ch < nCh; ++ch)
@@ -796,13 +804,14 @@ void MultiCompDSP::processMultiband(const float* const* input, const float* cons
         {
             float splitDry = 0.0f;
             for (int band = 0; band < kMultiCompBands; ++band)
-                splitDry += bands[static_cast<size_t>(band)][static_cast<size_t>(ch)][static_cast<size_t>(i)];
+                if (!anySolo || solos[static_cast<size_t>(band)])
+                    splitDry += bands[static_cast<size_t>(band)][static_cast<size_t>(ch)][static_cast<size_t>(i)];
             dry[static_cast<size_t>(ch * maxBlock + i)] = splitDry;
         }
         for (int band = 0; band < kMultiCompBands; ++band)
         {
             const size_t bandIndex = static_cast<size_t>(band);
-            const bool solo = params.mbSolo[bandIndex].load(std::memory_order_relaxed);
+            const bool solo = solos[bandIndex];
             const bool mutedBySolo = anySolo && !solo;
             float& envelope = multibandEnvelopes[static_cast<size_t>(band * kMaxChannels + ch)];
             if ((activeBandMask & static_cast<std::uint8_t>(1u << band)) == 0)
@@ -982,13 +991,19 @@ void MultiCompDSP::updateMeters(float inPeak, float* const* out, int nCh, int nS
 int MultiCompDSP::getLatencySamples() const noexcept
 {
     const auto mode = static_cast<MultiCompMode>(std::clamp(params.mode.load(std::memory_order_relaxed), 0, 7));
-    return latencySamplesForMode(mode);
+    const float globalLookaheadMs = params.globalLookahead.load(std::memory_order_relaxed);
+    const float digitalLookaheadMs = params.digitalLookahead.load(std::memory_order_relaxed);
+    return latencySamplesForMode(mode, globalLookaheadMs, digitalLookaheadMs);
 }
 
-int MultiCompDSP::latencySamplesForMode(MultiCompMode mode) const noexcept
+int MultiCompDSP::latencySamplesForMode(MultiCompMode mode, float globalLookaheadMs,
+                                        float digitalLookaheadMs) const noexcept
 {
-    const int lookahead = static_cast<int>(std::round(std::clamp(params.globalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f) * 0.001f * static_cast<float>(sampleRate)));
-    const int digital = mode == MultiCompMode::Digital ? static_cast<int>(std::round(std::clamp(params.digitalLookahead.load(std::memory_order_relaxed), 0.0f, 10.0f) * 0.001f * static_cast<float>(sampleRate))) : 0;
+    const int lookahead = static_cast<int>(std::round(std::clamp(globalLookaheadMs, 0.0f, 10.0f)
+        * 0.001f * static_cast<float>(sampleRate)));
+    const int digital = mode == MultiCompMode::Digital
+        ? static_cast<int>(std::round(std::clamp(digitalLookaheadMs, 0.0f, 10.0f)
+            * 0.001f * static_cast<float>(sampleRate))) : 0;
     // JUCE keeps PDC constant at the maximum anti-alias group delay.  The
     // multiband path is native-rate, so it contributes only lookahead here.
     const int antiAlias = mode == MultiCompMode::Multiband ? 0 : antiAliasLatency;

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -85,6 +85,7 @@ private:
     static constexpr int kBypassRampMs = 30;
     static constexpr int kSidechainListenRampMs = 30;
     static constexpr int kAutoGainTransitionMs = 50;
+    static constexpr int kAutoGainMeasurementWindow = 64;
     static constexpr int kCrossoverRampMs = 20;
     static constexpr int kCrossoverCoefficientInterval = 8;
 
@@ -107,6 +108,9 @@ private:
     void updateMeters(float inPeak, float* const* out, int nCh, int nSamples);
     void processLatencyHistory(const float* const* in, float* const* out, int nCh,
                                int nSamples, int delay, bool emit) noexcept;
+    void processSidechainListenHistory(const float* const* sidechain, int nCh,
+                                       int nSamples, int delay) noexcept;
+    void resetAutoGainMeasurement() noexcept;
     int latencySamplesForMode(MultiCompMode mode, float globalLookaheadMs,
                               float digitalLookaheadMs) const noexcept;
 
@@ -162,6 +166,9 @@ private:
     bool firstBlock = true;
     int lastMode = -1;
     int autoGainHoldSamples = 0;
+    double autoGainInputPower = 0.0;
+    double autoGainOutputPower = 0.0;
+    int autoGainMeasurementCount = 0;
     int antiAliasLatency = 0;
 
     std::array<std::atomic<float>, kMultiCompBands> bandGR{{0.0f, 0.0f, 0.0f, 0.0f}};

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -12,6 +12,7 @@
 #include "../../shared-dpf/dsp/DuskOversampler.hpp"
 #include "../../shared-dpf/dsp/DuskSmoothed.hpp"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstdint>
@@ -23,6 +24,9 @@ namespace duskaudio
 class MultiCompDSP
 {
 public:
+    static constexpr float kMinPublishedGainReductionDb = -60.0f;
+    static constexpr float kMaxPublishedGainReductionDb = 0.0f;
+
     enum class Parameter
     {
         Mode, Bypass, StereoLink, Mix, SidechainHP, TruePeakEnable, TruePeakQuality, ExternalSidechain, AutoMakeup, Distortion, DistortionAmount,
@@ -59,9 +63,16 @@ public:
 
     float getBandGainReduction(int band) const noexcept
     {
-        return band >= 0 && band < kMultiCompBands ? bandGR[static_cast<size_t>(band)].load(std::memory_order_relaxed) : 0.0f;
+        return band >= 0 && band < kMultiCompBands
+            ? std::clamp(bandGR[static_cast<size_t>(band)].load(std::memory_order_relaxed),
+                         kMinPublishedGainReductionDb, kMaxPublishedGainReductionDb)
+            : 0.0f;
     }
-    float getGainReduction() const noexcept { return masterGR.load(std::memory_order_relaxed); }
+    float getGainReduction() const noexcept
+    {
+        return std::clamp(masterGR.load(std::memory_order_relaxed),
+                          kMinPublishedGainReductionDb, kMaxPublishedGainReductionDb);
+    }
     float getInputLevel() const noexcept { return inputLevel.load(std::memory_order_relaxed); }
     float getOutputLevel() const noexcept { return outputLevel.load(std::memory_order_relaxed); }
 
@@ -80,10 +91,11 @@ private:
     void processRange(const float* const* in, const float* const* sidechain,
                       float* const* out, int nCh, int nSamples,
                       bool externalSidechain, bool autoMakeup,
-                      MultiCompMode mode, int linkMode);
-    void syncModeParameters(MultiCompMode mode) noexcept;
+                      MultiCompMode mode, int linkMode, int actualOversampling,
+                      float digitalLookaheadMs);
+    void syncModeParameters(MultiCompMode mode, float digitalLookaheadMs) noexcept;
     void prepareLookahead(const float* const* in, const float* (&processingIn)[kMaxChannels],
-                          int nCh, int nSamples);
+                          int nCh, int nSamples, int delay);
     void processMultiband(const float* const* input, const float* const* sidechain,
                           float* const* output, int nCh, int nSamples);
     std::array<float, 3> crossoverTargets() const noexcept;
@@ -95,7 +107,8 @@ private:
     void updateMeters(float inPeak, float* const* out, int nCh, int nSamples);
     void processLatencyHistory(const float* const* in, float* const* out, int nCh,
                                int nSamples, int delay, bool emit) noexcept;
-    int latencySamplesForMode(MultiCompMode mode) const noexcept;
+    int latencySamplesForMode(MultiCompMode mode, float globalLookaheadMs,
+                              float digitalLookaheadMs) const noexcept;
 
     MultiCompParameterState params;
     MultiCompParameterState modeParams;
@@ -124,6 +137,8 @@ private:
     std::array<std::vector<float>, kMaxChannels> delayedInput;
     std::array<std::vector<float>, kMaxChannels> globalLookahead;
     std::array<int, kMaxChannels> globalLookaheadWrite{{0, 0}};
+    std::array<float, kMaxChannels> previousOversampledSidechain{{0.0f, 0.0f}};
+    std::array<bool, kMaxChannels> previousOversampledSidechainValid{{false, false}};
     std::array<float, kMultiCompBands * kMaxChannels> multibandEnvelopes{};
     std::uint8_t activeBandMask = 0x0f;
     std::array<int, kMultiCompBands> enabledBandIndices{{0, 1, 2, 3}};

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -79,7 +79,8 @@ private:
 
     void processRange(const float* const* in, const float* const* sidechain,
                       float* const* out, int nCh, int nSamples,
-                      bool externalSidechain, bool autoMakeup);
+                      bool externalSidechain, bool autoMakeup,
+                      MultiCompMode mode, int linkMode);
     void syncModeParameters(MultiCompMode mode) noexcept;
     void prepareLookahead(const float* const* in, const float* (&processingIn)[kMaxChannels],
                           int nCh, int nSamples);
@@ -91,8 +92,10 @@ private:
     void updateCrossoverTargets() noexcept;
     void rebuildMultibandTopology(std::uint8_t mask) noexcept;
     DuskCrossover& crossoverForBoundary(int boundary, int channel, bool sidechain) noexcept;
-    void updateMeters(const float* const* in, float* const* out, int nCh, int nSamples);
-    void processLatencyHistory(const float* const* in, float* const* out, int nCh, int nSamples, bool emit) noexcept;
+    void updateMeters(float inPeak, float* const* out, int nCh, int nSamples);
+    void processLatencyHistory(const float* const* in, float* const* out, int nCh,
+                               int nSamples, int delay, bool emit) noexcept;
+    int latencySamplesForMode(MultiCompMode mode) const noexcept;
 
     MultiCompParameterState params;
     MultiCompParameterState modeParams;
@@ -116,6 +119,8 @@ private:
     std::array<int, kMaxChannels> dryPathWrite{{0, 0}};
     std::array<std::vector<float>, kMaxChannels> bypassDelay;
     int bypassWrite = 0;
+    std::array<std::vector<float>, kMaxChannels> sidechainListenDelay;
+    std::array<int, kMaxChannels> sidechainListenWrite{{0, 0}};
     std::array<std::vector<float>, kMaxChannels> delayedInput;
     std::array<std::vector<float>, kMaxChannels> globalLookahead;
     std::array<int, kMaxChannels> globalLookaheadWrite{{0, 0}};

--- a/plugins/multi-comp/core/MultiCompHelpers.hpp
+++ b/plugins/multi-comp/core/MultiCompHelpers.hpp
@@ -193,7 +193,7 @@ inline float interpolateOversampledSidechain(float current, float next,
                                               int phase, int factor) noexcept
 {
     if (factor <= 1) return current;
-    const float position = static_cast<float>(std::clamp(phase, 0, factor - 1))
+    const float position = static_cast<float>(std::clamp(phase, 0, factor - 1) + 1)
                          / static_cast<float>(factor);
     return current + (next - current) * position;
 }

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -6,6 +6,10 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
 #include <vector>
 
 using duskaudio::DuskCrossover;
@@ -1489,8 +1493,213 @@ void testHardwareRateRefreshAfterOversamplingChange()
     }
 }
 
+float renderSoloedHighFrequencyPeak(float mix)
+{
+    constexpr int blockSize = 256;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Multiband));
+    dsp.setParameter(MultiCompDSP::Parameter::MbMix, mix);
+    dsp.setParameter(MultiCompDSP::Parameter::MbOutput, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setMultibandParameter(0, MultiCompDSP::MultibandParameter::Solo, 1.0f);
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+    {
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Threshold, 0.0f);
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Ratio, 1.0f);
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Makeup, 0.0f);
+    }
+    dsp.prepare(48000.0, blockSize);
+
+    std::array<float, blockSize> input{}, output{};
+    const float* inputs[] = {input.data()};
+    float* outputs[] = {output.data()};
+    float peak = 0.0f;
+    for (int block = 0; block < 100; ++block)
+    {
+        for (int i = 0; i < blockSize; ++i)
+        {
+            const int sample = block * blockSize + i;
+            input[static_cast<size_t>(i)] = 0.5f * std::sin(
+                2.0f * kPi * 12000.0f * static_cast<float>(sample) / 48000.0f);
+        }
+        dsp.processBlock(inputs, outputs, 1, blockSize);
+        if (block == 99)
+            for (float sample : output) peak = std::max(peak, std::abs(sample));
+    }
+    return peak;
+}
+
+void testMultibandSoloMasksDryReference()
+{
+    const float halfMixPeak = renderSoloedHighFrequencyPeak(50.0f);
+    const float wetPeak = renderSoloedHighFrequencyPeak(100.0f);
+    const float delta = std::abs(halfMixPeak - wetPeak);
+    std::printf("multiband solo dry mask: 50%% peak %.9g; wet peak %.9g; delta %.9g\n",
+                halfMixPeak, wetPeak, delta);
+    require(wetPeak < 0.01f, "low solo rejects a 12 kHz signal on the wet path");
+    require(delta < 1.0e-5f, "multiband dry reference obeys the same solo mask as wet recombination");
+}
+
+std::vector<float> renderWithBlockSize(int oversampling, int blockSize)
+{
+    constexpr int totalSamples = 16384;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    dsp.setOversampling(oversampling);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -30.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 12.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalKnee, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalAttack, 0.1f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRelease, 50.0f);
+    dsp.prepare(48000.0, 512);
+
+    std::vector<float> input(totalSamples), output(totalSamples);
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        const float modulation = 0.55f + 0.4f * std::sin(2.0f * kPi * 3.7f * i / 48000.0f);
+        input[static_cast<size_t>(i)] = modulation
+            * std::sin(2.0f * kPi * 997.0f * static_cast<float>(i) / 48000.0f);
+    }
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        const float* inputs[] = {input.data() + offset};
+        float* outputs[] = {output.data() + offset};
+        dsp.processBlock(inputs, outputs, 1, count);
+    }
+    return output;
+}
+
+void testOversamplingBlockSizeInvariance()
+{
+    bool invariant = true;
+    for (int oversampling : {0, 1, 2})
+    {
+        const auto large = renderWithBlockSize(oversampling, 512);
+        const auto small = renderWithBlockSize(oversampling, 64);
+        float maxDelta = 0.0f;
+        for (size_t i = 0; i < large.size(); ++i)
+            maxDelta = std::max(maxDelta, std::abs(large[i] - small[i]));
+        std::printf("oversampling block invariance: os=%d max_delta=%.9g\n",
+                    oversampling, maxDelta);
+        invariant = invariant && maxDelta < 1.0e-7f;
+    }
+    require(invariant, "oversampled render is invariant between 512- and 64-sample blocks");
+}
+
+void testAllModesAreMonoSafe()
+{
+    constexpr int blockSize = 127;
+    for (int mode = 0; mode < 8; ++mode)
+    {
+        MultiCompDSP dsp;
+        dsp.setMode(mode);
+        dsp.setOversampling(2);
+        dsp.setParameter(MultiCompDSP::Parameter::GlobalLookahead, 3.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalLookahead, 4.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::StereoLinkMode, 0.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain, 1.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+        dsp.prepare(48000.0, blockSize);
+        std::array<float, blockSize> input{}, sidechain{}, output{};
+        for (int i = 0; i < blockSize; ++i)
+        {
+            input[static_cast<size_t>(i)] = 0.4f * std::sin(2.0f * kPi * 431.0f * i / 48000.0f);
+            sidechain[static_cast<size_t>(i)] = 0.7f * std::sin(2.0f * kPi * 997.0f * i / 48000.0f);
+        }
+        const float* inputs[] = {input.data()};
+        const float* sidechains[] = {sidechain.data()};
+        float* outputs[] = {output.data()};
+        for (int block = 0; block < 20; ++block)
+            dsp.processBlockExternal(inputs, sidechains, outputs, 1, blockSize);
+        for (float sample : output)
+            require(std::isfinite(sample), "mono processing remains finite in every mode");
+    }
+    std::puts("mono safety: all modes exercised with 4x, lookahead, external sidechain and stereo-link state");
+}
+
+void testPublishedGainReductionRange()
+{
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -60.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalKnee, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalAttack, 0.01f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRelease, 5000.0f);
+    dsp.prepare(48000.0, 256);
+    std::array<float, 256> input{}, output{};
+    input.fill(2.0f);
+    const float* inputs[] = {input.data()};
+    float* outputs[] = {output.data()};
+    for (int block = 0; block < 40; ++block) dsp.processBlock(inputs, outputs, 1, 256);
+    const float reduction = dsp.getGainReduction();
+    std::printf("published GR range: deep-compression reading %.9g dB\n", reduction);
+    require(reduction >= -60.0f && reduction <= 0.0f,
+            "published gain reduction stays inside its declared -60..0 dB range");
+}
+
+std::string sourceSection(const std::string& source, const char* begin, const char* end)
+{
+    const size_t first = source.find(begin);
+    const size_t last = source.find(end, first == std::string::npos ? 0 : first + 1);
+    require(first != std::string::npos && last != std::string::npos && last > first,
+            "DSP source snapshot section exists");
+    return source.substr(first, last - first);
+}
+
+size_t occurrenceCount(const std::string& text, const char* needle)
+{
+    size_t count = 0;
+    for (size_t at = 0; (at = text.find(needle, at)) != std::string::npos; at += std::strlen(needle))
+        ++count;
+    return count;
+}
+
+void testAtomicControlSnapshotsAreSingleLoad()
+{
+    std::string sourcePath = __FILE__;
+    const std::string suffix = "tests/MultiCompCoreTests.cpp";
+    const size_t suffixPosition = sourcePath.rfind(suffix);
+    require(suffixPosition != std::string::npos, "core-test source path is recognisable");
+    sourcePath.replace(suffixPosition, suffix.size(), "MultiCompDSP.cpp");
+    std::ifstream input(sourcePath);
+    require(input.good(), "MultiCompDSP source is available to structural regression");
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    const std::string source = contents.str();
+
+    const std::string prepare = sourceSection(source, "void MultiCompDSP::prepare(",
+                                               "void MultiCompDSP::reset(");
+    const std::string block = sourceSection(source, "void MultiCompDSP::processBlockExternal(",
+                                             "void MultiCompDSP::processLatencyHistory(");
+    const std::string range = sourceSection(source, "void MultiCompDSP::processRange(",
+                                             "void MultiCompDSP::processMultiband(");
+    const std::string lookahead = sourceSection(source, "void MultiCompDSP::prepareLookahead(",
+                                                 "void MultiCompDSP::syncModeParameters(");
+    require(occurrenceCount(prepare, "params.oversampling.load") == 1,
+            "prepare snapshots oversampling exactly once");
+    require(occurrenceCount(block, "params.oversampling.load") == 1,
+            "audio block snapshots oversampling exactly once");
+    require(occurrenceCount(block, "params.globalLookahead.load") == 1
+                && occurrenceCount(block, "params.digitalLookahead.load") == 1,
+            "audio block snapshots both lookaheads exactly once");
+    require(occurrenceCount(range, "params.oversampling.load") == 0
+                && occurrenceCount(range, "params.digitalLookahead.load") == 0
+                && occurrenceCount(lookahead, "params.globalLookahead.load") == 0,
+            "processing helpers consume block snapshots without atomic re-reads");
+    std::puts("atomic snapshots: oversampling/global lookahead/Digital lookahead loaded once per block");
+}
+
 int main()
 {
+    testAtomicControlSnapshotsAreSingleLoad();
+    testPublishedGainReductionRange();
+    testAllModesAreMonoSafe();
+    testOversamplingBlockSizeInvariance();
+    testMultibandSoloMasksDryReference();
     testInputMeterWithAliasedBuffers();
     testSingleBandModeClearsMultibandGainReductionMeters();
     testMultibandMidSideMixAndAutoMakeupDomains();

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -849,6 +849,79 @@ void testMultibandMixAlignment()
     std::printf("multiband mix alignment: max ripple %.5f dB\n", worstRippleDb);
 }
 
+struct StereoRms
+{
+    float left;
+    float right;
+};
+
+StereoRms renderNeutralMultibandMidSide(float mix, bool autoMakeup)
+{
+    constexpr int blockSize = 256;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Multiband));
+    dsp.setParameter(MultiCompDSP::Parameter::StereoLinkMode, 1.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::MbMix, mix);
+    dsp.setParameter(MultiCompDSP::Parameter::MbOutput, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::AutoMakeup, autoMakeup ? 1.0f : 0.0f);
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+    {
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Threshold, 0.0f);
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Ratio, 1.0f);
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Makeup, 0.0f);
+    }
+    dsp.prepare(48000.0, blockSize);
+
+    std::array<float, blockSize> inputLeft{}, inputRight{}, outputLeft{}, outputRight{};
+    const float* input[] = {inputLeft.data(), inputRight.data()};
+    float* output[] = {outputLeft.data(), outputRight.data()};
+    double leftSum = 0.0, rightSum = 0.0;
+    constexpr int totalBlocks = 240;
+    constexpr int measuredBlocks = 16;
+    for (int block = 0; block < totalBlocks; ++block)
+    {
+        for (int i = 0; i < blockSize; ++i)
+        {
+            const int sample = block * blockSize + i;
+            inputLeft[static_cast<size_t>(i)] = 0.6f * std::sin(
+                2.0f * kPi * 997.0f * static_cast<float>(sample) / 48000.0f);
+            inputRight[static_cast<size_t>(i)] = 0.25f * std::sin(
+                2.0f * kPi * 431.0f * static_cast<float>(sample) / 48000.0f);
+        }
+        dsp.processBlock(input, output, 2, blockSize);
+        if (block >= totalBlocks - measuredBlocks)
+            for (int i = 0; i < blockSize; ++i)
+            {
+                leftSum += static_cast<double>(outputLeft[static_cast<size_t>(i)])
+                         * outputLeft[static_cast<size_t>(i)];
+                rightSum += static_cast<double>(outputRight[static_cast<size_t>(i)])
+                          * outputRight[static_cast<size_t>(i)];
+            }
+    }
+    constexpr double measuredSamples = measuredBlocks * blockSize;
+    return {static_cast<float>(std::sqrt(leftSum / measuredSamples)),
+            static_cast<float>(std::sqrt(rightSum / measuredSamples))};
+}
+
+void testMultibandMidSideMixAndAutoMakeupDomains()
+{
+    const StereoRms fullWet = renderNeutralMultibandMidSide(100.0f, false);
+    const StereoRms halfMix = renderNeutralMultibandMidSide(50.0f, false);
+    const StereoRms autoMakeup = renderNeutralMultibandMidSide(100.0f, true);
+    const float halfLeftDb = duskaudio::gainToDecibels(halfMix.left / std::max(fullWet.left, 1.0e-9f));
+    const float halfRightDb = duskaudio::gainToDecibels(halfMix.right / std::max(fullWet.right, 1.0e-9f));
+    const float fullCombined = std::sqrt((fullWet.left * fullWet.left + fullWet.right * fullWet.right) * 0.5f);
+    const float autoCombined = std::sqrt((autoMakeup.left * autoMakeup.left + autoMakeup.right * autoMakeup.right) * 0.5f);
+    const float autoShiftDb = duskaudio::gainToDecibels(autoCombined / std::max(fullCombined, 1.0e-9f));
+    std::printf("multiband M/S domains: 50%% L %.4f dB R %.4f dB vs wet; auto-makeup %.4f dB\n",
+                halfLeftDb, halfRightDb, autoShiftDb);
+    require(std::abs(halfLeftDb) < 0.15f && std::abs(halfRightDb) < 0.15f
+                && std::abs(autoShiftDb) < 0.25f,
+            "multiband M/S mix and auto-makeup use an L/R split-dry reference");
+}
+
 float renderSidechainEqGR(float highGain)
 {
     MultiCompDSP dsp;
@@ -1134,6 +1207,64 @@ void testSidechainListenClearsGainReductionMeters()
             "sidechain Listen clears master and per-band gain-reduction meters");
 }
 
+void testSingleBandModeClearsMultibandGainReductionMeters()
+{
+    MultiCompDSP dsp;
+    dsp.prepare(48000.0, 256);
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Multiband));
+    configureStrongCompression(dsp, static_cast<int>(duskaudio::MultiCompMode::Multiband));
+    std::array<float, 256> input{}, output{};
+    input.fill(0.8f);
+    const float* ip[] = {input.data()};
+    float* op[] = {output.data()};
+    for (int block = 0; block < 32; ++block) dsp.processBlock(ip, op, 1, 256);
+    float activeBand = 0.0f;
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+        activeBand = std::min(activeBand, dsp.getBandGainReduction(band));
+    require(activeBand < -1.0f, "single-band meter test establishes multiband gain reduction");
+
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 1.0f);
+    dsp.processBlock(ip, op, 1, 256);
+    float singleBandMagnitude = 0.0f;
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+        singleBandMagnitude = std::max(singleBandMagnitude, std::abs(dsp.getBandGainReduction(band)));
+    std::printf("single-band GR meters: prior multiband %.4f dB; max stale band %.4f dB\n",
+                activeBand, singleBandMagnitude);
+    require(singleBandMagnitude == 0.0f,
+            "single-band processing clears per-band gain-reduction meters");
+}
+
+void testInputMeterWithAliasedBuffers()
+{
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    dsp.setOversampling(0);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 1.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalOutput, 6.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.prepare(48000.0, 256);
+
+    std::array<float, 256> inOut{};
+    const float* input[] = {inOut.data()};
+    float* output[] = {inOut.data()};
+    for (int block = 0; block < 16; ++block)
+    {
+        inOut.fill(0.25f);
+        dsp.processBlock(input, output, 1, 256);
+    }
+    const float expectedInputDb = duskaudio::gainToDecibels(0.25f);
+    const float inputMeterDb = dsp.getInputLevel();
+    const float outputMeterDb = dsp.getOutputLevel();
+    std::printf("aliased meters: input %.4f dB (expected %.4f); output %.4f dB\n",
+                inputMeterDb, expectedInputDb, outputMeterDb);
+    require(std::abs(inputMeterDb - expectedInputDb) < 0.05f
+                && outputMeterDb > inputMeterDb + 5.5f,
+            "input meter captures aliased input before output is written");
+}
+
 void testSidechainListenSwitchIsSmoothed()
 {
     MultiCompDSP dsp;
@@ -1183,6 +1314,63 @@ void testSidechainListenSwitchIsSmoothed()
             "sidechain Listen on reaches the listened signal");
     require(std::abs(listenOff.endpoint - input.back()) <= endpointTolerance,
             "sidechain Listen off reaches the non-listened signal");
+}
+
+void testSidechainListenCrossfadeIsLatencyAligned()
+{
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 256;
+    constexpr float amplitude = 0.5f;
+    constexpr float frequency = 121.6f;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    dsp.setOversampling(2);
+    dsp.setMix(100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::GlobalLookahead, 10.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalLookahead, 10.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 1.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalOutput, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.prepare(sampleRate, blockSize);
+
+    std::array<float, blockSize> input{}, output{};
+    const float* inputs[] = {input.data()};
+    float* outputs[] = {output.data()};
+    int64_t sample = 0;
+    auto renderBlock = [&]() {
+        for (int i = 0; i < blockSize; ++i, ++sample)
+            input[static_cast<size_t>(i)] = amplitude * std::sin(
+                2.0 * static_cast<double>(kPi) * frequency * static_cast<double>(sample) / sampleRate);
+        dsp.processBlock(inputs, outputs, 1, blockSize);
+    };
+
+    for (int block = 0; block < 32; ++block) renderBlock();
+    float beforePeak = 0.0f;
+    for (float value : output) beforePeak = std::max(beforePeak, std::abs(value));
+
+    dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 1.0f);
+    constexpr int rampSamples = 1440;
+    std::array<float, 6 * blockSize> transition{};
+    for (int block = 0; block < 6; ++block)
+    {
+        renderBlock();
+        std::copy(output.begin(), output.end(), transition.begin() + block * blockSize);
+    }
+    float midRampPeak = 0.0f;
+    constexpr int halfWindow = blockSize / 2;
+    for (int i = rampSamples / 2 - halfWindow; i < rampSamples / 2 + halfWindow; ++i)
+        midRampPeak = std::max(midRampPeak, std::abs(transition[static_cast<size_t>(i)]));
+
+    renderBlock();
+    float afterPeak = 0.0f;
+    for (float value : output) afterPeak = std::max(afterPeak, std::abs(value));
+    const float endpointPeak = std::min(beforePeak, afterPeak);
+    std::printf("Listen latency crossfade: before %.6f; mid-ramp %.6f; after %.6f; ratio %.3f\n",
+                beforePeak, midRampPeak, afterPeak, midRampPeak / endpointPeak);
+    require(endpointPeak > 0.45f, "Listen latency test establishes full-level endpoints");
+    require(midRampPeak >= endpointPeak * 0.8f,
+            "Listen crossfade does not collapse when lookahead and oversampling latency are engaged");
 }
 
 void testSettledBypassClearsGainReductionMeters()
@@ -1303,6 +1491,9 @@ void testHardwareRateRefreshAfterOversamplingChange()
 
 int main()
 {
+    testInputMeterWithAliasedBuffers();
+    testSingleBandModeClearsMultibandGainReductionMeters();
+    testMultibandMidSideMixAndAutoMakeupDomains();
     testTruePeakOversampledPhaseInterpolation();
     testCrossoverAutomationContinuity();
     testFourTimesHighFrequencyMixCoherence();
@@ -1310,6 +1501,7 @@ int main()
     testSettledBypassClearsGainReductionMeters();
     testSidechainListenClearsGainReductionMeters();
     testSidechainListenSwitchIsSmoothed();
+    testSidechainListenCrossfadeIsLatencyAligned();
     testBypassCompletesDuringSidechainListen();
     testAutoGainResetsOnModeChange();
     testAutoGainNeutralisesManualOutput();

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -1166,21 +1166,58 @@ void testAutoGainResetsOnModeChange()
 
 void testBypassCompletesDuringSidechainListen()
 {
-    MultiCompDSP dsp;
-    dsp.prepare(48000.0, 256);
-    dsp.setOversampling(0);
-    dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain, 1.0f);
-    dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 1.0f);
-    std::vector<float> input(256, 0.1f), sidechain(256, 0.8f), output(256);
-    const float* ip[] = {input.data()}; const float* sc[] = {sidechain.data()}; float* op[] = {output.data()};
-    for (int block = 0; block < 8; ++block) dsp.processBlockExternal(ip, sc, op, 1, 256);
-    dsp.setBypass(true);
-    for (int block = 0; block < 10; ++block) dsp.processBlockExternal(ip, sc, op, 1, 256);
-    float maxDryError = 0.0f;
-    for (float sample : output) maxDryError = std::max(maxDryError, std::abs(sample - 0.1f));
-    std::printf("bypass during sidechain listen: final sample %.9g; dry error %.9g\n",
-                output.back(), maxDryError);
-    require(maxDryError < 1.0e-7f, "bypass reaches settled dry output while sidechain Listen remains on");
+    struct Result { float maxDryError; float minimumListenTail; };
+    auto exercise = [](int channels) {
+        MultiCompDSP dsp;
+        dsp.prepare(48000.0, 256);
+        dsp.setOversampling(2);
+        dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+        dsp.setParameter(MultiCompDSP::Parameter::GlobalLookahead, 10.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalLookahead, 10.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, 0.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 1.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::SidechainHP, 0.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+        dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain, 1.0f);
+        std::array<std::vector<float>, 2> input{
+            std::vector<float>(256, 0.1f), std::vector<float>(256, 0.1f)};
+        std::array<std::vector<float>, 2> sidechain{
+            std::vector<float>(256, 0.2f), std::vector<float>(256, 0.2f)};
+        std::array<std::vector<float>, 2> output{
+            std::vector<float>(256), std::vector<float>(256)};
+        const float* ip[] = {input[0].data(), input[1].data()};
+        const float* sc[] = {sidechain[0].data(), sidechain[1].data()};
+        float* op[] = {output[0].data(), output[1].data()};
+        for (int block = 0; block < 8; ++block)
+            dsp.processBlockExternal(ip, sc, op, channels, 256);
+        dsp.setBypass(true);
+        for (int block = 0; block < 10; ++block)
+            dsp.processBlockExternal(ip, sc, op, channels, 256);
+        dsp.setParameter(MultiCompDSP::Parameter::GlobalSidechainListen, 1.0f);
+        for (auto& channel : sidechain) channel.assign(channel.size(), 0.8f);
+        for (int block = 0; block < 10; ++block)
+            dsp.processBlockExternal(ip, sc, op, channels, 256);
+        float maxDryError = 0.0f;
+        for (int ch = 0; ch < channels; ++ch)
+            for (float sample : output[static_cast<size_t>(ch)])
+                maxDryError = std::max(maxDryError, std::abs(sample - 0.1f));
+
+        dsp.setBypass(false);
+        dsp.processBlockExternal(ip, sc, op, channels, 256);
+        float minimumListenTail = output[0].back();
+        for (int ch = 1; ch < channels; ++ch)
+            minimumListenTail = std::min(minimumListenTail, output[static_cast<size_t>(ch)].back());
+        return Result{maxDryError, minimumListenTail};
+    };
+    const Result mono = exercise(1);
+    const Result stereo = exercise(2);
+    std::printf("bypass during Listen: mono/stereo dry errors %.9g/%.9g; current-sidechain tails %.9g/%.9g\n",
+                mono.maxDryError, stereo.maxDryError,
+                mono.minimumListenTail, stereo.minimumListenTail);
+    require(std::max(mono.maxDryError, stereo.maxDryError) < 1.0e-7f,
+            "mono and stereo bypass reach settled dry output while sidechain Listen remains on");
+    require(std::min(mono.minimumListenTail, stereo.minimumListenTail) > 0.18f,
+            "settled mono and stereo bypass advance the Listen ramp and latency delay together");
 }
 
 void testSidechainListenClearsGainReductionMeters()
@@ -1541,18 +1578,19 @@ void testMultibandSoloMasksDryReference()
     require(delta < 1.0e-5f, "multiband dry reference obeys the same solo mask as wet recombination");
 }
 
-std::vector<float> renderWithBlockSize(int oversampling, int blockSize)
+std::vector<float> renderWithBlockSize(int oversampling, int blockSize, bool autoMakeup)
 {
     constexpr int totalSamples = 16384;
     MultiCompDSP dsp;
     dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
     dsp.setOversampling(oversampling);
     dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
-    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -30.0f);
-    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 12.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -12.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 4.0f);
     dsp.setParameter(MultiCompDSP::Parameter::DigitalKnee, 0.0f);
     dsp.setParameter(MultiCompDSP::Parameter::DigitalAttack, 0.1f);
     dsp.setParameter(MultiCompDSP::Parameter::DigitalRelease, 50.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::AutoMakeup, autoMakeup ? 1.0f : 0.0f);
     dsp.prepare(48000.0, 512);
 
     std::vector<float> input(totalSamples), output(totalSamples);
@@ -1575,18 +1613,20 @@ std::vector<float> renderWithBlockSize(int oversampling, int blockSize)
 void testOversamplingBlockSizeInvariance()
 {
     bool invariant = true;
+    for (bool autoMakeup : {false, true})
     for (int oversampling : {0, 1, 2})
     {
-        const auto large = renderWithBlockSize(oversampling, 512);
-        const auto small = renderWithBlockSize(oversampling, 64);
+        const auto large = renderWithBlockSize(oversampling, 512, autoMakeup);
+        const auto small = renderWithBlockSize(oversampling, 128, autoMakeup);
         float maxDelta = 0.0f;
         for (size_t i = 0; i < large.size(); ++i)
             maxDelta = std::max(maxDelta, std::abs(large[i] - small[i]));
-        std::printf("oversampling block invariance: os=%d max_delta=%.9g\n",
-                    oversampling, maxDelta);
+        std::printf("oversampling block invariance: auto=%d os=%d max_delta=%.9g\n",
+                    autoMakeup ? 1 : 0, oversampling, maxDelta);
         invariant = invariant && maxDelta < 1.0e-7f;
     }
-    require(invariant, "oversampled render is invariant between 512- and 64-sample blocks");
+    require(invariant,
+            "oversampled render with Auto Makeup on and off is invariant between 512- and 128-sample blocks");
 }
 
 void testAllModesAreMonoSafe()
@@ -1699,6 +1739,7 @@ int main()
     testPublishedGainReductionRange();
     testAllModesAreMonoSafe();
     testOversamplingBlockSizeInvariance();
+    testBypassCompletesDuringSidechainListen();
     testMultibandSoloMasksDryReference();
     testInputMeterWithAliasedBuffers();
     testSingleBandModeClearsMultibandGainReductionMeters();
@@ -1711,7 +1752,6 @@ int main()
     testSidechainListenClearsGainReductionMeters();
     testSidechainListenSwitchIsSmoothed();
     testSidechainListenCrossfadeIsLatencyAligned();
-    testBypassCompletesDuringSidechainListen();
     testAutoGainResetsOnModeChange();
     testAutoGainNeutralisesManualOutput();
     testAutoGainBypassSettleBoundary();

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -10,6 +11,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 using duskaudio::DuskCrossover;
@@ -390,6 +392,47 @@ void testTruePeakOversampledPhaseInterpolation()
     const float spread = maximum - minimum;
     std::printf("true-peak 4x detector phases: held spread 0; interpolated spread %.6f\n", spread);
     require(spread > 0.5f, "fast true-peak transient changes across oversampled detector phases");
+}
+
+int detectorGainReductionOnset(int oversampling)
+{
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Digital));
+    dsp.setOversampling(oversampling);
+    dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain, 1.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalThreshold, -1.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRatio, 20.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalKnee, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalAttack, 0.01f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalRelease, 100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalLookahead, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::DigitalAdaptive, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.prepare(48000.0, 1);
+
+    float input = 0.25f, sidechain = 0.0f, output = 0.0f;
+    const float* inputs[] = {&input};
+    const float* sidechains[] = {&sidechain};
+    float* outputs[] = {&output};
+    constexpr int stepSample = 8;
+    for (int sample = 0; sample < 16; ++sample)
+    {
+        sidechain = sample >= stepSample ? 1.0f : 0.0f;
+        dsp.processBlockExternal(inputs, sidechains, outputs, 1, 1);
+        if (dsp.getGainReduction() < -0.0001f)
+            return sample;
+    }
+    return -1;
+}
+
+void testOversampledDetectorHasNativeRateStepTiming()
+{
+    const int oneXOnset = detectorGainReductionOnset(0);
+    const int fourXOnset = detectorGainReductionOnset(2);
+    std::printf("sidechain step at 8: 1x GR onset %d; 4x GR onset %d\n",
+                oneXOnset, fourXOnset);
+    require(oneXOnset == 8 && fourXOnset == oneXOnset,
+            "4x detector gain reduction starts on the same native sample as 1x");
 }
 
 void testLatencyMixBypassAndDigitalStereo()
@@ -1578,6 +1621,69 @@ void testMultibandSoloMasksDryReference()
     require(delta < 1.0e-5f, "multiband dry reference obeys the same solo mask as wet recombination");
 }
 
+void testMultibandAutomationUsesOneStereoSnapshot()
+{
+    constexpr int blockSize = 32768;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Multiband));
+    dsp.setMix(100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
+    {
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Threshold, 0.0f);
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Ratio, 1.0f);
+        dsp.setMultibandParameter(band, MultiCompDSP::MultibandParameter::Makeup, 0.0f);
+    }
+    dsp.prepare(48000.0, blockSize);
+
+    std::vector<float> input(static_cast<size_t>(blockSize));
+    std::vector<float> left(static_cast<size_t>(blockSize));
+    std::vector<float> right(static_cast<size_t>(blockSize));
+    for (int i = 0; i < blockSize; ++i)
+        input[static_cast<size_t>(i)] = 0.01f * std::sin(2.0f * kPi * 997.0f * i / 48000.0f);
+    const float* inputs[] = {input.data(), input.data()};
+    float* outputs[] = {left.data(), right.data()};
+
+    std::atomic<bool> writerReady{false};
+    std::atomic<bool> stopWriter{false};
+    std::atomic<unsigned> writes{0};
+    std::thread writer([&] {
+        writerReady.store(true, std::memory_order_release);
+        while (!stopWriter.load(std::memory_order_acquire))
+        {
+            const unsigned write = writes.fetch_add(1, std::memory_order_relaxed);
+            const float gainDb = (write & 1u) != 0u ? 12.0f : -12.0f;
+            dsp.setParameter(MultiCompDSP::Parameter::MbOutput, gainDb);
+            dsp.setMultibandParameter(0, MultiCompDSP::MultibandParameter::Makeup, gainDb);
+        }
+    });
+    while (!writerReady.load(std::memory_order_acquire)
+           || writes.load(std::memory_order_relaxed) < 100u)
+        std::this_thread::yield();
+
+    float worstDelta = 0.0f;
+    float signalPeak = 0.0f;
+    for (int block = 0; block < 16 && worstDelta < 1.0e-6f; ++block)
+    {
+        dsp.processBlock(inputs, outputs, 2, blockSize);
+        for (int i = 0; i < blockSize; ++i)
+        {
+            worstDelta = std::max(worstDelta, std::abs(left[static_cast<size_t>(i)] - right[static_cast<size_t>(i)]));
+            signalPeak = std::max(signalPeak, std::abs(left[static_cast<size_t>(i)]));
+            signalPeak = std::max(signalPeak, std::abs(right[static_cast<size_t>(i)]));
+        }
+    }
+    stopWriter.store(true, std::memory_order_release);
+    writer.join();
+
+    std::printf("multiband concurrent output/makeup: writes %u; signal peak %.9g; max L/R delta %.9g\n",
+                writes.load(std::memory_order_relaxed), signalPeak, worstDelta);
+    require(signalPeak > 1.0e-4f, "multiband stereo snapshot test processes nonzero signal");
+    require(worstDelta < 1.0e-6f,
+            "multiband parameter automation applies one parameter snapshot to both channels");
+}
+
 std::vector<float> renderWithBlockSize(int oversampling, int blockSize, bool autoMakeup)
 {
     constexpr int totalSamples = 16384;
@@ -1744,6 +1850,8 @@ int main()
     testInputMeterWithAliasedBuffers();
     testSingleBandModeClearsMultibandGainReductionMeters();
     testMultibandMidSideMixAndAutoMakeupDomains();
+    testMultibandAutomationUsesOneStereoSnapshot();
+    testOversampledDetectorHasNativeRateStepTiming();
     testTruePeakOversampledPhaseInterpolation();
     testCrossoverAutomationContinuity();
     testFourTimesHighFrequencyMixCoherence();

--- a/plugins/multi-comp/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/multi-comp/dpf-plugin/DistrhoPluginInfo.h
@@ -13,6 +13,9 @@
 // format supports them; JACK exposes all four inputs as named ports.
 #define DISTRHO_PLUGIN_NUM_INPUTS   4
 #define DISTRHO_PLUGIN_NUM_OUTPUTS  2
+// AU hosts filter insert menus by channel layout. Keep stereo as the default
+// while also exposing a true mono instance for mono Logic channel strips.
+#define DISTRHO_PLUGIN_EXTRA_IO     { 1, 1 },
 #define DISTRHO_PLUGIN_HAS_UI       1
 #define DISTRHO_PLUGIN_IS_RT_SAFE   1
 #define DISTRHO_PLUGIN_WANT_DIRECT_ACCESS 1

--- a/plugins/multi-comp/dpf-plugin/DistrhoPluginInfo.h
+++ b/plugins/multi-comp/dpf-plugin/DistrhoPluginInfo.h
@@ -13,9 +13,15 @@
 // format supports them; JACK exposes all four inputs as named ports.
 #define DISTRHO_PLUGIN_NUM_INPUTS   4
 #define DISTRHO_PLUGIN_NUM_OUTPUTS  2
-// AU hosts filter insert menus by channel layout. Keep stereo as the default
-// while also exposing a true mono instance for mono Logic channel strips.
-#define DISTRHO_PLUGIN_EXTRA_IO     { 1, 1 },
+// AU hosts filter insert menus by channel layout, and DPF's AU wrapper carries
+// every input channel on ONE element rather than a separate sidechain bus. The
+// base { 4, 2 } entry therefore describes a 4-in insert, which no stereo track
+// offers: without { 2, 2 } here auval reports the handling matrix as 1-1 and 4-2
+// only, and Logic omits the AU from every stereo channel strip. The three
+// entries are the three real layouts -- stereo with external sidechain, plain
+// stereo, and mono -- and run() picks the sidechain path off the input count
+// reported by ioChanged(), not off the output count.
+#define DISTRHO_PLUGIN_EXTRA_IO     { 2, 2 }, { 1, 1 },
 #define DISTRHO_PLUGIN_HAS_UI       1
 #define DISTRHO_PLUGIN_IS_RT_SAFE   1
 #define DISTRHO_PLUGIN_WANT_DIRECT_ACCESS 1

--- a/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompParams.hpp
@@ -73,6 +73,30 @@ inline constexpr std::array<Param, 63> kParams = {{
 inline constexpr int kParamCount = static_cast<int>(kParams.size());
 static_assert(kParamCount == static_cast<int>(ParamId::Count));
 static_assert(kParamCount == 63);
+#define MC_ASSERT_PARAM(name) \
+    static_assert(kParams[static_cast<size_t>(ParamId::name)].core == CoreParameter::name, \
+                  "kParams order does not match ParamId::" #name);
+MC_ASSERT_PARAM(Mode) MC_ASSERT_PARAM(Bypass) MC_ASSERT_PARAM(StereoLink) MC_ASSERT_PARAM(Mix)
+MC_ASSERT_PARAM(SidechainHP) MC_ASSERT_PARAM(TruePeakEnable) MC_ASSERT_PARAM(TruePeakQuality)
+MC_ASSERT_PARAM(ExternalSidechain) MC_ASSERT_PARAM(AutoMakeup) MC_ASSERT_PARAM(Distortion)
+MC_ASSERT_PARAM(DistortionAmount) MC_ASSERT_PARAM(Oversampling) MC_ASSERT_PARAM(GlobalLookahead)
+MC_ASSERT_PARAM(OptoPeakReduction) MC_ASSERT_PARAM(OptoGain) MC_ASSERT_PARAM(OptoLimit)
+MC_ASSERT_PARAM(FetInput) MC_ASSERT_PARAM(FetOutput) MC_ASSERT_PARAM(FetAttack) MC_ASSERT_PARAM(FetRelease)
+MC_ASSERT_PARAM(FetRatio) MC_ASSERT_PARAM(FetCurve) MC_ASSERT_PARAM(FetTransient) MC_ASSERT_PARAM(FetThreshold)
+MC_ASSERT_PARAM(VcaThreshold) MC_ASSERT_PARAM(VcaRatio) MC_ASSERT_PARAM(VcaAttack) MC_ASSERT_PARAM(VcaRelease)
+MC_ASSERT_PARAM(VcaOutput) MC_ASSERT_PARAM(VcaOverEasy) MC_ASSERT_PARAM(VcaClassicDetector)
+MC_ASSERT_PARAM(BusThreshold) MC_ASSERT_PARAM(BusRatio) MC_ASSERT_PARAM(BusAttack) MC_ASSERT_PARAM(BusRelease)
+MC_ASSERT_PARAM(BusMakeup) MC_ASSERT_PARAM(BusMix) MC_ASSERT_PARAM(StudioVcaThreshold)
+MC_ASSERT_PARAM(StudioVcaRatio) MC_ASSERT_PARAM(StudioVcaAttack) MC_ASSERT_PARAM(StudioVcaRelease)
+MC_ASSERT_PARAM(StudioVcaOutput) MC_ASSERT_PARAM(DigitalThreshold) MC_ASSERT_PARAM(DigitalRatio)
+MC_ASSERT_PARAM(DigitalKnee) MC_ASSERT_PARAM(DigitalAttack) MC_ASSERT_PARAM(DigitalRelease)
+MC_ASSERT_PARAM(DigitalLookahead) MC_ASSERT_PARAM(DigitalMix) MC_ASSERT_PARAM(DigitalOutput)
+MC_ASSERT_PARAM(DigitalAdaptive) MC_ASSERT_PARAM(Crossover1) MC_ASSERT_PARAM(Crossover2)
+MC_ASSERT_PARAM(Crossover3) MC_ASSERT_PARAM(GlobalSidechainListen) MC_ASSERT_PARAM(MbMix)
+MC_ASSERT_PARAM(MbOutput) MC_ASSERT_PARAM(NoiseEnable) MC_ASSERT_PARAM(ScLowFreq)
+MC_ASSERT_PARAM(ScLowGain) MC_ASSERT_PARAM(ScHighFreq) MC_ASSERT_PARAM(ScHighGain)
+MC_ASSERT_PARAM(StereoLinkMode)
+#undef MC_ASSERT_PARAM
 inline constexpr int kBandParamCount = 8 * duskaudio::kMultiCompBands;
 inline constexpr int kBandBase = kParamCount;
 inline constexpr int kMeterMaster = kBandBase + kBandParamCount;
@@ -121,9 +145,18 @@ template <class Descriptor>
 inline float hostMax(const Descriptor& d) noexcept { return hasSkew(d) ? 1.0f : d.max; }
 
 template <class Descriptor>
-inline float plainToHost(const Descriptor& d, float value) noexcept
+inline float snapPlainValue(const Descriptor& d, float value) noexcept
 {
     value = std::clamp(value, d.min, d.max);
+    if (d.interval > 0.0f)
+        value = d.min + d.interval * std::floor((value - d.min) / d.interval + 0.5f);
+    return std::clamp(value, d.min, d.max);
+}
+
+template <class Descriptor>
+inline float plainToHost(const Descriptor& d, float value) noexcept
+{
+    value = snapPlainValue(d, value);
     if (!hasSkew(d)) return value;
     const float proportion = (value - d.min) / (d.max - d.min);
     return std::pow(proportion, d.skew);
@@ -133,12 +166,9 @@ template <class Descriptor>
 inline float hostToPlain(const Descriptor& d, float value) noexcept
 {
     value = std::clamp(value, hostMin(d), hostMax(d));
-    if (!hasSkew(d)) return value;
+    if (!hasSkew(d)) return snapPlainValue(d, value);
     const float proportion = std::pow(value, 1.0f / d.skew);
-    float plain = d.min + (d.max - d.min) * proportion;
-    if (d.interval > 0.0f)
-        plain = d.min + d.interval * std::floor((plain - d.min) / d.interval + 0.5f);
-    return std::clamp(plain, d.min, d.max);
+    return snapPlainValue(d, d.min + (d.max - d.min) * proportion);
 }
 
 template <class Descriptor>

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -106,7 +106,9 @@ protected:
         // Output-only deliberately excludes kParameterIsAutomatable: hosts may
         // read these meters, but must never offer them as writable targets.
         p.hints = kParameterIsOutput;
-        p.ranges.min = -60.0f; p.ranges.max = 0.0f; p.ranges.def = 0.0f; p.unit = "dB";
+        p.ranges.min = duskaudio::MultiCompDSP::kMinPublishedGainReductionDb;
+        p.ranges.max = duskaudio::MultiCompDSP::kMaxPublishedGainReductionDb;
+        p.ranges.def = 0.0f; p.unit = "dB";
         if (index == multicompp::kMeterMaster) p.name = "GR";
         else { p.name = index == multicompp::kMeterBand0 ? "Low GR" : index == multicompp::kMeterBand1 ? "Low-Mid GR" : index == multicompp::kMeterBand2 ? "High-Mid GR" : "High GR"; }
         p.symbol = index == multicompp::kMeterMaster ? "gr_meter" : index == multicompp::kMeterBand0 ? "gr_low" : index == multicompp::kMeterBand1 ? "gr_lowmid" : index == multicompp::kMeterBand2 ? "gr_highmid" : "gr_high";
@@ -125,6 +127,31 @@ protected:
     void setParameterValue(uint32_t index, float value) override
     {
         if (index >= multicompp::kMeterMaster) return;
+        const auto x1 = static_cast<uint32_t>(multicompp::ParamId::Crossover1);
+        const auto x2 = static_cast<uint32_t>(multicompp::ParamId::Crossover2);
+        const auto x3 = static_cast<uint32_t>(multicompp::ParamId::Crossover3);
+        if (index >= x1 && index <= x3)
+        {
+            const auto& changed = multicompp::kParams[index];
+            values[index].store(multicompp::snapHostValue(changed, value), std::memory_order_relaxed);
+            const float f1 = multicompp::hostToPlain(
+                multicompp::kParams[x1], values[x1].load(std::memory_order_relaxed));
+            const float f2 = std::clamp(multicompp::hostToPlain(
+                multicompp::kParams[x2], values[x2].load(std::memory_order_relaxed)),
+                f1 * 1.5f, 5000.0f);
+            const float f3 = std::clamp(multicompp::hostToPlain(
+                multicompp::kParams[x3], values[x3].load(std::memory_order_relaxed)),
+                f2 * 1.5f, 16000.0f);
+            const float ordered[] = {f1, f2, f3};
+            for (uint32_t crossover = x1; crossover <= x3; ++crossover)
+            {
+                const float plain = ordered[crossover - x1];
+                values[crossover].store(multicompp::plainToHost(
+                    multicompp::kParams[crossover], plain), std::memory_order_relaxed);
+                dsp.setParameter(multicompp::kParams[crossover].core, plain);
+            }
+            return;
+        }
         multicompp::resolveParameter(static_cast<int>(index),
             [&](const multicompp::Param& d) {
                 const float v = multicompp::snapHostValue(d, value);
@@ -178,11 +205,18 @@ protected:
     void sampleRateChanged(double sr) override { dsp.prepare(sr, static_cast<int>(getBufferSize())); pushParameters(); updateLatency(); }
     void bufferSizeChanged(uint32_t bs) override { dsp.prepare(getSampleRate(), static_cast<int>(bs)); pushParameters(); updateLatency(); }
 
+    void ioChanged(uint16_t in, uint16_t out) override
+    {
+        // DISTRHO_PLUGIN_EXTRA_IO permits only matched mono or stereo layouts.
+        // DPF calls this while deactivated, so run() observes a stable count.
+        activeChannels = (in == 1 && out == 1) ? 1 : 2;
+    }
+
     void run(const float** inputs, float** outputs, uint32_t frames) override
     {
         const bool useSc = values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)].load(std::memory_order_relaxed) > 0.5f && inputs[2] != nullptr && inputs[3] != nullptr;
-        if (useSc) { const float* sc[2] = {inputs[2], inputs[3]}; dsp.processBlockExternal(inputs, sc, outputs, 2, static_cast<int>(frames)); }
-        else dsp.processBlock(inputs, outputs, 2, static_cast<int>(frames));
+        if (useSc) { const float* sc[2] = {inputs[2], inputs[3]}; dsp.processBlockExternal(inputs, sc, outputs, activeChannels, static_cast<int>(frames)); }
+        else dsp.processBlock(inputs, outputs, activeChannels, static_cast<int>(frames));
         // setLatency() is documented as callable from run(). The CLAP wrapper
         // latches a change here and publishes it at the next activate(), which
         // is the only point the CLAP spec allows the latency to move.
@@ -209,6 +243,7 @@ private:
     void updateLatency() { const int l = dsp.getLatencySamples(); if (l != lastLatency) { lastLatency = l; setLatency(static_cast<uint32_t>(l < 0 ? 0 : l)); } }
 
     duskaudio::MultiCompDSP dsp;
+    int activeChannels = DISTRHO_PLUGIN_NUM_OUTPUTS;
     std::array<std::atomic<float>, multicompp::kMeterMaster> values{};
     int lastLatency = -1;
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MultiCompPlugin)

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -16,6 +16,22 @@ inline bool hasStereoExternalSidechainPorts(int activeInputs,
     return activeInputs >= 4 && inputs != nullptr
         && inputs[2] != nullptr && inputs[3] != nullptr;
 }
+
+// The crossover frequencies the DSP will actually use, given the three the host
+// has set. Mirrors MultiCompDSP::crossoverTargets(), which re-derives this every
+// block from the raw parameters and never writes the result back.
+//
+// This must stay a pure read. Storing the ordered values into the parameter
+// array ratchets: raising Crossover 1 pushes Crossover 2 up, and lowering
+// Crossover 1 again leaves it there, so an automation pass permanently relocates
+// a neighbour the host never wrote and the parameter no longer matches its lane.
+inline std::array<float, 3> orderedCrossovers(float f1, float f2, float f3) noexcept
+{
+    const float o1 = f1 < 20.0f ? 20.0f : (f1 > 500.0f ? 500.0f : f1);
+    const float o2 = f2 < o1 * 1.5f ? o1 * 1.5f : (f2 > 5000.0f ? 5000.0f : f2);
+    const float o3 = f3 < o2 * 1.5f ? o2 * 1.5f : (f3 > 16000.0f ? 16000.0f : f3);
+    return {{o1, o2, o3}};
+}
 } // namespace multicompp::plugin_detail
 
 #ifndef MULTICOMP_PLUGIN_LOGIC_TEST
@@ -49,10 +65,24 @@ public:
     float bandGr(int b) const noexcept { return dsp.getBandGainReduction(b); }
     float inputLevel() const noexcept { return dsp.getInputLevel(); }
     float outputLevel() const noexcept { return dsp.getOutputLevel(); }
+    // The UI's view of a parameter. Crossovers report the frequency the DSP
+    // will use rather than the raw setting, so raising one handle visibly pushes
+    // the handles above it. The host-facing getParameterValue() deliberately
+    // does not do this: an automation lane must read back what it wrote.
     float parameterValue(uint32_t index) const noexcept
     {
-        return index < multicompp::kMeterMaster
-            ? values[index].load(std::memory_order_relaxed) : 0.0f;
+        if (index >= multicompp::kMeterMaster) return 0.0f;
+        const auto x1 = static_cast<uint32_t>(multicompp::ParamId::Crossover1);
+        const auto x3 = static_cast<uint32_t>(multicompp::ParamId::Crossover3);
+        if (index < x1 || index > x3) return values[index].load(std::memory_order_relaxed);
+        const auto plain = [this](uint32_t i) {
+            return multicompp::hostToPlain(multicompp::kParams[i],
+                                           values[i].load(std::memory_order_relaxed));
+        };
+        const auto ordered = multicompp::plugin_detail::orderedCrossovers(
+            plain(x1), plain(x1 + 1), plain(x3));
+        return multicompp::plainToHost(multicompp::kParams[index],
+                                       ordered[index - x1]);
     }
 
 protected:
@@ -148,31 +178,9 @@ protected:
     void setParameterValue(uint32_t index, float value) override
     {
         if (index >= multicompp::kMeterMaster) return;
-        const auto x1 = static_cast<uint32_t>(multicompp::ParamId::Crossover1);
-        const auto x2 = static_cast<uint32_t>(multicompp::ParamId::Crossover2);
-        const auto x3 = static_cast<uint32_t>(multicompp::ParamId::Crossover3);
-        if (index >= x1 && index <= x3)
-        {
-            const auto& changed = multicompp::kParams[index];
-            values[index].store(multicompp::snapHostValue(changed, value), std::memory_order_relaxed);
-            const float f1 = multicompp::hostToPlain(
-                multicompp::kParams[x1], values[x1].load(std::memory_order_relaxed));
-            const float f2 = std::clamp(multicompp::hostToPlain(
-                multicompp::kParams[x2], values[x2].load(std::memory_order_relaxed)),
-                f1 * 1.5f, 5000.0f);
-            const float f3 = std::clamp(multicompp::hostToPlain(
-                multicompp::kParams[x3], values[x3].load(std::memory_order_relaxed)),
-                f2 * 1.5f, 16000.0f);
-            const float ordered[] = {f1, f2, f3};
-            for (uint32_t crossover = x1; crossover <= x3; ++crossover)
-            {
-                const float plain = ordered[crossover - x1];
-                values[crossover].store(multicompp::plainToHost(
-                    multicompp::kParams[crossover], plain), std::memory_order_relaxed);
-                dsp.setParameter(multicompp::kParams[crossover].core, plain);
-            }
-            return;
-        }
+        // Crossovers take the ordinary path: each one stores exactly what the
+        // host set. The DSP re-derives the ordering from all three every block,
+        // so nothing here needs to -- and must not -- rewrite its neighbours.
         multicompp::resolveParameter(static_cast<int>(index),
             [&](const multicompp::Param& d) {
                 const float v = multicompp::snapHostValue(d, value);

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -1,15 +1,27 @@
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace multicompp::plugin_detail
+{
+inline bool hasStereoExternalSidechainPorts(int activeChannels,
+                                            const float* const* inputs) noexcept
+{
+    return activeChannels > 1 && inputs != nullptr
+        && inputs[2] != nullptr && inputs[3] != nullptr;
+}
+} // namespace multicompp::plugin_detail
+
+#ifndef MULTICOMP_PLUGIN_LOGIC_TEST
+
 #include "DistrhoPlugin.hpp"
 #include "MultiCompAccess.hpp"
 #include "MultiCompParams.hpp"
 #include "MultiCompProgramPresets.hpp"
 #include "MultiCompVersion.hpp"
 #include "util/CrashLog.hpp"
-
-#include <array>
-#include <atomic>
-#include <cstdint>
-#include <cstring>
-#include <string>
 
 START_NAMESPACE_DISTRHO
 
@@ -33,6 +45,11 @@ public:
     float bandGr(int b) const noexcept { return dsp.getBandGainReduction(b); }
     float inputLevel() const noexcept { return dsp.getInputLevel(); }
     float outputLevel() const noexcept { return dsp.getOutputLevel(); }
+    float parameterValue(uint32_t index) const noexcept
+    {
+        return index < multicompp::kMeterMaster
+            ? values[index].load(std::memory_order_relaxed) : 0.0f;
+    }
 
 protected:
     const char* getLabel() const override { return "MultiComp2"; }
@@ -214,7 +231,8 @@ protected:
 
     void run(const float** inputs, float** outputs, uint32_t frames) override
     {
-        const bool useSc = values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)].load(std::memory_order_relaxed) > 0.5f && inputs[2] != nullptr && inputs[3] != nullptr;
+        const bool useSc = values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)].load(std::memory_order_relaxed) > 0.5f
+            && multicompp::plugin_detail::hasStereoExternalSidechainPorts(activeChannels, inputs);
         if (useSc) { const float* sc[2] = {inputs[2], inputs[3]}; dsp.processBlockExternal(inputs, sc, outputs, activeChannels, static_cast<int>(frames)); }
         else dsp.processBlock(inputs, outputs, activeChannels, static_cast<int>(frames));
         // setLatency() is documented as callable from run(). The CLAP wrapper
@@ -257,3 +275,7 @@ float multiCompGetGainReduction(void* p) noexcept { return p ? asMultiComp(p)->g
 float multiCompGetBandGainReduction(void* p, int band) noexcept { return p ? asMultiComp(p)->bandGr(band) : 0.0f; }
 float multiCompGetInputLevel(void* p) noexcept { return p ? asMultiComp(p)->inputLevel() : -60.0f; }
 float multiCompGetOutputLevel(void* p) noexcept { return p ? asMultiComp(p)->outputLevel() : -60.0f; }
+float multiCompGetParameterValue(void* p, uint32_t index) noexcept
+{ return p ? asMultiComp(p)->parameterValue(index) : 0.0f; }
+
+#endif // MULTICOMP_PLUGIN_LOGIC_TEST

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -6,10 +6,14 @@
 
 namespace multicompp::plugin_detail
 {
-inline bool hasStereoExternalSidechainPorts(int activeChannels,
+// The aux ports exist only on the full DISTRHO_PLUGIN_NUM_INPUTS layout. The
+// output count cannot stand in for that: the AU { 2, 2 } layout is stereo out
+// with a two-channel input element, so a test against the channel count would
+// index inputs[2]/inputs[3] past the end of a two-element array.
+inline bool hasStereoExternalSidechainPorts(int activeInputs,
                                             const float* const* inputs) noexcept
 {
-    return activeChannels > 1 && inputs != nullptr
+    return activeInputs >= 4 && inputs != nullptr
         && inputs[2] != nullptr && inputs[3] != nullptr;
 }
 } // namespace multicompp::plugin_detail
@@ -224,15 +228,19 @@ protected:
 
     void ioChanged(uint16_t in, uint16_t out) override
     {
-        // DISTRHO_PLUGIN_EXTRA_IO permits only matched mono or stereo layouts.
-        // DPF calls this while deactivated, so run() observes a stable count.
+        // DISTRHO_PLUGIN_EXTRA_IO permits { 4, 2 }, { 2, 2 } and { 1, 1 }. The
+        // input count is kept separately from the processing width because the
+        // two disagree on { 4, 2 }, where the extra pair is the sidechain and
+        // not audio to compress. DPF calls this while deactivated, so run()
+        // observes a stable pair.
+        activeInputs = static_cast<int>(in);
         activeChannels = (in == 1 && out == 1) ? 1 : 2;
     }
 
     void run(const float** inputs, float** outputs, uint32_t frames) override
     {
         const bool useSc = values[static_cast<size_t>(multicompp::ParamId::ExternalSidechain)].load(std::memory_order_relaxed) > 0.5f
-            && multicompp::plugin_detail::hasStereoExternalSidechainPorts(activeChannels, inputs);
+            && multicompp::plugin_detail::hasStereoExternalSidechainPorts(activeInputs, inputs);
         if (useSc) { const float* sc[2] = {inputs[2], inputs[3]}; dsp.processBlockExternal(inputs, sc, outputs, activeChannels, static_cast<int>(frames)); }
         else dsp.processBlock(inputs, outputs, activeChannels, static_cast<int>(frames));
         // setLatency() is documented as callable from run(). The CLAP wrapper
@@ -261,6 +269,10 @@ private:
     void updateLatency() { const int l = dsp.getLatencySamples(); if (l != lastLatency) { lastLatency = l; setLatency(static_cast<uint32_t>(l < 0 ? 0 : l)); } }
 
     duskaudio::MultiCompDSP dsp;
+    // Formats other than AU always present the full input set, and ioChanged()
+    // is only called where a host narrows it, so the declared count is the
+    // correct default rather than a placeholder.
+    int activeInputs = DISTRHO_PLUGIN_NUM_INPUTS;
     int activeChannels = DISTRHO_PLUGIN_NUM_OUTPUTS;
     std::array<std::atomic<float>, multicompp::kMeterMaster> values{};
     int lastLatency = -1;

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -1,6 +1,10 @@
 #include "MultiCompParams.hpp"
 #include "MultiCompProgramPresets.hpp"
 
+#define MULTICOMP_UI_LOGIC_TEST
+#include "MultiCompUI.cpp"
+#undef MULTICOMP_UI_LOGIC_TEST
+
 #include <array>
 #include <cmath>
 #include <cstdio>
@@ -36,6 +40,32 @@ void testHostParameterTapers()
                 "Digital Attack follows JUCE skew at quarter points");
     }
     std::puts("host tapers: VCA Ratio and Digital Attack match JUCE at 0.25/0.5/0.75");
+}
+
+void testParameterIntervals()
+{
+    const multicompp::Param linear = {
+        "linear_interval", "Linear Interval", "", 10.0f, 20.0f, 10.0f,
+        MultiCompDSP::Parameter::Mode, false, 2.0f, 1.0f};
+    require(multicompp::hostToPlain(linear, 13.1f) == 14.0f,
+            "linear host-to-plain mapping applies the descriptor interval");
+    require(multicompp::plainToHost(linear, 13.1f) == 14.0f,
+            "linear plain-to-host mapping applies the descriptor interval");
+
+    const multicompp::Param skewed = {
+        "skewed_interval", "Skewed Interval", "", 1.0f, 121.0f, 1.0f,
+        MultiCompDSP::Parameter::Mode, false, 5.0f, 0.5f};
+    const float expectedHost = std::pow((16.0f - skewed.min) / (skewed.max - skewed.min),
+                                        skewed.skew);
+    require(std::abs(multicompp::plainToHost(skewed, 14.0f) - expectedHost) < 1.0e-7f,
+            "skewed plain-to-host mapping snaps before applying the unchanged taper");
+    require(multicompp::hostToPlain(skewed, expectedHost) == 16.0f,
+            "skewed host-to-plain mapping snaps after applying the unchanged taper");
+    require(std::abs(multicompp::plainToHost(
+                         skewed, multicompp::hostToPlain(skewed, expectedHost)) - expectedHost)
+                <= 1.5e-8f,
+            "symmetric interval snapping preserves the skewed taper round trip");
+    std::puts("parameter intervals: applied symmetrically for linear and skewed mappings");
 }
 
 void testStrictStateValidationAndRoundTrip()
@@ -110,7 +140,43 @@ void testStrictStateValidationAndRoundTrip()
 
 void testFactoryPresetOwnership()
 {
-    auto verifyPreset = [](const duskaudio::MultiCompPreset& preset) {
+    using ParamId = multicompp::ParamId;
+    struct PresetOwnership
+    {
+        std::array<ParamId, 13> parameters;
+        size_t parameterCount;
+        bool ownsBandParameters;
+    };
+    const std::array<PresetOwnership, 8> expectedOwnership = {{
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::OptoPeakReduction, ParamId::OptoGain, ParamId::OptoLimit}, 7, false},
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::FetInput, ParamId::FetOutput, ParamId::FetAttack, ParamId::FetRelease,
+          ParamId::FetRatio, ParamId::FetCurve, ParamId::FetTransient, ParamId::FetThreshold},
+         12, false},
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::VcaThreshold, ParamId::VcaRatio, ParamId::VcaAttack, ParamId::VcaRelease,
+          ParamId::VcaOutput, ParamId::VcaOverEasy, ParamId::VcaClassicDetector}, 11, false},
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::BusThreshold, ParamId::BusRatio, ParamId::BusAttack, ParamId::BusRelease,
+          ParamId::BusMakeup, ParamId::BusMix}, 10, false},
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::FetInput, ParamId::FetOutput, ParamId::FetAttack, ParamId::FetRelease,
+          ParamId::FetRatio, ParamId::FetCurve, ParamId::FetTransient, ParamId::FetThreshold},
+         12, false},
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::StudioVcaThreshold, ParamId::StudioVcaRatio, ParamId::StudioVcaAttack,
+          ParamId::StudioVcaRelease, ParamId::StudioVcaOutput}, 9, false},
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::DigitalThreshold, ParamId::DigitalRatio, ParamId::DigitalKnee,
+          ParamId::DigitalAttack, ParamId::DigitalRelease, ParamId::DigitalLookahead,
+          ParamId::DigitalMix, ParamId::DigitalOutput, ParamId::DigitalAdaptive}, 13, false},
+        {{ParamId::Mode, ParamId::Mix, ParamId::SidechainHP, ParamId::AutoMakeup,
+          ParamId::Crossover1, ParamId::Crossover2, ParamId::Crossover3,
+          ParamId::MbMix, ParamId::MbOutput}, 9, true},
+    }};
+
+    auto verifyPreset = [&expectedOwnership](const duskaudio::MultiCompPreset& preset) {
         std::array<float, multicompp::kMeterMaster> values{};
         std::array<bool, multicompp::kMeterMaster> owned{};
         values.fill(-123.0f);
@@ -274,24 +340,17 @@ void testFactoryPresetOwnership()
                 break;
         }
 
-        for (const auto id : {multicompp::ParamId::Bypass,
-                              multicompp::ParamId::StereoLink,
-                              multicompp::ParamId::TruePeakEnable,
-                              multicompp::ParamId::TruePeakQuality,
-                              multicompp::ParamId::ExternalSidechain,
-                              multicompp::ParamId::Distortion,
-                              multicompp::ParamId::DistortionAmount,
-                              multicompp::ParamId::Oversampling,
-                              multicompp::ParamId::GlobalLookahead,
-                              multicompp::ParamId::GlobalSidechainListen,
-                              multicompp::ParamId::NoiseEnable,
-                              multicompp::ParamId::ScLowFreq,
-                              multicompp::ParamId::ScLowGain,
-                              multicompp::ParamId::ScHighFreq,
-                              multicompp::ParamId::ScHighGain,
-                              multicompp::ParamId::StereoLinkMode})
-            require(!owned[static_cast<size_t>(id)],
-                    "factory preset leaves machine/global parameter untouched");
+        require(preset.mode >= 0 && static_cast<size_t>(preset.mode) < expectedOwnership.size(),
+                "factory preset mode has an ownership table entry");
+        std::array<bool, multicompp::kMeterMaster> expected{};
+        const auto& modeOwnership = expectedOwnership[static_cast<size_t>(preset.mode)];
+        for (size_t i = 0; i < modeOwnership.parameterCount; ++i)
+            expected[static_cast<size_t>(modeOwnership.parameters[i])] = true;
+        if (modeOwnership.ownsBandParameters)
+            for (int i = multicompp::kBandBase; i < multicompp::kMeterMaster; ++i)
+                expected[static_cast<size_t>(i)] = true;
+        require(owned == expected,
+                "factory preset owns exactly the common and active-mode parameters");
     };
 
     for (const auto& preset : multicompp::kFactoryPresets)
@@ -317,10 +376,13 @@ void testHostProgramChangeAppliesBandParameters()
     std::array<float, multicompp::kMeterMaster> hostValues{};
     hostValues.fill(-123.0f);
 
-    multicompp::applyPresetToHostParameters(multibandProgram,
-        [&](int parameterIndex, float hostValue) {
+    auto setHostParameter = [&](int parameterIndex, float hostValue) {
+        const bool validIndex = parameterIndex >= 0 && parameterIndex < multicompp::kMeterMaster;
+        require(validIndex, "host program change emits an in-range parameter index");
+        if (validIndex)
             hostValues[static_cast<size_t>(parameterIndex)] = hostValue;
-        });
+    };
+    multicompp::applyPresetToHostParameters(multibandProgram, setHostParameter);
 
     for (int band = 0; band < duskaudio::kMultiCompBands; ++band)
         for (int field = 0; field < 8; ++field)
@@ -332,6 +394,43 @@ void testHostProgramChangeAppliesBandParameters()
                     "host program change applies every Multiband parameter in host space");
         }
     std::puts("host program change: every Multiband parameter applied in host space");
+}
+
+void testFractionalEnumUiAndDspAgreement()
+{
+    for (const float hostValue : {0.4f, 0.6f, 1.4f, 1.6f, 6.6f})
+    {
+        const auto& mode = multicompp::kParams[static_cast<size_t>(multicompp::ParamId::Mode)];
+        const int dspIndex = static_cast<int>(multicompp::snapHostValue(mode, hostValue));
+        const int uiIndex = multicompp::ui_detail::choiceIndex(hostValue, 8);
+        require(uiIndex == dspIndex,
+                "fractional enum host values select the same UI and DSP index");
+    }
+    std::puts("fractional enum automation: UI and DSP select the same rounded index");
+}
+
+void testHostProgramChangeUpdatesUiMirror()
+{
+    for (size_t presetIndex = 0; presetIndex < multicompp::kFactoryPresets.size(); ++presetIndex)
+    {
+        multicompp::StateValues uiValues{};
+        for (size_t i = 0; i < uiValues.size(); ++i)
+            uiValues[i] = -123.0f + static_cast<float>(i) * 0.01f;
+        auto expected = uiValues;
+        multicompp::applyPresetToHostParameters(multicompp::kFactoryPresets[presetIndex],
+            [&](int parameterIndex, float hostValue)
+            {
+                expected[static_cast<size_t>(parameterIndex)] = hostValue;
+            });
+
+        const int selected = multicompp::ui_detail::loadProgramIntoMirror(
+            static_cast<uint32_t>(presetIndex), uiValues);
+        require(selected == static_cast<int>(presetIndex),
+                "host program change selects the recalled preset in the UI");
+        require(uiValues == expected,
+                "host program change updates the UI mirror to the applied preset values");
+    }
+    std::puts("host program change: UI mirror matches every applied factory preset");
 }
 
 static_assert(multicompp::kParamCount == 63,
@@ -394,9 +493,12 @@ void testFractionalIntegerAutomationStaysLoadable()
 int main()
 {
     testHostParameterTapers();
+    testParameterIntervals();
     testStrictStateValidationAndRoundTrip();
     testFactoryPresetOwnership();
     testHostProgramChangeAppliesBandParameters();
+    testHostProgramChangeUpdatesUiMirror();
+    testFractionalEnumUiAndDspAgreement();
     testFractionalIntegerAutomationStaysLoadable();
     std::puts("Multi-Comp plugin-layer tests: PASS");
     return 0;

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -512,6 +512,25 @@ std::string readSiblingSource(const char* filename)
     return contents.str();
 }
 
+// The parameter store keeps what the host wrote; only the read-back orders the
+// three. Sweeping Crossover 1 up and back down must therefore leave Crossover 2
+// exactly where it started -- if the ordering were stored, it would not.
+void testCrossoverOrderingDoesNotRatchet()
+{
+    // What the host owns: never rewritten by the ordering.
+    const float rawX1Start = 100.0f, rawX2 = 300.0f, rawX3 = 2000.0f;
+    const auto atRest = multicompp::plugin_detail::orderedCrossovers(rawX1Start, rawX2, rawX3);
+    const auto raised = multicompp::plugin_detail::orderedCrossovers(500.0f, rawX2, rawX3);
+    const auto returned = multicompp::plugin_detail::orderedCrossovers(rawX1Start, rawX2, rawX3);
+    std::printf("crossover sweep: X2 reads %.0f Hz at rest, %.0f Hz with X1 at 500, %.0f Hz back at 100\n",
+                static_cast<double>(atRest[1]), static_cast<double>(raised[1]),
+                static_cast<double>(returned[1]));
+    reviewCheck(raised[1] > atRest[1],
+                "raising Crossover 1 pushes the Crossover 2 the UI displays");
+    reviewCheck(returned[1] == atRest[1] && returned[2] == atRest[2],
+                "lowering Crossover 1 again returns the displayed neighbours");
+}
+
 // One case per DISTRHO_PLUGIN_EXTRA_IO layout. The { 2, 2 } row is the one the
 // output count could not express: it is stereo, so a channel-count test would
 // have called it sidechain-capable and read two elements past the end of the
@@ -653,6 +672,7 @@ void testFractionalIntegerAutomationStaysLoadable()
 int main()
 {
     testRunGuardsSidechainPortsPerLayout();
+    testCrossoverOrderingDoesNotRatchet();
     testQuantisedFineStepFallsBackToRestingPrecision();
     testShippingUiHasNoDeadCrossoverDescriptor();
     testCrossoverMirrorRefreshesEveryPluginChangedValue();

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -1,5 +1,10 @@
 #include "MultiCompParams.hpp"
 #include "MultiCompProgramPresets.hpp"
+#include "DistrhoPluginInfo.h"
+
+#ifndef DISTRHO_PLUGIN_EXTRA_IO
+#error "Multi-Comp must advertise its AU mono input/output layout"
+#endif
 
 #define MULTICOMP_UI_LOGIC_TEST
 #include "MultiCompUI.cpp"
@@ -16,6 +21,11 @@ using duskaudio::MultiCompDSP;
 
 namespace
 {
+constexpr uint16_t kAdvertisedExtraIo[][2] = {DISTRHO_PLUGIN_EXTRA_IO};
+static_assert(sizeof(kAdvertisedExtraIo) / sizeof(kAdvertisedExtraIo[0]) == 1
+              && kAdvertisedExtraIo[0][0] == 1 && kAdvertisedExtraIo[0][1] == 1,
+              "Multi-Comp AU extra I/O must be exactly one matched mono layout");
+
 void require(bool condition, const char* message)
 {
     if (!condition) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
@@ -409,6 +419,23 @@ void testFractionalEnumUiAndDspAgreement()
     std::puts("fractional enum automation: UI and DSP select the same rounded index");
 }
 
+void testCrossoverReadoutUsesEffectiveOrdering()
+{
+    multicompp::StateValues values{};
+    for (int i = 0; i < multicompp::kMeterMaster; ++i)
+        values[static_cast<size_t>(i)] = multicompp::resolveParameter(i,
+            [](const multicompp::Param& d) { return multicompp::hostDefault(d); },
+            [](const multicompp::BandParam& d, int) { return multicompp::hostDefault(d); });
+    const auto x1 = static_cast<uint32_t>(multicompp::ParamId::Crossover1);
+    const auto x2 = static_cast<uint32_t>(multicompp::ParamId::Crossover2);
+    values[x1] = multicompp::plainToHost(multicompp::kParams[x1], 500.0f);
+    values[x2] = multicompp::plainToHost(multicompp::kParams[x2], 300.0f);
+    const float effective = multicompp::ui_detail::effectiveCrossoverPlain(x2, values);
+    std::printf("ordered crossover readout: requested 300 Hz; effective %.0f Hz\n", effective);
+    require(effective == 750.0f,
+            "XOVER 2 readout reports the DSP's 1.5x ordering clamp");
+}
+
 void testHostProgramChangeUpdatesUiMirror()
 {
     for (size_t presetIndex = 0; presetIndex < multicompp::kFactoryPresets.size(); ++presetIndex)
@@ -492,6 +519,7 @@ void testFractionalIntegerAutomationStaysLoadable()
 
 int main()
 {
+    testCrossoverReadoutUsesEffectiveOrdering();
     testHostParameterTapers();
     testParameterIntervals();
     testStrictStateValidationAndRoundTrip();

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -10,11 +10,21 @@
 #include "MultiCompUI.cpp"
 #undef MULTICOMP_UI_LOGIC_TEST
 
+#define MULTICOMP_PLUGIN_LOGIC_TEST
+#include "MultiCompPlugin.cpp"
+#undef MULTICOMP_PLUGIN_LOGIC_TEST
+
+#define DUSK_IMGUI_WIDGETS_LOGIC_TEST
+#include "../../shared-dpf/ui/DuskImGuiWidgets.hpp"
+#undef DUSK_IMGUI_WIDGETS_LOGIC_TEST
+
 #include <array>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
+#include <sstream>
 #include <string>
 
 using duskaudio::MultiCompDSP;
@@ -29,6 +39,12 @@ static_assert(sizeof(kAdvertisedExtraIo) / sizeof(kAdvertisedExtraIo[0]) == 1
 void require(bool condition, const char* message)
 {
     if (!condition) { std::fprintf(stderr, "FAIL: %s\n", message); std::exit(1); }
+}
+
+int reviewFailureCount = 0;
+void reviewCheck(bool condition, const char* message)
+{
+    if (!condition) { std::fprintf(stderr, "FAIL: %s\n", message); ++reviewFailureCount; }
 }
 
 void testHostParameterTapers()
@@ -419,7 +435,7 @@ void testFractionalEnumUiAndDspAgreement()
     std::puts("fractional enum automation: UI and DSP select the same rounded index");
 }
 
-void testCrossoverReadoutUsesEffectiveOrdering()
+void testCrossoverMirrorRefreshesEveryPluginChangedValue()
 {
     multicompp::StateValues values{};
     for (int i = 0; i < multicompp::kMeterMaster; ++i)
@@ -428,12 +444,92 @@ void testCrossoverReadoutUsesEffectiveOrdering()
             [](const multicompp::BandParam& d, int) { return multicompp::hostDefault(d); });
     const auto x1 = static_cast<uint32_t>(multicompp::ParamId::Crossover1);
     const auto x2 = static_cast<uint32_t>(multicompp::ParamId::Crossover2);
+    const auto x3 = static_cast<uint32_t>(multicompp::ParamId::Crossover3);
     values[x1] = multicompp::plainToHost(multicompp::kParams[x1], 500.0f);
     values[x2] = multicompp::plainToHost(multicompp::kParams[x2], 300.0f);
-    const float effective = multicompp::ui_detail::effectiveCrossoverPlain(x2, values);
-    std::printf("ordered crossover readout: requested 300 Hz; effective %.0f Hz\n", effective);
-    require(effective == 750.0f,
-            "XOVER 2 readout reports the DSP's 1.5x ordering clamp");
+    values[x3] = multicompp::plainToHost(multicompp::kParams[x3], 2000.0f);
+    const auto staleValues = values;
+    auto pluginValues = values;
+    pluginValues[x2] = multicompp::plainToHost(multicompp::kParams[x2], 750.0f);
+    multicompp::ui_detail::refreshCrossoverMirror(values,
+        [&pluginValues](uint32_t index) { return pluginValues[index]; });
+    const float staleX2 = multicompp::hostToPlain(multicompp::kParams[x2], staleValues[x2]);
+    const float mirroredX2 = multicompp::hostToPlain(multicompp::kParams[x2], values[x2]);
+    values[x2] = multicompp::plainToHost(multicompp::kParams[x2], 5000.0f);
+    values[x3] = multicompp::plainToHost(multicompp::kParams[x3], 2000.0f);
+    pluginValues = values;
+    pluginValues[x3] = multicompp::plainToHost(multicompp::kParams[x3], 7500.0f);
+    multicompp::ui_detail::refreshCrossoverMirror(values,
+        [&pluginValues](uint32_t index) { return pluginValues[index]; });
+    const float mirroredX3 = multicompp::hostToPlain(multicompp::kParams[x3], values[x3]);
+    std::printf("ordered crossover mirror: stale X2 %.0f Hz; refreshed X2 %.0f Hz; sibling X3 %.0f Hz\n",
+                staleX2, mirroredX2, mirroredX3);
+    reviewCheck(values[x1] == pluginValues[x1]
+                    && values[x2] == pluginValues[x2]
+                    && values[x3] == pluginValues[x3],
+                "UI mirror refreshes the plugin's full ordered crossover set");
+    reviewCheck(mirroredX2 == 750.0f && mirroredX3 == 7500.0f,
+                "crossover handles and readouts use the refreshed plugin values");
+}
+
+std::string readSiblingSource(const char* filename)
+{
+    std::string sourcePath = __FILE__;
+    const size_t slash = sourcePath.rfind('/');
+    require(slash != std::string::npos, "plugin-layer test source path is recognisable");
+    sourcePath.replace(slash + 1, std::string::npos, filename);
+    std::ifstream input(sourcePath);
+    require(input.good(), "reviewed source file is available to structural regression");
+    std::ostringstream contents;
+    contents << input.rdbuf();
+    return contents.str();
+}
+
+void testMonoRunGuardsStereoSidechainPorts()
+{
+    float main = 0.1f, sidechain = 0.8f;
+    const float* monoInputs[] = {&main};
+    const float* stereoInputs[] = {&main, &main, &sidechain, &sidechain};
+    const bool externalArmed = true;
+    const bool monoUsesSidechain = externalArmed
+        && multicompp::plugin_detail::hasStereoExternalSidechainPorts(1, monoInputs);
+    const bool stereoUsesSidechain = externalArmed
+        && multicompp::plugin_detail::hasStereoExternalSidechainPorts(2, stereoInputs);
+    std::printf("external sidechain armed: mono uses aux ports %s; stereo uses aux ports %s\n",
+                monoUsesSidechain ? "yes" : "no", stereoUsesSidechain ? "yes" : "no");
+    reviewCheck(!monoUsesSidechain,
+                "mono run path does not index absent stereo sidechain ports");
+    reviewCheck(stereoUsesSidechain,
+                "stereo run path still accepts its external sidechain ports");
+}
+
+void testQuantisedFineStepFallsBackToRestingPrecision()
+{
+    const float minValue = 0.0f, maxValue = 1.0f, value = 0.0f;
+    const float coordinateStep = 0.0008f * (maxValue - minValue);
+    const float adjacent = std::min(maxValue, value + coordinateStep);
+    const auto quantisedDisplay = [](float coordinate) {
+        return std::round(60.0f + coordinate * 100.0f);
+    };
+    const float fineStep = std::fabs(quantisedDisplay(adjacent) - quantisedDisplay(value));
+    const int decimals = duskdpf::dragDecimalPlaces(fineStep, "%.0f");
+    std::printf("quantised tapered fine-step: display delta %.1f, drag decimals %d\n",
+                fineStep, decimals);
+    reviewCheck(decimals == 0,
+                "a quantised fine-step collapse falls back to resting precision");
+    reviewCheck(duskdpf::dragDecimalPlaces(0.01f, "%.1f") == 2
+                    && duskdpf::dragDecimalPlaces(1.0f, "%.1f") == 1,
+                "nonzero fine steps still add precision only when needed");
+}
+
+void testShippingUiHasNoDeadCrossoverDescriptor()
+{
+    const std::string source = readSiblingSource("MultiCompUI.cpp");
+    const bool hasDeadDescriptor = source.find("const auto& d = multicompp::kParams[p];")
+        != std::string::npos;
+    std::printf("shipping UI dead crossover descriptor present: %s\n",
+                hasDeadDescriptor ? "yes" : "no");
+    reviewCheck(!hasDeadDescriptor, "shipping crossover UI has no unused descriptor variable");
 }
 
 void testHostProgramChangeUpdatesUiMirror()
@@ -519,7 +615,11 @@ void testFractionalIntegerAutomationStaysLoadable()
 
 int main()
 {
-    testCrossoverReadoutUsesEffectiveOrdering();
+    testMonoRunGuardsStereoSidechainPorts();
+    testQuantisedFineStepFallsBackToRestingPrecision();
+    testShippingUiHasNoDeadCrossoverDescriptor();
+    testCrossoverMirrorRefreshesEveryPluginChangedValue();
+    require(reviewFailureCount == 0, "review regressions are fixed");
     testHostParameterTapers();
     testParameterIntervals();
     testStrictStateValidationAndRoundTrip();

--- a/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPluginLayerTests.cpp
@@ -31,10 +31,17 @@ using duskaudio::MultiCompDSP;
 
 namespace
 {
+// DPF prepends { DISTRHO_PLUGIN_NUM_INPUTS, DISTRHO_PLUGIN_NUM_OUTPUTS } to
+// this table, so the entries here are the two layouts narrower than the full
+// sidechain one. Dropping { 2, 2 } takes the AU off every stereo track, since
+// the base entry is a 4-in insert no stereo strip offers.
 constexpr uint16_t kAdvertisedExtraIo[][2] = {DISTRHO_PLUGIN_EXTRA_IO};
-static_assert(sizeof(kAdvertisedExtraIo) / sizeof(kAdvertisedExtraIo[0]) == 1
-              && kAdvertisedExtraIo[0][0] == 1 && kAdvertisedExtraIo[0][1] == 1,
-              "Multi-Comp AU extra I/O must be exactly one matched mono layout");
+static_assert(sizeof(kAdvertisedExtraIo) / sizeof(kAdvertisedExtraIo[0]) == 2
+              && kAdvertisedExtraIo[0][0] == 2 && kAdvertisedExtraIo[0][1] == 2
+              && kAdvertisedExtraIo[1][0] == 1 && kAdvertisedExtraIo[1][1] == 1,
+              "Multi-Comp AU extra I/O must advertise matched stereo then mono");
+static_assert(DISTRHO_PLUGIN_NUM_INPUTS == 4 && DISTRHO_PLUGIN_NUM_OUTPUTS == 2,
+              "the sidechain gate keys off an input count of 4; update it with the port count");
 
 void require(bool condition, const char* message)
 {
@@ -470,6 +477,26 @@ void testCrossoverMirrorRefreshesEveryPluginChangedValue()
                 "UI mirror refreshes the plugin's full ordered crossover set");
     reviewCheck(mirroredX2 == 750.0f && mirroredX3 == 7500.0f,
                 "crossover handles and readouts use the refreshed plugin values");
+
+    // Mid-drag: the plugin still reports the pre-edit value for the handle the
+    // user is holding, because only the AU wrapper writes a UI parameter change
+    // through synchronously. That handle must keep the value the mouse just set
+    // while its neighbours still adopt the DSP's ordering.
+    values[x2] = multicompp::plainToHost(multicompp::kParams[x2], 900.0f);
+    const float draggedHost = values[x2];
+    pluginValues = values;
+    pluginValues[x2] = multicompp::plainToHost(multicompp::kParams[x2], 750.0f);
+    pluginValues[x3] = multicompp::plainToHost(multicompp::kParams[x3], 9000.0f);
+    multicompp::ui_detail::refreshCrossoverMirror(values,
+        [&pluginValues](uint32_t index) { return pluginValues[index]; }, x2);
+    const float heldX2 = multicompp::hostToPlain(multicompp::kParams[x2], values[x2]);
+    const float siblingX3 = multicompp::hostToPlain(multicompp::kParams[x3], values[x3]);
+    std::printf("mid-drag mirror: held X2 %.0f Hz (plugin still says 750); sibling X3 %.0f Hz\n",
+                heldX2, siblingX3);
+    reviewCheck(values[x2] == draggedHost,
+                "the crossover under an active drag keeps the value the mouse set");
+    reviewCheck(siblingX3 == 9000.0f,
+                "crossovers not being dragged still follow the plugin's ordering");
 }
 
 std::string readSiblingSource(const char* filename)
@@ -485,22 +512,32 @@ std::string readSiblingSource(const char* filename)
     return contents.str();
 }
 
-void testMonoRunGuardsStereoSidechainPorts()
+// One case per DISTRHO_PLUGIN_EXTRA_IO layout. The { 2, 2 } row is the one the
+// output count could not express: it is stereo, so a channel-count test would
+// have called it sidechain-capable and read two elements past the end of the
+// array the host supplied.
+void testRunGuardsSidechainPortsPerLayout()
 {
     float main = 0.1f, sidechain = 0.8f;
     const float* monoInputs[] = {&main};
-    const float* stereoInputs[] = {&main, &main, &sidechain, &sidechain};
+    const float* stereoInputs[] = {&main, &main};
+    const float* sidechainInputs[] = {&main, &main, &sidechain, &sidechain};
     const bool externalArmed = true;
     const bool monoUsesSidechain = externalArmed
         && multicompp::plugin_detail::hasStereoExternalSidechainPorts(1, monoInputs);
     const bool stereoUsesSidechain = externalArmed
         && multicompp::plugin_detail::hasStereoExternalSidechainPorts(2, stereoInputs);
-    std::printf("external sidechain armed: mono uses aux ports %s; stereo uses aux ports %s\n",
-                monoUsesSidechain ? "yes" : "no", stereoUsesSidechain ? "yes" : "no");
+    const bool fullUsesSidechain = externalArmed
+        && multicompp::plugin_detail::hasStereoExternalSidechainPorts(4, sidechainInputs);
+    std::printf("external sidechain armed: 1-in uses aux ports %s; 2-in %s; 4-in %s\n",
+                monoUsesSidechain ? "yes" : "no", stereoUsesSidechain ? "yes" : "no",
+                fullUsesSidechain ? "yes" : "no");
     reviewCheck(!monoUsesSidechain,
                 "mono run path does not index absent stereo sidechain ports");
-    reviewCheck(stereoUsesSidechain,
-                "stereo run path still accepts its external sidechain ports");
+    reviewCheck(!stereoUsesSidechain,
+                "stereo-insert run path does not index absent sidechain ports");
+    reviewCheck(fullUsesSidechain,
+                "full input layout still accepts its external sidechain ports");
 }
 
 void testQuantisedFineStepFallsBackToRestingPrecision()
@@ -615,7 +652,7 @@ void testFractionalIntegerAutomationStaysLoadable()
 
 int main()
 {
-    testMonoRunGuardsStereoSidechainPorts();
+    testRunGuardsSidechainPortsPerLayout();
     testQuantisedFineStepFallsBackToRestingPrecision();
     testShippingUiHasNoDeadCrossoverDescriptor();
     testCrossoverMirrorRefreshesEveryPluginChangedValue();

--- a/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
@@ -30,14 +30,22 @@ inline int loadProgramIntoMirror(uint32_t index, std::array<float, N>& values)
     return static_cast<int>(index);
 }
 
+// Mirrors the plugin's ordered crossover set, so raising one handle also shows
+// the DSP pushing its neighbours. skipIndex excludes the handle the user is
+// dragging: only the AU wrapper applies a UI parameter write synchronously
+// (CLAP queues it to the next process() call, LV2 to an atom port), so reading
+// that one back mid-gesture returns the pre-edit value and drags the handle
+// backwards under the mouse. Its neighbours have no such pending write.
 template <size_t N, typename ReadParameter>
-inline void refreshCrossoverMirror(std::array<float, N>& values, ReadParameter readParameter)
+inline void refreshCrossoverMirror(std::array<float, N>& values, ReadParameter readParameter,
+                                   uint32_t skipIndex = ~uint32_t(0))
 {
     const auto x1 = static_cast<uint32_t>(ParamId::Crossover1);
     const auto x3 = static_cast<uint32_t>(ParamId::Crossover3);
     if (x3 >= N) return;
     for (uint32_t index = x1; index <= x3; ++index)
-        values[index] = readParameter(index);
+        if (index != skipIndex)
+            values[index] = readParameter(index);
 }
 } // namespace multicompp::ui_detail
 
@@ -228,6 +236,8 @@ private:
     ImFont* labelFont = nullptr;
     duskdpf::SupportersOverlay supporters;
     bool showSupporters = false;
+    // Index of the crossover handle under an active drag, or ~0 for none.
+    uint32_t draggedCrossover = ~uint32_t(0);
     int currentPreset = -1;
 
     float value(uint32_t p) const { return values[p]; }
@@ -238,7 +248,8 @@ private:
         void* const instance = getPluginInstancePointer();
         if (instance == nullptr) return;
         multicompp::ui_detail::refreshCrossoverMirror(values,
-            [instance](uint32_t index) { return multiCompGetParameterValue(instance, index); });
+            [instance](uint32_t index) { return multiCompGetParameterValue(instance, index); },
+            draggedCrossover);
     }
 
     void setValue(uint32_t p, float v)
@@ -596,7 +607,7 @@ private:
         char handleId[48];
         std::snprintf(handleId, sizeof(handleId), "##mc_%s", label);
         ImGui::InvisibleButton(handleId, ImVec2(24 * panel.scale(), 54 * panel.scale()));
-        if (ImGui::IsItemActivated()) editParameter(p, true);
+        if (ImGui::IsItemActivated()) { editParameter(p, true); draggedCrossover = p; }
         if (ImGui::IsItemActive())
         {
             const float mouseX = (ImGui::GetMousePos().x - panel.P(0, 0).x) / panel.scale();
@@ -604,7 +615,13 @@ private:
                 (mouseX - trackStart) / (trackEnd - trackStart), 0.0f, 1.0f);
             setParam(p, normalized);
         }
-        if (ImGui::IsItemDeactivated()) editParameter(p, false);
+        if (ImGui::IsItemDeactivated())
+        {
+            editParameter(p, false);
+            // Released: the pending write has had the gesture to land, and the
+            // next refresh adopts whatever ordering the DSP settled on.
+            draggedCrossover = ~uint32_t(0);
+        }
     }
 
     float meter(uint32_t p) const

--- a/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
@@ -30,17 +30,14 @@ inline int loadProgramIntoMirror(uint32_t index, std::array<float, N>& values)
     return static_cast<int>(index);
 }
 
-template <size_t N>
-inline float effectiveCrossoverPlain(uint32_t index, const std::array<float, N>& values)
+template <size_t N, typename ReadParameter>
+inline void refreshCrossoverMirror(std::array<float, N>& values, ReadParameter readParameter)
 {
     const auto x1 = static_cast<uint32_t>(ParamId::Crossover1);
-    const auto x2 = static_cast<uint32_t>(ParamId::Crossover2);
     const auto x3 = static_cast<uint32_t>(ParamId::Crossover3);
-    if (index < x1 || index > x3 || x3 >= N) return 0.0f;
-    const float f1 = hostToPlain(kParams[x1], values[x1]);
-    const float f2 = std::clamp(hostToPlain(kParams[x2], values[x2]), f1 * 1.5f, 5000.0f);
-    const float f3 = std::clamp(hostToPlain(kParams[x3], values[x3]), f2 * 1.5f, 16000.0f);
-    return index == x1 ? f1 : index == x2 ? f2 : f3;
+    if (x3 >= N) return;
+    for (uint32_t index = x1; index <= x3; ++index)
+        values[index] = readParameter(index);
 }
 } // namespace multicompp::ui_detail
 
@@ -55,6 +52,9 @@ inline float effectiveCrossoverPlain(uint32_t index, const std::array<float, N>&
 
 #include <cstdio>
 #include <cstring>
+
+DUSK_WEAK float multiCompGetParameterValue(void* pluginInstancePointer,
+                                            uint32_t index) noexcept;
 
 START_NAMESPACE_DISTRHO
 
@@ -150,19 +150,15 @@ public:
         if (idx >= static_cast<uint32_t>(multicompp::kMeterMaster)) return;
         currentPreset = -1;
         values[idx] = value;
-        if (idx >= P_X1 && idx <= P_X3)
-        {
-            const float effective = multicompp::ui_detail::effectiveCrossoverPlain(idx, values);
-            value = multicompp::plainToHost(multicompp::kParams[idx], effective);
-            values[idx] = value;
-        }
         setParameterValue(idx, value);
+        if (idx >= P_X1 && idx <= P_X3) refreshCrossoverMirror();
     }
 
 protected:
     void parameterChanged(uint32_t index, float value) override
     {
         if (index < values.size()) values[index] = value;
+        if (index >= P_X1 && index <= P_X3) refreshCrossoverMirror();
     }
 
     void stateChanged(const char* key, const char* state) override
@@ -181,7 +177,11 @@ protected:
         currentPreset = multicompp::ui_detail::loadProgramIntoMirror(index, values);
     }
 
-    void uiIdle() override { repaint(); }
+    void uiIdle() override
+    {
+        refreshCrossoverMirror();
+        repaint();
+    }
 
     void onImGuiDisplay() override
     {
@@ -231,6 +231,15 @@ private:
     int currentPreset = -1;
 
     float value(uint32_t p) const { return values[p]; }
+
+    void refreshCrossoverMirror()
+    {
+        if (multiCompGetParameterValue == nullptr) return;
+        void* const instance = getPluginInstancePointer();
+        if (instance == nullptr) return;
+        multicompp::ui_detail::refreshCrossoverMirror(values,
+            [instance](uint32_t index) { return multiCompGetParameterValue(instance, index); });
+    }
 
     void setValue(uint32_t p, float v)
     {
@@ -575,8 +584,7 @@ private:
     {
         const float trackStart = x - 100.0f;
         const float trackEnd = x + 100.0f;
-        const auto& d = multicompp::kParams[p];
-        const float physicalValue = multicompp::ui_detail::effectiveCrossoverPlain(p, values);
+        const float physicalValue = multicompp::hostToPlain(multicompp::kParams[p], values[p]);
         const float t = std::clamp(values[p], 0.0f, 1.0f);
         const float handleX = trackStart + t * (trackEnd - trackStart);
         dl->AddLine(panel.P(trackStart, 392), panel.P(trackEnd, 392), IM_COL32(70, 75, 84, 255), 4 * panel.scale());

--- a/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
@@ -2,18 +2,44 @@
 // Multi-Comp 2 Dear ImGui UI.  The controls mirror EnhancedCompressorEditor and
 // ModernCompressorPanels; the DSP and parameter ownership remain in the shell/core.
 
-#include "DistrhoUI.hpp"
-#include "MultiCompAccess.hpp"
 #include "MultiCompParams.hpp"
 #include "MultiCompProgramPresets.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+
+namespace multicompp::ui_detail
+{
+inline int choiceIndex(float hostValue, int count) noexcept
+{
+    return std::clamp(static_cast<int>(std::round(hostValue)), 0, count - 1);
+}
+
+template <size_t N>
+inline int loadProgramIntoMirror(uint32_t index, std::array<float, N>& values)
+{
+    if (index >= kFactoryPresets.size()) return -1;
+    applyPresetToHostParameters(kFactoryPresets[index],
+        [&values](int parameterIndex, float hostValue)
+        {
+            if (parameterIndex >= 0 && static_cast<size_t>(parameterIndex) < values.size())
+                values[static_cast<size_t>(parameterIndex)] = hostValue;
+        });
+    return static_cast<int>(index);
+}
+} // namespace multicompp::ui_detail
+
+#ifndef MULTICOMP_UI_LOGIC_TEST
+
+#include "DistrhoUI.hpp"
+#include "MultiCompAccess.hpp"
 #include "MultiCompVersion.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp"
 
-#include <algorithm>
-#include <array>
-#include <cmath>
 #include <cstdio>
 #include <cstring>
 
@@ -133,7 +159,7 @@ protected:
 
     void programLoaded(uint32_t index) override
     {
-        currentPreset = index < multicompp::kFactoryPresets.size() ? static_cast<int>(index) : -1;
+        currentPreset = multicompp::ui_detail::loadProgramIntoMirror(index, values);
     }
 
     void uiIdle() override { repaint(); }
@@ -207,7 +233,8 @@ private:
     void titleHit(ImDrawList* dl)
     {
         panel.text(dl, 22, 11, 24, kText, "Multi-Comp 2", -1, true);
-        panel.text(dl, 24, 40, 10, kDim, modeName(static_cast<int>(value(P_MODE))), -1);
+        panel.text(dl, 24, 40, 10, kDim,
+                   modeName(multicompp::ui_detail::choiceIndex(value(P_MODE), 8)), -1);
         panel.text(dl, kDesignW - 20, 20, 11, kDim, "Dusk Audio", 1);
         ImGui::SetCursorScreenPos(panel.P(12, 7));
         ImGui::InvisibleButton("##mc_title", ImVec2(190 * panel.scale(), 44 * panel.scale()));
@@ -218,7 +245,7 @@ private:
                float x, float y, float w, const char* caption)
     {
         panel.text(ImGui::GetWindowDrawList(), x, y, 9.5f, kDim, caption, 0, true);
-        const int selected = std::clamp(static_cast<int>(value(p)), 0, count - 1);
+        const int selected = multicompp::ui_detail::choiceIndex(value(p), count);
         const ImVec2 p0 = panel.P(x - w * 0.5f, y + 16);
         const ImVec2 p1 = panel.P(x + w * 0.5f, y + 43);
         ImDrawList* dl = ImGui::GetWindowDrawList();
@@ -401,8 +428,8 @@ private:
 
     void drawModePanel(ImDrawList* dl)
     {
-        drawSection(dl, kPanelTop, kDesignH - 8, modeName(static_cast<int>(value(P_MODE))));
-        const int mode = std::clamp(static_cast<int>(value(P_MODE)), 0, 7);
+        const int mode = multicompp::ui_detail::choiceIndex(value(P_MODE), 8);
+        drawSection(dl, kPanelTop, kDesignH - 8, modeName(mode));
         if (mode == 7)
             drawMeter(dl, 1062, kPanelTop + 24, 42, 92, meter(kMeterMaster), kAccent, "MASTER GR");
         else
@@ -608,3 +635,5 @@ private:
 UI* createUI() { return new MultiCompUI(); }
 
 END_NAMESPACE_DISTRHO
+
+#endif // MULTICOMP_UI_LOGIC_TEST

--- a/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
@@ -193,6 +193,19 @@ protected:
 
     void onImGuiDisplay() override
     {
+        // The crossovers are only submitted in Multiband mode. If the host
+        // switches Mode away mid-drag the widget stops being drawn, so ImGui
+        // never reports IsItemDeactivated for it: the gesture would stay open on
+        // the host and the mirror would skip that crossover for the rest of the
+        // session. Close it here instead, from the fact that nothing re-armed
+        // the flag on the previous frame.
+        if (draggedCrossover != kNoCrossover && !draggedCrossoverStillDrawn)
+        {
+            editParameter(draggedCrossover, false);
+            draggedCrossover = kNoCrossover;
+        }
+        draggedCrossoverStillDrawn = false;
+
         const float winW = static_cast<float>(getWidth());
         const float winH = static_cast<float>(getHeight());
         const float scale = std::min(winW / kDesignW, winH / kDesignH);
@@ -236,8 +249,13 @@ private:
     ImFont* labelFont = nullptr;
     duskdpf::SupportersOverlay supporters;
     bool showSupporters = false;
-    // Index of the crossover handle under an active drag, or ~0 for none.
-    uint32_t draggedCrossover = ~uint32_t(0);
+    static constexpr uint32_t kNoCrossover = ~uint32_t(0);
+    // The crossover handle under an active drag. Owns both the open automation
+    // gesture and the mirror's skip, so the two cannot disagree.
+    uint32_t draggedCrossover = kNoCrossover;
+    // Set by crossover() on every frame it submits the held handle, and read
+    // once per frame to notice a handle that stopped being drawn mid-drag.
+    bool draggedCrossoverStillDrawn = false;
     int currentPreset = -1;
 
     float value(uint32_t p) const { return values[p]; }
@@ -608,6 +626,7 @@ private:
         std::snprintf(handleId, sizeof(handleId), "##mc_%s", label);
         ImGui::InvisibleButton(handleId, ImVec2(24 * panel.scale(), 54 * panel.scale()));
         if (ImGui::IsItemActivated()) { editParameter(p, true); draggedCrossover = p; }
+        if (draggedCrossover == p) draggedCrossoverStillDrawn = true;
         if (ImGui::IsItemActive())
         {
             const float mouseX = (ImGui::GetMousePos().x - panel.P(0, 0).x) / panel.scale();
@@ -620,7 +639,7 @@ private:
             editParameter(p, false);
             // Released: the pending write has had the gesture to land, and the
             // next refresh adopts whatever ordering the DSP settled on.
-            draggedCrossover = ~uint32_t(0);
+            if (draggedCrossover == p) draggedCrossover = kNoCrossover;
         }
     }
 

--- a/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompUI.cpp
@@ -29,6 +29,19 @@ inline int loadProgramIntoMirror(uint32_t index, std::array<float, N>& values)
         });
     return static_cast<int>(index);
 }
+
+template <size_t N>
+inline float effectiveCrossoverPlain(uint32_t index, const std::array<float, N>& values)
+{
+    const auto x1 = static_cast<uint32_t>(ParamId::Crossover1);
+    const auto x2 = static_cast<uint32_t>(ParamId::Crossover2);
+    const auto x3 = static_cast<uint32_t>(ParamId::Crossover3);
+    if (index < x1 || index > x3 || x3 >= N) return 0.0f;
+    const float f1 = hostToPlain(kParams[x1], values[x1]);
+    const float f2 = std::clamp(hostToPlain(kParams[x2], values[x2]), f1 * 1.5f, 5000.0f);
+    const float f3 = std::clamp(hostToPlain(kParams[x3], values[x3]), f2 * 1.5f, 16000.0f);
+    return index == x1 ? f1 : index == x2 ? f2 : f3;
+}
 } // namespace multicompp::ui_detail
 
 #ifndef MULTICOMP_UI_LOGIC_TEST
@@ -137,6 +150,12 @@ public:
         if (idx >= static_cast<uint32_t>(multicompp::kMeterMaster)) return;
         currentPreset = -1;
         values[idx] = value;
+        if (idx >= P_X1 && idx <= P_X3)
+        {
+            const float effective = multicompp::ui_detail::effectiveCrossoverPlain(idx, values);
+            value = multicompp::plainToHost(multicompp::kParams[idx], effective);
+            values[idx] = value;
+        }
         setParameterValue(idx, value);
     }
 
@@ -557,7 +576,7 @@ private:
         const float trackStart = x - 100.0f;
         const float trackEnd = x + 100.0f;
         const auto& d = multicompp::kParams[p];
-        const float physicalValue = multicompp::hostToPlain(d, values[p]);
+        const float physicalValue = multicompp::ui_detail::effectiveCrossoverPlain(p, values);
         const float t = std::clamp(values[p], 0.0f, 1.0f);
         const float handleX = trackStart + t * (trackEnd - trackStart);
         dl->AddLine(panel.P(trackStart, 392), panel.P(trackEnd, 392), IM_COL32(70, 75, 84, 255), 4 * panel.scale());

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -26,10 +26,38 @@
 #include <utility>   // std::swap (RealFFT::transform) — don't rely on transitive headers
 #include <vector>
 
+#ifndef DUSK_IMGUI_WIDGETS_LOGIC_TEST
 #include "DuskImGuiFont.hpp"  // CrispFontSet — nearest-size face per label
+#endif
 
 namespace duskdpf
 {
+
+inline int restingDecimalPlaces(const char* fmt) noexcept
+{
+    int decimals = 0;
+    if (fmt == nullptr) return decimals;
+    for (const char* p = fmt; *p; ++p)
+        if (*p == '.')
+        {
+            for (const char* q = p + 1; *q >= '0' && *q <= '9'; ++q)
+                decimals = decimals * 10 + (*q - '0');
+            break;
+        }
+    return decimals;
+}
+
+inline int dragDecimalPlaces(float fineStep, const char* fmt) noexcept
+{
+    const int resting = restingDecimalPlaces(fmt);
+    if (!std::isfinite(fineStep) || fineStep <= 1.0e-9f)
+        return resting;
+    int fine = static_cast<int>(std::ceil(-std::log10(fineStep)));
+    fine = std::clamp(fine, 0, 4);
+    return std::max(resting, fine);
+}
+
+#ifndef DUSK_IMGUI_WIDGETS_LOGIC_TEST
 
 // Adapter the UI implements to forward parameter edits to the host.
 struct ParamHost
@@ -541,12 +569,10 @@ public:
                 float adjacent = std::min(maxV, value + coordinateStep);
                 if (adjacent == value) adjacent = std::max(minV, value - coordinateStep);
                 const float fineStep = std::fabs(displayValue(adjacent) - displayValue(value));
-                int d = (int) std::ceil(-std::log10(fineStep > 1e-9f ? fineStep : 1e-9f));
-                d = d < 0 ? 0 : (d > 4 ? 4 : d);
+                const int d = dragDecimalPlaces(fineStep, fmt);
                 // resting precision from fmt (digits after the '.'); never show FEWER
                 // decimals than at rest -> if fine-step isn't finer, leave as-is.
-                int restD = 0; for (const char* p = fmt; *p; ++p)
-                    if (*p == '.') { for (const char* q = p + 1; *q >= '0' && *q <= '9'; ++q) restD = restD * 10 + (*q - '0'); break; }
+                const int restD = restingDecimalPlaces(fmt);
                 if (d <= restD)
                     std::snprintf(num, sizeof(num), fmt, displayValue(value));
                 else
@@ -817,5 +843,7 @@ private:
     int n = 0;
     std::vector<float> re, im, window;
 };
+
+#endif // DUSK_IMGUI_WIDGETS_LOGIC_TEST
 
 } // namespace duskdpf

--- a/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-dpf/ui/DuskImGuiWidgets.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdint>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for mono, stereo, and external sidechain channel layouts.
  - Improved parameter handling for crossover frequencies, enums, presets, and fine adjustments.
  - Added more accurate latency, lookahead, metering, sidechain listening, and auto-makeup behavior.
  - Improved multiband controls, solo masking, bypass alignment, and stereo linking.

- **Bug Fixes**
  - Fixed crossover display synchronization during editing and mode changes.
  - Corrected oversampled sidechain timing, gain-reduction limits, and stale meter values.
  - Improved behavior across block sizes, automation, mono operation, and concurrent parameter changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->