### PR TITLE
Multi-Comp: harden bypass and restore detector controls

### DIFF
--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -322,6 +322,7 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     processLatencyHistory(in, out, nCh, nSamples, blockLatency, requestedBypass && bypassSettled);
     if (requestedBypass && bypassSettled)
     {
+        previousBusSidechainValid = {{false, false}};
         processSidechainListenHistory(filteredSidechain, nCh, nSamples, blockLatency);
         for (int i = 0; i < nSamples; ++i) (void)sidechainListenRamp.next();
         masterGR.store(0.0f, std::memory_order_relaxed);
@@ -697,6 +698,10 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
     }
     busMixRamp.setTarget(std::clamp(params.busMix.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f));
     digitalMixRamp.setTarget(std::clamp(params.digitalMix.load(std::memory_order_relaxed) * 0.01f, 0.0f, 1.0f));
+    const bool linkedBusPathActive = mode == MultiCompMode::Bus
+        && linkMode == 0 && linkAmount > 0.0001f && nCh > 1;
+    if (!linkedBusPathActive)
+        previousBusSidechainValid = {{false, false}};
     for (int i = 0; i < nSamples; ++i)
     {
         const float scaledOutputDb = manualOutputDb * manualMakeupScaleRamp.next();

--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -53,6 +53,8 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     previousOversampledSidechainValid = {{false, false}};
     previousOptoOwnSidechain = {{0.0f, 0.0f}};
     previousOptoOwnSidechainValid = {{false, false}};
+    previousBusSidechain = {{0.0f, 0.0f}};
+    previousBusSidechainValid = {{false, false}};
     const size_t dryDelaySize = static_cast<size_t>(std::max(1, antiAliasLatency + static_cast<int>(std::ceil(sampleRate * 0.01)) + 1));
     for (auto& line : dryPathDelay) line.assign(dryDelaySize, 0.0f);
     dryPathWrite = {{0, 0}};
@@ -110,6 +112,8 @@ void MultiCompDSP::reset()
     previousOversampledSidechainValid = {{false, false}};
     previousOptoOwnSidechain = {{0.0f, 0.0f}};
     previousOptoOwnSidechainValid = {{false, false}};
+    previousBusSidechain = {{0.0f, 0.0f}};
+    previousBusSidechainValid = {{false, false}};
     for (auto& line : dryPathDelay) std::fill(line.begin(), line.end(), 0.0f);
     dryPathWrite = {{0, 0}};
     for (auto& line : bypassDelay) std::fill(line.begin(), line.end(), 0.0f);
@@ -660,6 +664,13 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
     for (auto& os : oversamplers) os.setFactor(actualOs);
     optoLinkedDetectorOversampler.setFactor(actualOs);
     modes.setRate(sampleRate, actualOs);
+    if (mode == MultiCompMode::Bus)
+        modes.setBusSidechainControls(
+            params.sidechainHP.load(std::memory_order_relaxed),
+            params.scLowFreq.load(std::memory_order_relaxed),
+            params.scLowGain.load(std::memory_order_relaxed),
+            params.scHighFreq.load(std::memory_order_relaxed),
+            params.scHighGain.load(std::memory_order_relaxed));
     manualMakeupScaleRamp.setTarget(autoMakeup ? 0.0f : 1.0f);
     if (firstBlock) manualMakeupScaleRamp.snap(autoMakeup ? 0.0f : 1.0f);
     syncModeParameters(mode, digitalLookaheadMs);
@@ -667,6 +678,7 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
     {
         previousOversampledSidechainValid = {{false, false}};
         previousOptoOwnSidechainValid = {{false, false}};
+        previousBusSidechainValid = {{false, false}};
         for (int i = 0; i < nSamples; ++i) (void)manualMakeupScaleRamp.next();
         processMultiband(in, external ? sidechain : nullptr, out, nCh, nSamples);
         return;
@@ -717,6 +729,51 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
                 optoLinkedPhases[static_cast<size_t>(linkedPhase++)] = sample;
                 return sample;
             });
+        if (mode == MultiCompMode::Bus && link)
+        {
+            std::array<float, 4> inputLeftPhases{}, inputRightPhases{};
+            std::array<float, 4> outputLeftPhases{}, outputRightPhases{};
+            oversamplers[0].upsampleSample(in[0][i], inputLeftPhases.data());
+            oversamplers[1].upsampleSample(in[1][i], inputRightPhases.data());
+            for (int ch = 0; ch < 2; ++ch)
+                if (!previousBusSidechainValid[static_cast<size_t>(ch)])
+                {
+                    previousBusSidechain[static_cast<size_t>(ch)] = ch == 0 ? sc0 : sc1;
+                    previousBusSidechainValid[static_cast<size_t>(ch)] = true;
+                }
+            for (int phase = 0; phase < actualOs; ++phase)
+            {
+                const float phaseSc0 = actualOs == 1 ? sc0
+                    : interpolateOversampledSidechain(
+                        previousBusSidechain[0], sc0, phase, actualOs);
+                const float phaseSc1 = actualOs == 1 ? sc1
+                    : interpolateOversampledSidechain(
+                        previousBusSidechain[1], sc1, phase, actualOs);
+                modes.processBusPair(
+                    inputLeftPhases[static_cast<size_t>(phase)],
+                    inputRightPhases[static_cast<size_t>(phase)],
+                    phaseSc0, phaseSc1, modeParams, localBusMix,
+                    external, linkAmount,
+                    outputLeftPhases[static_cast<size_t>(phase)],
+                    outputRightPhases[static_cast<size_t>(phase)]);
+                outputLeftPhases[static_cast<size_t>(phase)] = applyCoreDistortion(
+                    outputLeftPhases[static_cast<size_t>(phase)],
+                    distortionType, distortionAmount);
+                outputRightPhases[static_cast<size_t>(phase)] = applyCoreDistortion(
+                    outputRightPhases[static_cast<size_t>(phase)],
+                    distortionType, distortionAmount);
+            }
+            out[0][i] = oversamplers[0].downsampleSample(outputLeftPhases.data());
+            out[1][i] = oversamplers[1].downsampleSample(outputRightPhases.data());
+            previousBusSidechain = {{sc0, sc1}};
+            // The generic per-channel path is skipped this sample, so its
+            // carried endpoints stop tracking the input.  Invalidate them here
+            // and let the next generic sample re-seed instead of interpolating
+            // from an arbitrarily old value when the link is switched off.
+            previousOversampledSidechainValid = {{false, false}};
+            previousOptoOwnSidechainValid = {{false, false}};
+            continue;
+        }
         for (int ch = 0; ch < nCh; ++ch)
         {
             const float input = in[ch][i];

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -21,6 +21,8 @@
 namespace duskaudio
 {
 
+struct MultiCompDSPTestAccess;
+
 class MultiCompDSP
 {
 public:
@@ -81,6 +83,8 @@ public:
     int getLatencySamples() const noexcept;
 
 private:
+    friend struct MultiCompDSPTestAccess;
+
     static constexpr int kMaxChannels = 2;
     static constexpr int kBypassRampMs = 30;
     static constexpr int kSidechainListenRampMs = 30;

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -146,6 +146,8 @@ private:
     std::array<bool, kMaxChannels> previousOversampledSidechainValid{{false, false}};
     std::array<float, kMaxChannels> previousOptoOwnSidechain{{0.0f, 0.0f}};
     std::array<bool, kMaxChannels> previousOptoOwnSidechainValid{{false, false}};
+    std::array<float, kMaxChannels> previousBusSidechain{{0.0f, 0.0f}};
+    std::array<bool, kMaxChannels> previousBusSidechainValid{{false, false}};
     std::array<float, kMultiCompBands * kMaxChannels> multibandEnvelopes{};
     std::uint8_t activeBandMask = 0x0f;
     std::array<int, kMultiCompBands> enabledBandIndices{{0, 1, 2, 3}};

--- a/plugins/multi-comp/core/MultiCompHelpers.hpp
+++ b/plugins/multi-comp/core/MultiCompHelpers.hpp
@@ -253,6 +253,24 @@ public:
         return compensateBaseRate(wet);
     }
     template <class Fn> float processSample(float input, Fn&& fn) noexcept { return process(input, static_cast<Fn&&>(fn)); }
+    int getFactor() const noexcept { return oversampler.getFactor(); }
+    void upsampleSample(float input, float* phases) noexcept
+    {
+        oversampler.upsampleSample(input, phases);
+    }
+    float downsampleSample(float* phases) noexcept
+    {
+        const int phaseCount = oversampler.getFactor();
+        if (phaseDelaySamples > 0)
+            for (int phase = 0; phase < phaseCount; ++phase)
+            {
+                const float delayed = phaseDelay[static_cast<size_t>(phaseWritePosition)];
+                phaseDelay[static_cast<size_t>(phaseWritePosition)] = phases[phase];
+                phaseWritePosition = (phaseWritePosition + 1) % phaseDelaySamples;
+                phases[phase] = delayed;
+            }
+        return compensateBaseRate(oversampler.downsampleSample(phases));
+    }
     float latency() const noexcept { return static_cast<float>(maxLatency); }
     bool isOversamplingOff() const noexcept { return oversamplingOff; }
 private:

--- a/plugins/multi-comp/core/MultiCompModes.hpp
+++ b/plugins/multi-comp/core/MultiCompModes.hpp
@@ -45,6 +45,9 @@ public:
         for (auto& d : studioFet) d = StudioFETState{};
         for (auto& d : studioVca) d = StudioVCAState{};
         for (auto& d : digital) d = DigitalState{};
+        for (auto& filter : busSidechainHighPass) filter.reset();
+        for (auto& filter : busSidechainLowShelf) filter.reset();
+        for (auto& filter : busSidechainHighShelf) filter.reset();
         prepareHardware(modeRate);
         for (int ch = 0; ch < kChannels; ++ch)
         {
@@ -84,6 +87,9 @@ public:
         for (auto& d : studioFet) d = StudioFETState{};
         for (auto& d : studioVca) d = StudioVCAState{};
         for (auto& d : digital) d = DigitalState{};
+        for (auto& filter : busSidechainHighPass) filter.reset();
+        for (auto& filter : busSidechainLowShelf) filter.reset();
+        for (auto& filter : busSidechainHighShelf) filter.reset();
         for (auto& delay : digitalDelay)
             for (auto& x : delay) x = 0.0f;
         digitalWrite.fill(0);
@@ -134,6 +140,56 @@ public:
         return 0.0f;
     }
 
+    void setBusSidechainControls(float highPassFrequency,
+                                 float lowFrequency, float lowGain,
+                                 float highFrequency, float highGain) noexcept
+    {
+        const float rate = static_cast<float>(fs * osFactor);
+        const float hp = std::clamp(highPassFrequency, 0.0f, 500.0f);
+        const float lowF = std::clamp(lowFrequency, 60.0f, 500.0f);
+        const float lowG = std::clamp(lowGain, -12.0f, 12.0f);
+        const float highF = std::clamp(highFrequency, 2000.0f, 16000.0f);
+        const float highG = std::clamp(highGain, -12.0f, 12.0f);
+        if (rate != busSidechainRate || hp != busSidechainHighPassFrequency)
+            for (auto& filter : busSidechainHighPass)
+                filter.setCoeffs(Biquad::highPass(rate, std::max(hp, 20.0f), 0.707f));
+        if (rate != busSidechainRate || lowF != busSidechainLowFrequency
+            || lowG != busSidechainLowGain)
+            for (auto& filter : busSidechainLowShelf)
+                filter.setCoeffs(Biquad::shelfSlope1(rate, lowF, lowG, false));
+        if (rate != busSidechainRate || highF != busSidechainHighFrequency
+            || highG != busSidechainHighGain)
+            for (auto& filter : busSidechainHighShelf)
+                filter.setCoeffs(Biquad::shelfSlope1(rate, highF, highG, true));
+        busSidechainRate = rate;
+        busSidechainHighPassFrequency = hp;
+        busSidechainLowFrequency = lowF;
+        busSidechainLowGain = lowG;
+        busSidechainHighFrequency = highF;
+        busSidechainHighGain = highG;
+    }
+
+    void processBusPair(float inputLeft, float inputRight,
+                        float sidechainLeft, float sidechainRight,
+                        const MultiCompParameterState& p, float mix,
+                        bool external, float linkAmount,
+                        float& outputLeft, float& outputRight) noexcept
+    {
+        auto& left = bus[0];
+        auto& right = bus[1];
+        const float sr = static_cast<float>(fs * osFactor);
+        const float leftLevel = busRmsLevel(left,
+            external ? std::abs(sidechainLeft) : busFeedbackRect(left, 0, sr), sr);
+        const float rightLevel = busRmsLevel(right,
+            external ? std::abs(sidechainRight) : busFeedbackRect(right, 1, sr), sr);
+        const float linkedLevel = std::max(leftLevel, rightLevel);
+        const float amount = std::clamp(linkAmount, 0.0f, 1.0f);
+        advanceBusEnvelope(left, leftLevel + (linkedLevel - leftLevel) * amount, p, sr);
+        advanceBusEnvelope(right, rightLevel + (linkedLevel - rightLevel) * amount, p, sr);
+        outputLeft = renderBusOutput(inputLeft, 0, p, mix);
+        outputRight = renderBusOutput(inputRight, 1, p, mix);
+    }
+
 private:
     struct OptoState
     {
@@ -177,6 +233,12 @@ private:
     std::array<StudioFETState, 2> studioFet{};
     std::array<StudioVCAState, 2> studioVca{};
     std::array<DigitalState, 2> digital{};
+    std::array<Biquad, 2> busSidechainHighPass, busSidechainLowShelf,
+                          busSidechainHighShelf;
+    float busSidechainRate = 0.0f;
+    float busSidechainHighPassFrequency = -1.0f;
+    float busSidechainLowFrequency = -1.0f, busSidechainLowGain = 0.0f;
+    float busSidechainHighFrequency = -1.0f, busSidechainHighGain = 0.0f;
     std::array<std::vector<float>, kChannels> digitalDelay;
     std::array<int, 2> digitalWrite{{0, 0}};
 
@@ -893,14 +955,16 @@ private:
         return std::clamp(out * decibelsToGain(p.fetOutput.load(std::memory_order_relaxed)), -2.0f, 2.0f);
     }
 
-    float processVCA(float input, int ch, float sidechain, const MultiCompParameterState& p, bool external) noexcept
+    float processVCA(float input, int ch, float sidechain,
+                     const MultiCompParameterState& p, bool /*external*/) noexcept
     {
         auto& d = vca[ch];
         const float sr = static_cast<float>(fs * osFactor);
-        // JUCE's VCA is feed-forward: internal detection is the audio input
-        // even when the host-side stereo-link buffer is populated.  Only an
-        // actual external sidechain replaces the detector source.
-        const float detect = std::abs(external ? sidechain : input);
+        // The DSP has already selected, filtered and stereo-linked the
+        // detector signal for both internal and external operation. VCA is
+        // feed-forward, so consuming that signal preserves its topology while
+        // making the global sidechain controls effective.
+        const float detect = std::abs(sidechain);
         d.rate = d.rate * 0.95f + std::abs(detect - d.previous) * 0.05f;
         d.previous = detect;
         const float rmsMs = p.vcaClassicDetector.load(std::memory_order_relaxed) ? 0.010f : 0.005f + 0.030f * std::exp(-3.0f * std::clamp((gainToDecibels(std::max(detect, 0.0001f)) + 20.0f) / 30.0f, 0.0f, 1.0f));
@@ -958,47 +1022,98 @@ private:
         return std::clamp(out * decibelsToGain(p.vcaOutput.load(std::memory_order_relaxed)), -2.0f, 2.0f);
     }
 
-    float processBus(float input, int ch, float sidechain, const MultiCompParameterState& p, float mix, bool external) noexcept
+    float busFeedbackRect(BusState& d, int ch, float sr) noexcept
     {
-        auto& d = bus[ch];
-        const float sr = static_cast<float>(fs * osFactor);
-        const float fb = d.compressed;
         const float alpha = 1.0f / (1.0f + kDuskTwoPi * 60.0f / sr);
-        d.hp = alpha * (d.hp + fb - d.prev); d.prev = fb;
-        d.hp2 = alpha * (d.hp2 + d.hp - d.prev2); d.prev2 = d.hp;
-        const float rect = external ? std::abs(sidechain) : std::abs(d.hp2);
-        const float rc = std::exp(-1.0f / (0.005f * sr));
-        d.rms = rc * d.rms + (1.0f - rc) * rect * rect;
-        const float level = std::sqrt(std::max(0.0f, d.rms));
+        d.hp = alpha * (d.hp + d.compressed - d.prev);
+        d.prev = d.compressed;
+        d.hp2 = alpha * (d.hp2 + d.hp - d.prev2);
+        d.prev2 = d.hp;
+        float detector = d.hp2;
+        const size_t channel = static_cast<size_t>(std::clamp(ch, 0, 1));
+        if (busSidechainHighPassFrequency >= 1.0f)
+            detector = busSidechainHighPass[channel].process(detector);
+        if (std::abs(busSidechainLowGain) > 0.001f)
+            detector = busSidechainLowShelf[channel].process(detector);
+        if (std::abs(busSidechainHighGain) > 0.001f)
+            detector = busSidechainHighShelf[channel].process(detector);
+        return std::abs(detector);
+    }
+
+    static float busRmsLevel(BusState& d, float rectified, float sr) noexcept
+    {
+        const float coefficient = std::exp(-1.0f / (0.005f * sr));
+        d.rms = coefficient * d.rms
+              + (1.0f - coefficient) * rectified * rectified;
+        return std::sqrt(std::max(0.0f, d.rms));
+    }
+
+    static float busReduction(float level, const MultiCompParameterState& p) noexcept
+    {
         const float ratios[3] = {2.0f, 4.0f, 10.0f};
-        const float ratio = ratios[std::clamp(p.busRatio.load(std::memory_order_relaxed), 0, 2)];
-        const float over = gainToDecibels(std::max(level, 1.0e-9f) / decibelsToGain(p.busThreshold.load(std::memory_order_relaxed)));
+        const float ratio = ratios[std::clamp(
+            p.busRatio.load(std::memory_order_relaxed), 0, 2)];
+        const float over = gainToDecibels(std::max(level, 1.0e-9f)
+            / decibelsToGain(p.busThreshold.load(std::memory_order_relaxed)));
         const float slope = 1.0f - 1.0f / ratio;
-        float reduction = over <= -5.0f ? 0.0f : (over >= 5.0f ? over * slope : slope * (over + 5.0f) * (over + 5.0f) / (2.0f * 10.0f));
-        reduction = std::min(reduction, 20.0f);
-        const float attacks[6] = {0.1f, 0.3f, 1, 3, 10, 30};
-        const float releases[5] = {100, 300, 600, 1200, -1};
-        const float attack = attacks[std::clamp(p.busAttack.load(std::memory_order_relaxed), 0, 5)] * 0.001f;
-        float release = releases[std::clamp(p.busRelease.load(std::memory_order_relaxed), 0, 4)] * 0.001f;
+        const float reduction = over <= -5.0f ? 0.0f
+            : (over >= 5.0f ? over * slope
+                            : slope * (over + 5.0f) * (over + 5.0f) / 20.0f);
+        return std::min(reduction, 20.0f);
+    }
+
+    static void advanceBusEnvelope(BusState& d, float level,
+                                   const MultiCompParameterState& p,
+                                   float sr) noexcept
+    {
+        const float reduction = busReduction(level, p);
+        const float attacks[6] = {0.1f, 0.3f, 1.0f, 3.0f, 10.0f, 30.0f};
+        const float releases[5] = {100.0f, 300.0f, 600.0f, 1200.0f, -1.0f};
+        const float attack = attacks[std::clamp(
+            p.busAttack.load(std::memory_order_relaxed), 0, 5)] * 0.001f;
+        float release = releases[std::clamp(
+            p.busRelease.load(std::memory_order_relaxed), 0, 4)] * 0.001f;
         if (release < 0.0f)
         {
             const float delta = std::abs(level - d.previous);
             d.previous = d.previous * 0.95f + level * 0.05f;
             const float transientDensity = std::clamp(delta * 20.0f, 0.0f, 1.0f);
             const float compressionFactor = std::clamp(reduction / 12.0f, 0.0f, 1.0f);
-            release = 0.15f + (1.0f - transientDensity) * compressionFactor * (0.45f - 0.15f);
+            release = 0.15f + (1.0f - transientDensity) * compressionFactor * 0.30f;
         }
         const float target = decibelsToGain(-reduction);
-        const float coeff = std::exp(-1.0f / (std::max(1.0f, (target < d.envelope ? attack : release) * sr)));
-        d.envelope = target + (d.envelope - target) * coeff;
+        const float time = target < d.envelope ? attack : release;
+        const float coefficient = std::exp(-1.0f
+            / std::max(1.0f, time * sr));
+        d.envelope = target + (d.envelope - target) * coefficient;
+        if (!std::isfinite(d.envelope)) d.envelope = 1.0f;
+    }
+
+    float renderBusOutput(float input, int ch,
+                          const MultiCompParameterState& p, float mix) noexcept
+    {
+        auto& d = bus[ch];
         const float transformed = inputTransformerBus[ch].processSample(input, ch);
         float out = transformed * d.envelope;
         d.compressed = out;
         out += 0.004f * out * out + 0.003f * out * out * out;
         out = outputTransformerBus[ch].processSample(out, ch);
-        out = busConvolution.processSample(out, ch) * busHardwareGain * decibelsToGain(p.busMakeup.load(std::memory_order_relaxed));
+        out = busConvolution.processSample(out, ch) * busHardwareGain
+            * decibelsToGain(p.busMakeup.load(std::memory_order_relaxed));
         out = std::clamp(out, -2.0f, 2.0f);
         return out * mix + input * (1.0f - mix);
+    }
+
+    float processBus(float input, int ch, float sidechain,
+                     const MultiCompParameterState& p, float mix,
+                     bool external) noexcept
+    {
+        auto& d = bus[ch];
+        const float sr = static_cast<float>(fs * osFactor);
+        const float level = busRmsLevel(d,
+            external ? std::abs(sidechain) : busFeedbackRect(d, ch, sr), sr);
+        advanceBusEnvelope(d, level, p, sr);
+        return renderBusOutput(input, ch, p, mix);
     }
 
     float processStudioVCA(float input, int ch, float sidechain, const MultiCompParameterState& p, bool external) noexcept

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -1870,6 +1870,239 @@ void testAnalogStereoLinkSharesEnvelope()
     }
 }
 
+std::array<float, 2> renderInternalStereoLink(int mode, float linkAmount,
+                                               int oversampling)
+{
+    constexpr int blockSize = 256;
+    MultiCompDSP dsp;
+    dsp.setMode(mode);
+    dsp.setOversampling(oversampling);
+    dsp.setStereoLink(linkAmount);
+    dsp.setMix(100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::AutoMakeup, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::SidechainHP, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScLowGain, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScHighGain, 0.0f);
+    configureStrongCompression(dsp, mode);
+    dsp.prepare(48000.0, blockSize);
+
+    std::array<float, blockSize> inputLeft{}, inputRight{};
+    std::array<float, blockSize> outputLeft{}, outputRight{};
+    const float* input[] = {inputLeft.data(), inputRight.data()};
+    float* output[] = {outputLeft.data(), outputRight.data()};
+    std::array<double, 2> power{{0.0, 0.0}};
+    constexpr int totalBlocks = 120;
+    constexpr int measuredBlocks = 8;
+    for (int block = 0; block < totalBlocks; ++block)
+    {
+        for (int i = 0; i < blockSize; ++i)
+        {
+            const float carrier = std::sin(2.0f * kPi * 997.0f
+                * static_cast<float>(block * blockSize + i) / 48000.0f);
+            inputLeft[static_cast<size_t>(i)] = 0.5f * carrier;
+            inputRight[static_cast<size_t>(i)] = 0.02f * carrier;
+        }
+        dsp.processBlock(input, output, 2, blockSize);
+        if (block >= totalBlocks - measuredBlocks)
+            for (int i = 0; i < blockSize; ++i)
+            {
+                power[0] += static_cast<double>(outputLeft[static_cast<size_t>(i)])
+                          * outputLeft[static_cast<size_t>(i)];
+                power[1] += static_cast<double>(outputRight[static_cast<size_t>(i)])
+                          * outputRight[static_cast<size_t>(i)];
+            }
+    }
+    constexpr double sampleCount = measuredBlocks * blockSize;
+    return {{static_cast<float>(std::sqrt(power[0] / sampleCount)),
+             static_cast<float>(std::sqrt(power[1] / sampleCount))}};
+}
+
+void testSplitOversamplingMatchesFunctorPath()
+{
+    for (const int factor : {1, 2, 4})
+    {
+        duskaudio::MultiCompAntiAliasing direct, split;
+        direct.setFactor(factor);
+        split.setFactor(factor);
+        direct.prepare(64);
+        split.prepare(64);
+        direct.setFactor(factor);
+        split.setFactor(factor);
+        direct.reset();
+        split.reset();
+        float maxDelta = 0.0f;
+        float signalPeak = 0.0f;
+        for (int sampleIndex = 0; sampleIndex < 4096; ++sampleIndex)
+        {
+            const float input = 0.47f * std::sin(2.0f * kPi * 7313.0f
+                * static_cast<float>(sampleIndex) / 48000.0f);
+            const auto process = [](float sample) noexcept {
+                return 0.75f * sample + 0.1f * sample * sample * sample;
+            };
+            const float expected = direct.processSample(input, process);
+            std::array<float, 4> phases{};
+            split.upsampleSample(input, phases.data());
+            for (int phase = 0; phase < factor; ++phase)
+                phases[static_cast<size_t>(phase)] = process(
+                    phases[static_cast<size_t>(phase)]);
+            const float actual = split.downsampleSample(phases.data());
+            maxDelta = std::max(maxDelta, std::abs(actual - expected));
+            signalPeak = std::max(signalPeak, std::max(std::abs(actual), std::abs(expected)));
+        }
+        std::printf("split oversampling: factor=%dx signal peak %.9g max delta %.9g\n",
+                    factor, signalPeak, maxDelta);
+        require(signalPeak > 1.0e-4f,
+                "split oversampling comparison produces output");
+        require(maxDelta == 0.0f,
+                "split oversampling is sample-identical to the functor path");
+    }
+}
+
+float renderInternalSidechainShelf(duskaudio::MultiCompMode mode, float highGainDb)
+{
+    constexpr int blockSize = 256;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(mode));
+    dsp.setOversampling(0);
+    dsp.setMix(100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::AutoMakeup, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::SidechainHP, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScLowGain, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScHighFreq, 2000.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScHighGain, highGainDb);
+    configureStrongCompression(dsp, static_cast<int>(mode));
+    dsp.prepare(48000.0, blockSize);
+
+    std::array<float, blockSize> input{}, output{};
+    const float* inputs[] = {input.data()};
+    float* outputs[] = {output.data()};
+    double power = 0.0;
+    constexpr int totalBlocks = 120;
+    constexpr int measuredBlocks = 8;
+    for (int block = 0; block < totalBlocks; ++block)
+    {
+        for (int i = 0; i < blockSize; ++i)
+            input[static_cast<size_t>(i)] = 0.2f * std::sin(2.0f * kPi * 8000.0f
+                * static_cast<float>(block * blockSize + i) / 48000.0f);
+        dsp.processBlock(inputs, outputs, 1, blockSize);
+        if (block >= totalBlocks - measuredBlocks)
+            for (float sample : output) power += static_cast<double>(sample) * sample;
+    }
+    return static_cast<float>(std::sqrt(power / (measuredBlocks * blockSize)));
+}
+
+void testVcaAndBusInternalDetectorControls()
+{
+    for (const auto mode : {duskaudio::MultiCompMode::VCA,
+                            duskaudio::MultiCompMode::Bus})
+        for (const int oversampling : {0, 1, 2})
+        {
+            const auto independent = renderInternalStereoLink(
+                static_cast<int>(mode), 0.0f, oversampling);
+            const auto linked = renderInternalStereoLink(
+                static_cast<int>(mode), 100.0f, oversampling);
+            const auto partial = renderInternalStereoLink(
+                static_cast<int>(mode), 50.0f, oversampling);
+            const float quietRatio = linked[1] / independent[1];
+            const float partialQuietRatio = partial[1] / independent[1];
+            const float loudDeltaDb = duskaudio::gainToDecibels(linked[0] / independent[0]);
+            std::printf("internal detector link: mode=%d os=%dx quiet ratio "
+                        "full %.6f partial %.6f loud delta %+.6f dB\n",
+                        static_cast<int>(mode), oversampling == 2 ? 4 : oversampling == 1 ? 2 : 1,
+                        quietRatio, partialQuietRatio, loudDeltaDb);
+            require(independent[0] > 1.0e-5f && independent[1] > 1.0e-5f
+                        && linked[0] > 1.0e-5f && linked[1] > 1.0e-5f,
+                    "internal detector link comparison produces stereo output");
+            require(quietRatio < 0.8f,
+                    "100% internal stereo link makes the loud channel compress the quiet channel");
+            require(quietRatio < partialQuietRatio && partialQuietRatio < 1.0f,
+                    "partial internal stereo link stays between independent and fully linked");
+            require(std::abs(loudDeltaDb) < 0.1f,
+                    "internal stereo link leaves the already-dominant channel unchanged");
+        }
+
+    for (const auto mode : {duskaudio::MultiCompMode::VCA,
+                            duskaudio::MultiCompMode::Bus})
+    {
+        const float cut = renderInternalSidechainShelf(mode, -12.0f);
+        const float boost = renderInternalSidechainShelf(mode, 12.0f);
+        const float shelfDeltaDb = duskaudio::gainToDecibels(boost / cut);
+        std::printf("internal sidechain shelf: mode=%d -12 dB RMS %.9g; "
+                    "+12 dB RMS %.9g; output delta %+.6f dB\n",
+                    static_cast<int>(mode), cut, boost, shelfDeltaDb);
+        require(cut > 1.0e-5f && boost > 1.0e-5f,
+                "internal sidechain shelf comparison produces output");
+        require(shelfDeltaDb < -3.0f,
+                "internal detector consumes the sidechain shelf EQ");
+    }
+}
+
+void testLinkedBusResetDeterminism()
+{
+    constexpr int blockSize = 256;
+    constexpr int blocks = 16;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Bus));
+    dsp.setOversampling(2);
+    dsp.setStereoLink(65.0f);
+    dsp.setMix(100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::AutoMakeup, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::SidechainHP, 180.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScLowFreq, 120.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScLowGain, -6.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScHighFreq, 3000.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ScHighGain, 9.0f);
+    configureStrongCompression(dsp, static_cast<int>(duskaudio::MultiCompMode::Bus));
+    dsp.prepare(48000.0, blockSize);
+
+    std::array<float, blockSize> inputLeft{}, inputRight{};
+    std::array<float, blockSize> outputLeft{}, outputRight{};
+    const float* input[] = {inputLeft.data(), inputRight.data()};
+    float* output[] = {outputLeft.data(), outputRight.data()};
+    auto render = [&]() {
+        std::vector<float> result(static_cast<size_t>(2 * blocks * blockSize));
+        for (int block = 0; block < blocks; ++block)
+        {
+            for (int i = 0; i < blockSize; ++i)
+            {
+                const int sampleIndex = block * blockSize + i;
+                inputLeft[static_cast<size_t>(i)] = 0.45f * std::sin(
+                    2.0f * kPi * 713.0f * static_cast<float>(sampleIndex) / 48000.0f);
+                inputRight[static_cast<size_t>(i)] = 0.07f * std::sin(
+                    2.0f * kPi * 3299.0f * static_cast<float>(sampleIndex) / 48000.0f);
+            }
+            dsp.processBlock(input, output, 2, blockSize);
+            std::copy(outputLeft.begin(), outputLeft.end(),
+                result.begin() + static_cast<ptrdiff_t>(2 * block * blockSize));
+            std::copy(outputRight.begin(), outputRight.end(),
+                result.begin() + static_cast<ptrdiff_t>((2 * block + 1) * blockSize));
+        }
+        return result;
+    };
+
+    const auto first = render();
+    dsp.reset();
+    const auto second = render();
+    float signalPeak = 0.0f;
+    float maxDelta = 0.0f;
+    for (size_t i = 0; i < first.size(); ++i)
+    {
+        signalPeak = std::max(signalPeak, std::max(std::abs(first[i]), std::abs(second[i])));
+        maxDelta = std::max(maxDelta, std::abs(first[i] - second[i]));
+    }
+    std::printf("linked Bus reset: signal peak %.9g max delta %.9g\n",
+                signalPeak, maxDelta);
+    require(signalPeak > 1.0e-4f, "linked Bus reset comparison produces output");
+    require(maxDelta == 0.0f,
+            "reset clears linked Bus detector, filter and split-oversampling state");
+}
+
 std::array<float, 2> renderOptoInternalStereo(float leftDbfs, float rightDbfs,
                                                float peakReduction,
                                                float linkAmount = 100.0f,
@@ -3304,6 +3537,9 @@ int main()
     testMixBypassAndBlockEdges();
     testLatencyMixBypassAndDigitalStereo();
     testAnalogStereoLinkSharesEnvelope();
+    testSplitOversamplingMatchesFunctorPath();
+    testVcaAndBusInternalDetectorControls();
+    testLinkedBusResetDeterminism();
     testOptoInternalStereoLinkUsesSignedMaximum();
     testDigitalLookaheadMixAlignment();
     testMultibandMixAlignment();

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -14,6 +14,17 @@
 #include <thread>
 #include <vector>
 
+namespace duskaudio
+{
+struct MultiCompDSPTestAccess
+{
+    static std::array<bool, 2> busSidechainValidity(const MultiCompDSP& dsp) noexcept
+    {
+        return dsp.previousBusSidechainValid;
+    }
+};
+}
+
 using duskaudio::DuskCrossover;
 using duskaudio::MultiCompDSP;
 
@@ -2103,6 +2114,86 @@ void testLinkedBusResetDeterminism()
             "reset clears linked Bus detector, filter and split-oversampling state");
 }
 
+void testLinkedBusReentryReseedsSidechainInterpolation()
+{
+    constexpr int blockSize = 64;
+    MultiCompDSP dsp;
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Bus));
+    dsp.setOversampling(2);
+    dsp.setStereoLink(100.0f);
+    dsp.setExternalSidechain(true);
+    dsp.setMix(100.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::AutoMakeup, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::SidechainHP, 0.0f);
+    configureStrongCompression(dsp, static_cast<int>(duskaudio::MultiCompMode::Bus));
+    dsp.prepare(48000.0, blockSize);
+
+    std::array<float, blockSize> inputLeft{}, inputRight{}, sidechain{};
+    std::array<float, blockSize> outputLeft{}, outputRight{};
+    const float* input[] = {inputLeft.data(), inputRight.data()};
+    const float* external[] = {sidechain.data(), sidechain.data()};
+    float* output[] = {outputLeft.data(), outputRight.data()};
+    for (int i = 0; i < blockSize; ++i)
+    {
+        inputLeft[static_cast<size_t>(i)] = 0.4f * std::sin(
+            2.0f * kPi * 997.0f * static_cast<float>(i) / 48000.0f);
+        inputRight[static_cast<size_t>(i)] = 0.2f * std::sin(
+            2.0f * kPi * 1709.0f * static_cast<float>(i) / 48000.0f);
+        sidechain[static_cast<size_t>(i)] = 0.8f;
+    }
+
+    const auto validity = [&] {
+        return duskaudio::MultiCompDSPTestAccess::busSidechainValidity(dsp);
+    };
+    const auto both = [](const std::array<bool, 2>& value, bool expected) {
+        return value[0] == expected && value[1] == expected;
+    };
+
+    dsp.processBlockExternal(input, external, output, 2, blockSize);
+    require(both(validity(), true),
+            "linked stereo Bus processing retains interpolation endpoints");
+
+    dsp.setStereoLink(0.0f);
+    dsp.processBlockExternal(input, external, output, 2, blockSize);
+    require(both(validity(), false),
+            "unlinked Bus processing invalidates linked interpolation endpoints");
+
+    dsp.setStereoLink(100.0f);
+    dsp.processBlockExternal(input, external, output, 2, blockSize);
+    require(both(validity(), true),
+            "linked Bus processing re-seeds invalid interpolation endpoints");
+
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::VCA));
+    dsp.processBlockExternal(input, external, output, 2, blockSize);
+    require(both(validity(), false),
+            "a non-Bus mode invalidates linked Bus interpolation endpoints");
+
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Bus));
+    dsp.processBlockExternal(input, external, output, 2, blockSize);
+    require(both(validity(), true),
+            "returning to linked Bus processing re-seeds interpolation endpoints");
+
+    dsp.setBypass(true);
+    for (int block = 0; block < 32; ++block)
+        dsp.processBlockExternal(input, external, output, 2, blockSize);
+    require(both(validity(), false),
+            "settled bypass invalidates linked Bus interpolation endpoints");
+
+    dsp.setBypass(false);
+    dsp.processBlockExternal(input, external, output, 2, blockSize);
+    require(both(validity(), true),
+            "leaving bypass re-seeds linked Bus interpolation endpoints");
+
+    const float* monoInput[] = {inputLeft.data()};
+    const float* monoExternal[] = {sidechain.data()};
+    float* monoOutput[] = {outputLeft.data()};
+    dsp.processBlockExternal(monoInput, monoExternal, monoOutput, 1, blockSize);
+    require(both(validity(), false),
+            "mono Bus processing invalidates stereo linked interpolation endpoints");
+}
+
 std::array<float, 2> renderOptoInternalStereo(float leftDbfs, float rightDbfs,
                                                float peakReduction,
                                                float linkAmount = 100.0f,
@@ -3540,6 +3631,7 @@ int main()
     testSplitOversamplingMatchesFunctorPath();
     testVcaAndBusInternalDetectorControls();
     testLinkedBusResetDeterminism();
+    testLinkedBusReentryReseedsSidechainInterpolation();
     testOptoInternalStereoLinkUsesSignedMaximum();
     testDigitalLookaheadMixAlignment();
     testMultibandMixAlignment();

--- a/plugins/multi-comp/multicomp.cpp
+++ b/plugins/multi-comp/multicomp.cpp
@@ -5402,7 +5402,13 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
     if (bypassAlignSize > 1)
     {
         const int ns = buffer.getNumSamples();
-        for (int ch = 0; ch < juce::jmin(buffer.getNumChannels(), 2); ++ch)
+        // bypassAlignBuf is sized jmin(preparedChannels, 2), so a mono-prepared
+        // instance owns ONE channel. The host can still present a wider buffer;
+        // indexing past the allocation returns a null write pointer and stores
+        // to address 0. Bound the loop by what was allocated.
+        const int alignChannels = juce::jmin(buffer.getNumChannels(),
+                                             bypassAlignBuf.getNumChannels());
+        for (int ch = 0; ch < alignChannels; ++ch)
         {
             int wp = bypassAlignWritePos[static_cast<size_t>(ch)];
             const float* in = buffer.getReadPointer(ch);
@@ -5430,7 +5436,11 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         // allocate on the real-time path).
         if (bypassAlignSize <= 1 || D + ns >= bypassAlignSize)
             return;
-        for (int ch = 0; ch < juce::jmin(buf.getNumChannels(), 2); ++ch)
+        // Same clamp as the writer above. Channels with no recorded history keep
+        // the dry input already in buf, which is the same graceful degradation
+        // the oversized-block fallback above relies on.
+        for (int ch = 0; ch < juce::jmin(buf.getNumChannels(),
+                                         bypassAlignBuf.getNumChannels()); ++ch)
         {
             const int preWp = (ch == 0) ? alignPreWp0 : alignPreWp1;
             float* out = buf.getWritePointer(ch);
@@ -5478,7 +5488,15 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             // current audio for time-aligned dry capture on unbypass.
             if (bypassFadeDelaySize > 1)
             {
-                for (int ch = 0; ch < nc; ++ch)
+                // prepareToPlay sizes these from getTotalNumOutputChannels().
+                // A host can hand processBlock a buffer with more channels than
+                // that; writing past the allocation makes getWritePointer return
+                // null and the store lands at address 0. Clamp to what was
+                // actually allocated rather than trusting the buffer's count.
+                const int warmChannels = juce::jmin(nc,
+                    bypassFadeDelayBuf.getNumChannels(),
+                    static_cast<int>(bypassFadeDelayWritePos.size()));
+                for (int ch = 0; ch < warmChannels; ++ch)
                 {
                     int& wp = bypassFadeDelayWritePos[static_cast<size_t>(ch)];
                     for (int i = 0; i < ns; ++i)
@@ -5589,7 +5607,15 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
 
             if (bypassFadeDelaySize > 1)
             {
-                for (int ch = 0; ch < nc; ++ch)
+                // prepareToPlay sizes these from getTotalNumOutputChannels().
+                // A host can hand processBlock a buffer with more channels than
+                // that; writing past the allocation makes getWritePointer return
+                // null and the store lands at address 0. Clamp to what was
+                // actually allocated rather than trusting the buffer's count.
+                const int warmChannels = juce::jmin(nc,
+                    bypassFadeDelayBuf.getNumChannels(),
+                    static_cast<int>(bypassFadeDelayWritePos.size()));
+                for (int ch = 0; ch < warmChannels; ++ch)
                 {
                     int& wp = bypassFadeDelayWritePos[static_cast<size_t>(ch)];
                     for (int i = 0; i < ns; ++i)
@@ -5740,7 +5766,12 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
             // Feed each input sample through the dedicated delay line and capture
             // the delayed output. This produces a properly sequenced block of
             // time-aligned dry audio without touching the processing lookahead.
-            for (int ch = 0; ch < fadeChannels; ++ch)
+            // fadeChannels is clamped to bypassFadeBuffer only; the delay
+            // line and its write positions are separate allocations.
+            const int delayChannels = juce::jmin(fadeChannels,
+                bypassFadeDelayBuf.getNumChannels(),
+                static_cast<int>(bypassFadeDelayWritePos.size()));
+            for (int ch = 0; ch < delayChannels; ++ch)
             {
                 float* dst = bypassFadeBuffer.getWritePointer(ch);
                 int& wp = bypassFadeDelayWritePos[static_cast<size_t>(ch)];
@@ -6454,7 +6485,12 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
         {
             int fadeSamples = juce::jmin(bypassFadeRemaining, numSamples);
             float fadeLen = static_cast<float>(bypassFadeActualLength);
-            for (int ch = 0; ch < numChannels; ++ch)
+            // numChannels comes from the buffer; bypassFadeBuffer was sized in
+            // prepareToPlay. Reading past it returns null and dereferencing that
+            // crashes the render thread mid-crossfade.
+            const int xfadeChannels = juce::jmin(numChannels,
+                                                 bypassFadeBuffer.getNumChannels());
+            for (int ch = 0; ch < xfadeChannels; ++ch)
             {
                 float* out = buffer.getWritePointer(ch);
                 const float* dry = bypassFadeBuffer.getReadPointer(ch);
@@ -6852,7 +6888,10 @@ void UniversalCompressor::processBlock(juce::AudioBuffer<float>& buffer, juce::M
     {
         int fadeSamples = juce::jmin(bypassFadeRemaining, numSamples);
         float fadeLen = static_cast<float>(bypassFadeActualLength);
-        for (int ch = 0; ch < numChannels; ++ch)
+        // Same clamp as the standard path's crossfade.
+        const int xfadeChannels = juce::jmin(numChannels,
+                                             bypassFadeBuffer.getNumChannels());
+        for (int ch = 0; ch < xfadeChannels; ++ch)
         {
             float* out = buffer.getWritePointer(ch);
             const float* dry = bypassFadeBuffer.getReadPointer(ch);

--- a/plugins/shared-daf/dsp/DuskOversampler.hpp
+++ b/plugins/shared-daf/dsp/DuskOversampler.hpp
@@ -126,6 +126,60 @@ public:
         return process2x(x, [this, &f](float s) noexcept { return process4xInner(s, f); });
     }
 
+    // Split form for a caller that must process multiple channels in lockstep.
+    // `phases` has room for four samples; only getFactor() entries are used.
+    // Calling upsampleSample() followed by downsampleSample() advances exactly
+    // the same filter state as processSample().
+    void upsampleSample(float x, float* phases) noexcept
+    {
+        if (factor == 1)
+        {
+            phases[0] = x;
+            return;
+        }
+
+        upA.push(x);
+        const float a0 = 2.0f * upA.out(hbtaps::kA);
+        upA.push(0.0f);
+        const float a1 = 2.0f * upA.out(hbtaps::kA);
+        if (factor == 2)
+        {
+            phases[0] = a0;
+            phases[1] = a1;
+            return;
+        }
+
+        upB.push(a0);
+        phases[0] = 2.0f * upB.out(hbtaps::kB);
+        upB.push(0.0f);
+        phases[1] = 2.0f * upB.out(hbtaps::kB);
+        upB.push(a1);
+        phases[2] = 2.0f * upB.out(hbtaps::kB);
+        upB.push(0.0f);
+        phases[3] = 2.0f * upB.out(hbtaps::kB);
+    }
+
+    float downsampleSample(const float* phases) noexcept
+    {
+        if (factor == 1) return phases[0];
+        if (factor == 2)
+        {
+            downA.push(phases[0]);
+            downA.push(phases[1]);
+            return downA.out(hbtaps::kA);
+        }
+
+        downB.push(phases[0]);
+        downB.push(phases[1]);
+        const float a0 = downB.out(hbtaps::kB);
+        downB.push(phases[2]);
+        downB.push(phases[3]);
+        const float a1 = downB.out(hbtaps::kB);
+        downA.push(a0);
+        downA.push(a1);
+        return downA.out(hbtaps::kA);
+    }
+
 private:
     // base <-> 2x via stage A.
     template <class Fn>


### PR DESCRIPTION
## Summary

- prevent bypass and latency paths from writing past channel-sized delay storage
- restore Stereo Link and internal sidechain EQ in VCA and Bus modes
- preserve Bus feedback topology across 1x, 2x, and 4x oversampling
- add asymmetric stereo, sidechain-EQ, reset, split-oversampling, and channel-bound regressions

Closes #220

## Verification

- full DAF build: AU, VST3, CLAP, LV2, standalone passed
- ctest: 2/2 passed in 10.14 s
- Linux GCC 12 amd64 core suite passed in the prior #220 verification
- deliberate regressions failed each repaired assertion before restoration
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable high-pass and shelf filtering for bus sidechains.
  * Improved stereo-linked processing for Bus and VCA modes.
  * Enhanced oversampling for synchronized stereo processing.

* **Bug Fixes**
  * Improved sidechain consistency during bypass, mode, link, and mono/stereo changes.
  * Improved reset behavior across oversampling modes.
  * Prevented buffer access issues when hosts provide more channels than configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->