### PR TITLE
Multi-Comp 2: apply post-merge review follow-ups

### DIFF
--- a/plugins/multi-comp/core/MultiCompModes.hpp
+++ b/plugins/multi-comp/core/MultiCompModes.hpp
@@ -545,11 +545,12 @@ private:
         // follower on a 997 Hz sine.  At 48 kHz, fixed-point iteration of one
         // full-wave period gives peaks of 0.925093862 for the 0.4 ms / 8 ms
         // integrator and 0.994476788 for that peak follower.  Therefore the
-        // exact calibration-condition correction is
-        // 20*log10(0.994476788 / 0.925093862) = 0.628177 dB.
-        constexpr float detectorIntegrationCalibrationDb = 0.628177f;
+        // exact calibration-condition correction is the peak ratio
+        // 0.994476788 / 0.925093862 = 1.07500095 (= 0.628177 dB), stored as
+        // the linear factor so the per-sample path carries no pow().
+        constexpr float detectorIntegrationCalibrationGain = 1.07500095f;
         const float integratedDetectorLevel = d.detectorLevel
-            * decibelsToGain(detectorIntegrationCalibrationDb);
+            * detectorIntegrationCalibrationGain;
         const float effectiveDetectorLevel = std::min(
             d.detectorPeak, integratedDetectorLevel);
         const float uncorrectedInputLevelDb = gainToDecibels(effectiveDetectorLevel);

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -718,7 +718,7 @@ OptoCrestResult measureOptoCrestResponse(OptoCrestStimulus stimulus)
             10.0f * std::log10(static_cast<float>(controlPower / activePower))};
 }
 
-void testOptoCrestResponse()
+void reportOptoCrestResponse()
 {
     const auto sine = measureOptoCrestResponse(OptoCrestStimulus::Sine);
     const auto burst = measureOptoCrestResponse(OptoCrestStimulus::Burst);
@@ -1226,7 +1226,7 @@ OptoAttackCrossings measureOptoAttackCrossings(float peakReduction, float levelD
     return {finalReduction, crossing(0.63f), crossing(0.90f)};
 }
 
-void testOptoAttackCrossings()
+void reportOptoAttackCrossings()
 {
     struct Row { float peakReduction, inputDbfs, exposure, crossing63, crossing90; };
     constexpr std::array<Row, 9> rows{{
@@ -1308,7 +1308,7 @@ OptoReleaseLocalTaus measureOptoReleaseLocalTaus(float peakReduction, float leve
             localTau(0.250f, 1.000f), localTau(2.000f, 4.000f)};
 }
 
-void testOptoReleaseLocalTaus()
+void reportOptoReleaseLocalTaus()
 {
     struct ExposureRow { float exposure, earlyTarget, midTarget, lateTarget; };
     constexpr std::array<ExposureRow, 4> rows{{
@@ -3258,15 +3258,15 @@ int main()
     testOptoDriveApplicability();
     testGoldenVectors();
     testOptoHarmonicContent();
-    testOptoCrestResponse();
+    reportOptoCrestResponse();
     testOptoCrestSweep();
     testOptoBroadbandStaticLaw();
     testOptoBurstRateSweep();
     testOptoPluginLevelReferencePoints();
     testOptoDetectorFrequencyWeighting();
     testOptoDetectorMemory();
-    testOptoAttackCrossings();
-    testOptoReleaseLocalTaus();
+    reportOptoAttackCrossings();
+    reportOptoReleaseLocalTaus();
     testOptoInactivePeakReduction();
     testOptoMeterMatchesOutputReduction();
     testOptoMeasuredOnsets();

--- a/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/dpf-plugin/MultiCompPlugin.cpp
@@ -72,8 +72,12 @@ public:
     float parameterValue(uint32_t index) const noexcept
     {
         if (index >= multicompp::kMeterMaster) return 0.0f;
-        const auto x1 = static_cast<uint32_t>(multicompp::ParamId::Crossover1);
-        const auto x3 = static_cast<uint32_t>(multicompp::ParamId::Crossover3);
+        constexpr auto x1 = static_cast<uint32_t>(multicompp::ParamId::Crossover1);
+        constexpr auto x3 = static_cast<uint32_t>(multicompp::ParamId::Crossover3);
+        // plain(x1 + 1) and ordered[index - x1] below assume the three
+        // crossover ids are contiguous.
+        static_assert(x3 == x1 + 2,
+                      "Crossover1..Crossover3 must be contiguous parameter ids");
         if (index < x1 || index > x3) return values[index].load(std::memory_order_relaxed);
         const auto plain = [this](uint32_t i) {
             return multicompp::hostToPlain(multicompp::kParams[i],


### PR DESCRIPTION
Store the detector integration calibration as its linear factor (1.07500095 = 0.628177 dB) so the per-sample Opto path carries no pow(); rename the three print-only diagnostics (crest response triplet, attack crossings, release local taus) to report* to make their non-asserting intent explicit; and static_assert the Crossover1..3 id contiguity that parameterValue()'s lane arithmetic assumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Opto detector calibration consistency while preserving the expected integrated signal level.
  - Added safeguards for crossover parameter handling, reducing the risk of incorrect parameter mapping.

- **Diagnostics**
  - Refined Opto diagnostic reporting without changing the measurements or results produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->