### PR TITLE
Multi-Comp 2: integrate Opto campaign and UI

### DIFF
--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -1,6 +1,6 @@
 name: DAF Plugins (build + release)
 
-# One reusable pipeline for ALL DAF (Dusk Audio Framework) plugins. Replaces
+# One reusable pipeline for ALL DAF (DISTRHO Plugin Framework) plugins. Replaces
 # the per-plugin ad-hoc DAF workflows (tapemachine2-release.yml, daf-au-test.yml).
 #
 # DAF plugins are NOT JUCE — each is built by its own standalone CMake under
@@ -8,9 +8,10 @@ name: DAF Plugins (build + release)
 # They do not go through the JUCE pipeline in build.yml.
 #
 # A single registry (see the "plan" step) drives a dynamic matrix:
-#   - PR touching any daf-plugin OR shared-daf   -> build ALL DAF plugins (smoke).
-#     This is the shared-code safety net: shared-daf/ is compiled into every DAF
-#     plugin, so a change there is verified against all of them.
+#   - PR touching plugin-local daf-plugin/core   -> build the touched plugin(s).
+#   - PR touching shared-daf, this workflow or its gate scripts -> build ALL DAF
+#     plugins. This is the shared-code safety net: shared-daf/ is compiled into
+#     every DAF plugin, so a change there is verified against all of them.
 #   - workflow_dispatch                          -> build one (input) or all.
 #   - push tag '<plugin>-v*'                      -> build + release THAT plugin.
 #
@@ -91,6 +92,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          # PR planning compares the exact base and head commits. The default
+          # one-commit checkout contains only the synthetic merge commit.
+          fetch-depth: 0
 
       - name: Resolve build set + release info
         id: plan
@@ -99,19 +103,19 @@ jobs:
           # ---- Plugin registry (single source of truth) -------------------
           # key   : workflow_dispatch value + artifact base
           # dir   : standalone CMake dir
-          # base  : daf_add_plugin() name -> build/bin/<base>.{vst3,clap,lv2,component}
+          # base  : dpf_add_plugin() name -> build/bin/<base>.{vst3,clap,lv2,component}
           # project: project(<name> ...) token, for the tag<->CMake version guard
-          # au    : DAF_PLUGIN_UNIQUE_ID (AU subtype code)
+          # au    : DISTRHO_PLUGIN_UNIQUE_ID (AU subtype code)
           # name  : human display name
           # tag   : release tag PREFIX (version is the suffix)
           # asset : release/website asset base (asset zip = <asset>-<os>.zip)
           cat > registry.json <<'JSON'
           [
-            {"key":"tapemachine-2","dir":"plugins/TapeMachine/daf-plugin","base":"tape_machine_2","project":"TapeMachine2DAF","au":"DsTM","uri":"https://dusk-audio.github.io/plugins/tapemachine-2","name":"TapeMachine 2","tag":"tapemachine-2-v","asset":"tapemachine-2"},
-            {"key":"4k-eq-2","dir":"plugins/4k-eq/daf-plugin","base":"four_k_eq_2","project":"FourKEQ2DAF","au":"DsFq","uri":"https://dusk-audio.github.io/plugins/4k-eq-2","name":"4K EQ 2","tag":"4k-eq-2-v","asset":"4k-eq-2"},
-            {"key":"tape-echo-2","dir":"plugins/tape-echo/daf-plugin","base":"tape_echo","project":"TapeEchoDAF","au":"DsTE","uri":"https://dusk-audio.github.io/plugins/tape-echo","name":"Tape Echo 2","tag":"tape-echo-2-v","asset":"tape-echo-2"},
-            {"key":"multi-q-2","dir":"plugins/multi-q/daf-plugin","base":"multi_q_2","project":"MultiQ2DAF","au":"DsMq","uri":"https://dusk-audio.github.io/plugins/multi-q-2","name":"Multi-Q 2","tag":"multi-q-2-v","asset":"multi-q-2"}
-            ,{"key":"multi-comp-2","dir":"plugins/multi-comp/daf-plugin","base":"multi_comp_2","project":"MultiComp2DAF","au":"DsMc","uri":"https://dusk-audio.github.io/plugins/multi-comp-2","name":"Multi-Comp 2","tag":"multi-comp-2-v","asset":"multi-comp-2"}
+            {"key":"tapemachine-2","dir":"plugins/TapeMachine/daf-plugin","base":"tape_machine_2","project":"TapeMachine2DPF","au":"DsTM","uri":"https://dusk-audio.github.io/plugins/tapemachine-2","name":"TapeMachine 2","tag":"tapemachine-2-v","asset":"tapemachine-2"},
+            {"key":"4k-eq-2","dir":"plugins/4k-eq/daf-plugin","base":"four_k_eq_2","project":"FourKEQ2DPF","au":"DsFq","uri":"https://dusk-audio.github.io/plugins/4k-eq-2","name":"4K EQ 2","tag":"4k-eq-2-v","asset":"4k-eq-2"},
+            {"key":"tape-echo-2","dir":"plugins/tape-echo/daf-plugin","base":"tape_echo","project":"TapeEchoDPF","au":"DsTE","uri":"https://dusk-audio.github.io/plugins/tape-echo","name":"Tape Echo 2","tag":"tape-echo-2-v","asset":"tape-echo-2"},
+            {"key":"multi-q-2","dir":"plugins/multi-q/daf-plugin","base":"multi_q_2","project":"MultiQ2DPF","au":"DsMq","uri":"https://dusk-audio.github.io/plugins/multi-q-2","name":"Multi-Q 2","tag":"multi-q-2-v","asset":"multi-q-2"}
+            ,{"key":"multi-comp-2","dir":"plugins/multi-comp/daf-plugin","base":"multi_comp_2","project":"MultiComp2DPF","au":"DsMc","uri":"https://dusk-audio.github.io/plugins/multi-comp-2","name":"Multi-Comp 2","tag":"multi-comp-2-v","asset":"multi-comp-2"}
           ]
           JSON
 
@@ -148,8 +152,44 @@ jobs:
             # --- Dispatch, single plugin ---
             MATRIX=$(jq -c --arg k "${{ github.event.inputs.plugin }}" 'map(select(.key==$k))' registry.json)
             if [ "$MATRIX" = "[]" ]; then echo "::error::unknown plugin '${{ github.event.inputs.plugin }}'"; exit 1; fi
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # --- PR: build touched plugins, or all when shared infrastructure changed ---
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            CHANGED_PATHS=$(git diff --name-only --diff-filter=ACDMRT "$BASE_SHA" "$HEAD_SHA")
+            echo "=== changed paths ==="
+            printf '%s\n' "$CHANGED_PATHS"
+
+            BUILD_ALL=false
+            while IFS= read -r changed_path; do
+              case "$changed_path" in
+                plugins/shared-daf/*|.github/workflows/daf-build.yml|.github/scripts/*)
+                  BUILD_ALL=true
+                  break
+                  ;;
+              esac
+            done <<< "$CHANGED_PATHS"
+
+            if [ "$BUILD_ALL" = true ]; then
+              MATRIX=$(jq -c '.' registry.json)
+            else
+              CHANGED_JSON=$(printf '%s\n' "$CHANGED_PATHS" \
+                | jq -Rsc 'split("\n") | map(select(length > 0))')
+              # Each registry dir ends in /daf-plugin; its parent is the plugin
+              # root and therefore also owns the sibling core/ directory.
+              MATRIX=$(jq -c --argjson paths "$CHANGED_JSON" '
+                [.[]
+                 | . as $plugin
+                 | ($plugin.dir | sub("/daf-plugin$"; "")) as $root
+                 | select(any($paths[]; startswith($root + "/")))]
+              ' registry.json)
+              if [ "$MATRIX" = "[]" ]; then
+                echo "::error::PR matched the DAF workflow but no registered plugin owns its changed paths"
+                exit 1
+              fi
+            fi
           else
-            # --- PR / dispatch-all: build every DAF plugin ---
+            # --- Dispatch-all: build every DAF plugin ---
             MATRIX=$(jq -c '.' registry.json)
           fi
 

--- a/HANDOFF-MC2.md
+++ b/HANDOFF-MC2.md
@@ -5,11 +5,13 @@ You are the planner and reviewer; delegate implementation to Codex via the
 file. The campaign log memory `mc2-la2a-campaign.md` is the long-form record;
 this file is the working state.
 
-**Snapshot authority:** the campaign worktree named in section 2, at committed
-HEAD `e0a4f21` plus its listed pre-existing working-tree changes, is the source
-for the measurements below. `origin/main` was `c1f9ae4` when this snapshot was
-recorded. These committed trees are close but not identical; do not substitute
-one for the other or combine files from the unrelated primary checkout.
+**Snapshot authority:** the renamed campaign worktree named in section 2, at
+committed HEAD `d090a7b`, is the current source tree for the measurements below.
+It is based on `origin/main` at `f7edaea`. The measurements were first recorded
+from the historical pre-rename `e0a4f21` worktree plus its listed changes, then
+the campaign state was ported and verified with identical gate output. Do not
+substitute `origin/main`, the historical worktree, or files from the unrelated
+primary checkout.
 
 ---
 
@@ -50,7 +52,13 @@ sustained 0.5 ms). Rules earned:
 
 ## 1. Scope — binding owner decisions
 
-- **Opto only** until finished; then match the reference UI. Bugs found in
+- **DSP remains Opto only.** On 2026-08-22 the owner explicitly authorised Opto
+  UI work to proceed in parallel while further reference DSP measurements are
+  pending. Later that day the owner explicitly widened UI shell scope only:
+  remove the visible Global and Sidechain bands and make the shared header
+  conform to TapeMachine 2 / Tape Echo 2. That shell change applies across all
+  modes; it does not authorise DSP or per-mode panel changes. Keep UI and DSP
+  iterations isolated. Bugs found in
   other modes get issues, not fixes (#220 deferred; same
   `external ? sidechain : input` dead-link bug likely in VCA ~line 854 and
   Bus ~line 960 of MultiCompModes.hpp — needs its own issue).
@@ -66,32 +74,36 @@ sustained 0.5 ms). Rules earned:
 ## 2. Repository state
 
 Worktree (all work happens here):
-`/private/tmp/claude-502/-Users-marckorte-projects-dusk-audio-plugins/ea21f9ad-379c-40f2-86e2-dfd1e8d95e07/scratchpad/mc2`
+`/private/tmp/claude-502/-Users-marckorte-projects-dusk-audio-plugins/d3a95f36-6e62-4446-9f5b-32717dcb08a6/scratchpad/mc2-port`
 
 - **Authoritative 2026-08-22 campaign snapshot:** worktree branch
-  `multi-comp-2/review-followups` at `e0a4f21`, with its existing uncommitted
-  changes preserved. `origin/main` is `c1f9ae4` (merged PR #222). A direct tree
-  comparison shows one three-line difference in `MultiCompPlugin.cpp`; the two
-  revisions are therefore not content-equal.
+  `multi-comp-2/opto-campaign-snapshot` at `d090a7b`, based on `origin/main`
+  `f7edaea` (merged PR #223). Its tracked tree contains the faithfully ported
+  campaign changes and the selective DAF build-workflow edit; a clean checkout
+  of `origin/main` does not contain the same gate set.
+- **Historical pre-rename 2026-08-22 source:** branch
+  `multi-comp-2/review-followups` at `e0a4f21`, plus its five then-uncommitted
+  files, with `origin/main` at `c1f9ae4`. This identifies the source from which
+  the current snapshot was ported; it is stale and is not a worktree to use.
 - **Historical 2026-08-21 handoff refs:** `main=662d6d5` and review branch
   `bad1c54`. They identify the earlier post-PR-#221 state only and are not the
   source for the current gate table.
-- Pre-existing modified files in the authoritative worktree are
-  `.github/workflows/daf-build.yml`, `MultiCompModes.hpp`,
-  `MultiCompCoreTests.cpp`, `MultiCompPluginLayerTests.cpp`, and
-  `MultiCompUI.cpp`. Preserve them; never treat a clean `e0a4f21` checkout as
-  the measured tree.
-- **Uncommitted, never touch:** `.github/workflows/daf-build.yml` (owner's
-  own edit). It also survives in `git stash` as a backup from a rebase.
-- Build dir `build-mc2` in the worktree root; configure command if needed:
+- The ported campaign files are `.github/workflows/daf-build.yml`,
+  `MultiCompModes.hpp`, `MultiCompCoreTests.cpp`,
+  `MultiCompPluginLayerTests.cpp`, and `MultiCompUI.cpp`. They are committed in
+  the authoritative snapshot. The workflow change remains owner-controlled and
+  outside the Opto task; do not modify it.
+- Pre-existing untracked `b/` is the configured build directory, not a source
+  change. Preserve it; configure command if needed:
   ```bash
   cmake -U 'SDL2*' -U 'pkgcfg_lib_SDL2*' -S plugins/multi-comp/daf-plugin \
-    -B build-mc2 -DCMAKE_BUILD_TYPE=Release -DDAF_PATH=$HOME/projects/DAF \
+    -B b -DCMAKE_BUILD_TYPE=Release -DDAF_PATH=$HOME/projects/DAF \
     -DDAFWIDGETS_PATH=$HOME/projects/DAF-Widgets -DDUSK_DAF_INSTALL_LOCAL=OFF \
     -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=TRUE
   ```
-- DAF fork `~/projects/DAF`: AU render guard already merged to fork main.
-  Do not modify. Never repoint CI to upstream DAF.
+- DAF fork `~/projects/DAF`: pinned at `788eb019`; DAF-Widgets is pinned at
+  `91e0004e`. Do not modify either checkout or point builds away from these hard
+  forks.
 - Measurements: `~/projects/dusk-audio-tools/plugins/MultiComp/measurements/`
   (17 JSON + probe scripts). Read before measuring anything new.
 
@@ -107,6 +119,7 @@ Worktree (all work happens here):
 | output ceiling | worst 0.230 dB, peak +4.68 dBFS |
 | burst-rate sweep, 2/5/10/20/40 Hz | +0.407 / +0.563 / +0.187 / +0.384 / +0.792 dB |
 | crest sweep | -0.141 / -0.540 / **+0.615 held out** / -0.709 dB |
+| dense programme, PR 0.4/0.55/0.7/0.85/1.0 | +0.224 / +0.033 / +1.000 / +1.488 / +2.012 dB |
 | harmonics | fundamental 0.0002 dB; compressed H2-H5 worst 0.071 dB |
 | sample-rate invariance | 0.002 dB spread |
 | asymmetric stereo | -0.19 / -0.25 dB, symmetric |
@@ -114,9 +127,14 @@ Worktree (all work happens here):
 
 The older 2026-08-21 tree was verified to <0.001 dB across
 macOS-clang-arm64, Linux-gcc-x86-64, Linux-arm64, and both fp-contract modes.
-That result is historical, not verification of the modified 2026-08-22
-working tree; rerun the Linux and fp-contract checks before declaring a DSP
-change done.
+That result is historical. The current follow-up tree passes on default macOS,
+macOS with `-ffp-contract=off`, and Linux GCC 12. Linux matches the no-contract
+macOS detector-weighting rows within 0.000229 dB, but default macOS differs in
+the low-frequency rows by up to 0.004563 dB; shape RMS is 0.096646 dB on
+default macOS, 0.098245 dB without contraction, and 0.098219 dB on Linux. No
+gate changes pass/fail state, but the old cross-platform <0.001 dB claim does
+not apply to this default-clang weighting baseline. No production DSP change
+was retained in this follow-up; future DSP work must still run all three checks.
 
 ### The remaining emulation gap (open, structural)
 
@@ -125,24 +143,114 @@ The reference's crest response is NON-MONOTONIC (10.19 → 14.07 → 11.33 →
 residuals are -0.141 / -0.540 / +0.615 held out / -0.709 dB; the four-row RMS
 is 0.546 dB. The older +0.71/-1.28 dB residuals and 0.96 → 0.75 RMS
 comparison describe the historical 2026-08-21 silence-gate trajectory only.
-Five mechanisms already tried and rejected WITH numbers (see the crest test's
-comment block and campaign log): 0.8 ms integrator, 6000 dB/s cell slew,
+Five earlier mechanisms were tried and rejected WITH numbers (see the crest
+test's comment block and campaign log): 0.8 ms integrator, 6000 dB/s cell slew,
 0.4 ms reservoir + slew, shorter reservoirs, duration-gated charge cap. Each
 fixed one row by breaking burst-rate or a neighbour. A real fix needs
-structure the model lacks: two detector paths combining nonlinearly, charge
-saturation on very short events, or a non-magnitude rectifier law. Do NOT fit
+structure the model lacks: two detector paths combining nonlinearly or a
+short-event charge-saturation mechanism distinct from the rejected
+duration-gated cap. The follow-up audit below also excludes simple
+repetition-blend scaling and a calibrated power/RMS rectifier. Do NOT fit
 another correction term on top.
 
-**Dense-programme A/B vs the reference had not been re-run when this snapshot
-was recorded.** The +1.66 dB PR-0.7 result and the +0.3 to +0.8 dB interpolated
-estimate are both historical 2026-08-21 context, not current measurements.
-Measuring this is the top verification task.
+**Dense-programme A/B was re-run on the renamed `d090a7b` VST3.** On material
+with 17.794665 dB crest, the authoritative PR sweep is:
+
+| PR | reference GR | our GR | total-RMS residual | frame p50 | frame p95 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 0.40 | 1.664 | 1.887 | +0.224 | +0.264 | +0.805 |
+| 0.55 | 5.956 | 5.989 | +0.033 | +0.152 | +0.881 |
+| 0.70 | 12.928 | 13.927 | +1.000 | +1.196 | +2.239 |
+| 0.85 | 19.286 | 20.774 | +1.488 | +1.656 | +2.843 |
+| 1.00 | 21.192 | 23.204 | +2.012 | +2.206 | +3.403 |
+
+Total-RMS residual mean/worst/RMS is +0.951/+2.012/1.209 dB. An independent
+mine-side render reproduced our PR-0.55 and PR-0.85 GR as 5.989099 and
+20.774064 dB. The campaign table reports PR 1.0 as +2.012 dB; the earlier
+artifact-level calculation was +2.012752 dB. That 0.000752 dB reporting
+difference changes no conclusion or gate. Restricting the earlier three-row
+analysis to the input duration changes its deltas by no more than 0.001445 dB.
+The older +1.66 dB PR-0.7 result and +0.3 to +0.8 dB crest-interpolated estimate
+are historical 2026-08-21 context only; the five-point sweep falsifies that
+estimate. The near match at PR 0.4-0.55 followed by monotonic +1.000 to +2.012
+dB over-compression establishes PR as a missing dynamic axis. The single-PR
+crest gate cannot predict this programme result, and the static-law gates
+exclude a corresponding steady-state curve error.
 Renderer: `~/projects/dusk-audio-plugins/build/tests/duskverb_render/duskverb_render`,
 reference AU `/Library/Audio/Plug-Ins/Components/uaudio_teletronix_la-2a_tc.component`,
 harness in `~/projects/dusk-audio-tools/plugins/MultiComp/tests/reference_comparison/`.
 **Render our build with `--vst3`, never `--au`** (AU resolves through the
 global registry and can silently load a stale installed build). GR is always
 `output(PR=0) - output(PR=x)` at the same Gain, never input - output.
+
+### 2026-08-22 follow-up audit and excluded mechanisms
+
+- The detector-weighting mean removal is authoritative for the shape score,
+  but it is no longer blind to absolute level. The gate now separately pins the
+  mean at -0.237425 dB and the 1 kHz row at -0.174332 dB while retaining the
+  0.096646 dB mean-removed shape RMS; the static sine and broadband gates own
+  absolute level accuracy. Breaking the integration calibration moved the
+  anchors to -0.297932/-0.258481 dB and failed the new assertion; restoring it
+  returned the full suite to PASS.
+- The five burst-rate periods divide 48 kHz exactly, each burst is exactly 480
+  samples, and reference/control use the same 6.0-7.5 s scoring window and
+  stimulus. No hardcoded divisor, count, or rate mismatch explains the
+  one-sided residual. The bias remains an emulation gap, not an arithmetic fix.
+- `testOptoLimitDynamics` measures charge/attack t90, not release. At PR 1.0 /
+  -12 dBFS the residual changes from +0.604 ms after a 10 ms exposure to
+  -10.437 ms after 100 ms and -12.333 ms after 1 s; the held-out PR 1.0 /
+  -3 dBFS / 1 s row is -25.104 ms. This duration-dependent sign change links
+  the extreme row to short-event charge (gap 4), not release decay (gap 3).
+- Scaling the existing repetition blend to 75% was falsified: crest residuals
+  became -0.141/-1.629/-0.709/-1.643 dB and fitted RMS rose from 0.521 to
+  1.338 dB. A power/RMS rectifier, with its 997 Hz calibration derived rather
+  than fitted, raised short-event recovery RMS from 0.701056 to 1.032525 dB and
+  worst error from 1.385892 to 3.064520 dB. Both experiments were reverted;
+  there is no production DSP change from this follow-up.
+- A diagnostic run over all 60,000 sixteen-sample blocks of the authoritative
+  dense stimulus found that the integrated follower already controls the hard
+  `min(peak, integrated)` in 92.0733% of blocks. Mean peak/integrated separation
+  rises from +1.219 dB in the loudest input-RMS quintile to +2.784 dB in the
+  quietest. A blend bounded between the paths can therefore only raise the
+  detector in the valleys. The parameter-free below-minimum competition
+  `min^2/max` was tested as the remaining direction: crest residuals became
+  -0.176/-1.903/-0.869/-0.433 dB, fitted RMS rose from 0.521 to 1.131 dB, and
+  worst error rose from 0.709 to 1.903 dB. It also crossed the compressed
+  harmonic-regime floor. The experiment and diagnostic scaffolding were
+  reverted before the restored full-suite PASS.
+- The purported remaining “charge saturation” candidate is not absent from
+  this source. `followTarget` already makes charge rate depend on remaining
+  capacity, using fitted fast/slow exponents 5.1/1.5 and a fast minimum rate of
+  0.150. A second reservoir cannot be identified from the existing single-event
+  and periodic-burst corpus without becoming another correction term.
+- A temporary 16-sample-block diagnostic swept the dense stimulus across all
+  five PR values. Blocks ended with cell state above the instantaneous target
+  84.181-87.921% of the time. Mean total over-target retention was
+  0.960528/1.791087/2.097717/2.108555/2.006334 dB at PR
+  0.4/0.55/0.7/0.85/1.0. At PR 1.0 that retention was distributed across the
+  fast/mid/slow cells as 0.663660/0.860702/0.534533 dB; no single population
+  owns the error. `repetitionBlend` was exactly zero at every sampled block.
+  This does not support a fast-charge-only or repetition-only edit, and it does
+  not identify the reference's PR-dependent event law without event-aligned
+  reference residuals. The diagnostic scaffolding was reverted.
+- The existing Compress-mode PR-1.0/-24 dBFS/1 s attack report reaches t90 in
+  9.493 ms versus 15.917 ms on the reference, so a one-knob reduction of the
+  high-drive fast-rate pivot from 18 to 15 dB was tested. It failed its nearest
+  neighbour before programme scoring: short-event charge fitted RMS/worst rose
+  from 0.414244/0.716022 to 0.469745/0.994778 dB and tripped the gate. The pivot
+  was restored to 18 dB. A simple high-drive attack slowdown is therefore not
+  the shared fix.
+
+**Next required reference measurement:** sweep dynamic behaviour across PR
+0.4/0.55/0.7/0.85/1.0 rather than treating event pairing as the missing axis.
+For each PR, use the same level- and crest-controlled dynamic stimulus and its
+stationary control, retain the PR=0 render at the same Gain, and report
+total-RMS GR plus frame p50/p95 and event-aligned attack/inter-event residuals.
+This localises whether the divergence after PR 0.55 is acquired while charging
+or retained between events. The earlier paired-event charge-capacity matrix is
+a downstream discriminator only if the PR sweep demonstrates history-dependent
+retention; it is no longer the next measurement. No further DSP structure is
+justified until the PR-dependent dynamic error is localised.
 
 ## 4. Review findings addressed vs declined (CodeRabbit, two batches)
 
@@ -163,12 +271,29 @@ Declined, with reasons — do not silently re-apply:
   duplication (clamp chains are semantically identical today) but cross-layer
   (core must stay framework-free); small standalone task if wanted.
 
-## 5. After the emulation: UI restyle (#212) and geometry (#213)
+## 5. Parallel Opto UI restyle (#212), shell conformity, and geometry (#213)
 
 - Reference UI 950 x 263 (2U, 3.6:1), vector primitives only, NO third-party
   artwork/marks. LA-2A skin on the Opto panel only; other modes and chrome
   keep the Dusk dark theme. Panel readouts: Peak Reduction and Gain 0-100,
   Comp/Limit, meter reads GR.
+- The stable visible Opto contract is Peak Reduction, Gain, Comp/Limit, the GR
+  meter, compact Mix and 0-500 Hz Sidechain HP trims, plus the shell's
+  eight-button Mode row and Bypass control. The other removed Global/Sidechain
+  controls remain host-visible parameters and keep their state/automation
+  ownership; they are no longer rendered as utility bands. Remaining emulation
+  work is internal and is not expected to add Opto faceplate controls.
+- The GR needle now applies a display-only, elapsed-time 300 ms RC response;
+  Peak Reduction, Gain, and Mix value bubbles are unitless. A GR/+4/+10 meter
+  selector is not implemented: the existing output bridge publishes block peak,
+  and no authoritative RMS integration or +4/+10 digital calibration has been
+  specified. Do not infer those choices from the reference artwork.
+- The uncommitted 2026-08-22 shell pass now uses the Tape Echo 2 header contract:
+  `MULTI-COMP / MC-2 / version`, previous/next factory preset, preset browser,
+  INIT, SAVE, and right-aligned `DUSK AUDIO`. The Opto editor is 1120 x 380;
+  other modes remain 1120 x 486. Both are aspect locked with the active design
+  size as their minimum. `design-qa.md` records the native 2x comparison and
+  interaction evidence.
 - The geometry-contract fix (now in main) is still UNVERIFIED in Logic (AU
   cache needs restart/rescan). `kGeometryDiagnosticEnabled`
   (MultiCompUI.cpp) is now false; flip true only while collecting a host

--- a/PROMPT-MC2-OPTO-GAPS.md
+++ b/PROMPT-MC2-OPTO-GAPS.md
@@ -25,8 +25,9 @@ Then read:
 1. `~/.claude/projects/-Users-marckorte-projects-dusk-audio-plugins/memory/mc2-la2a-campaign.md`
    — long-form campaign log: decisions, reference facts, refuted claims.
 2. `HANDOFF-MC2.md` from the selected worktree — authoritative working state
-   for the 2026-08-22 snapshot. Its gate table matches "Current measured state"
-   below; older revision references inside it are explicitly historical.
+   for the renamed 2026-08-22 snapshot. Its gate table matches "Current measured
+   state" below; pre-rename revision references inside it are explicitly
+   historical.
 3. `~/projects/dusk-audio-tools/plugins/MultiComp/handoff/HANDOFF-2026-08-21.md`
    — the measurement-side handoff, including the seven excluded hypotheses.
 4. `~/projects/dusk-audio-tools/plugins/MultiComp/tests/reference_comparison/README.md`
@@ -39,18 +40,20 @@ memory-curve window). Read per-point data, never a verdict sentence.
 
 ## Repository state
 
-- **Authoritative snapshot: 2026-08-22.** `origin/main` = `c1f9ae4`
-  (Multi-Comp 2 post-merge review follow-ups, #222).
-  The local `main` branch in `~/projects/dusk-audio-plugins` is **stale** at
-  `40f10f8` — fetch before branching off it.
+- **Authoritative renamed snapshot: 2026-08-22.** `origin/main` = `f7edaea`
+  (DAF rename, #223); campaign branch
+  `multi-comp-2/opto-campaign-snapshot` = `d090a7b`. The branch contains the
+  ported Opto gate set; `origin/main` does not.
 - Existing worktree with the build dir already configured:
-  `/private/tmp/claude-502/-Users-marckorte-projects-dusk-audio-plugins/ea21f9ad-379c-40f2-86e2-dfd1e8d95e07/scratchpad/mc2`
-  (branch `multi-comp-2/review-followups` @ `e0a4f21`, plus its pre-existing
-  working-tree changes). Its committed tree is not content-equal to
-  `origin/main`: a direct comparison shows a three-line difference in
-  `MultiCompPlugin.cpp`. Reuse this exact worktree and preserve its dirty state,
-  or reproduce and document the snapshot deliberately; do not work in the
-  primary checkout, which is on an unrelated branch.
+  `/private/tmp/claude-502/-Users-marckorte-projects-dusk-audio-plugins/d3a95f36-6e62-4446-9f5b-32717dcb08a6/scratchpad/mc2-port`
+  (branch `multi-comp-2/opto-campaign-snapshot` @ `d090a7b`). Its tracked tree
+  is the authoritative port; `b/` is its configured, pre-existing untracked
+  build directory and must be preserved. Do not use the unrelated primary
+  checkout or the stale pre-rename worktree.
+- **Historical pre-rename provenance:** `origin/main=c1f9ae4`; campaign branch
+  `multi-comp-2/review-followups=e0a4f21` plus its then-uncommitted changes.
+  These revisions explain where the ported measurements came from but are not
+  valid worktrees for current changes.
 - Opto DSP: `plugins/multi-comp/core/MultiCompModes.hpp` (`processOpto`,
   `OptoState`, the `opto*` coefficient members) and
   `plugins/multi-comp/core/MultiCompDSP.cpp`.
@@ -85,7 +88,14 @@ Second tripwire on macOS: rebuild with `-ffp-contract=off` and diff the gate
 outputs against the normal build. Any gate that moves is a rounding-difference
 amplifier — find the branch, don't retune around it.
 
-## Current measured state (re-run 2026-08-22, macOS clang, `e0a4f21` worktree snapshot)
+Known baseline exception measured on the 2026-08-22 follow-up: all three core
+runs pass, and Linux GCC 12 matches no-contract macOS detector-weighting rows
+within 0.000229 dB. Default macOS differs only in the low-frequency weighting
+rows by up to 0.004563 dB (shape RMS 0.096646 default, 0.098245 no-contract,
+0.098219 Linux). This is not permission to widen gates, and future DSP work
+must still run the full matrix.
+
+## Current measured state (re-run 2026-08-22, macOS clang, `d090a7b` renamed snapshot)
 
 Suite: **PASS**. These are the same authoritative snapshot recorded in
 `HANDOFF-MC2.md`.
@@ -107,23 +117,39 @@ Open gaps, in the order they should be attacked:
 
 | # | gap | current numbers |
 |---|---|---|
-| 1 | dense-programme A/B **not re-measured** since the silence-gate fix | stale: +1.66 dB over-compression, PR 0.7 |
+| 1 | dense-programme A/B | +0.224 / +0.033 / +1.000 / +1.488 / +2.012 dB at PR 0.4/0.55/0.7/0.85/1.0; material crest 17.795 dB |
 | 2 | crest sweep residuals (structural) | -0.141 / -0.540 / **+0.615 held out** / -0.709 dB |
 | 3 | short-event release decay | RMS 0.701, worst **1.386 dB** |
 | 4 | short-event charge | fitted RMS 0.414 worst 0.716; held-out RMS 0.301 worst 0.401 dB |
-| 5 | burst-rate **one-sided** bias, 2-40 Hz | +0.407 / +0.563 / +0.187 / +0.384 / +0.792 dB (all positive, mean +0.47) |
-| 6 | detector weighting **mean offset** | -0.237 dB mean, removed by the gate; shape RMS 0.097 dB; raw worst -0.524 dB @ 20 Hz |
-| 7 | Limit-mode t90 at the extreme | PR 1.0 @ -3 dBFS: ref 36.0 ms vs ours 10.9 ms (-25.1 ms, held out) |
-| 8 | stale comment block in `testOptoCrestSweep` | claims -0.20/-0.26/+0.71/-1.28 and four-row RMS 0.75; actual is now -0.141/-0.540/+0.615/-0.709, four-row RMS ~0.55 |
+| 5 | burst-rate **one-sided** bias, 2-40 Hz | +0.407 / +0.563 / +0.187 / +0.384 / +0.792 dB (all positive, mean +0.47); arithmetic audit clean, structural gap remains |
+| 6 | detector weighting absolute anchor (resolved) | mean -0.237 dB, 1 kHz -0.174 dB, shape RMS 0.097 dB; all three are now guarded |
+| 7 | Limit-mode charge t90 at the extreme | PR 1.0 @ -3 dBFS / 1 s: ref 36.0 ms vs ours 10.9 ms (-25.1 ms, held out); this is charge, not release |
+| 8 | crest comment block (resolved) | now records -0.141/-0.540/+0.615/-0.709 dB and labels the older trajectory historical |
 
 ## Work order
 
-### Step 1 — measure before editing (blocking, no DSP changes until done)
+### Step 1 — measured baseline (complete; repeat after every DSP change)
 
-Re-run the dense-programme A/B against the live reference AU. Nothing else
-starts until this number exists, because every remaining decision depends on
-whether the programme error is still +1.66 dB or now +0.3 to +0.8 dB as the
-current crest rows predict.
+The renamed `d090a7b` VST3 was re-run against the live reference AU on material
+with 17.794665 dB crest. The authoritative sweep is:
+
+| PR | reference GR | our GR | total-RMS residual | frame p50 | frame p95 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 0.40 | 1.664 | 1.887 | +0.224 | +0.264 | +0.805 |
+| 0.55 | 5.956 | 5.989 | +0.033 | +0.152 | +0.881 |
+| 0.70 | 12.928 | 13.927 | +1.000 | +1.196 | +2.239 |
+| 0.85 | 19.286 | 20.774 | +1.488 | +1.656 | +2.843 |
+| 1.00 | 21.192 | 23.204 | +2.012 | +2.206 | +3.403 |
+
+Total-RMS residual mean/worst/RMS is +0.951/+2.012/1.209 dB. Mine-side
+re-renders independently reproduce our PR-0.55 and PR-0.85 GR as 5.989099 and
+20.774064 dB. The campaign table reports PR 1.0 as +2.012 dB; the earlier
+artifact-level calculation was +2.012752 dB, a 0.000752 dB reporting difference
+with no gate impact. Input-duration-only scoring on the earlier three-row sweep
+differs by at most 0.001445 dB, excluding render tail length as the cause. The
+historical +0.3 to +0.8 dB crest-interpolated prediction is falsified: the near
+match at PR 0.4-0.55 becomes monotonic over-compression above PR 0.55. Repeat
+the five-point measurement after any DSP change.
 
 - renderer: `~/projects/dusk-audio-plugins/build/tests/duskverb_render/duskverb_render`
 - reference: `/Library/Audio/Plug-Ins/Components/uaudio_teletronix_la-2a_tc.component`
@@ -137,29 +163,29 @@ current crest rows predict.
   already cost one whole A/B that nearly got recorded as a DSP defect.
 - **GR is always `output(PR=0) - output(PR=x)` at the same Gain**, never
   input minus output.
-- Report the programme delta at PR 0.7 and at least two other PR settings, plus
-  the crest of the material each was measured on.
+- Report all five programme deltas at PR 0.4/0.55/0.7/0.85/1.0, their frame
+  p50/p95 residuals, and the crest of the material.
 
 ### Step 2 — the cheap, provably-bounded items
 
 Do these next; they are small and independent of the structural work.
 
-- **Gap 8**: re-measure, then correct the stale comment block in
-  `testOptoCrestSweep`. Do not loosen the `require()` thresholds to match — if
-  the residuals improved, the thresholds may tighten, never widen.
-- **Gap 5**: five of five burst-rate rows err positive. A one-sided residual is
-  a constant, not noise. Before sweeping anything, grep the burst-rate path for
-  a hardcoded divisor, count, or rate constant — a suspiciously clean bias is
-  an arithmetic bug far more often than a tuning problem.
-- **Gap 6**: decide whether the -0.237 dB detector-weighting mean offset is a
-  real level error in the detector path or an artifact of that gate's operating
-  point. The gate currently subtracts it, which means a real 0.24 dB error would
-  be invisible. Answer with a measurement, then either fix the DSP or document
-  in the test why removing the mean is correct.
-- **Gap 7**: the Limit t90 is 3.3x fast at PR 1.0 / -3 dBFS. Establish whether
-  this is one extreme corner or the visible end of a release-law error that also
-  shows up in gaps 3 and 4 — a shared mechanism would change the priority of the
-  structural work below.
+- **Gap 8 — complete**: the crest comment now records the current residuals and
+  explicitly labels the older trajectory historical. Thresholds were not
+  loosened.
+- **Gap 5 — arithmetic audit complete, gap remains**: all five periods divide
+  48 kHz exactly, each burst is exactly 480 samples, and reference/control use
+  the same stimulus and 6.0-7.5 s scoring window. No divisor, count, or rate
+  mismatch was found; do not retune speculatively from the one-sided sign.
+- **Gap 6 — complete**: the shape score correctly removes its mean, while new
+  absolute assertions pin both the -0.237425 dB mean and -0.174332 dB 1 kHz
+  offsets. The static sine and broadband gates independently own level
+  accuracy. A deliberately broken integration calibration failed the new
+  assertion before the original constant was restored and the suite passed.
+- **Gap 7 — classified**: this gate's t90 is charge/attack, not release. At PR
+  1.0 / -12 dBFS its residual changes from +0.604 ms at 10 ms exposure to
+  -10.437 ms at 100 ms and -12.333 ms at 1 s; the held-out PR 1.0 / -3 dBFS /
+  1 s row is -25.104 ms. Treat it with gap 4, not gap 3.
 
 ### Step 3 — the structural gap (gaps 2, 3, 4)
 
@@ -171,15 +197,47 @@ cannot produce that shape. Our model reproduces the shape but not the residuals.
 detector weighting shape, duty cycle at fixed rate, level variation between
 events, metric windowing, the broadband static law, accumulation across repeated
 events, a 0.8 ms integrator, 6000 dB/s cell slew, a 0.4 ms reservoir plus slew,
-shorter reservoirs, and a duration-gated charge cap. Each of the last five fixed
-one row and broke burst-rate or a neighbour.
+shorter reservoirs, a duration-gated charge cap, scaling the repetition blend,
+and a power/RMS rectifier. Scaling repetition blend to 75% raised fitted crest
+RMS from 0.521 to 1.338 dB; the calibrated power rectifier raised short-event
+recovery RMS from 0.701056 to 1.032525 dB and worst error from 1.385892 to
+3.064520 dB. Both were reverted. A dense-stimulus diagnostic then found the
+integrated path already controls `min(peak, integrated)` in 92.0733% of blocks,
+with mean path separation increasing from +1.219 dB in the loudest input-RMS
+quintile to +2.784 dB in the quietest. Parameter-free below-minimum competition
+(`min^2/max`) worsened crest fitted RMS 0.521 -> 1.131 dB and worst error
+0.709 -> 1.903 dB, so nonlinear two-path competition was also reverted.
+
+A temporary five-PR dense diagnostic also found cell state above the current
+target in 84.181-87.921% of 16-sample blocks. Mean retained excess was
+0.960528/1.791087/2.097717/2.108555/2.006334 dB at PR
+0.4/0.55/0.7/0.85/1.0. At PR 1.0 the fast/mid/slow contributions were
+0.663660/0.860702/0.534533 dB, and `repetitionBlend` was zero throughout. The
+error is not owned by one charge population or the repetition path; the
+temporary diagnostic scaffolding was reverted.
+
+The Compress-mode PR-1.0/-24 dBFS/1 s attack report reaches t90 in 9.493 ms
+versus 15.917 ms on the reference. Lowering the existing high-drive fast-rate
+pivot from 18 to 15 dB was tested as a one-knob slowdown, but short-event charge
+fitted RMS/worst worsened from 0.414244/0.716022 to 0.469745/0.994778 dB and
+failed before programme scoring. The pivot was restored; do not repeat this
+simple rate change.
 
 **Do not fit another correction term on top of the existing model.** A real fix
-needs structure the model lacks. The candidates that have not been tested:
+now needs a new reference discriminator. The source already implements
+capacity-limited charge in `followTarget`: attack rate depends on remaining
+capacity with fast/slow exponents 5.1/1.5 and a fast minimum rate of 0.150.
+Adding another charge reservoir from the existing single-event and periodic
+burst rows would be an unidentifiable correction, not a measured mechanism.
 
-- two detector paths combining **nonlinearly** rather than by max or sum,
-- charge saturation on very short events,
-- a rectifier law that is not plain magnitude.
+Before another DSP edit, localise the newly measured PR axis. At PR
+0.4/0.55/0.7/0.85/1.0, run the same level- and crest-controlled dynamic
+stimulus and a stationary control, always with a PR=0 render at the same Gain.
+Record total-RMS GR, frame p50/p95, and event-aligned attack/inter-event
+residuals. The discriminator is whether the divergence acquired above PR 0.55
+appears during charge or persists through the gaps. The paired-event
+charge-capacity matrix is deferred unless this PR sweep specifically shows
+history-dependent retention.
 
 State the hypothesis and the experiment that would falsify it **before** editing
 anything structural. One knob per iteration, fresh measurement between. If a
@@ -192,29 +250,37 @@ marginal win, and it belongs in the campaign log where the next session looks.
 
 ## Hard scope walls
 
-- **Opto mode only.** Bugs found in the other seven modes get GitHub issues, not
-  fixes. Known and deferred: #220, plus the same `external ? sidechain : input`
-  dead-link bug that likely exists in VCA (~line 854) and Bus (~line 960) of
-  `MultiCompModes.hpp` — that needs its own issue, not a patch in this work.
-- **No UI work.** The LA-2A panel restyle (#212) and the geometry contract
-  (#213) are a separate task, after the emulation is finished.
+- **DSP and per-mode panels: Opto mode only.** Bugs found in the other seven
+  modes get GitHub issues, not fixes. Known and deferred: #220, plus the same
+  `external ? sidechain : input` dead-link bug that likely exists in VCA
+  (~line 854) and Bus (~line 960) of `MultiCompModes.hpp` — that needs its own
+  issue, not a patch in this work. Owner-directed shell conformity is the sole
+  cross-mode UI exception: the visible Global/Sidechain bands are removed and
+  the shared header follows TapeMachine 2 / Tape Echo 2, while their parameters
+  remain available to host state and automation.
+- **Keep UI and DSP iterations isolated.** On 2026-08-22 the owner authorised
+  the Opto panel restyle (#212) to proceed in parallel while reference DSP
+  measurements are pending. The later 2026-08-22 shell-conformity direction is
+  implemented in the working tree as a 1120 x 486 header/layout change; do not
+  treat it as authority to alter the seven other mode panels. Do not mix visual
+  edits into a DSP experiment. Geometry-contract verification (#213) remains a
+  separate host-validation task.
 - **Idle-state harmonics are out of scope.** Worst idle error is 1.86 dB on H5
   at roughly -110 dBc. Inaudible. Leave it.
-- **Do not touch** `.github/workflows/daf-build.yml` — it carries the owner's own
-  uncommitted edit.
+- **Do not touch** `.github/workflows/daf-build.yml` — it carries the owner's
+  selective dispatch edit, committed in the campaign snapshot but outside this
+  task.
 - **DAF and DAF-Widgets are HARD FORKS. `DISTRHO/DPF` and
   `DISTRHO/DPF-Widgets` are not references — never read, diff, cherry-pick,
   merge from, or cite upstream, and never point any build or CI at it.** Ours
   are `dusk-audio/DAF` and `dusk-audio/DAF-Widgets`; CI pins them at
-  `eb54f2f4` and `668de17f`. There is no "upstream fixed it" path.
+  `788eb019` and `91e0004e`. There is no "upstream fixed it" path.
 - **Do not modify the fork checkout at `~/projects/DAF`** either. The build
   consumes it via `-DDAF_PATH=$HOME/projects/DAF`; a local edit makes your build
   disagree with CI, which clones the pinned ref — you would be measuring a
-  framework nobody else has. If a build breaks, fix the plugin code. Note the
-  checkout is on `main` at `74451d58`. The AU render-guard commit is merged to
-  fork `main` (as `49aa4d41`, PR #14), so `HANDOFF-MC2.md` §2 is correct on that
-  point. CI still pins the older `eb54f2f4`, which predates it — bumping that pin
-  is a deliberate framework advance, not part of this task.
+  framework nobody else has. If a build breaks, fix the plugin code. The local
+  framework checkouts and CI are currently aligned at `788eb019` and `91e0004e`;
+  advancing either pin is not part of this task.
 - Do not re-apply the review findings that were declined with reasons (UI
   minimum size, deriving test thresholds from production constants, splitting
   fast/slow test targets, PR=0 baseline caching). They are listed with rationale

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,92 @@
+# Multi-Comp 2 Opto Rack-Proportion QA
+
+## Evidence
+
+- Source visual truth: `b/uad-la2a-silver-reference.png`, the official 1908 x
+  530 UAD LA-2A Silver faceplate supplied as the realism and density reference.
+- Initial compact implementation: `b/mc2-opto-compact-preview.png`.
+- Revised native implementation: `b/mc2-opto-centered-preview.png`.
+- Normalized implementation faceplate: `b/mc2-opto-faceplate-normalized.png`.
+- Full-view comparison input: `b/mc2-opto-reference-comparison.png`, with the
+  source on top and the revised implementation below in the same image.
+- Focused VU comparison input: `b/mc2-opto-vu-comparison.png`, with the source on
+  the left and the revised implementation on the right.
+- State: Opto mode, Smooth Opto Vocal, Compress, bypass off.
+- Native viewport: 1120 x 380 design pixels; captured as a 2464 x 1048 macOS
+  window at 2x backing density, including the title bar and capture shadow.
+- Density normalization: the 2240 x 620 implementation faceplate was cropped
+  from the native capture, downsampled to 1908 x 528 with Lanczos, and padded by
+  one pixel above and below to match the source's 1908 x 530 dimensions.
+
+## Findings
+
+No actionable P0, P1, or P2 visual differences remain for the requested rack
+proportion, control centering, or VU correction.
+
+- Fonts and typography: the implementation preserves the product's established
+  crisp sans hierarchy while following the source's large red faceplate title,
+  compact engraved control labels, and restrained meter typography. The Dusk
+  wording is intentionally original rather than reproducing the source logo.
+- Spacing and layout rhythm: the implementation faceplate is 1120 x 310 design
+  pixels, an aspect of 3.613:1 versus the 3.600:1 source. The switch and main
+  knob centers sit at 54.8% of faceplate height, matching the source's visual
+  center and leaving a narrow, even lower rail instead of a blank lower field.
+- Colors and visual tokens: brushed silver, graphite housings, amber meter
+  illumination, black engraving, and restrained red accents retain the source's
+  hardware palette without copying its branding.
+- Image quality and asset fidelity: the native renderer is sharp at 2x, with no
+  stretched bitmap, placeholder, halo, or compression artifact. Hardware is
+  rendered in the plugin's established DAF style; no third-party logo asset is
+  reproduced.
+- Copy and content: the face says `LEVELING AMPLIFIER`; `DUSK AUDIO` appears only
+  in the common header. Gain, Peak Reduction, Mix, Compress/Limit, GR, and Opto
+  Cell labels remain complete and coherent.
+- Icons and hardware details: rack slots, fasteners, knob scales, pointer marks,
+  switch hardware, and the meter bezel remain aligned and stylistically
+  consistent. The common-header arrows and actions are unchanged.
+- Accessibility and resilience: active Compress/Limit state uses switch position,
+  label brightness, and a red rule rather than color alone. Uniform aspect-locked
+  scaling preserves text and hit-target relationships.
+- Interaction/state scope: the edited knob and switch hit areas use the same
+  coordinates as their visible bodies. Mode-height selection is covered by the
+  plugin-layer regression for Opto, fractional automation around the mode
+  boundary, non-Opto modes, and Multiband. Browser-console checks are not
+  applicable to this native DAF/OpenGL editor.
+
+The full comparison shows the complete rack composition at matched dimensions.
+The focused meter comparison was required because the initial compact pass left
+the arc radius from the former tall housing, which was difficult to judge at
+full-view scale.
+
+## Comparison History
+
+- Initial P1: the previous 1120 x 416 faceplate had a 2.692:1 aspect and retained
+  substantially more lower chassis than the 3.600:1 source.
+- Fix: reduced the Opto faceplate to 1120 x 310 and the Opto editor to 1120 x 380.
+  Added mode-aware geometry so non-Opto modes, especially Multiband, retain the
+  original 1120 x 486 canvas.
+- Post-fix P2: `b/mc2-opto-compact-preview.png` showed the switch and knobs below
+  the faceplate's visual center, while the unchanged 185-pixel VU radius crowded
+  the shortened meter's top label and tick arc.
+- Fix: moved the switch, Gain, Peak Reduction, and Mix centers up by 45 design
+  pixels and recalibrated the VU radius from 185 to 165 design pixels.
+- Post-fix evidence: `b/mc2-opto-reference-comparison.png` shows matched rack
+  proportion and centered controls; `b/mc2-opto-vu-comparison.png` shows clear
+  separation between the VU title, arc, labels, and needle.
+
+## Implementation Checklist
+
+- [x] Match the source-like shallow rack proportion.
+- [x] Remove the excessive lower empty field.
+- [x] Center the switch and knobs vertically.
+- [x] Recalibrate the VU arc for the shorter housing.
+- [x] Keep original Dusk branding and copy.
+- [x] Preserve the taller canvas for all non-Opto modes.
+- [x] Compare source and revised implementation together at equal dimensions.
+- [x] Inspect the meter in a focused, equal-size comparison.
+
+## Follow-up Polish
+
+No P3 visual follow-up is required for this scope.
+
+final result: passed

--- a/plugins/multi-comp/core/MultiCompModes.hpp
+++ b/plugins/multi-comp/core/MultiCompModes.hpp
@@ -66,11 +66,35 @@ public:
         const double newFs = sampleRate > 0.0 ? sampleRate : 48000.0;
         const int newFactor = oversamplingFactor == 4 ? 4 : (oversamplingFactor == 2 ? 2 : 1);
         if (newFs == fs && newFactor == osFactor) return;
+        const double oldModeRate = fs * osFactor;
         fs = newFs;
         osFactor = newFactor;
         const float sr = static_cast<float>(fs * osFactor);
         transientShaper.setRate(sr);
         updateRateCoefficients(sr);
+        // The Opto fields below store elapsed or remaining samples. Preserve
+        // their physical time when runtime oversampling changes the rate.
+        const double counterScale = static_cast<double>(sr) / oldModeRate;
+        const auto scaleCounter = [counterScale](int value, int maximum) {
+            if (value <= 0) return 0;
+            return std::min(maximum, std::max(1, static_cast<int>(
+                std::lround(static_cast<double>(value) * counterScale))));
+        };
+        for (auto& d : opto)
+        {
+            d.detectorExposureSamples = scaleCounter(
+                d.detectorExposureSamples, optoChargeTopOffSamples);
+            d.detectorFloorOnlySamples = scaleCounter(
+                d.detectorFloorOnlySamples, optoDetectorFloorHoldSamples);
+            d.detectorUnsupportedSamples = scaleCounter(
+                d.detectorUnsupportedSamples, optoDetectorSilenceHoldSamples);
+            d.detectorReleaseExposureSamples = scaleCounter(
+                d.detectorReleaseExposureSamples, optoChargeTopOffSamples);
+            d.detectorSilentSamples = scaleCounter(
+                d.detectorSilentSamples, optoDetectorSilenceHoldSamples);
+            d.colourPeakHold = scaleCounter(
+                d.colourPeakHold, optoColourPeakHoldSamples);
+        }
         updateHardwareRate(sr);
         selectHardwareGains();
     }
@@ -140,7 +164,15 @@ private:
         float gain = 1, detectorLevel = 0, detectorPeak = 0;
         float colourPeak = 0, colourDc = 0;
         float fastGrDb = 0, midGrDb = 0, slowGrDb = 0;
-        int detectorExposureSamples = 0, colourPeakHold = 0;
+        float fastSustainedTargetDb = 0;
+        float fastAttackReferencePhase = 0;
+        float programmeMemory = 0;
+        float detectorFloorPeak = 0, nextEventWeight = 1;
+        int detectorExposureSamples = 0, detectorFloorOnlySamples = 0;
+        int detectorUnsupportedSamples = 0;
+        int detectorReleaseExposureSamples = 0;
+        int colourPeakHold = 0;
+        bool detectorEventActive = false;
         // Starts saturated so a freshly reset state counts as silent.
         int detectorSilentSamples = 1 << 20;
     };
@@ -192,12 +224,20 @@ private:
     std::array<std::array<Biquad, kOptoDetectorSections>, kChannels> optoDetectorWeighting;
     float optoInvSampleRate = 1.0f / 48000.0f;
     float optoDetectorAttack = 0, optoDetectorRelease = 0;
+    float optoDetectorFloorPeakAttack = 0, optoDetectorFloorPeakRelease = 0;
     float optoDetectorPeakAttack = 0, optoDetectorPeakRelease = 0;
     float optoColourPeakRelease = 0, optoColourDcSmoothing = 0;
-    int optoChargeTopOffSamples = 1, optoColourPeakHoldSamples = 1;
-    int optoDetectorSilenceHoldSamples = 1;
-    float optoFastAttack = 0, optoSlowAttack = 0;
-    float optoFastRelease = 0, optoMidRelease = 0, optoSlowRelease = 0;
+    int optoChargeTopOffSamples = 1, optoFastPathSamples = 1;
+    int optoColourPeakHoldSamples = 1;
+    int optoDetectorSilenceHoldSamples = 1, optoDetectorFloorHoldSamples = 1;
+    float optoSlowAttack = 0;
+    float optoSustainedTargetSmoothing = 0, optoSustainedTopOffAttack = 0;
+    float optoLimitFastTopOffAttack = 0, optoLimitSlowTopOffAttack = 0;
+    float optoFastAttackAtCalibrationRate = 0;
+    float optoCalibrationRateRatio = 1;
+    float optoFlashRelease = 0, optoFastRelease = 0;
+    float optoMidRelease = 0, optoSlowRelease = 0;
+    float optoProgrammeMemoryRelease = 0;
     float fetTilt = 0, fetHardwareGain = 1.0f;
     float busHardwareGain = 1.0f;
     std::array<float, 3> fetHardwareGains{{1.0f, 1.0f, 1.0f}};
@@ -234,28 +274,43 @@ private:
     {
         optoInvSampleRate = 1.0f / sr;
         // The 0.4 ms / 8 ms rectifier supplies the programme integration that
-        // separates sustained energy from unsupported peaks.  The original
-        // 50 us / 40 ms peak follower remains as a ceiling after calibration;
-        // it does not drive a second gain-cell path.
+        // separates sustained energy from unsupported peaks. The 50 us /
+        // 40 ms follower supplies both the calibrated ceiling and the first
+        // 1.5 ms of the isolated-event fast-cell target.
         constexpr float detectorAttackSeconds = 0.000400f;
         optoDetectorAttack = std::exp(-optoInvSampleRate / detectorAttackSeconds);
         optoDetectorRelease = std::exp(-optoInvSampleRate / 0.008f);
+        optoDetectorFloorPeakAttack = std::exp(-optoInvSampleRate / 0.010f);
+        optoDetectorFloorPeakRelease = std::exp(-optoInvSampleRate / 0.100f);
         optoDetectorPeakAttack = std::exp(-optoInvSampleRate / 0.000050f);
         optoDetectorPeakRelease = std::exp(-optoInvSampleRate / 0.040f);
         optoColourPeakRelease = std::exp(-optoInvSampleRate / 0.040f);
         optoChargeTopOffSamples = std::max(1, static_cast<int>(
             std::lround(0.020f * sr)));
+        optoFastPathSamples = std::max(1, static_cast<int>(
+            std::lround(0.0015f * sr)));
         optoColourPeakHoldSamples = std::max(1, static_cast<int>(
             std::lround(0.002f * sr)));
         optoDetectorSilenceHoldSamples = std::max(1, static_cast<int>(
             std::lround(0.0005f * sr)));
+        optoDetectorFloorHoldSamples = std::max(1, static_cast<int>(
+            std::lround(0.030f * sr)));
         optoColourDcSmoothing = 1.0f - std::exp(
             -kDuskTwoPi * 10.0f * optoInvSampleRate);
-        optoFastAttack = std::exp(-optoInvSampleRate / 0.021f);
+        constexpr float optoCalibrationRate = 96000.0f;
+        optoFastAttackAtCalibrationRate = std::exp(
+            -1.0f / (0.021f * optoCalibrationRate));
+        optoCalibrationRateRatio = optoCalibrationRate / sr;
         optoSlowAttack = std::exp(-optoInvSampleRate / 0.190f);
+        optoSustainedTargetSmoothing = std::exp(-optoInvSampleRate / 0.001f);
+        optoSustainedTopOffAttack = std::exp(-optoInvSampleRate / 0.014f);
+        optoLimitFastTopOffAttack = std::exp(-optoInvSampleRate / 0.0013f);
+        optoLimitSlowTopOffAttack = std::exp(-optoInvSampleRate / 0.0037f);
+        optoFlashRelease = std::exp(-optoInvSampleRate / 0.010f);
         optoFastRelease = std::exp(-optoInvSampleRate / 0.064f);
         optoMidRelease = std::exp(-optoInvSampleRate / 0.185f);
         optoSlowRelease = std::exp(-optoInvSampleRate / 1.174f);
+        optoProgrammeMemoryRelease = std::exp(-optoInvSampleRate / 0.250f);
         fetTilt = 1.0f - std::exp(-2.0f * kDuskPi * 800.0f / sr);
         // Measured UAD LA-2A detector weighting. The shelf's equivalent Q is
         // the JSON fit's S=0.6998415302 converted to the RBJ shelf-Q form.
@@ -420,8 +475,43 @@ private:
         if (position <= 0.0f)
             return std::max(0.0f, curve[0] + position * (curve[1] - curve[0]));
         if (position >= static_cast<float>(curve.size() - 1))
-            return curve.back() + (position - static_cast<float>(curve.size() - 1))
-                * (curve.back() - curve[curve.size() - 2]);
+        {
+            const float extraPosition
+                = position - static_cast<float>(curve.size() - 1);
+            if (limit)
+                return curve.back() + extraPosition
+                    * (curve.back() - curve[curve.size() - 2]);
+
+            // Transition from the table's final measured slope to just below
+            // unity (1.90 dB GR per 2 dB input), then approach the Limit
+            // continuation smoothly. Both joins are C1: a hard slope change at
+            // the table edge and the old min() crossing produced unmeasured
+            // output-slope steps.
+            constexpr float compressInitialSlope = 1.90f;
+            constexpr float slopeTransitionPositions = 0.10f;
+            const float tableEndSlope = curve.back()
+                - curve[curve.size() - 2];
+            if (extraPosition < slopeTransitionPositions)
+                return curve.back() + tableEndSlope * extraPosition
+                    + (compressInitialSlope - tableEndSlope)
+                        * extraPosition * extraPosition
+                        / (2.0f * slopeTransitionPositions);
+            const float limitSlope = kOptoLimitCurve.back()
+                - kOptoLimitCurve[kOptoLimitCurve.size() - 2];
+            const float limitContinuation = kOptoLimitCurve.back()
+                + extraPosition * limitSlope;
+            const float transitionValue = curve.back()
+                + slopeTransitionPositions
+                    * (tableEndSlope + compressInitialSlope) * 0.5f;
+            const float limitAtTransition = kOptoLimitCurve.back()
+                + slopeTransitionPositions * limitSlope;
+            const float initialGap = limitAtTransition - transitionValue;
+            const float convergenceRate = (compressInitialSlope - limitSlope)
+                / initialGap;
+            return limitContinuation - initialGap
+                * std::exp(-convergenceRate
+                    * (extraPosition - slopeTransitionPositions));
+        }
         const size_t index = static_cast<size_t>(position);
         const float fraction = position - static_cast<float>(index);
         return curve[index] + fraction * (curve[index + 1] - curve[index]);
@@ -524,9 +614,6 @@ private:
             ++d.detectorSilentSamples;
         const bool hasDetectorInput
             = d.detectorSilentSamples < optoDetectorSilenceHoldSamples;
-        d.detectorExposureSamples = hasDetectorInput
-            ? std::min(d.detectorExposureSamples + 1, optoChargeTopOffSamples)
-            : 0;
         for (auto& filter : optoDetectorWeighting[static_cast<size_t>(ch)])
             sc = filter.process(sc);
         const float pr = std::clamp(p.optoPeakReduction.load(std::memory_order_relaxed), 0.0f, 100.0f);
@@ -541,6 +628,68 @@ private:
             ? optoDetectorPeakAttack : optoDetectorPeakRelease;
         d.detectorPeak = detectorAbs
             + (d.detectorPeak - detectorAbs) * detectorPeakCoeff;
+        constexpr float detectorSupportFloor = 0.006309573f; // -44 dBFS
+        const bool detectorAboveSupportFloor
+            = detectorInputAbs > detectorSupportFloor;
+        // A persistent sub-audible floor can keep the relative silence gate
+        // open. Require 30 ms: even a 20 Hz sine whose peak only just clears
+        // the support floor returns above it within 25 ms, so audible
+        // low-frequency zero crossings cannot masquerade as floor noise.
+        const bool hadPersistentFloor
+            = d.detectorFloorOnlySamples >= optoDetectorFloorHoldSamples;
+        if (detectorAboveSupportFloor
+            && hadPersistentFloor)
+        {
+            // A hard reset at detectorSupportFloor made otherwise identical
+            // events over -43 and -45 dBFS beds differ by 6.84 dB. Blend the
+            // retained exposure across the sub-audible floor range: a -80 dBFS
+            // or lower floor behaves as silence, while the blend reaches the
+            // uninterrupted-exposure path continuously at -44 dBFS.
+            constexpr float lowestExposureFloorDb = -80.0f;
+            constexpr float detectorSupportFloorDb = -44.0f;
+            const float floorExposurePosition = std::clamp(
+                (gainToDecibels(std::max(d.detectorFloorPeak, 1.0e-12f))
+                    - lowestExposureFloorDb)
+                    / (detectorSupportFloorDb - lowestExposureFloorDb),
+                0.0f, 1.0f);
+            const float floorExposureBlend = floorExposurePosition
+                * floorExposurePosition * (3.0f - 2.0f * floorExposurePosition);
+            d.detectorExposureSamples = static_cast<int>(std::lround(
+                static_cast<float>(d.detectorExposureSamples)
+                    * floorExposureBlend));
+            d.detectorEventActive = false;
+            d.nextEventWeight = 1.0f - floorExposureBlend;
+        }
+        // Once a real floor starts, bridge its exact waveform-zero samples;
+        // do not turn an untouched run of digital zero into floor history.
+        const bool floorSignalPresent = detectorInputAbs > 1.0e-12f
+            || d.detectorFloorOnlySamples > 0;
+        if (!detectorAboveSupportFloor && floorSignalPresent)
+        {
+            // Track the recent floor rather than freezing the first few
+            // samples after the signal crosses -44 dBFS. The 10 ms attack /
+            // 100 ms release spans low-frequency cycles but forgets a decayed
+            // tail before a later event. The slower attack also prevents the few
+            // below-threshold samples at an event's rising edge from
+            // materially contaminating the estimate before it is consumed.
+            const float floorPeakCoeff
+                = detectorInputAbs > d.detectorFloorPeak
+                    ? optoDetectorFloorPeakAttack
+                    : optoDetectorFloorPeakRelease;
+            d.detectorFloorPeak = detectorInputAbs
+                + (d.detectorFloorPeak - detectorInputAbs) * floorPeakCoeff;
+            d.detectorFloorOnlySamples = std::min(
+                d.detectorFloorOnlySamples + 1, optoDetectorFloorHoldSamples);
+        }
+        else
+        {
+            d.detectorFloorOnlySamples = 0;
+            d.detectorFloorPeak = 0.0f;
+        }
+        const int previousDetectorExposureSamples = d.detectorExposureSamples;
+        d.detectorExposureSamples = hasDetectorInput
+            ? std::min(d.detectorExposureSamples + 1, optoChargeTopOffSamples)
+            : 0;
         // The static law was measured with the original 50 us / 40 ms peak
         // follower on a 997 Hz sine.  At 48 kHz, fixed-point iteration of one
         // full-wave period gives peaks of 0.925093862 for the 0.4 ms / 8 ms
@@ -565,10 +714,20 @@ private:
         const float fluctuationDb = std::clamp(
             detectorSeparationDb - sineSeparationGuardDb,
             0.0f, maximumFittedSeparationDb - sineSeparationGuardDb);
+        const float exposureSaturation = std::clamp(
+            static_cast<float>(d.detectorExposureSamples)
+                / static_cast<float>(optoChargeTopOffSamples),
+            0.0f, 1.0f);
+        const float sustainedExposurePosition = std::clamp(
+            (exposureSaturation - 0.75f) / 0.25f, 0.0f, 1.0f);
+        const float sustainedExposureBlend = sustainedExposurePosition
+            * sustainedExposurePosition * (3.0f - 2.0f * sustainedExposurePosition);
         // The constrained fit uses the -36/-30/-18/-12 dBFS broadband points
-        // while retaining the crest triplet; -24 dBFS is held out.
+        // while retaining the crest triplet; -24 dBFS is held out. Sustained
+        // exposure uses the separately measured dense-programme correction.
         constexpr float broadbandFitPivotDb = -18.0f;
-        constexpr float broadbandFitAtPivot = 0.010f;
+        const float broadbandFitAtPivot = 0.010f
+            + (0.055f - 0.010f) * sustainedExposureBlend;
         constexpr float broadbandFitSlope = -0.0167f;
         const float broadbandCorrectionDb = fluctuationDb
             * (broadbandFitAtPivot + broadbandFitSlope
@@ -578,6 +737,29 @@ private:
         const float thresholdDb = optoThresholdDb(pr, limit);
         const float overdriveDb = inputLevelDb - thresholdDb;
         const float targetGrDb = pr <= 10.0f ? 0.0f : optoCurveDb(overdriveDb, limit);
+        // The fast cell has a second, peak-fed charge path. The isolated event
+        // grid shows full peak contribution at -12 dBFS but progressively
+        // companded contribution toward 0 dBFS; sustained signals are
+        // unchanged because their calibrated integrated and peak levels meet.
+        const float peakInputLevelDb = uncorrectedInputLevelDb
+            + std::max(0.0f, detectorSeparationDb);
+        const float peakSeparationDb = std::max(
+            0.0f, peakInputLevelDb - inputLevelDb);
+        const float fastLevelBlend = std::clamp(
+            -peakInputLevelDb / 12.0f, 0.0f, 1.0f);
+        const float fastExposureBlend = std::clamp(
+            1.0f - static_cast<float>(
+                d.detectorExposureSamples - optoDetectorSilenceHoldSamples)
+                / static_cast<float>(std::max(
+                    1, optoFastPathSamples - optoDetectorSilenceHoldSamples)),
+            0.0f, 1.0f);
+        const float fastPeakBlend = fastLevelBlend * fastExposureBlend;
+        const float fastInputLevelDb = inputLevelDb
+            + peakSeparationDb * fastPeakBlend;
+        const float fastTargetGrDb = pr <= 10.0f ? 0.0f
+            : fastPeakBlend > 0.0f
+                ? optoCurveDb(fastInputLevelDb - thresholdDb, limit)
+                : targetGrDb;
         // The release populations partition, rather than augment, the static
         // law. Their measured 11.02 / 8.01 / 3.20 dB amplitudes sum to the
         // 22.23 dB target at the memory-curve operating point.
@@ -593,47 +775,151 @@ private:
         constexpr float lowDriveSlowShare = 2.674f / lowDriveTotal;
         const float driveBlend = 1.0f / (1.0f + std::exp(
             -(overdriveDb - 5.0f) / 0.8f));
-        const float fastShare = lowDriveFastShare
+        const float baseFastShare = lowDriveFastShare
             + (highDriveFastShare - lowDriveFastShare) * driveBlend;
-        const float midShare = lowDriveMidShare
+        const float baseMidShare = lowDriveMidShare
             + (highDriveMidShare - lowDriveMidShare) * driveBlend;
+        const float limitFastShareBoost = limit ? 0.175f : 0.0f;
+        const float fastShare = baseFastShare + limitFastShareBoost;
+        const float midShare = baseMidShare - limitFastShareBoost;
         const float slowShare = lowDriveSlowShare
             + (highDriveSlowShare - lowDriveSlowShare) * driveBlend;
-        // The measured 21 ms fast charge applies at the amplitude-fit point.
-        // At high drive, the independent rate and remaining-capacity exponents
-        // are calibrated against the 2/5/20/40 Hz repeated-burst points (10 Hz
-        // held out). An empty population charges quickly, then its rate falls
-        // as it approaches capacity. This raises the per-event charge without
-        // turning dense repetition into an equivalent sustained tone.
+        // The base 21 ms fast charge applies at the amplitude-fit point. At
+        // high drive, the rate and remaining-capacity exponents are calibrated
+        // jointly against isolated events and the 2/5/20/40 Hz repeated-burst
+        // points (10 Hz held out). An empty population charges quickly, then
+        // slows as it approaches capacity.
         constexpr float lowDriveAttackRate = 2.1f;
-        constexpr float highDriveFastAttackRate = 200.0f;
+        constexpr float highDriveFastAttackRate = 1600.0f;
         constexpr float highDriveSlowAttackRate = 200.0f;
-        constexpr float highDriveFastChargeExponent = 3.0f;
+        constexpr float highDriveFastChargeExponent = 5.1f;
         constexpr float highDriveSlowChargeExponent = 1.5f;
         constexpr float highDriveFastMinimumChargeRate = 0.150f;
+        // The isolated-event grid shows that empty-cell charge is much less
+        // level-dependent than final GR capacity. Scale the high-drive rate
+        // inversely around the fitted 18 dB pivot; later fill remains limited
+        // by the capacity exponent below.
+        constexpr float fastRatePivotDb = 18.0f;
+        const float fastRateRatio
+            = fastRatePivotDb / std::max(targetGrDb, 1.0f);
+        const float fastRateRatioSquared = fastRateRatio * fastRateRatio;
+        const float fastRateCompanding = std::clamp(
+            fastRateRatioSquared * fastRateRatioSquared, 0.25f, 2.0f);
+        const float compandedFastAttackRate
+            = highDriveFastAttackRate * fastRateCompanding;
+        const float fastExposureRateScale = 1.0f - sustainedExposureBlend;
         const float fastAttackRate = lowDriveAttackRate
-            + (highDriveFastAttackRate - lowDriveAttackRate) * driveBlend;
+            + (compandedFastAttackRate * fastExposureRateScale
+                - lowDriveAttackRate) * driveBlend;
+        const float selectedHighDriveSlowAttackRate = limit
+            ? 50.0f : highDriveSlowAttackRate;
         const float slowAttackRate = lowDriveAttackRate
-            + (highDriveSlowAttackRate - lowDriveAttackRate) * driveBlend;
+            + (selectedHighDriveSlowAttackRate - lowDriveAttackRate) * driveBlend;
+        const float limitSlowRateBlend = std::clamp(
+            (pr - 60.0f) / 40.0f, 0.0f, 1.0f);
+        const float selectedLimitSlowPopulationAttackRate = 5.0f
+            + (35.0f - 5.0f) * limitSlowRateBlend;
+        const float limitSlowPopulationAttackRate = lowDriveAttackRate
+            + (selectedLimitSlowPopulationAttackRate - lowDriveAttackRate)
+                * driveBlend;
         const float fastChargeExponent = 1.0f
             + (highDriveFastChargeExponent - 1.0f) * driveBlend;
         const float slowChargeExponent = 1.0f
             + (highDriveSlowChargeExponent - 1.0f) * driveBlend;
-        // A finite top-off rate applies only after 20 ms of uninterrupted
-        // exposure. It lets a sustained source reach cell capacity without
-        // changing the charge of the measured 5 ms and 10 ms burst events.
-        const float fastMinimumChargeRate
-            = d.detectorExposureSamples >= optoChargeTopOffSamples
-                ? highDriveFastMinimumChargeRate * driveBlend : 0.0f;
-        const float fastAttackCoeff = std::max(
-            0.0f, 1.0f - (1.0f - optoFastAttack) * fastAttackRate);
+        const float fastCellTargetGrDb = fastShare * fastTargetGrDb;
+        d.fastSustainedTargetDb = fastCellTargetGrDb
+            + (d.fastSustainedTargetDb - fastCellTargetGrDb)
+                * optoSustainedTargetSmoothing;
+        // The nonlinear attack was fitted at the shipping 2x processing rate
+        // (96 kHz). Advance that discrete charge law on a fixed 96 kHz clock;
+        // scaling 1-coeff at the processing rate saturates at different attack
+        // rates for 1x, 2x and 4x.
+        const float fastAttackCoeffAtCalibrationRate = std::max(
+            0.0f, 1.0f
+                - (1.0f - optoFastAttackAtCalibrationRate) * fastAttackRate);
+        d.fastAttackReferencePhase += optoCalibrationRateRatio;
+        const int fastAttackReferenceSteps = static_cast<int>(
+            d.fastAttackReferencePhase);
+        d.fastAttackReferencePhase -= static_cast<float>(
+            fastAttackReferenceSteps);
         const float slowAttackCoeff = std::max(
             0.0f, 1.0f - (1.0f - optoSlowAttack) * slowAttackRate);
+        const float slowPopulationAttackCoeff = limit ? std::max(
+            0.0f, 1.0f - (1.0f - optoSlowAttack)
+                * limitSlowPopulationAttackRate) : slowAttackCoeff;
         const bool detectorDriven = detectorAbs > effectiveDetectorLevel * 0.4f;
-        const auto followTarget = [detectorDriven, hasDetectorInput](
+        // Support is intentionally judged against the frequency-weighted peak:
+        // replacing it with an unweighted peak preserves the 1 kHz grid but
+        // adds 0.55 dB of over-compression on the dense reference programme.
+        const bool detectorInputPeakSupported = detectorInputAbs
+                > detectorSupportFloor || detectorInputAbs
+            > std::max(d.detectorPeak * 0.04f, 1.0e-9f);
+        const bool detectorInputStartsNewEvent = detectorInputAbs
+            > std::max(d.detectorPeak * 0.50f, 1.0e-9f);
+        const int previousUnsupportedSamples = d.detectorUnsupportedSamples;
+        d.detectorUnsupportedSamples = detectorInputPeakSupported
+            ? 0 : std::min(d.detectorUnsupportedSamples + 1,
+                           optoDetectorSilenceHoldSamples);
+        const bool detectorSupported = detectorInputPeakSupported
+            || d.detectorUnsupportedSamples < optoDetectorSilenceHoldSamples;
+        d.programmeMemory *= optoProgrammeMemoryRelease;
+        if (hasDetectorInput && detectorAboveSupportFloor
+            && !d.detectorEventActive)
+        {
+            d.programmeMemory = std::min(
+                d.programmeMemory + 0.25f * d.nextEventWeight, 1.0f);
+            d.detectorEventActive = true;
+            d.nextEventWeight = 1.0f;
+        }
+        else if (!hasDetectorInput)
+        {
+            d.detectorEventActive = false;
+            d.nextEventWeight = 1.0f;
+        }
+        if (!detectorSupported
+            && previousUnsupportedSamples < optoDetectorSilenceHoldSamples)
+            d.detectorReleaseExposureSamples = previousDetectorExposureSamples;
+        else if (detectorInputStartsNewEvent)
+            d.detectorReleaseExposureSamples = 0;
+        const bool retainPreviousExposure
+            = d.detectorReleaseExposureSamples > 0;
+        const int releaseExposureSamples = retainPreviousExposure
+            ? d.detectorReleaseExposureSamples : d.detectorExposureSamples;
+        const float releaseExposureLinear = std::clamp(
+            static_cast<float>(releaseExposureSamples)
+                / static_cast<float>(optoChargeTopOffSamples),
+            0.0f, 1.0f);
+        const float releaseExposureBlend
+            = releaseExposureLinear * releaseExposureLinear;
+        const float repetitionBlend = std::clamp(
+            (d.programmeMemory - 0.25f) / 0.75f, 0.0f, 1.0f);
+        const float repeatedExposureTopOff = 0.90f * repetitionBlend * std::clamp(
+            (static_cast<float>(d.detectorExposureSamples)
+                - 0.40f * static_cast<float>(optoChargeTopOffSamples))
+                / (0.10f * static_cast<float>(optoChargeTopOffSamples)),
+            0.0f, 1.0f);
+        const float fastMinimumChargeRate = highDriveFastMinimumChargeRate
+            * driveBlend * repeatedExposureTopOff;
+        const float fastRecoveryBlend = std::max(
+            releaseExposureBlend, repetitionBlend);
+        const float exposureDependentFastRelease = optoFlashRelease
+            + (optoFastRelease - optoFlashRelease) * fastRecoveryBlend;
+        const float fastRelease = exposureDependentFastRelease
+            + (optoSlowRelease - exposureDependentFastRelease) * repetitionBlend;
+        const float midReleaseExposureBlend = std::clamp(
+            3.2f * static_cast<float>(releaseExposureSamples)
+                / static_cast<float>(optoChargeTopOffSamples),
+            0.0f, 1.0f);
+        const float exposureDependentMidRelease = detectorSupported ? optoMidRelease
+            : optoFlashRelease
+                + (optoMidRelease - optoFlashRelease)
+                    * std::max(midReleaseExposureBlend, repetitionBlend);
+        const auto followTarget = [detectorDriven, detectorSupported,
+                                   hasDetectorInput](
                                       float& state, float target, float attack,
                                       float release, float chargeExponent,
-                                      float minimumChargeRate) noexcept {
+                                      float minimumChargeRate,
+                                      int attackSteps = 1) noexcept {
             // Silence discharges the cells directly; cascading the detector's
             // 40 ms waveform integration into them is what produced D3e's
             // false 8-120 ms hold. A stale detector envelope may continue a
@@ -641,31 +927,64 @@ private:
             // the selected detector input supports it again.
             if (!hasDetectorInput)
                 state *= release;
+            else if (!detectorSupported)
+                state *= release;
             else if (!detectorDriven && target > state)
                 return;
             else if (target > state)
             {
-                const float remainingFraction = target > 1.0e-9f
-                    ? std::clamp((target - state) / target, 0.0f, 1.0f)
-                    : 0.0f;
-                const float curvedAttackStep = (1.0f - attack) * std::max(
-                    std::pow(remainingFraction, chargeExponent - 1.0f),
-                    minimumChargeRate);
-                state += curvedAttackStep * (target - state);
+                const auto advanceAttack = [&] {
+                    const float remainingFraction = target > 1.0e-9f
+                        ? std::clamp((target - state) / target, 0.0f, 1.0f)
+                        : 0.0f;
+                    const float curvedAttackStep = (1.0f - attack) * std::max(
+                        std::pow(remainingFraction, chargeExponent - 1.0f),
+                        minimumChargeRate);
+                    state += curvedAttackStep * (target - state);
+                };
+                for (int step = 0; step < attackSteps; ++step)
+                    advanceAttack();
             }
             else
                 state = target + (state - target) * release;
         };
-        // Three independent gain-reduction populations. Exposure changes only
-        // their fill; their discharge constants never change with drive,
-        // exposure, or Peak Reduction.
-        followTarget(d.fastGrDb, fastShare * targetGrDb,
-                     fastAttackCoeff, optoFastRelease, fastChargeExponent,
-                     fastMinimumChargeRate);
+        // Three gain-reduction populations share the static capacity. The
+        // fast and mid releases interpolate with event exposure and programme
+        // memory; the slow optical afterglow retains its measured 1.174 s tau.
+        followTarget(d.fastGrDb, fastCellTargetGrDb,
+                     fastAttackCoeffAtCalibrationRate, fastRelease,
+                     fastChargeExponent, fastMinimumChargeRate,
+                     fastAttackReferenceSteps);
         followTarget(d.midGrDb, midShare * targetGrDb,
-                     slowAttackCoeff, optoMidRelease, slowChargeExponent, 0.0f);
+                     slowAttackCoeff, exposureDependentMidRelease,
+                     slowChargeExponent, 0.0f);
         followTarget(d.slowGrDb, slowShare * targetGrDb,
-                     slowAttackCoeff, optoSlowRelease, slowChargeExponent, 0.0f);
+                     slowPopulationAttackCoeff, optoSlowRelease,
+                     slowChargeExponent, 0.0f);
+        const float sustainedTopOffBase = std::min(
+            d.fastSustainedTargetDb, fastCellTargetGrDb);
+        // The 0.12 dB full-scale bias closes the measured long-exposure
+        // residual. Scale it into the onset so a target crossing zero cannot
+        // toggle a 0.12 dB step; the exposure blend starts at 15 ms and reaches
+        // full strength at 20 ms.
+        const float sustainedTopOffTarget = sustainedTopOffBase > 0.0f
+            ? sustainedTopOffBase
+                + 0.12f * std::min(sustainedTopOffBase, 1.0f)
+            : 0.0f;
+        if (sustainedExposureBlend > 0.0f
+            && sustainedTopOffTarget > d.fastGrDb)
+        {
+            const float limitTopOffAttack = optoLimitFastTopOffAttack
+                + (optoLimitSlowTopOffAttack - optoLimitFastTopOffAttack)
+                    * limitSlowRateBlend;
+            const float sustainedTopOffAttack = limit
+                ? limitTopOffAttack : optoSustainedTopOffAttack;
+            const float blendedTopOffAttack = sustainedExposureBlend >= 1.0f
+                ? sustainedTopOffAttack
+                : std::pow(sustainedTopOffAttack, sustainedExposureBlend);
+            d.fastGrDb = sustainedTopOffTarget
+                + (d.fastGrDb - sustainedTopOffTarget) * blendedTopOffAttack;
+        }
         const float dynamicGrDb = std::max(
             0.0f, d.fastGrDb + d.midGrDb + d.slowGrDb);
         const float dynamicMeasuredGain = decibelsToGain(-dynamicGrDb);

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -214,10 +215,13 @@ void testOptoDriveApplicability()
 }
 
 OptoStaticRender renderOptoStatic(float inputDbfs, float peakReduction, bool limit,
-                                  float frequencyHz = 997.0f)
+                                  float frequencyHz = 997.0f,
+                                  float gainKnob = duskaudio::optoGainDbToKnob(0.0f),
+                                  double sampleRate = 48000.0)
 {
-    constexpr int kSamples = 24000;
-    constexpr int kMeasureSamples = 4096;
+    const int kSamples = static_cast<int>(std::lround(0.5 * sampleRate));
+    const int kMeasureSamples = static_cast<int>(
+        std::lround((4096.0 / 48000.0) * sampleRate));
     constexpr int kBlockSize = 256;
     MultiCompDSP dsp;
     dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Opto));
@@ -229,9 +233,9 @@ OptoStaticRender renderOptoStatic(float inputDbfs, float peakReduction, bool lim
     dsp.setParameter(MultiCompDSP::Parameter::GlobalLookahead, 0.0f);
     dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
     dsp.setParameter(MultiCompDSP::Parameter::OptoPeakReduction, peakReduction);
-    dsp.setParameter(MultiCompDSP::Parameter::OptoGain, duskaudio::optoGainDbToKnob(0.0f));
+    dsp.setParameter(MultiCompDSP::Parameter::OptoGain, gainKnob);
     dsp.setParameter(MultiCompDSP::Parameter::OptoLimit, limit ? 1.0f : 0.0f);
-    dsp.prepare(48000.0, kBlockSize);
+    dsp.prepare(sampleRate, kBlockSize);
     const float amplitude = duskaudio::decibelsToGain(inputDbfs);
     double sum = 0.0;
     std::array<float, kBlockSize> input{};
@@ -241,7 +245,8 @@ OptoStaticRender renderOptoStatic(float inputDbfs, float peakReduction, bool lim
         const int count = std::min(kBlockSize, kSamples - blockStart);
         for (int i = 0; i < count; ++i)
             input[static_cast<size_t>(i)] = amplitude * std::sin(
-                2.0f * kPi * frequencyHz * static_cast<float>(blockStart + i) / 48000.0f);
+                2.0f * kPi * frequencyHz * static_cast<float>(blockStart + i)
+                / static_cast<float>(sampleRate));
         const float* inputs[] = {input.data()};
         float* outputs[] = {output.data()};
         dsp.processBlock(inputs, outputs, 1, count);
@@ -264,12 +269,16 @@ float renderOptoStaticMeter(float inputDbfs, float peakReduction, bool limit)
 }
 
 float measureOptoStaticGr(float inputDbfs, float peakReduction, bool limit,
-                          float frequencyHz = 997.0f)
+                          float frequencyHz = 997.0f,
+                          float gainKnob = duskaudio::optoGainDbToKnob(0.0f),
+                          double sampleRate = 48000.0)
 {
     // Reference definition: output(PR=0) minus output(PR=x), at identical
     // input level and Gain.  Input-minus-output is intentionally never used.
-    const float baseline = renderOptoStatic(inputDbfs, 0.0f, limit, frequencyHz).rms;
-    const float reduced = renderOptoStatic(inputDbfs, peakReduction, limit, frequencyHz).rms;
+    const float baseline = renderOptoStatic(
+        inputDbfs, 0.0f, limit, frequencyHz, gainKnob, sampleRate).rms;
+    const float reduced = renderOptoStatic(
+        inputDbfs, peakReduction, limit, frequencyHz, gainKnob, sampleRate).rms;
     require(baseline > 1.0e-7f && reduced > 1.0e-9f,
             "Opto static-law comparison produces measurable output");
     return duskaudio::gainToDecibels(baseline) - duskaudio::gainToDecibels(reduced);
@@ -351,6 +360,29 @@ void testOptoDetectorFrequencyWeighting()
                 meanDelta, shapeRms);
     require(shapeRms < 0.12f,
             "Opto detector weighting shape survives after removing broadband offset");
+}
+
+void testOptoSubBassFloorContinuity()
+{
+    constexpr std::array<float, 6> frequencies{{
+        32.0f, 33.0f, 33.4f, 33.5f, 34.0f, 35.0f}};
+    float previous = 0.0f;
+    float worstAdjacentDelta = 0.0f;
+    for (size_t i = 0; i < frequencies.size(); ++i)
+    {
+        const float reduction = measureOptoStaticGr(
+            -38.0f, 100.0f, false, frequencies[i]);
+        if (i > 0)
+            worstAdjacentDelta = std::max(
+                worstAdjacentDelta, std::abs(reduction - previous));
+        previous = reduction;
+        std::printf("opto sub-bass floor: %.1f Hz %.6f dB GR\n",
+                    frequencies[i], reduction);
+    }
+    std::printf("opto sub-bass floor: worst adjacent delta %.6f dB\n",
+                worstAdjacentDelta);
+    require(worstAdjacentDelta < 0.10f,
+            "Opto sustained sub-bass response is continuous across the floor hold boundary");
 }
 
 void testOptoInactivePeakReduction()
@@ -451,6 +483,107 @@ void testOptoLimitTopBrickWall()
             "Opto Limit reaches the measured near-brick-wall GR at high overshoot");
     require(std::abs((limit - compress) - 8.1815f) < 0.10f,
             "Opto Limit diverges from Compress by the measured amount at high overshoot");
+}
+
+void testOptoOverloadCompression()
+{
+    // Fresh licensed reference-AU renders captured 2026-08-21 at 48 kHz,
+    // Compress, PR=0.7, Gain=0.321868896. Each reduction is the same-Gain
+    // PR=0 control output minus the active output, so ceiling gain cancels.
+    struct Row { float inputDbfs, referenceReduction; };
+    constexpr std::array<Row, 2> rows{{
+        {6.0f, 25.391453f},
+        {12.0f, 24.107744f}
+    }};
+    float squaredError = 0.0f;
+    float worstError = 0.0f;
+    for (const auto& row : rows)
+    {
+        const float measured = measureOptoStaticGr(
+            row.inputDbfs, 70.0f, false, 1000.0f, 32.1868896f);
+        const float delta = measured - row.referenceReduction;
+        std::printf("opto overload: input %+.1f dBFS reference %.6f dB "
+                    "measured %.6f dB delta %+.6f dB\n",
+                    row.inputDbfs, row.referenceReduction, measured, delta);
+        squaredError += delta * delta;
+        worstError = std::max(worstError, std::abs(delta));
+    }
+    const float rmsError = std::sqrt(squaredError / rows.size());
+    std::printf("opto overload summary: RMS %.6f dB worst %.6f dB\n",
+                rmsError, worstError);
+    require(rmsError < 0.50f && worstError < 0.70f,
+            "Opto Compress matches measured +6/+12 dBFS overload reduction");
+}
+
+void testOptoOverloadOrderingAndMonotonicity()
+{
+    constexpr std::array<float, 22> levelsDbfs{{
+        -3.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f,
+        5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f,
+        13.0f, 14.0f, 15.0f, 16.0f, 17.0f, 18.0f
+    }};
+    float previousCompressOutputDb = 0.0f;
+    float worstCompressOverLimit = 0.0f;
+    float worstOutputDrop = 0.0f;
+    for (size_t row = 0; row < levelsDbfs.size(); ++row)
+    {
+        const float baselineOutputDb = duskaudio::gainToDecibels(
+            renderOptoStatic(levelsDbfs[row], 0.0f, false,
+                             1000.0f, 32.1868896f).rms);
+        const float compressOutputDb = duskaudio::gainToDecibels(
+            renderOptoStatic(levelsDbfs[row], 100.0f, false,
+                             1000.0f, 32.1868896f).rms);
+        const float limitOutputDb = duskaudio::gainToDecibels(
+            renderOptoStatic(levelsDbfs[row], 100.0f, true,
+                             1000.0f, 32.1868896f).rms);
+        const float compress = baselineOutputDb - compressOutputDb;
+        const float limit = baselineOutputDb - limitOutputDb;
+        worstCompressOverLimit = std::max(
+            worstCompressOverLimit, compress - limit);
+        if (row > 0)
+            worstOutputDrop = std::max(
+                worstOutputDrop, previousCompressOutputDb - compressOutputDb);
+        previousCompressOutputDb = compressOutputDb;
+        std::printf("opto overload invariant: input %+.1f dBFS Compress %.6f dB "
+                    "Limit %.6f dB separation %+.6f dB active output %.6f dBFS\n",
+                    levelsDbfs[row], compress, limit, limit - compress,
+                    compressOutputDb);
+    }
+    std::printf("opto overload invariant summary: Compress-over-Limit %.6f dB; "
+                "worst active-output drop %.6f dB\n",
+                worstCompressOverLimit, worstOutputDrop);
+    require(worstCompressOverLimit < 0.05f,
+            "Opto Limit remains at least as strong as Compress above the measured range");
+    require(worstOutputDrop < 0.01f,
+            "Opto Compress overload output remains monotonic with rising input");
+}
+
+void testOptoSampleRateParity()
+{
+    struct Row { double sampleRate; float referenceReduction; };
+    constexpr std::array<Row, 2> rows{{
+        {44100.0, 7.780751f},
+        {96000.0, 7.779223f}
+    }};
+    std::array<float, rows.size()> deltas{};
+    for (size_t row = 0; row < rows.size(); ++row)
+    {
+        const float measured = measureOptoStaticGr(
+            -24.0f, 70.0f, false, 1000.0f, 32.1868896f,
+            rows[row].sampleRate);
+        deltas[row] = measured - rows[row].referenceReduction;
+        std::printf("opto sample rate: %.1f kHz reference %.6f dB measured "
+                    "%.6f dB delta %+.6f dB\n",
+                    rows[row].sampleRate / 1000.0,
+                    rows[row].referenceReduction, measured, deltas[row]);
+        require(std::abs(deltas[row]) < 0.30f,
+                "Opto static reduction matches the reference across sample rates");
+    }
+    const float residualSpread = std::abs(deltas[1] - deltas[0]);
+    std::printf("opto sample rate summary: residual spread %.6f dB\n",
+                residualSpread);
+    require(residualSpread < 0.01f,
+            "Opto reference residual is invariant from 44.1 to 96 kHz");
 }
 
 void prepareOptoDynamicsDsp(MultiCompDSP& dsp, float peakReduction)
@@ -849,6 +982,361 @@ void testOptoCrestSweep()
                 && fittedRmsError < 0.85f && fittedWorstError < 1.40f
                 && std::abs(heldOutError) < 1.10f,
             "Opto linked-stereo crest sweep preserves its measured shape and bounded residual");
+}
+
+constexpr std::array<int, 7> kOptoShortEventTraceOffsets{{
+    0, 48, 96, 192, 384, 768, 1536}};
+
+std::array<float, kOptoShortEventTraceOffsets.size()>
+measureOptoShortEventTrace(int eventSamples, float peakDbfs,
+                           float preEventFloorDbfs = -200.0f,
+                           int repeatGapSamples = 0,
+                           float repeatGapFloorDbfs = -200.0f)
+{
+    // One event from reset, immediately followed by a -48 dBFS probe. The
+    // matched PR=0 control removes Gain/output-stage response; one complete
+    // 1 kHz cycle at probe start measures retained cell charge without
+    // averaging it into the subsequent release.
+    constexpr int kSampleRate = 48000;
+    constexpr int kBlockSize = 256;
+    constexpr int kEventStart = kSampleRate / 10;
+    constexpr int kProbeSamples = kSampleRate / 1000;
+    const int secondEventStart = repeatGapSamples > 0
+        ? kEventStart + eventSamples + repeatGapSamples : kEventStart;
+    const int eventEnd = secondEventStart + eventSamples;
+    MultiCompDSP control;
+    MultiCompDSP active;
+    prepareOptoDynamicsDsp(control, 0.0f);
+    prepareOptoDynamicsDsp(active, 70.0f);
+    control.setParameter(MultiCompDSP::Parameter::OptoGain, 23.754f);
+    active.setParameter(MultiCompDSP::Parameter::OptoGain, 23.754f);
+    const int latency = control.getLatencySamples();
+    const int tailSamples = latency + kOptoShortEventTraceOffsets.back()
+        + kProbeSamples;
+    const int totalSamples = eventEnd + tailSamples;
+    const float eventAmplitude = duskaudio::decibelsToGain(peakDbfs);
+    const float probeAmplitude = duskaudio::decibelsToGain(-48.0f);
+    const float preEventAmplitude = preEventFloorDbfs > -190.0f
+        ? duskaudio::decibelsToGain(preEventFloorDbfs) : 0.0f;
+    const float repeatGapAmplitude = repeatGapFloorDbfs > -190.0f
+        ? duskaudio::decibelsToGain(repeatGapFloorDbfs) : 0.0f;
+    std::vector<float> input(static_cast<size_t>(totalSamples));
+    for (int sample = 0; sample < totalSamples; ++sample)
+    {
+        const float amplitude = sample < kEventStart ? preEventAmplitude
+            : sample < kEventStart + eventSamples ? eventAmplitude
+            : sample < secondEventStart ? repeatGapAmplitude
+            : sample < eventEnd ? eventAmplitude : probeAmplitude;
+        input[static_cast<size_t>(sample)] = amplitude * std::sin(
+            2.0f * kPi * 1000.0f * static_cast<float>(sample) / kSampleRate);
+    }
+
+    std::vector<float> controlOutput(static_cast<size_t>(totalSamples));
+    std::vector<float> activeOutput(static_cast<size_t>(totalSamples));
+    std::array<float, kBlockSize> controlBlock{};
+    std::array<float, kBlockSize> activeBlock{};
+    for (int blockStart = 0; blockStart < totalSamples; blockStart += kBlockSize)
+    {
+        const int count = std::min(kBlockSize, totalSamples - blockStart);
+        const float* inputs[] = {input.data() + blockStart};
+        float* controlOutputs[] = {controlBlock.data()};
+        float* activeOutputs[] = {activeBlock.data()};
+        control.processBlock(inputs, controlOutputs, 1, count);
+        active.processBlock(inputs, activeOutputs, 1, count);
+        std::copy_n(controlBlock.data(), count, controlOutput.data() + blockStart);
+        std::copy_n(activeBlock.data(), count, activeOutput.data() + blockStart);
+    }
+
+    const int probeStart = eventEnd + latency;
+    const auto fundamentalAmplitude = [](const std::vector<float>& output,
+                                         int start) {
+        double sine = 0.0;
+        double cosine = 0.0;
+        for (int i = 0; i < kProbeSamples; ++i)
+        {
+            const double phase = 2.0 * static_cast<double>(kPi) * 1000.0
+                * static_cast<double>(start + i) / kSampleRate;
+            sine += output[static_cast<size_t>(start + i)] * std::sin(phase);
+            cosine += output[static_cast<size_t>(start + i)] * std::cos(phase);
+        }
+        return 2.0 / kProbeSamples * std::hypot(sine, cosine);
+    };
+    std::array<float, kOptoShortEventTraceOffsets.size()> trace{};
+    for (size_t i = 0; i < trace.size(); ++i)
+    {
+        const int start = probeStart + kOptoShortEventTraceOffsets[i];
+        trace[i] = 20.0f * std::log10(static_cast<float>(
+            fundamentalAmplitude(controlOutput, start)
+            / fundamentalAmplitude(activeOutput, start)));
+    }
+    return trace;
+}
+
+void testOptoNoiseFloorDoesNotPrechargeEvent()
+{
+    const float silent = measureOptoShortEventTrace(48, -4.0f)[0];
+    const float floored = measureOptoShortEventTrace(48, -4.0f, -90.0f)[0];
+    const float delta = floored - silent;
+    std::printf("opto pre-event floor: silence %.6f dB -90 dBFS %.6f dB "
+                "delta %+.6f dB\n", silent, floored, delta);
+    require(std::abs(delta) < 0.10f,
+            "Opto sub-audible input floor does not precharge a later event");
+}
+
+void testOptoEventChargeHasNoAbsoluteFloorCliff()
+{
+    constexpr std::array<std::array<float, 2>, 3> bedPairs{{
+        {{-45.0f, -43.0f}}, {{-63.0f, -61.0f}}, {{-79.0f, -77.0f}}
+    }};
+    float worstDelta = 0.0f;
+    for (const auto& pair : bedPairs)
+    {
+        const float lower = measureOptoShortEventTrace(
+            48, -4.0f, pair[0])[0];
+        const float upper = measureOptoShortEventTrace(
+            48, -4.0f, pair[1])[0];
+        const float delta = upper - lower;
+        worstDelta = std::max(worstDelta, std::abs(delta));
+        std::printf("opto event floor boundary: %.0f dBFS bed %.6f dB %.0f "
+                    "dBFS bed %.6f dB delta %+.6f dB\n",
+                    pair[0], lower, pair[1], upper, delta);
+    }
+    require(worstDelta < 0.50f,
+            "Opto event charge has no cliff at the detector support floor");
+}
+
+void testOptoNoiseFloorDoesNotPrechargeRepeatedEvent()
+{
+    constexpr int kGapSamples = 50 * 48000 / 1000;
+    const float silent = measureOptoShortEventTrace(
+        48, -4.0f, -200.0f, kGapSamples, -200.0f)[0];
+    const float floored = measureOptoShortEventTrace(
+        48, -4.0f, -200.0f, kGapSamples, -90.0f)[0];
+    const float delta = floored - silent;
+    std::printf("opto inter-event floor: silence %.6f dB -90 dBFS %.6f dB "
+                "delta %+.6f dB\n", silent, floored, delta);
+    require(std::abs(delta) < 0.10f,
+            "Opto sub-audible gap does not precharge a repeated event");
+}
+
+enum class OptoFloorCondition { Silence, DecayingTail, Hum };
+
+float measureOptoEventChargeAfterFloor(OptoFloorCondition condition,
+                                       float humPhase = 0.0f)
+{
+    constexpr int kSampleRate = 48000;
+    constexpr int kInitialEventSamples = kSampleRate / 10;
+    constexpr int kGapSamples = 2 * kSampleRate;
+    constexpr int kTailSamples = kSampleRate / 10;
+    constexpr int kTestEventSamples = kSampleRate / 1000;
+    duskaudio::MultiCompModes modes;
+    duskaudio::MultiCompParameterState parameters;
+    parameters.optoPeakReduction.store(70.0f, std::memory_order_relaxed);
+    parameters.optoGain.store(
+        duskaudio::kOptoGainUnityKnob, std::memory_order_relaxed);
+    parameters.noiseEnable.store(false, std::memory_order_relaxed);
+    modes.prepare(kSampleRate, 1, 1);
+    for (int sample = 0; sample < kInitialEventSamples; ++sample)
+    {
+        const float input = duskaudio::decibelsToGain(-6.0f) * std::sin(
+            2.0f * kPi * 1000.0f * static_cast<float>(sample) / kSampleRate);
+        modes.process(duskaudio::MultiCompMode::Opto,
+                      input, 0, input, parameters);
+    }
+    for (int sample = 0; sample < kGapSamples; ++sample)
+    {
+        float input = 0.0f;
+        if (condition == OptoFloorCondition::DecayingTail)
+        {
+            const float levelDb = sample < kTailSamples
+                ? -40.0f - 50.0f * static_cast<float>(sample)
+                    / static_cast<float>(kTailSamples)
+                : -90.0f;
+            input = duskaudio::decibelsToGain(levelDb) * std::sin(
+                2.0f * kPi * 1000.0f * static_cast<float>(sample)
+                    / kSampleRate);
+        }
+        else if (condition == OptoFloorCondition::Hum)
+            input = duskaudio::decibelsToGain(-50.0f) * std::sin(
+                2.0f * kPi * 60.0f * static_cast<float>(sample) / kSampleRate
+                    + humPhase);
+        modes.process(duskaudio::MultiCompMode::Opto,
+                      input, 0, input, parameters);
+    }
+    const float reductionBefore
+        = -modes.gainReduction(duskaudio::MultiCompMode::Opto, 0);
+    for (int sample = 0; sample < kTestEventSamples; ++sample)
+    {
+        const float input = duskaudio::decibelsToGain(-4.0f) * std::sin(
+            2.0f * kPi * 1000.0f * static_cast<float>(sample) / kSampleRate);
+        modes.process(duskaudio::MultiCompMode::Opto,
+                      input, 0, input, parameters);
+    }
+    return -modes.gainReduction(duskaudio::MultiCompMode::Opto, 0)
+        - reductionBefore;
+}
+
+void testOptoFloorHistoryDoesNotChangeEventCharge()
+{
+    const float silent = measureOptoEventChargeAfterFloor(
+        OptoFloorCondition::Silence);
+    const float decaying = measureOptoEventChargeAfterFloor(
+        OptoFloorCondition::DecayingTail);
+    float minimumHum = std::numeric_limits<float>::infinity();
+    float maximumHum = -std::numeric_limits<float>::infinity();
+    for (int phase = 0; phase < 16; ++phase)
+    {
+        const float charge = measureOptoEventChargeAfterFloor(
+            OptoFloorCondition::Hum,
+            2.0f * kPi * static_cast<float>(phase) / 16.0f);
+        minimumHum = std::min(minimumHum, charge);
+        maximumHum = std::max(maximumHum, charge);
+    }
+    std::printf("opto floor history: silence %.6f dB decaying-tail %.6f dB "
+                "delta %+.6f dB; 60 Hz phase range %.6f..%.6f dB "
+                "spread %.6f dB\n",
+                silent, decaying, decaying - silent,
+                minimumHum, maximumHum, maximumHum - minimumHum);
+    require(std::abs(decaying - silent) < 0.50f
+                && maximumHum - minimumHum < 0.50f,
+            "Opto floor history and hum phase do not change event charge");
+}
+
+void testOptoTrueSilenceRetainsExposureForRelease()
+{
+    constexpr int kSampleRate = 48000;
+    constexpr int kExposureSamples = kSampleRate / 10;
+    constexpr int kReleaseSamples = kSampleRate / 100;
+    duskaudio::MultiCompModes modes;
+    duskaudio::MultiCompParameterState parameters;
+    parameters.optoPeakReduction.store(70.0f, std::memory_order_relaxed);
+    parameters.optoGain.store(duskaudio::kOptoGainUnityKnob, std::memory_order_relaxed);
+    parameters.noiseEnable.store(false, std::memory_order_relaxed);
+    modes.prepare(kSampleRate, 1, 1);
+    for (int sample = 0; sample < kExposureSamples; ++sample)
+    {
+        const float input = duskaudio::decibelsToGain(-6.0f) * std::sin(
+            2.0f * kPi * 1000.0f * static_cast<float>(sample) / kSampleRate);
+        modes.process(duskaudio::MultiCompMode::Opto, input, 0, input, parameters);
+    }
+    const float initialReduction = -modes.gainReduction(duskaudio::MultiCompMode::Opto, 0);
+    for (int sample = 0; sample < kReleaseSamples; ++sample)
+        modes.process(duskaudio::MultiCompMode::Opto, 0.0f, 0, 0.0f, parameters);
+    const float retainedReduction = -modes.gainReduction(duskaudio::MultiCompMode::Opto, 0);
+    const float retainedFraction = retainedReduction
+        / std::max(initialReduction, 1.0e-6f);
+    std::printf("opto true-silence release: initial %.6f dB retained@10ms "
+                "%.6f dB fraction %.6f\n",
+                initialReduction, retainedReduction, retainedFraction);
+    require(initialReduction > 10.0f && retainedFraction > 0.85f,
+            "Opto exact-silence release retains the preceding event exposure");
+}
+
+void testOptoShortEventCharge()
+{
+    constexpr std::array<int, 4> durations{{17, 48, 144, 480}};
+    constexpr std::array<float, 4> peaksDbfs{{-12.0f, -8.0f, -4.0f, -0.25f}};
+    constexpr std::array<std::array<float, 4>, 4> reference{{
+        {{6.92236f, 8.13157f, 8.82621f, 8.69921f}},
+        {{9.55162f, 10.59441f, 11.62389f, 12.72483f}},
+        {{13.34629f, 15.57380f, 17.44177f, 18.84350f}},
+        {{15.07678f, 17.90595f, 20.62950f, 23.07068f}}
+    }};
+    // These checkerboard points are excluded from the fitted summary so a
+    // charge-law change must generalise across both duration and amplitude.
+    constexpr std::array<std::array<bool, 4>, 4> heldOut{{
+        {{false, false, false, true}},
+        {{false, true, false, false}},
+        {{false, false, true, false}},
+        {{true, false, false, false}}
+    }};
+    float fittedSquaredError = 0.0f;
+    float fittedWorstError = 0.0f;
+    float heldOutSquaredError = 0.0f;
+    float heldOutWorstError = 0.0f;
+    int fittedCount = 0;
+    int heldOutCount = 0;
+    for (size_t duration = 0; duration < durations.size(); ++duration)
+        for (size_t peak = 0; peak < peaksDbfs.size(); ++peak)
+        {
+            const float measured = measureOptoShortEventTrace(
+                durations[duration], peaksDbfs[peak])[0];
+            const float delta = measured - reference[duration][peak];
+            std::printf("opto short-event charge: %.3f ms peak %.2f dBFS "
+                        "reference %.5f dB measured %.6f dB delta %+.6f dB%s\n",
+                        1000.0f * durations[duration] / 48000.0f,
+                        peaksDbfs[peak], reference[duration][peak], measured,
+                        delta, heldOut[duration][peak] ? " (held out)" : "");
+            if (heldOut[duration][peak])
+            {
+                heldOutSquaredError += delta * delta;
+                heldOutWorstError = std::max(heldOutWorstError, std::abs(delta));
+                ++heldOutCount;
+            }
+            else
+            {
+                fittedSquaredError += delta * delta;
+                fittedWorstError = std::max(fittedWorstError, std::abs(delta));
+                ++fittedCount;
+            }
+        }
+    const float fittedRms = std::sqrt(fittedSquaredError / fittedCount);
+    const float heldOutRms = std::sqrt(heldOutSquaredError / heldOutCount);
+    std::printf("opto short-event charge summary: fitted RMS %.6f dB worst %.6f dB; "
+                "held-out RMS %.6f dB worst %.6f dB\n",
+                fittedRms, fittedWorstError, heldOutRms, heldOutWorstError);
+    require(fittedRms < 0.42f && fittedWorstError < 0.75f
+                && heldOutRms < 0.50f && heldOutWorstError < 0.75f,
+            "Opto nonlinear charge law matches isolated duration/amplitude grid");
+}
+
+void testOptoShortEventRelease()
+{
+    struct Row
+    {
+        int durationSamples;
+        float peakDbfs;
+        std::array<float, kOptoShortEventTraceOffsets.size()> reference;
+    };
+    // Checkerboard rows span both axes of the charge grid. Scoring change from
+    // the first probe cycle isolates recovery shape from initial charge error.
+    constexpr std::array<Row, 4> rows{{
+        {17, -8.0f, {{8.131574f, 8.069341f, 7.722107f, 6.827592f,
+                       5.295952f, 3.266975f, 1.656423f}}},
+        {48, -4.0f, {{11.623894f, 11.018592f, 10.439475f, 9.360288f,
+                       7.511415f, 4.922399f, 2.667509f}}},
+        {144, -12.0f, {{13.346288f, 12.721900f, 12.122308f, 11.001453f,
+                         9.058014f, 6.256186f, 3.648758f}}},
+        {480, -0.25f, {{23.070678f, 22.489624f, 21.939834f, 20.905922f,
+                         19.062774f, 16.080678f, 12.110521f}}}
+    }};
+    float squaredError = 0.0f;
+    float worstError = 0.0f;
+    int count = 0;
+    for (const auto& row : rows)
+    {
+        const auto measured = measureOptoShortEventTrace(
+            row.durationSamples, row.peakDbfs);
+        std::printf("opto short-event release: %.3f ms peak %.2f dBFS decay",
+                    1000.0f * row.durationSamples / 48000.0f, row.peakDbfs);
+        for (size_t i = 1; i < measured.size(); ++i)
+        {
+            const float referenceDecay = row.reference[i] - row.reference[0];
+            const float measuredDecay = measured[i] - measured[0];
+            const float delta = measuredDecay - referenceDecay;
+            std::printf(" %dms:%+.3f", kOptoShortEventTraceOffsets[i] * 1000 / 48000,
+                        delta);
+            squaredError += delta * delta;
+            worstError = std::max(worstError, std::abs(delta));
+            ++count;
+        }
+        std::printf(" dB\n");
+    }
+    const float rmsError = std::sqrt(squaredError / count);
+    std::printf("opto short-event release summary: RMS %.6f dB worst %.6f dB\n",
+                rmsError, worstError);
+    require(rmsError < 0.75f && worstError < 1.50f,
+            "Opto short-event recovery follows the measured exposure-dependent shape");
 }
 
 float measureOptoBroadbandStaticLaw(const std::vector<float>& unitRmsNoise,
@@ -1250,6 +1738,217 @@ void reportOptoAttackCrossings()
                     row.crossing63, row.crossing90,
                     measured.crossing63, measured.crossing90, measured.finalReduction);
     }
+}
+
+struct OptoOutputDynamics
+{
+    float finalReduction = 0.0f;
+    float crossing90 = 0.0f;
+    bool crossing90Found = false;
+};
+
+OptoOutputDynamics measureOptoOutputDynamics(float peakReduction,
+                                              float inputDbfs,
+                                              float exposureSeconds,
+                                              bool limit)
+{
+    // Match the reference campaign's control/active output extraction. A
+    // four-cycle moving-power envelope avoids comparing its rendered audio
+    // metrics with the plugin's internal end-of-block meter.
+    constexpr int kSampleRate = 48000;
+    constexpr int kBlockSize = 64;
+    constexpr int kEventStart = kSampleRate;
+    constexpr int kEnvelopeSamples = 4 * kSampleRate / 1000;
+    constexpr int kTailSamples = kSampleRate / 5;
+    const int eventSamples = static_cast<int>(
+        std::lround(exposureSeconds * kSampleRate));
+    const int totalSamples = kEventStart + eventSamples + kTailSamples;
+    const float baselineAmplitude = duskaudio::decibelsToGain(-40.0f);
+    const float eventAmplitude = duskaudio::decibelsToGain(inputDbfs);
+
+    MultiCompDSP control;
+    MultiCompDSP active;
+    prepareOptoDynamicsDsp(control, 0.0f);
+    prepareOptoDynamicsDsp(active, peakReduction);
+    control.setParameter(MultiCompDSP::Parameter::OptoLimit, limit ? 1.0f : 0.0f);
+    active.setParameter(MultiCompDSP::Parameter::OptoLimit, limit ? 1.0f : 0.0f);
+    std::vector<float> controlOutput(static_cast<size_t>(totalSamples));
+    std::vector<float> activeOutput(static_cast<size_t>(totalSamples));
+    std::array<float, kBlockSize> input{};
+    std::array<float, kBlockSize> controlBlock{};
+    std::array<float, kBlockSize> activeBlock{};
+    for (int blockStart = 0; blockStart < totalSamples; blockStart += kBlockSize)
+    {
+        const int count = std::min(kBlockSize, totalSamples - blockStart);
+        for (int i = 0; i < count; ++i)
+        {
+            const int sample = blockStart + i;
+            const float amplitude = sample >= kEventStart
+                    && sample < kEventStart + eventSamples
+                ? eventAmplitude : baselineAmplitude;
+            input[static_cast<size_t>(i)] = amplitude * std::sin(
+                2.0f * kPi * 1000.0f * static_cast<float>(sample)
+                / static_cast<float>(kSampleRate));
+        }
+        const float* inputs[] = {input.data()};
+        float* controlOutputs[] = {controlBlock.data()};
+        float* activeOutputs[] = {activeBlock.data()};
+        control.processBlock(inputs, controlOutputs, 1, count);
+        active.processBlock(inputs, activeOutputs, 1, count);
+        std::copy_n(controlBlock.data(), count,
+                    controlOutput.data() + blockStart);
+        std::copy_n(activeBlock.data(), count,
+                    activeOutput.data() + blockStart);
+    }
+
+    std::vector<double> controlPrefix(static_cast<size_t>(totalSamples + 1));
+    std::vector<double> activePrefix(static_cast<size_t>(totalSamples + 1));
+    for (int sample = 0; sample < totalSamples; ++sample)
+    {
+        const double controlSample = controlOutput[static_cast<size_t>(sample)];
+        const double activeSample = activeOutput[static_cast<size_t>(sample)];
+        controlPrefix[static_cast<size_t>(sample + 1)]
+            = controlPrefix[static_cast<size_t>(sample)]
+                + controlSample * controlSample;
+        activePrefix[static_cast<size_t>(sample + 1)]
+            = activePrefix[static_cast<size_t>(sample)]
+                + activeSample * activeSample;
+    }
+    auto reductionAt = [&](int sample) {
+        const int first = std::max(0, sample - kEnvelopeSamples / 2);
+        const int last = std::min(totalSamples, first + kEnvelopeSamples);
+        const double controlPower = controlPrefix[static_cast<size_t>(last)]
+            - controlPrefix[static_cast<size_t>(first)];
+        const double activePower = activePrefix[static_cast<size_t>(last)]
+            - activePrefix[static_cast<size_t>(first)];
+        return 10.0f * std::log10(static_cast<float>(
+            std::max(controlPower, 1.0e-24) / std::max(activePower, 1.0e-24)));
+    };
+    auto medianReduction = [&](int first, int last) {
+        std::vector<float> values;
+        values.reserve(static_cast<size_t>(std::max(0, last - first)));
+        for (int sample = first; sample < last; ++sample)
+            values.push_back(reductionAt(sample));
+        const auto middle = values.begin()
+            + static_cast<std::ptrdiff_t>(values.size() / 2);
+        std::nth_element(values.begin(), middle, values.end());
+        return *middle;
+    };
+
+    const int latency = control.getLatencySamples();
+    const int outputOn = kEventStart + latency;
+    const int outputOff = outputOn + eventSamples;
+    constexpr int kGuardSamples = 3 * kSampleRate / 1000;
+    const float finalWindowSeconds = std::min(
+        std::max(exposureSeconds * 0.40f, 0.004f), 0.050f);
+    const int finalStart = std::max(
+        outputOn + kGuardSamples,
+        outputOff - static_cast<int>(std::lround(
+            finalWindowSeconds * kSampleRate)));
+    const int finalStop = std::max(finalStart + 1, outputOff - kGuardSamples);
+    const float initialReduction = medianReduction(
+        outputOn - kSampleRate / 10, outputOn - kGuardSamples);
+    const float finalReduction = medianReduction(finalStart, finalStop);
+    const float target = initialReduction
+        + 0.90f * (finalReduction - initialReduction);
+    const int attackStart = outputOn + kGuardSamples;
+    const int attackStop = outputOff - kGuardSamples;
+    float crossing90 = exposureSeconds;
+    bool crossing90Found = false;
+    for (int sample = attackStart; sample < attackStop; ++sample)
+        if (reductionAt(sample) >= target)
+        {
+            crossing90 = static_cast<float>(sample - attackStart)
+                / static_cast<float>(kSampleRate);
+            crossing90Found = true;
+            break;
+        }
+    return {finalReduction, crossing90, crossing90Found};
+}
+
+void testOptoLimitDynamics()
+{
+    struct Row
+    {
+        float peakReduction;
+        float inputDbfs;
+        float exposureSeconds;
+        float finalReduction;
+        float crossing90;
+        bool heldOut;
+    };
+    constexpr std::array<Row, 12> rows{{
+        {60.0f, -12.0f, 0.010f, 9.391500f, 0.001646f, false},
+        {60.0f, -12.0f, 0.100f, 11.060040f, 0.007042f, false},
+        {60.0f, -12.0f, 1.000f, 11.832684f, 0.036000f, false},
+        {100.0f, -12.0f, 0.010f, 23.023195f, 0.002146f, false},
+        {100.0f, -12.0f, 0.100f, 31.567879f, 0.021208f, false},
+        {100.0f, -12.0f, 1.000f, 31.895535f, 0.023604f, false},
+        {30.0f, -24.0f, 0.100f, 0.003595f, 0.000000f, true},
+        {60.0f, -24.0f, 0.100f, 1.586796f, 0.033542f, true},
+        {100.0f, -24.0f, 0.100f, 18.567860f, 0.013604f, true},
+        {30.0f, -3.0f, 0.010f, 4.562598f, 0.001771f, true},
+        {60.0f, -3.0f, 0.100f, 19.506279f, 0.012063f, true},
+        {100.0f, -3.0f, 1.000f, 40.970371f, 0.035979f, true}
+    }};
+    float finalSquaredError = 0.0f;
+    float finalWorstError = 0.0f;
+    float crossingWorstError = 0.0f;
+    float heldOutSquaredError = 0.0f;
+    float heldOutWorstError = 0.0f;
+    float heldOutCrossingWorstError = 0.0f;
+    int fittedCount = 0;
+    int heldOutCount = 0;
+    bool allMeaningfulCrossingsFound = true;
+    for (const auto& row : rows)
+    {
+        const auto measured = measureOptoOutputDynamics(
+            row.peakReduction, row.inputDbfs, row.exposureSeconds, true);
+        const float finalDelta = measured.finalReduction - row.finalReduction;
+        const float crossingDelta = measured.crossing90 - row.crossing90;
+        if (row.finalReduction > 0.1f)
+            allMeaningfulCrossingsFound = allMeaningfulCrossingsFound
+                && measured.crossing90Found;
+        std::printf("opto Limit dynamics: PR %.1f input %.1f exposure %.3f "
+                    "final ref/measured "
+                    "%.6f/%.6f delta %+.6f dB; t90 ref/measured %.6f/%.6f "
+                    "delta %+.6f s%s\n",
+                    row.peakReduction * 0.01f, row.inputDbfs, row.exposureSeconds,
+                    row.finalReduction, measured.finalReduction, finalDelta,
+                    row.crossing90, measured.crossing90, crossingDelta,
+                    row.heldOut ? " (held out)" : "");
+        if (row.heldOut)
+        {
+            heldOutSquaredError += finalDelta * finalDelta;
+            heldOutWorstError = std::max(heldOutWorstError, std::abs(finalDelta));
+            if (row.finalReduction > 0.1f)
+                heldOutCrossingWorstError = std::max(
+                    heldOutCrossingWorstError, std::abs(crossingDelta));
+            ++heldOutCount;
+        }
+        else
+        {
+            finalSquaredError += finalDelta * finalDelta;
+            finalWorstError = std::max(finalWorstError, std::abs(finalDelta));
+            crossingWorstError = std::max(crossingWorstError,
+                                          std::abs(crossingDelta));
+            ++fittedCount;
+        }
+    }
+    const float finalRmsError = std::sqrt(finalSquaredError / fittedCount);
+    const float heldOutRmsError = std::sqrt(heldOutSquaredError / heldOutCount);
+    std::printf("opto Limit dynamics summary: final RMS %.6f dB worst %.6f dB; "
+                "t90 worst %.6f s; held-out RMS %.6f dB worst %.6f dB "
+                "t90 worst %.6f s\n",
+                finalRmsError, finalWorstError, crossingWorstError,
+                heldOutRmsError, heldOutWorstError,
+                heldOutCrossingWorstError);
+    require(allMeaningfulCrossingsFound
+                && finalRmsError < 0.50f && finalWorstError < 0.80f
+                && crossingWorstError < 0.013f
+                && heldOutRmsError < 0.80f && heldOutWorstError < 1.50f
+                && heldOutCrossingWorstError < 0.030f,
+            "Opto Limit charge follows the measured duration and PR grid");
 }
 
 struct OptoReleaseLocalTaus
@@ -1970,7 +2669,10 @@ void testOptoInternalStereoLinkUsesSignedMaximum()
         std::printf("opto dual-mono link identity: os=%dx worst delta %.9f dB\n",
                     oversampling == 2 ? 4 : oversampling == 1 ? 2 : 1,
                     worstDeltaDb);
-        matches = matches && worstDeltaDb < 1.0e-5f;
+        // FMA contraction moves the 4x accumulation by about 0.000012 dB.
+        // Keep the identity guard far below the 0.5 dB routing oracle while
+        // allowing that harmless compiler-level rounding difference.
+        matches = matches && worstDeltaDb < 1.0e-4f;
     }
     require(matches,
             "Opto internal stereo link uses the signed maximum detector on both channels");
@@ -2958,6 +3660,84 @@ void testHardwareRateRefreshAfterOversamplingChange()
     }
 }
 
+void testOptoExposureTimebaseSurvivesRateChange()
+{
+    duskaudio::MultiCompParameterState parameters;
+    parameters.optoPeakReduction.store(70.0f, std::memory_order_relaxed);
+    parameters.optoGain.store(duskaudio::optoGainDbToKnob(0.0f),
+                              std::memory_order_relaxed);
+    duskaudio::MultiCompModes switched;
+    duskaudio::MultiCompModes reference;
+    switched.prepare(48000.0, 256, 1);
+    reference.prepare(48000.0, 256, 2);
+    constexpr float kAmplitude = 0.6309573445f; // -4 dBFS
+    constexpr double kFrequency = 997.0;
+    double switchedTime = 0.0;
+    auto processDuration = [&](duskaudio::MultiCompModes& modes,
+                               double rate, double seconds, double& time) {
+        const int samples = static_cast<int>(std::lround(rate * seconds));
+        for (int sample = 0; sample < samples; ++sample)
+        {
+            const float input = kAmplitude * std::sin(
+                2.0 * static_cast<double>(kPi) * kFrequency * time);
+            (void)modes.process(duskaudio::MultiCompMode::Opto,
+                                input, 0, input, parameters);
+            time += 1.0 / rate;
+        }
+    };
+    processDuration(switched, 48000.0, 0.010, switchedTime);
+    switched.setRate(48000.0, 2);
+    processDuration(switched, 96000.0, 0.015, switchedTime);
+
+    double referenceTime = 0.0;
+    processDuration(reference, 96000.0, 0.025, referenceTime);
+    const float switchedGr = switched.gainReduction(
+        duskaudio::MultiCompMode::Opto, 0);
+    const float referenceGr = reference.gainReduction(
+        duskaudio::MultiCompMode::Opto, 0);
+    const float delta = switchedGr - referenceGr;
+    std::printf("opto exposure rate switch: 10 ms@48 + 15 ms@96 %.6f dB; "
+                "25 ms@96 %.6f dB; delta %+.6f dB\n",
+                switchedGr, referenceGr, delta);
+    require(std::abs(delta) < 0.20f,
+            "Opto exposure keeps its physical time across an oversampling-rate change");
+}
+
+void testOptoFastChargeIsOversamplingInvariant()
+{
+    duskaudio::MultiCompParameterState parameters;
+    parameters.optoPeakReduction.store(70.0f, std::memory_order_relaxed);
+    parameters.optoGain.store(duskaudio::kOptoGainUnityKnob,
+                              std::memory_order_relaxed);
+    constexpr float kAmplitude = 0.6309573445f; // -4 dBFS peak
+    std::array<float, 3> reductions{};
+    size_t row = 0;
+    for (const int factor : {1, 2, 4})
+    {
+        duskaudio::MultiCompModes modes;
+        modes.prepare(48000.0, 1, factor);
+        const int samples = static_cast<int>(
+            std::lround(0.00025 * 48000.0 * factor));
+        for (int sample = 0; sample < samples; ++sample)
+        {
+            const float input = kAmplitude * std::sin(
+                2.0f * kPi * 1000.0f * static_cast<float>(sample)
+                    / static_cast<float>(48000 * factor));
+            modes.process(duskaudio::MultiCompMode::Opto,
+                          input, 0, input, parameters);
+        }
+        reductions[row++] = -modes.gainReduction(
+            duskaudio::MultiCompMode::Opto, 0);
+    }
+    const auto spread = std::minmax_element(reductions.begin(), reductions.end());
+    const float difference = *spread.second - *spread.first;
+    std::printf("opto fast-charge rate parity: 1x %.6f dB 2x %.6f dB "
+                "4x %.6f dB spread %.6f dB\n",
+                reductions[0], reductions[1], reductions[2], difference);
+    require(*spread.first > 0.1f && difference < 0.25f,
+            "Opto isolated fast charge preserves physical time across oversampling factors");
+}
+
 float renderSoloedHighFrequencyPeak(float mix)
 {
     constexpr int blockSize = 256;
@@ -3259,19 +4039,31 @@ int main()
     testGoldenVectors();
     testOptoHarmonicContent();
     reportOptoCrestResponse();
+    testOptoShortEventRelease();
+    testOptoShortEventCharge();
+    testOptoNoiseFloorDoesNotPrechargeEvent();
+    testOptoEventChargeHasNoAbsoluteFloorCliff();
+    testOptoNoiseFloorDoesNotPrechargeRepeatedEvent();
+    testOptoFloorHistoryDoesNotChangeEventCharge();
+    testOptoTrueSilenceRetainsExposureForRelease();
     testOptoCrestSweep();
     testOptoBroadbandStaticLaw();
     testOptoBurstRateSweep();
     testOptoPluginLevelReferencePoints();
     testOptoDetectorFrequencyWeighting();
+    testOptoSubBassFloorContinuity();
     testOptoDetectorMemory();
     reportOptoAttackCrossings();
+    testOptoLimitDynamics();
     reportOptoReleaseLocalTaus();
     testOptoInactivePeakReduction();
     testOptoMeterMatchesOutputReduction();
     testOptoMeasuredOnsets();
     testOptoThresholdOnlyCurveCollapse();
     testOptoLimitTopBrickWall();
+    testOptoOverloadCompression();
+    testOptoOverloadOrderingAndMonotonicity();
+    testOptoSampleRateParity();
     testAtomicControlSnapshotsAreSingleLoad();
     testPublishedGainReductionRange();
     testAllModesAreMonoSafe();
@@ -3296,6 +4088,8 @@ int main()
     testAutoGainBypassSettleBoundary();
     testAutoGainEffectiveExternalSidechain();
     testHardwareRateRefreshAfterOversamplingChange();
+    testOptoExposureTimebaseSurvivesRateChange();
+    testOptoFastChargeIsOversamplingInvariant();
     testOptoStereoDetectorIsolation();
     testPrepareAtDefaultRateAndFactor();
     testCrossoverFlatness();

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -319,8 +319,10 @@ void testOptoPluginLevelReferencePoints()
 
 void testOptoDetectorFrequencyWeighting()
 {
-    // The broadband offset belongs to the later colouration phase. This gate
-    // removes its mean and judges only the measured detector-weighting shape.
+    // Detector weighting is normalised at 1 kHz, so its shape score removes a
+    // uniform operating-point offset. Absolute mean and 1 kHz anchors below
+    // keep that removal from hiding a real detector-level regression; the
+    // static-law and broadband gates independently own level accuracy.
     constexpr std::array<float, 31> frequencies{{
         20.0f, 25.178508f, 31.697864f, 39.905247f, 50.237728f,
         63.245552f, 79.621437f, 100.237450f, 126.191467f, 158.865646f,
@@ -356,8 +358,13 @@ void testOptoDetectorFrequencyWeighting()
     for (const float delta : deltas)
         shapeSquaredError += (delta - meanDelta) * (delta - meanDelta);
     const float shapeRms = std::sqrt(shapeSquaredError / static_cast<float>(deltas.size()));
-    std::printf("opto detector weighting summary: mean offset %+.6f dB shape RMS %.6f dB\n",
-                meanDelta, shapeRms);
+    constexpr size_t kOneKhzRow = 17;
+    const float oneKhzDelta = deltas[kOneKhzRow];
+    std::printf("opto detector weighting summary: mean offset %+.6f dB "
+                "1 kHz offset %+.6f dB shape RMS %.6f dB\n",
+                meanDelta, oneKhzDelta, shapeRms);
+    require(std::abs(meanDelta) < 0.30f && std::abs(oneKhzDelta) < 0.25f,
+            "Opto detector weighting keeps its absolute operating-point anchor");
     require(shapeRms < 0.12f,
             "Opto detector weighting shape survives after removing broadband offset");
 }
@@ -972,12 +979,11 @@ void testOptoCrestSweep()
     // No tested causal charge mechanism reconciled the 20 dB row with the
     // burst-rate gate. Pin the reproduced non-monotonic shape and the known
     // residual so a later mechanism cannot silently regress either side.
-    // The pinned residuals are the rounding-robust silence-gate trajectory
-    // (identical across platforms and fp-contract modes to <0.001 dB):
-    // -0.20 / -0.26 / +0.71 (held out) / -1.28 dB. Against the reference it
-    // trades the old macOS-FMA-only trajectory's +1.86 dB held-out error for
-    // -1.28 dB on the 23.8 dB crest row; the four-row RMS improves 0.96 ->
-    // 0.75 dB. The remaining shape error is the same open structural defect.
+    // The current rounding-robust residuals are -0.141 / -0.540 / +0.615
+    // (held out) / -0.709 dB: 0.546 dB RMS across all four rows and 0.521 dB
+    // across the three fitted rows. The older -0.20 / -0.26 / +0.71 / -1.28
+    // dB trajectory and its 0.96 -> 0.75 dB comparison are historical. The
+    // remaining shape error is the same open structural defect.
     require(finiteAndCorrectCrest && nonMonotonicShape
                 && fittedRmsError < 0.85f && fittedWorstError < 1.40f
                 && std::abs(heldOutError) < 1.10f,

--- a/plugins/multi-comp/daf-plugin/DafPluginInfo.h
+++ b/plugins/multi-comp/daf-plugin/DafPluginInfo.h
@@ -33,7 +33,7 @@
 #define DAF_UI_CUSTOM_INCLUDE_PATH  "DearImGui.hpp"
 #define DAF_UI_CUSTOM_WIDGET_TYPE   DGL_NAMESPACE::ImGuiTopLevelWidget
 #define DAF_UI_DEFAULT_WIDTH        1120
-#define DAF_UI_DEFAULT_HEIGHT       760
+#define DAF_UI_DEFAULT_HEIGHT       380
 #define DAF_UI_USER_RESIZABLE       1
 #define DAF_PLUGIN_CLAP_FEATURES "audio-effect", "compressor", "stereo"
 #define DAF_PLUGIN_LV2_CATEGORY "lv2:CompressorPlugin"

--- a/plugins/multi-comp/daf-plugin/MultiCompPlugin.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompPlugin.cpp
@@ -204,8 +204,7 @@ protected:
     void loadProgram(uint32_t index) override
     {
         if (index >= multicompp::kFactoryPresets.size()) return;
-        const auto& q = multicompp::kFactoryPresets[index];
-        multicompp::applyPresetToHostParameters(q,
+        multicompp::applyFactoryPresetToHostParameters(index,
         [this](int parameterIndex, float hostValue)
         {
             setParameterValue(static_cast<uint32_t>(parameterIndex), hostValue);

--- a/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
@@ -612,6 +612,31 @@ void testHostProgramChangeUpdatesUiMirror()
     std::puts("host program change: UI mirror matches every applied factory preset");
 }
 
+void testOptoFaceplateContract()
+{
+    constexpr float referenceAspect = 950.0f / 263.0f;
+    const float aspect = multicompp::ui_detail::optoFaceplateAspect();
+    require(std::abs(aspect - referenceAspect) < 0.01f,
+            "Opto faceplate follows the reference 950-by-263 proportions");
+
+    const float zero = multicompp::ui_detail::optoMeterNeedleAngle(0.0f);
+    const float ten = multicompp::ui_detail::optoMeterNeedleAngle(-10.0f);
+    const float twenty = multicompp::ui_detail::optoMeterNeedleAngle(-20.0f);
+    require(std::isfinite(zero) && std::isfinite(ten) && std::isfinite(twenty)
+                && zero > ten && ten > twenty,
+            "Opto GR needle moves monotonically from zero to 20 dB reduction");
+    require(std::strcmp(multicompp::ui_detail::optoModeLabel(0.0f), "COMP") == 0
+                && std::strcmp(multicompp::ui_detail::optoModeLabel(1.0f), "LIMIT") == 0,
+            "Opto mode control exposes the Comp and Limit panel labels");
+    require(std::strcmp(multicompp::ui_detail::optoMeterLabel(), "GR") == 0,
+            "Opto analogue meter is fixed to the GR panel readout");
+    std::printf("opto faceplate: aspect %.6f reference %.6f; meter angles "
+                "0/10/20 dB %.6f/%.6f/%.6f rad; modes %s/%s\n",
+                aspect, referenceAspect, zero, ten, twenty,
+                multicompp::ui_detail::optoModeLabel(0.0f),
+                multicompp::ui_detail::optoModeLabel(1.0f));
+}
+
 static_assert(multicompp::kParamCount == 63,
               "DAF host table must exclude the two JUCE-inert controls");
 } // namespace
@@ -675,6 +700,7 @@ int main()
     testCrossoverOrderingDoesNotRatchet();
     testQuantisedFineStepFallsBackToRestingPrecision();
     testShippingUiHasNoDeadCrossoverDescriptor();
+    testOptoFaceplateContract();
     testCrossoverMirrorRefreshesEveryPluginChangedValue();
     require(reviewFailureCount == 0, "review regressions are fixed");
     testHostParameterTapers();

--- a/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
@@ -578,6 +578,29 @@ void testQuantisedFineStepFallsBackToRestingPrecision()
                 "nonzero fine steps still add precision only when needed");
 }
 
+void testOptoSidechainHpUsesPhysicalDragDomain()
+{
+    const auto parameter = static_cast<uint32_t>(multicompp::ParamId::SidechainHP);
+    const auto& descriptor = multicompp::kParams[parameter];
+    const float draggedHz = duskdaf::dragKnobCoordinate(
+        0.0f, -66.0f, descriptor.min, descriptor.max, false);
+    const float draggedHost = multicompp::plainToHost(descriptor, draggedHz);
+    const float resultingHz = multicompp::hostToPlain(descriptor, draggedHost);
+    const float oldHostDrag = duskdaf::dragKnobCoordinate(
+        0.0f, -66.0f, multicompp::hostMin(descriptor),
+        multicompp::hostMax(descriptor), false);
+    const float oldResultingHz = multicompp::hostToPlain(descriptor, oldHostDrag);
+
+    require(multicompp::ui_detail::optoKnobUsesPlainDomainDrag(parameter)
+                && !multicompp::ui_detail::optoKnobUsesPlainDomainDrag(
+                    static_cast<uint32_t>(multicompp::ParamId::Mix)),
+            "only the tapered Opto SC HP knob opts into physical-domain dragging");
+    require(resultingHz == 165.0f && oldResultingHz == 54.0f,
+            "a 66-pixel SC HP drag reaches 165 Hz instead of the old 54 Hz");
+    std::printf("Opto SC HP drag: 66 px reaches %.0f Hz (old host-domain drag %.0f Hz)\n",
+                resultingHz, oldResultingHz);
+}
+
 void testShippingUiHasNoDeadCrossoverDescriptor()
 {
     const std::string source = readSiblingSource("MultiCompUI.cpp");
@@ -586,6 +609,61 @@ void testShippingUiHasNoDeadCrossoverDescriptor()
     std::printf("shipping UI dead crossover descriptor present: %s\n",
                 hasDeadDescriptor ? "yes" : "no");
     reviewCheck(!hasDeadDescriptor, "shipping crossover UI has no unused descriptor variable");
+}
+
+void testShippingUiUsesConformingHeaderWithoutUtilityBands()
+{
+    const std::string source = readSiblingSource("MultiCompUI.cpp");
+    const std::string info = readSiblingSource("DafPluginInfo.h");
+    auto countText = [&source](const char* text) {
+        size_t count = 0;
+        for (size_t at = source.find(text); at != std::string::npos;
+             at = source.find(text, at + 1))
+            ++count;
+        return count;
+    };
+    const bool drawsGlobalBand = source.find("drawGlobal(dl);") != std::string::npos;
+    const bool drawsSidechainBand = source.find("drawSidechain(dl);") != std::string::npos;
+    const bool hasConformingIdentity = source.find("\"MULTI-COMP\"") != std::string::npos
+        && source.find("\"MC-2\"") != std::string::npos
+        && source.find("\"DUSK AUDIO\"") != std::string::npos;
+    const bool hasPresetActions = source.find("##mc_presetprev") != std::string::npos
+        && source.find("##mc_presetnext") != std::string::npos
+        && source.find("##mc_init") != std::string::npos
+        && source.find("##mc_save") != std::string::npos;
+    const bool hasCompactDefaultHeight =
+        info.find("#define DAF_UI_DEFAULT_HEIGHT       380") != std::string::npos;
+    const bool hasSingleHeaderIdentity = countText("\"DUSK AUDIO\"") == 1
+        && source.find("\"DUSK\"") == std::string::npos;
+    const bool hasSimplifiedOptoTitle =
+        source.find("\"LEVELING AMPLIFIER\"") != std::string::npos
+        && source.find("\"OPTICAL LEVELING AMPLIFIER\"") == std::string::npos;
+    const bool hasOptoSidechainHp =
+        source.find("optoKnob(dl, \"opto_sc_hp\", P_SC_HP") != std::string::npos;
+    const bool hasModeButtonRow =
+        source.find("##mc_mode_button_%d") != std::string::npos;
+    const bool hasModeDropdown = source.find("ImGui::BeginCombo(\"##mc_mode\"")
+        != std::string::npos;
+
+    std::printf("header conformity: global=%s sidechain=%s identity=%s actions=%s height380=%s "
+                "single-brand=%s opto-title=%s\n",
+                drawsGlobalBand ? "drawn" : "removed",
+                drawsSidechainBand ? "drawn" : "removed",
+                hasConformingIdentity ? "yes" : "no",
+                hasPresetActions ? "yes" : "no",
+                hasCompactDefaultHeight ? "yes" : "no",
+                hasSingleHeaderIdentity ? "yes" : "no",
+                hasSimplifiedOptoTitle ? "yes" : "no");
+    reviewCheck(!drawsGlobalBand && !drawsSidechainBand,
+                "shipping UI omits the visible Global and Sidechain utility bands");
+    reviewCheck(hasConformingIdentity && hasPresetActions && hasCompactDefaultHeight,
+                "shipping UI follows the MC-2 identity, preset-action, and compact-height contract");
+    reviewCheck(hasSingleHeaderIdentity && hasSimplifiedOptoTitle,
+                "Dusk Audio appears only in the header and Opto uses the simplified faceplate title");
+    reviewCheck(hasOptoSidechainHp,
+                "Opto faceplate exposes the existing Sidechain HP parameter");
+    reviewCheck(hasModeButtonRow && !hasModeDropdown,
+                "all eight compressor modes are exposed as top-row buttons");
 }
 
 void testHostProgramChangeUpdatesUiMirror()
@@ -612,12 +690,51 @@ void testHostProgramChangeUpdatesUiMirror()
     std::puts("host program change: UI mirror matches every applied factory preset");
 }
 
+void testPresetIdentityFollowsPresetOwnership()
+{
+    const int factoryPreset = 5;
+    const auto mode = static_cast<uint32_t>(multicompp::ParamId::Mode);
+    const auto bypass = static_cast<uint32_t>(multicompp::ParamId::Bypass);
+    const auto oversampling = static_cast<uint32_t>(multicompp::ParamId::Oversampling);
+    const auto externalSidechain =
+        static_cast<uint32_t>(multicompp::ParamId::ExternalSidechain);
+
+    const bool factoryContract =
+        multicompp::ui_detail::selectionOwnsParam(factoryPreset, false, false, mode)
+        && !multicompp::ui_detail::selectionOwnsParam(
+            factoryPreset, false, false, bypass)
+        && !multicompp::ui_detail::selectionOwnsParam(
+            factoryPreset, false, false, oversampling)
+        && !multicompp::ui_detail::selectionOwnsParam(
+            factoryPreset, false, false, externalSidechain);
+    const bool userContract =
+        multicompp::ui_detail::selectionOwnsParam(-1, true, false, oversampling)
+        && !multicompp::ui_detail::selectionOwnsParam(-1, true, false, bypass);
+    const bool defaultContract =
+        multicompp::ui_detail::selectionOwnsParam(-1, false, true, oversampling)
+        && !multicompp::ui_detail::selectionOwnsParam(-1, false, true, bypass);
+    const bool customContract =
+        !multicompp::ui_detail::selectionOwnsParam(-1, false, false, mode);
+
+    require(factoryContract && userContract && defaultContract && customContract,
+            "preset identity clears only when an edit changes state that selection owns");
+    std::puts("preset identity: factory machine controls and every bypass preserve selection");
+}
+
 void testOptoFaceplateContract()
 {
-    constexpr float referenceAspect = 950.0f / 263.0f;
+    using Layout = multicompp::ui_detail::OptoFaceplateLayout;
+    constexpr float referenceAspect = 1120.0f / 310.0f;
     const float aspect = multicompp::ui_detail::optoFaceplateAspect();
-    require(std::abs(aspect - referenceAspect) < 0.01f,
-            "Opto faceplate follows the reference 950-by-263 proportions");
+    require(Layout::left == 0.0f && Layout::right == 1120.0f
+                && Layout::top == 344.0f && Layout::bottom == 654.0f
+                && std::abs(aspect - referenceAspect) < 0.01f,
+            "Opto faceplate fills the complete mode canvas below the toolbar");
+    require(multicompp::ui_detail::designHeightForMode(0.0f) == 380.0f
+                && multicompp::ui_detail::designHeightForMode(0.4f) == 380.0f
+                && multicompp::ui_detail::designHeightForMode(0.6f) == 486.0f
+                && multicompp::ui_detail::designHeightForMode(7.0f) == 486.0f,
+            "Opto uses the compact rack canvas while every other mode keeps the full canvas");
 
     const float zero = multicompp::ui_detail::optoMeterNeedleAngle(0.0f);
     const float ten = multicompp::ui_detail::optoMeterNeedleAngle(-10.0f);
@@ -625,11 +742,23 @@ void testOptoFaceplateContract()
     require(std::isfinite(zero) && std::isfinite(ten) && std::isfinite(twenty)
                 && zero > ten && ten > twenty,
             "Opto GR needle moves monotonically from zero to 20 dB reduction");
-    require(std::strcmp(multicompp::ui_detail::optoModeLabel(0.0f), "COMP") == 0
+    require(std::strcmp(multicompp::ui_detail::optoModeLabel(0.0f), "COMPRESS") == 0
                 && std::strcmp(multicompp::ui_detail::optoModeLabel(1.0f), "LIMIT") == 0,
             "Opto mode control exposes the Comp and Limit panel labels");
     require(std::strcmp(multicompp::ui_detail::optoMeterLabel(), "GR") == 0,
             "Opto analogue meter is fixed to the GR panel readout");
+    const float afterOneTimeConstant =
+        multicompp::ui_detail::optoMeterBallisticStep(0.0f, -20.0f, 0.300f);
+    reviewCheck(std::abs(afterOneTimeConstant + 12.64241f) < 0.001f,
+                "Opto needle applies a 300 ms RC response instead of raw block GR");
+    reviewCheck(std::strcmp(multicompp::ui_detail::optoKnobValueSuffix(), "") == 0,
+                "Opto knob value bubbles show unitless 0-100 values");
+    const float idleReadout = multicompp::ui_detail::optoMeterReadoutAmount(0.0f);
+    require(idleReadout == 0.0f && !std::signbit(idleReadout)
+                && multicompp::ui_detail::optoMeterReadoutAmount(-12.5f) == 12.5f
+                && multicompp::ui_detail::optoMeterReadoutAmount(1.0f) == 0.0f
+                && multicompp::ui_detail::optoMeterReadoutAmount(-150.0f) == 99.9f,
+            "Opto GR readout is positive, bounded, and never displays negative zero");
     std::printf("opto faceplate: aspect %.6f reference %.6f; meter angles "
                 "0/10/20 dB %.6f/%.6f/%.6f rad; modes %s/%s\n",
                 aspect, referenceAspect, zero, ten, twenty,
@@ -699,7 +828,9 @@ int main()
     testRunGuardsSidechainPortsPerLayout();
     testCrossoverOrderingDoesNotRatchet();
     testQuantisedFineStepFallsBackToRestingPrecision();
+    testOptoSidechainHpUsesPhysicalDragDomain();
     testShippingUiHasNoDeadCrossoverDescriptor();
+    testShippingUiUsesConformingHeaderWithoutUtilityBands();
     testOptoFaceplateContract();
     testCrossoverMirrorRefreshesEveryPluginChangedValue();
     require(reviewFailureCount == 0, "review regressions are fixed");
@@ -709,6 +840,7 @@ int main()
     testFactoryPresetOwnership();
     testHostProgramChangeAppliesBandParameters();
     testHostProgramChangeUpdatesUiMirror();
+    testPresetIdentityFollowsPresetOwnership();
     testFractionalEnumUiAndDspAgreement();
     testFractionalIntegerAutomationStaysLoadable();
     std::puts("Multi-Comp plugin-layer tests: PASS");

--- a/plugins/multi-comp/daf-plugin/MultiCompProgramPresets.hpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompProgramPresets.hpp
@@ -123,4 +123,51 @@ void applyPresetToHostParameters(const duskaudio::MultiCompPreset& preset,
             setHostParameter(kBandBase + band * 8 + field, plainToHost(d, value));
         });
 }
+
+struct ExpandedFactoryPreset
+{
+    std::array<float, kMeterMaster> hostValues{};
+    std::array<bool, kMeterMaster> ownsParameter{};
+};
+
+// Expand the small core preset records into their exact host-domain writes once
+// at module load.  The UI receives a parameter callback for every automation
+// change, so rebuilding all 13 records there made preset-name synchronisation
+// needlessly quadratic in the parameter table size.
+inline const std::array<ExpandedFactoryPreset, kFactoryPresets.size()>
+    kExpandedFactoryPresets = [] {
+        std::array<ExpandedFactoryPreset, kFactoryPresets.size()> expanded{};
+        for (size_t presetIndex = 0; presetIndex < kFactoryPresets.size(); ++presetIndex)
+            applyPresetToHostParameters(kFactoryPresets[presetIndex],
+                [&expanded, presetIndex](int parameterIndex, float hostValue)
+                {
+                    if (parameterIndex < 0 || parameterIndex >= kMeterMaster) return;
+                    auto& preset = expanded[presetIndex];
+                    preset.hostValues[static_cast<size_t>(parameterIndex)] = hostValue;
+                    preset.ownsParameter[static_cast<size_t>(parameterIndex)] = true;
+                });
+        return expanded;
+    }();
+
+inline bool presetOwnsParam(int presetIndex, uint32_t parameterIndex) noexcept
+{
+    return presetIndex >= 0
+        && static_cast<size_t>(presetIndex) < kExpandedFactoryPresets.size()
+        && parameterIndex < static_cast<uint32_t>(kMeterMaster)
+        && kExpandedFactoryPresets[static_cast<size_t>(presetIndex)]
+               .ownsParameter[static_cast<size_t>(parameterIndex)];
+}
+
+template <class SetHostParameter>
+void applyFactoryPresetToHostParameters(uint32_t presetIndex,
+                                        SetHostParameter&& setHostParameter)
+{
+    if (presetIndex >= kExpandedFactoryPresets.size()) return;
+    const auto& preset = kExpandedFactoryPresets[presetIndex];
+    for (int parameterIndex = 0; parameterIndex < kMeterMaster; ++parameterIndex)
+        if (presetOwnsParam(static_cast<int>(presetIndex),
+                            static_cast<uint32_t>(parameterIndex)))
+            setHostParameter(parameterIndex,
+                             preset.hostValues[static_cast<size_t>(parameterIndex)]);
+}
 } // namespace multicompp

--- a/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
@@ -17,6 +17,34 @@ inline int choiceIndex(float hostValue, int count) noexcept
     return std::clamp(static_cast<int>(std::round(hostValue)), 0, count - 1);
 }
 
+struct OptoFaceplateLayout
+{
+    static constexpr float left = 34.0f;
+    static constexpr float right = 1086.0f;
+    static constexpr float top = 362.0f;
+    static constexpr float bottom = 653.0f;
+};
+
+inline constexpr float optoFaceplateAspect() noexcept
+{
+    return (OptoFaceplateLayout::right - OptoFaceplateLayout::left)
+        / (OptoFaceplateLayout::bottom - OptoFaceplateLayout::top);
+}
+
+inline float optoMeterNeedleAngle(float gainReductionDb) noexcept
+{
+    constexpr float pi = 3.14159265358979323846f;
+    const float amount = std::clamp(-gainReductionDb / 20.0f, 0.0f, 1.0f);
+    return (55.0f - 110.0f * amount) * pi / 180.0f;
+}
+
+inline const char* optoModeLabel(float hostValue) noexcept
+{
+    return choiceIndex(hostValue, 2) == 0 ? "COMP" : "LIMIT";
+}
+
+inline constexpr const char* optoMeterLabel() noexcept { return "GR"; }
+
 template <size_t N>
 inline int loadProgramIntoMirror(uint32_t index, std::array<float, N>& values)
 {
@@ -74,6 +102,7 @@ constexpr float kHeaderH = 64.0f;
 constexpr float kGlobalH = 132.0f;
 constexpr float kSidechainH = 126.0f;
 constexpr float kPanelTop = kHeaderH + kGlobalH + kSidechainH;
+constexpr float kUiPi = duskdaf::DuskPanel::kPi;
 // Set to true only while collecting a host geometry measurement.
 constexpr bool kGeometryDiagnosticEnabled = false;
 
@@ -83,6 +112,11 @@ constexpr ImU32 kLine = IM_COL32(75, 79, 90, 255);
 constexpr ImU32 kText = IM_COL32(232, 234, 238, 255);
 constexpr ImU32 kDim = IM_COL32(162, 168, 180, 255);
 constexpr ImU32 kAccent = IM_COL32(65, 194, 220, 255);
+constexpr ImU32 kOptoFace = IM_COL32(211, 204, 184, 255);
+constexpr ImU32 kOptoFaceLight = IM_COL32(235, 229, 208, 255);
+constexpr ImU32 kOptoInk = IM_COL32(43, 41, 37, 255);
+constexpr ImU32 kOptoTrim = IM_COL32(92, 72, 54, 255);
+constexpr ImU32 kOptoRed = IM_COL32(159, 48, 39, 255);
 constexpr ImU32 kBandColors[4] = {
     IM_COL32(92, 165, 235, 255), IM_COL32(92, 205, 150, 255),
     IM_COL32(232, 185, 74, 255), IM_COL32(224, 100, 93, 255)
@@ -265,6 +299,7 @@ protected:
 private:
     std::array<float, multicompp::kTotalParamCount> values{};
     duskdaf::DuskPanel panel;
+    ImDrawListSplitter optoKnobSplitter;
     duskdaf::CrispFontSet fontSet;
     ImFont* labelFont = nullptr;
     duskdaf::SupportersOverlay supporters;
@@ -518,7 +553,11 @@ private:
     {
         const int mode = multicompp::ui_detail::choiceIndex(value(P_MODE), 8);
         drawSection(dl, kPanelTop, kDesignH - 8, modeName(mode));
-        if (mode == 7)
+        if (mode == 0)
+        {
+            // Opto owns a panel-integrated analogue GR meter.
+        }
+        else if (mode == 7)
             drawMeter(dl, 1062, kPanelTop + 24, 42, 92, meter(kMeterMaster), kAccent, "MASTER GR");
         else
             drawMeter(dl, 28, kPanelTop + 42, 48, 300, meter(kMeterMaster), kAccent, "MASTER GR");
@@ -538,11 +577,216 @@ private:
 
     void drawOpto(ImDrawList* dl)
     {
-        knob(dl, "opto_peak", P_OPTO_PEAK, 250, 380, "PEAK REDUCTION", "%.0f", "%");
-        knob(dl, "opto_gain", P_OPTO_GAIN, 420, 380, "GAIN", "%.0f", "%");
-        knob(dl, "opto_mix", P_MIX, 590, 380, "MIX", "%.0f", "%");
-        panel.toggle("opto_limit", P_OPTO_LIMIT, 690, 366, 820, 392, values[P_OPTO_LIMIT], "LIMIT");
-        panel.text(dl, 560, 500, 12, kDim, "Program-dependent optical envelope", 0);
+        using Layout = multicompp::ui_detail::OptoFaceplateLayout;
+        const float left = Layout::left;
+        const float right = Layout::right;
+        const float top = Layout::top;
+        const float bottom = Layout::bottom;
+
+        dl->AddRectFilled(panel.P(left + 4, top + 6), panel.P(right + 4, bottom + 6),
+                          IM_COL32(0, 0, 0, 90), 7.0f * panel.scale());
+        dl->AddRectFilled(panel.P(left, top), panel.P(right, bottom),
+                          kOptoTrim, 7.0f * panel.scale());
+        dl->AddRectFilled(panel.P(left + 5, top + 5), panel.P(right - 5, bottom - 5),
+                          kOptoFace, 4.0f * panel.scale());
+        dl->AddLine(panel.P(left + 8, top + 8), panel.P(right - 8, top + 8),
+                    IM_COL32(255, 252, 235, 145), panel.scale());
+        dl->AddLine(panel.P(left + 8, bottom - 8), panel.P(right - 8, bottom - 8),
+                    IM_COL32(74, 60, 48, 150), panel.scale());
+
+        for (const ImVec2 screw : {ImVec2(left + 18, top + 18),
+                                   ImVec2(right - 18, top + 18),
+                                   ImVec2(left + 18, bottom - 18),
+                                   ImVec2(right - 18, bottom - 18)})
+        {
+            dl->AddCircleFilled(panel.P(screw.x, screw.y), 6.0f * panel.scale(),
+                                IM_COL32(75, 73, 68, 255), 20);
+            dl->AddCircleFilled(panel.P(screw.x - 1.0f, screw.y - 1.0f),
+                                4.2f * panel.scale(), IM_COL32(177, 174, 163, 255), 20);
+            dl->AddLine(panel.P(screw.x - 2.5f, screw.y + 1.0f),
+                        panel.P(screw.x + 2.5f, screw.y - 1.0f),
+                        IM_COL32(72, 69, 63, 255), panel.scale());
+        }
+
+        panel.text(dl, 560, top + 13, 13.0f, kOptoInk, "DUSK OPTO LEVELER", 0, true);
+        panel.text(dl, 560, top + 31, 8.5f, IM_COL32(91, 84, 72, 255),
+                   "PROGRAM-DEPENDENT LEVELING AMPLIFIER", 0, true);
+        optoModeSwitch(dl, 112, 492);
+        optoKnob(dl, "opto_gain", P_OPTO_GAIN, 264, 505, 58.0f, "GAIN");
+        drawOptoMeter(dl, 389, 407, 324, 160, meter(kMeterMaster));
+        optoKnob(dl, "opto_peak", P_OPTO_PEAK, 829, 505, 58.0f,
+                 "PEAK REDUCTION");
+        optoKnob(dl, "opto_mix", P_MIX, 1000, 505, 39.0f, "MIX", false);
+    }
+
+    void optoKnob(ImDrawList* dl, const char* id, uint32_t p, float x, float y,
+                  float radius, const char* label, bool numberedScale = true)
+    {
+        // Put the shared gesture/editor layer above the custom body while
+        // letting it mutate the value first, so the pointer and readout update
+        // in the same frame. The active-only bubble exposes shift-fine values.
+        optoKnobSplitter.Split(dl, 2);
+        optoKnobSplitter.SetCurrentChannel(dl, 1);
+        panel.knob(id, p, hostMinimum(p), hostMaximum(p), x, y, radius,
+                   values[p], hostDefaultValue(p), false, false, "%.0f", "%",
+                   0, true, false, nullptr, false, 1.0f, 0.0f, label, true,
+                   nullptr, false, 0.0f, 0.0f, false, true, 9.5f, true, false,
+                   &knobHostToPlain, &knobPlainToHost, this);
+        optoKnobSplitter.SetCurrentChannel(dl, 0);
+
+        const float plain = plainValueForHost(p, values[p]);
+        const float minimum = plainValueForHost(p, hostMinimum(p));
+        const float maximum = plainValueForHost(p, hostMaximum(p));
+        const float t = std::clamp((plain - minimum)
+            / std::max(maximum - minimum, 1.0e-6f), 0.0f, 1.0f);
+        const ImVec2 center = panel.P(x, y);
+        const float scaledRadius = radius * panel.scale();
+
+        for (int tick = 0; tick <= 10; ++tick)
+        {
+            const float angle = duskdaf::DuskPanel::knobAngle(
+                static_cast<float>(tick) / 10.0f);
+            const ImVec2 direction(std::sin(angle), -std::cos(angle));
+            const float inner = scaledRadius + 5.0f * panel.scale();
+            const float outer = scaledRadius
+                + (tick % 5 == 0 ? 13.0f : 9.0f) * panel.scale();
+            dl->AddLine(ImVec2(center.x + direction.x * inner,
+                               center.y + direction.y * inner),
+                        ImVec2(center.x + direction.x * outer,
+                               center.y + direction.y * outer),
+                        kOptoInk, (tick % 5 == 0 ? 1.8f : 1.0f) * panel.scale());
+        }
+
+        dl->AddCircleFilled(ImVec2(center.x + 2.0f * panel.scale(),
+                                   center.y + 3.0f * panel.scale()),
+                            scaledRadius, IM_COL32(0, 0, 0, 85), 56);
+        dl->AddCircleFilled(center, scaledRadius, IM_COL32(28, 28, 27, 255), 56);
+        for (int ridge = 0; ridge < 24; ++ridge)
+        {
+            const float angle = 2.0f * kUiPi
+                * static_cast<float>(ridge) / 24.0f;
+            const ImVec2 direction(std::sin(angle), -std::cos(angle));
+            dl->AddLine(ImVec2(center.x + direction.x * scaledRadius * 0.82f,
+                               center.y + direction.y * scaledRadius * 0.82f),
+                        ImVec2(center.x + direction.x * scaledRadius * 0.97f,
+                               center.y + direction.y * scaledRadius * 0.97f),
+                        IM_COL32(116, 112, 102, 150), 1.4f * panel.scale());
+        }
+        dl->AddCircleFilled(center, scaledRadius * 0.72f,
+                            IM_COL32(56, 55, 52, 255), 48);
+        dl->AddCircleFilled(ImVec2(center.x - scaledRadius * 0.12f,
+                                   center.y - scaledRadius * 0.14f),
+                            scaledRadius * 0.57f, IM_COL32(78, 76, 70, 255), 42);
+        dl->AddCircle(center, scaledRadius, IM_COL32(12, 12, 11, 255), 56,
+                      1.5f * panel.scale());
+        const float pointerAngle = duskdaf::DuskPanel::knobAngle(t);
+        const ImVec2 pointer(std::sin(pointerAngle), -std::cos(pointerAngle));
+        dl->AddLine(ImVec2(center.x + pointer.x * scaledRadius * 0.18f,
+                           center.y + pointer.y * scaledRadius * 0.18f),
+                    ImVec2(center.x + pointer.x * scaledRadius * 0.88f,
+                           center.y + pointer.y * scaledRadius * 0.88f),
+                    kOptoFaceLight, 3.2f * panel.scale());
+
+        if (numberedScale)
+        {
+            panel.text(dl, x - radius - 16.0f, y + radius * 0.70f, 8.5f,
+                       kOptoInk, "0", 0, true);
+            panel.text(dl, x, y - radius - 24.0f, 8.5f, kOptoInk, "50", 0, true);
+            panel.text(dl, x + radius + 16.0f, y + radius * 0.70f, 8.5f,
+                       kOptoInk, "100", 0, true);
+        }
+        char readout[16];
+        std::snprintf(readout, sizeof(readout), "%.0f%%", static_cast<double>(plain));
+        dl->AddRectFilled(panel.P(x - 24.0f, y + radius + 10.0f),
+                          panel.P(x + 24.0f, y + radius + 29.0f),
+                          IM_COL32(43, 41, 37, 255), 2.0f * panel.scale());
+        panel.text(dl, x, y + radius + 14.0f, 9.5f, kOptoFaceLight,
+                   readout, 0, true);
+        panel.text(dl, x, y + radius + 35.0f, numberedScale ? 10.0f : 9.0f,
+                   kOptoInk, label, 0, true);
+        optoKnobSplitter.Merge(dl);
+    }
+
+    void optoModeSwitch(ImDrawList* dl, float x, float y)
+    {
+        const ImVec2 p0 = panel.P(x - 38.0f, y - 82.0f);
+        const ImVec2 p1 = panel.P(x + 38.0f, y + 78.0f);
+        ImGui::SetCursorScreenPos(p0);
+        ImGui::InvisibleButton("##opto_comp_limit", ImVec2(p1.x - p0.x, p1.y - p0.y));
+        if (ImGui::IsItemClicked())
+            setValue(P_OPTO_LIMIT, values[P_OPTO_LIMIT] > 0.5f ? 0.0f : 1.0f);
+
+        const bool limit = multicompp::ui_detail::choiceIndex(
+            values[P_OPTO_LIMIT], 2) == 1;
+        constexpr ImU32 inactiveMode = IM_COL32(111, 103, 88, 255);
+        panel.text(dl, x, y - 74.0f, 9.5f, limit ? kOptoRed : inactiveMode,
+                   multicompp::ui_detail::optoModeLabel(1.0f), 0, true);
+        panel.text(dl, x, y + 65.0f, 9.5f, !limit ? kOptoRed : inactiveMode,
+                   multicompp::ui_detail::optoModeLabel(0.0f), 0, true);
+        dl->AddRectFilled(panel.P(x - 14.0f, y - 42.0f),
+                          panel.P(x + 14.0f, y + 42.0f),
+                          IM_COL32(44, 42, 38, 255), 5.0f * panel.scale());
+        dl->AddRect(panel.P(x - 14.0f, y - 42.0f),
+                    panel.P(x + 14.0f, y + 42.0f),
+                    IM_COL32(18, 18, 17, 255), 5.0f * panel.scale(), 0,
+                    1.5f * panel.scale());
+        const float leverY = y + (limit ? -24.0f : 24.0f);
+        dl->AddLine(panel.P(x, y), panel.P(x, leverY),
+                    IM_COL32(168, 164, 151, 255), 5.0f * panel.scale());
+        dl->AddCircleFilled(panel.P(x, leverY), 8.0f * panel.scale(),
+                            IM_COL32(203, 198, 183, 255), 24);
+        dl->AddCircle(panel.P(x, leverY), 8.0f * panel.scale(),
+                      IM_COL32(34, 33, 30, 255), 24, 1.2f * panel.scale());
+        panel.text(dl, x, y + 93.0f, 8.5f, IM_COL32(91, 84, 72, 255),
+                   multicompp::ui_detail::optoModeLabel(values[P_OPTO_LIMIT]),
+                   0, true);
+    }
+
+    void drawOptoMeter(ImDrawList* dl, float x, float y, float w, float h, float gr)
+    {
+        dl->AddRectFilled(panel.P(x + 3.0f, y + 4.0f),
+                          panel.P(x + w + 3.0f, y + h + 4.0f),
+                          IM_COL32(0, 0, 0, 90), 5.0f * panel.scale());
+        dl->AddRectFilled(panel.P(x, y), panel.P(x + w, y + h),
+                          IM_COL32(47, 45, 41, 255), 5.0f * panel.scale());
+        dl->AddRectFilled(panel.P(x + 8.0f, y + 8.0f),
+                          panel.P(x + w - 8.0f, y + h - 8.0f),
+                          kOptoFaceLight, 2.0f * panel.scale());
+        const ImVec2 pivot = panel.P(x + w * 0.5f, y + h - 13.0f);
+        const float radius = 118.0f * panel.scale();
+        constexpr std::array<const char*, 5> labels{{"20", "15", "10", "5", "0"}};
+        for (size_t tick = 0; tick < labels.size(); ++tick)
+        {
+            const float amount = static_cast<float>(tick)
+                / static_cast<float>(labels.size() - 1);
+            const float angle = (-55.0f + 110.0f * amount)
+                * kUiPi / 180.0f;
+            const ImVec2 direction(std::sin(angle), -std::cos(angle));
+            dl->AddLine(ImVec2(pivot.x + direction.x * radius * 0.76f,
+                               pivot.y + direction.y * radius * 0.76f),
+                        ImVec2(pivot.x + direction.x * radius * 0.88f,
+                               pivot.y + direction.y * radius * 0.88f),
+                        kOptoInk, 1.4f * panel.scale());
+            panel.text(dl,
+                       x + w * 0.5f + direction.x * 76.0f,
+                       y + h - 17.0f - std::cos(angle) * 76.0f,
+                       8.0f, kOptoInk, labels[tick], 0, true);
+        }
+        panel.text(dl, x + w * 0.5f, y + 16.0f, 11.0f, kOptoRed,
+                   multicompp::ui_detail::optoMeterLabel(), 0, true);
+        const float needleAngle = multicompp::ui_detail::optoMeterNeedleAngle(gr);
+        const ImVec2 needle(std::sin(needleAngle), -std::cos(needleAngle));
+        dl->AddLine(pivot,
+                    ImVec2(pivot.x + needle.x * radius * 0.87f,
+                           pivot.y + needle.y * radius * 0.87f),
+                    kOptoRed, 2.2f * panel.scale());
+        dl->AddCircleFilled(pivot, 7.0f * panel.scale(), kOptoInk, 24);
+        char reading[24];
+        std::snprintf(reading, sizeof(reading), "%s %.1f dB",
+                      multicompp::ui_detail::optoMeterLabel(),
+                      static_cast<double>(std::clamp(-gr, 0.0f, 99.9f)));
+        panel.text(dl, x + w * 0.5f, y + h + 10.0f, 8.5f, kOptoInk,
+                   reading, 0, true);
     }
 
     void drawFet(ImDrawList* dl, bool studio)

--- a/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
+#include <cfloat>
 #include <cmath>
 #include <cstdint>
 
@@ -19,16 +21,25 @@ inline int choiceIndex(float hostValue, int count) noexcept
 
 struct OptoFaceplateLayout
 {
-    static constexpr float left = 34.0f;
-    static constexpr float right = 1086.0f;
-    static constexpr float top = 362.0f;
-    static constexpr float bottom = 653.0f;
+    static constexpr float left = 0.0f;
+    static constexpr float right = 1120.0f;
+    static constexpr float top = 344.0f;
+    static constexpr float bottom = 654.0f;
 };
 
 inline constexpr float optoFaceplateAspect() noexcept
 {
     return (OptoFaceplateLayout::right - OptoFaceplateLayout::left)
         / (OptoFaceplateLayout::bottom - OptoFaceplateLayout::top);
+}
+
+inline float designHeightForMode(float hostValue) noexcept
+{
+    // Opto is a single rack face and should have the same shallow proportion as
+    // the hardware it evokes. Multiband still needs the original tall canvas;
+    // keeping the decision here also gives fractional host automation the same
+    // rounding rule as the DSP and the mode picker.
+    return choiceIndex(hostValue, 8) == 0 ? 380.0f : 486.0f;
 }
 
 inline float optoMeterNeedleAngle(float gainReductionDb) noexcept
@@ -38,24 +49,62 @@ inline float optoMeterNeedleAngle(float gainReductionDb) noexcept
     return (55.0f - 110.0f * amount) * pi / 180.0f;
 }
 
+inline float optoMeterBallisticStep(float currentGainReductionDb,
+                                    float targetGainReductionDb,
+                                    float elapsedSeconds) noexcept
+{
+    // Display-only VU inertia. Use elapsed time rather than a per-frame blend
+    // so the response remains the same at different host repaint rates.
+    if (!std::isfinite(currentGainReductionDb)) currentGainReductionDb = 0.0f;
+    if (!std::isfinite(targetGainReductionDb) || !(elapsedSeconds > 0.0f))
+        return currentGainReductionDb;
+    constexpr float timeConstantSeconds = 0.300f;
+    const float boundedElapsed = std::min(elapsedSeconds, 3.0f);
+    const float response = 1.0f - std::exp(-boundedElapsed / timeConstantSeconds);
+    return currentGainReductionDb
+        + (targetGainReductionDb - currentGainReductionDb) * response;
+}
+
+inline constexpr const char* optoKnobValueSuffix() noexcept { return ""; }
+
+inline bool optoKnobUsesPlainDomainDrag(uint32_t parameter) noexcept
+{
+    return parameter == static_cast<uint32_t>(ParamId::SidechainHP);
+}
+
 inline const char* optoModeLabel(float hostValue) noexcept
 {
-    return choiceIndex(hostValue, 2) == 0 ? "COMP" : "LIMIT";
+    return choiceIndex(hostValue, 2) == 0 ? "COMPRESS" : "LIMIT";
 }
 
 inline constexpr const char* optoMeterLabel() noexcept { return "GR"; }
+
+inline float optoMeterReadoutAmount(float gainReductionDb) noexcept
+{
+    return std::clamp(std::max(0.0f, -gainReductionDb), 0.0f, 99.9f);
+}
 
 template <size_t N>
 inline int loadProgramIntoMirror(uint32_t index, std::array<float, N>& values)
 {
     if (index >= kFactoryPresets.size()) return -1;
-    applyPresetToHostParameters(kFactoryPresets[index],
+    applyFactoryPresetToHostParameters(index,
         [&values](int parameterIndex, float hostValue)
         {
             if (parameterIndex >= 0 && static_cast<size_t>(parameterIndex) < values.size())
                 values[static_cast<size_t>(parameterIndex)] = hostValue;
         });
     return static_cast<int>(index);
+}
+
+inline bool selectionOwnsParam(int currentFactoryPreset, bool userPresetActive,
+                               bool defaultsActive, uint32_t parameterIndex) noexcept
+{
+    if (currentFactoryPreset >= 0)
+        return presetOwnsParam(currentFactoryPreset, parameterIndex);
+    if (userPresetActive || defaultsActive)
+        return parameterIndex != static_cast<uint32_t>(ParamId::Bypass);
+    return false;
 }
 
 // Mirrors the plugin's ordered crossover set, so raising one handle also shows
@@ -86,8 +135,16 @@ inline void refreshCrossoverMirror(std::array<float, N>& values, ReadParameter r
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp"
 
+#include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <vector>
 
 DUSK_WEAK float multiCompGetParameterValue(void* pluginInstancePointer,
                                             uint32_t index) noexcept;
@@ -97,11 +154,13 @@ START_NAMESPACE_DAF
 namespace
 {
 constexpr float kDesignW = 1120.0f;
-constexpr float kDesignH = 760.0f;
-constexpr float kHeaderH = 64.0f;
-constexpr float kGlobalH = 132.0f;
-constexpr float kSidechainH = 126.0f;
-constexpr float kPanelTop = kHeaderH + kGlobalH + kSidechainH;
+constexpr float kHeaderH = 48.0f;
+// Mode panels were authored in the original 760 px canvas. Translate that
+// canvas upward so every mode keeps its internal proportions while the retired
+// Global and Sidechain bands disappear completely from the visible layout.
+constexpr float kModeCanvasTop = 322.0f;
+constexpr float kModeCanvasBottom = 760.0f;
+constexpr float kModeCanvasShiftY = kModeCanvasTop - kHeaderH;
 constexpr float kUiPi = duskdaf::DuskPanel::kPi;
 // Set to true only while collecting a host geometry measurement.
 constexpr bool kGeometryDiagnosticEnabled = false;
@@ -112,11 +171,10 @@ constexpr ImU32 kLine = IM_COL32(75, 79, 90, 255);
 constexpr ImU32 kText = IM_COL32(232, 234, 238, 255);
 constexpr ImU32 kDim = IM_COL32(162, 168, 180, 255);
 constexpr ImU32 kAccent = IM_COL32(65, 194, 220, 255);
-constexpr ImU32 kOptoFace = IM_COL32(211, 204, 184, 255);
-constexpr ImU32 kOptoFaceLight = IM_COL32(235, 229, 208, 255);
-constexpr ImU32 kOptoInk = IM_COL32(43, 41, 37, 255);
-constexpr ImU32 kOptoTrim = IM_COL32(92, 72, 54, 255);
-constexpr ImU32 kOptoRed = IM_COL32(159, 48, 39, 255);
+constexpr ImU32 kHeaderGreen = IM_COL32(76, 103, 48, 255);
+constexpr ImU32 kHeaderGreenDark = IM_COL32(39, 57, 24, 255);
+constexpr ImU32 kOptoInk = IM_COL32(31, 32, 31, 255);
+constexpr ImU32 kOptoRed = IM_COL32(151, 25, 31, 255);
 constexpr ImU32 kBandColors[4] = {
     IM_COL32(92, 165, 235, 255), IM_COL32(92, 205, 150, 255),
     IM_COL32(232, 185, 74, 255), IM_COL32(224, 100, 93, 255)
@@ -124,10 +182,9 @@ constexpr ImU32 kBandColors[4] = {
 
 // Parameter indices are aliases of the single table order in MultiCompParams.hpp.
 using ParamId = multicompp::ParamId;
-constexpr uint32_t P_MODE = static_cast<uint32_t>(ParamId::Mode), P_BYPASS = static_cast<uint32_t>(ParamId::Bypass), P_LINK = static_cast<uint32_t>(ParamId::StereoLink), P_MIX = static_cast<uint32_t>(ParamId::Mix);
-constexpr uint32_t P_SC_HP = static_cast<uint32_t>(ParamId::SidechainHP), P_TRUE_PEAK = static_cast<uint32_t>(ParamId::TruePeakEnable), P_TP_QUALITY = static_cast<uint32_t>(ParamId::TruePeakQuality), P_EXT_SC = static_cast<uint32_t>(ParamId::ExternalSidechain);
+constexpr uint32_t P_MODE = static_cast<uint32_t>(ParamId::Mode), P_BYPASS = static_cast<uint32_t>(ParamId::Bypass), P_MIX = static_cast<uint32_t>(ParamId::Mix);
+constexpr uint32_t P_SC_HP = static_cast<uint32_t>(ParamId::SidechainHP);
 #define MC_PID(name) static_cast<uint32_t>(ParamId::name)
-constexpr uint32_t P_AUTO = MC_PID(AutoMakeup), P_DIST = MC_PID(Distortion), P_DIST_AMT = MC_PID(DistortionAmount), P_OS = MC_PID(Oversampling), P_LOOK = MC_PID(GlobalLookahead);
 constexpr uint32_t P_OPTO_PEAK = MC_PID(OptoPeakReduction), P_OPTO_GAIN = MC_PID(OptoGain), P_OPTO_LIMIT = MC_PID(OptoLimit);
 constexpr uint32_t P_FET_IN = MC_PID(FetInput), P_FET_OUT = MC_PID(FetOutput), P_FET_ATTACK = MC_PID(FetAttack), P_FET_RELEASE = MC_PID(FetRelease);
 constexpr uint32_t P_FET_RATIO = MC_PID(FetRatio), P_FET_CURVE = MC_PID(FetCurve), P_FET_TRANSIENT = MC_PID(FetTransient), P_FET_THRESHOLD = MC_PID(FetThreshold);
@@ -140,18 +197,11 @@ constexpr uint32_t P_SVCA_RELEASE = MC_PID(StudioVcaRelease), P_SVCA_OUT = MC_PI
 constexpr uint32_t P_DIG_THRESHOLD = MC_PID(DigitalThreshold), P_DIG_RATIO = MC_PID(DigitalRatio), P_DIG_KNEE = MC_PID(DigitalKnee), P_DIG_ATTACK = MC_PID(DigitalAttack);
 constexpr uint32_t P_DIG_RELEASE = MC_PID(DigitalRelease), P_DIG_LOOK = MC_PID(DigitalLookahead), P_DIG_MIX = MC_PID(DigitalMix), P_DIG_OUT = MC_PID(DigitalOutput);
 constexpr uint32_t P_DIG_ADAPT = MC_PID(DigitalAdaptive), P_X1 = MC_PID(Crossover1), P_X2 = MC_PID(Crossover2), P_X3 = MC_PID(Crossover3);
-constexpr uint32_t P_SC_LISTEN = MC_PID(GlobalSidechainListen), P_MB_MIX = MC_PID(MbMix), P_MB_OUT = MC_PID(MbOutput);
-constexpr uint32_t P_NOISE = MC_PID(NoiseEnable), P_SC_LOW_FREQ = MC_PID(ScLowFreq), P_SC_LOW_GAIN = MC_PID(ScLowGain);
-constexpr uint32_t P_SC_HIGH_FREQ = MC_PID(ScHighFreq), P_SC_HIGH_GAIN = MC_PID(ScHighGain), P_LINK_MODE = MC_PID(StereoLinkMode);
+constexpr uint32_t P_MB_MIX = MC_PID(MbMix), P_MB_OUT = MC_PID(MbOutput);
 #undef MC_PID
 
 constexpr uint32_t kMeterMaster = static_cast<uint32_t>(multicompp::kMeterMaster);
 constexpr uint32_t kMeterBand0 = static_cast<uint32_t>(multicompp::kMeterBand0);
-
-const char* modeName(int mode)
-{
-    return mode >= 0 && mode < 8 ? multicompp::kModes[mode] : "Opto";
-}
 
 const char* bandName(int band)
 {
@@ -178,13 +228,17 @@ public:
                 values[multicompp::kBandBase + b * 8 + f] =
                     multicompp::hostDefault(multicompp::bandParam(f, b));
 
-        // Match the fixed design space and keep host-driven resizes on its aspect.
-        setGeometryConstraints(static_cast<uint32_t>(kDesignW * 0.5f),
-                               static_cast<uint32_t>(kDesignH * 0.5f), true);
+        // Opto opens as a shallow rack face. Other modes request their taller
+        // authored canvas when selected, preserving the user's current scale.
+        constrainedDesignH = multicompp::ui_detail::designHeightForMode(values[P_MODE]);
+        pendingDesignH = constrainedDesignH;
+        setGeometryConstraints(static_cast<uint32_t>(kDesignW),
+                               static_cast<uint32_t>(constrainedDesignH), true);
         static const float kFontSizes[] = {9.f, 11.f, 13.f, 16.f, 20.f, 26.f, 30.f};
         fontSet = duskdaf::loadCrispFontSet(kFontSizes, 7, getScaleFactor());
         labelFont = fontSet.primary();
         panel.setFontSet(fontSet);
+        scanUserPresets();
     }
 
     void beginEdit(uint32_t idx) override { editParameter(idx, true); }
@@ -192,8 +246,9 @@ public:
     void setParam(uint32_t idx, float value) override
     {
         if (idx >= static_cast<uint32_t>(multicompp::kMeterMaster)) return;
-        currentPreset = -1;
+        clearPresetSelectionForEdit(idx);
         values[idx] = value;
+        if (idx == P_MODE) scheduleModeGeometry(value);
         setParameterValue(idx, value);
         if (idx >= P_X1 && idx <= P_X3) refreshCrossoverMirror();
     }
@@ -202,7 +257,11 @@ protected:
     void parameterChanged(uint32_t index, float value) override
     {
         if (index < values.size()) values[index] = value;
+        if (index == P_MODE) scheduleModeGeometry(value);
         if (index >= P_X1 && index <= P_X3) refreshCrossoverMirror();
+        if (index < static_cast<uint32_t>(multicompp::kMeterMaster)
+            && index != P_BYPASS)
+            syncPresetSelection();
     }
 
     void stateChanged(const char* key, const char* state) override
@@ -212,18 +271,24 @@ protected:
         if (!multicompp::decodeState(state, decoded)) return;
         for (int i = 0; i < multicompp::kMeterMaster; ++i)
             values[static_cast<size_t>(i)] = decoded[static_cast<size_t>(i)];
-        currentPreset = -1;
+        scheduleModeGeometry(values[P_MODE]);
+        syncPresetSelection();
         repaint();
     }
 
     void programLoaded(uint32_t index) override
     {
         currentPreset = multicompp::ui_detail::loadProgramIntoMirror(index, values);
+        scheduleModeGeometry(values[P_MODE]);
+        currentUserName.clear();
+        currentUserPath.clear();
+        defaultsActive = currentPreset < 0 && matchesDefaults();
     }
 
     void uiIdle() override
     {
         refreshCrossoverMirror();
+        updateOptoMeter();
         repaint();
     }
 
@@ -244,9 +309,10 @@ protected:
 
         const float winW = static_cast<float>(getWidth());
         const float winH = static_cast<float>(getHeight());
-        const float scale = std::min(winW / kDesignW, winH / kDesignH);
+        const float designH = multicompp::ui_detail::designHeightForMode(value(P_MODE));
+        const float scale = std::min(winW / kDesignW, winH / designH);
         const ImVec2 origin((winW - kDesignW * scale) * 0.5f,
-                            (winH - kDesignH * scale) * 0.5f);
+                            (winH - designH * scale) * 0.5f);
         if (kGeometryDiagnosticEnabled && !geometryDiagnosticLogged)
         {
             GLint viewport[4]{};
@@ -258,7 +324,7 @@ protected:
                          static_cast<unsigned>(getWidth()),
                          static_cast<unsigned>(getHeight()),
                          static_cast<double>(getScaleFactor()),
-                         static_cast<double>(kDesignW), static_cast<double>(kDesignH),
+                         static_cast<double>(kDesignW), static_cast<double>(designH),
                          static_cast<double>(scale), static_cast<double>(origin.x),
                          static_cast<double>(origin.y), viewport[0], viewport[1],
                          viewport[2], viewport[3]);
@@ -280,20 +346,33 @@ protected:
         ImDrawList* dl = ImGui::GetWindowDrawList();
         dl->AddRectFilled(ImVec2(0, 0), ImVec2(winW, winH), IM_COL32(21, 22, 25, 255));
         drawHeader(dl);
-        drawGlobal(dl);
-        drawSidechain(dl);
+
+        // The mode-panel drawing code retains its original internal coordinates;
+        // translate only that canvas so removing the two utility bands does not
+        // perturb the carefully tuned per-mode layouts or hit targets.
+        panel.begin(scale, ImVec2(origin.x, origin.y - kModeCanvasShiftY * scale),
+                    labelFont, this);
         drawModePanel(dl);
 
+        // Overlays and the resize grip live in the compact visible canvas.
+        panel.begin(scale, origin, labelFont, this);
+
         if (showSupporters)
-            duskdaf::drawSupportersOverlay(panel, dl, kDesignW, kDesignH, showSupporters,
+            duskdaf::drawSupportersOverlay(panel, dl, kDesignW, designH, showSupporters,
                                            "Multi-Comp 2", MULTICOMP2_VERSION_STRING,
                                            &supporters);
 
         const duskdaf::ResizeGripState grip =
-            panel.resizeGrip(dl, winW, winH, kDesignW, kDesignH, 0.5f);
+            panel.resizeGrip(dl, winW, winH, kDesignW, designH, 0.5f);
         ImGui::End();
         ImGui::PopStyleVar(2);
-        if (grip.resized) setSize(grip.width, grip.height);
+        // A host can service either request synchronously, so never resize from
+        // inside the active ImGui window. A mode change takes priority over a
+        // resize-grip request made against the previous aspect ratio.
+        if (modeGeometryPending)
+            applyModeGeometry();
+        else if (grip.resized)
+            setSize(grip.width, grip.height);
     }
 
 private:
@@ -305,6 +384,12 @@ private:
     duskdaf::SupportersOverlay supporters;
     bool showSupporters = false;
     bool geometryDiagnosticLogged = false;
+    float constrainedDesignH = 380.0f;
+    float pendingDesignH = 380.0f;
+    bool modeGeometryPending = false;
+    float optoMeterGainReductionDb = 0.0f;
+    std::chrono::steady_clock::time_point optoMeterLastUpdate{};
+    bool optoMeterInitialized = false;
     static constexpr uint32_t kNoCrossover = ~uint32_t(0);
     // The crossover handle under an active drag. Owns both the open automation
     // gesture and the mirror's skip, so the two cannot disagree.
@@ -313,8 +398,168 @@ private:
     // once per frame to notice a handle that stopped being drawn mid-drag.
     bool draggedCrossoverStillDrawn = false;
     int currentPreset = -1;
+    bool defaultsActive = true;
+    std::string currentUserName;
+    std::string currentUserPath;
+    struct UserPreset
+    {
+        std::string name;
+        std::string path;
+        multicompp::StateValues values{};
+    };
+    std::vector<UserPreset> userPresets;
+    char saveBuf[64] = {};
+    bool saveFailed = false;
 
     float value(uint32_t p) const { return values[p]; }
+
+    void updateOptoMeter()
+    {
+        const auto now = std::chrono::steady_clock::now();
+        const float target = meter(kMeterMaster);
+        if (!optoMeterInitialized)
+        {
+            optoMeterGainReductionDb = target;
+            optoMeterInitialized = true;
+        }
+        else
+        {
+            const float elapsed = std::chrono::duration<float>(
+                now - optoMeterLastUpdate).count();
+            optoMeterGainReductionDb = multicompp::ui_detail::optoMeterBallisticStep(
+                optoMeterGainReductionDb, target, elapsed);
+        }
+        optoMeterLastUpdate = now;
+    }
+
+    void scheduleModeGeometry(float hostMode)
+    {
+        pendingDesignH = multicompp::ui_detail::designHeightForMode(hostMode);
+        modeGeometryPending = pendingDesignH != constrainedDesignH;
+    }
+
+    void applyModeGeometry()
+    {
+        modeGeometryPending = false;
+        const uint32_t width = getWidth();
+        const uint32_t targetHeight = static_cast<uint32_t>(std::lround(
+            static_cast<double>(width) * pendingDesignH / kDesignW));
+        setGeometryConstraints(static_cast<uint32_t>(kDesignW),
+                               static_cast<uint32_t>(pendingDesignH), true);
+        constrainedDesignH = pendingDesignH;
+        geometryDiagnosticLogged = false;
+        if (getHeight() != targetHeight)
+            setSize(width, targetHeight);
+    }
+
+    void clearPresetSelection(bool atDefaults)
+    {
+        currentPreset = -1;
+        currentUserName.clear();
+        currentUserPath.clear();
+        defaultsActive = atDefaults;
+    }
+
+    void clearPresetSelectionForEdit(uint32_t parameterIndex)
+    {
+        if (multicompp::ui_detail::selectionOwnsParam(
+                currentPreset, !currentUserName.empty(), defaultsActive,
+                parameterIndex))
+            clearPresetSelection(false);
+    }
+
+    bool parameterMatches(int index, float expected) const
+    {
+        const float range = multicompp::resolveParameter(index,
+            [](const multicompp::Param& d) {
+                return multicompp::hostMax(d) - multicompp::hostMin(d);
+            },
+            [](const multicompp::BandParam& d, int) {
+                return multicompp::hostMax(d) - multicompp::hostMin(d);
+            });
+        return std::fabs(values[static_cast<size_t>(index)] - expected)
+            <= std::max(1.0e-6f, range * 1.0e-5f);
+    }
+
+    bool matchesDefaults() const
+    {
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
+        {
+            if (i == static_cast<int>(P_BYPASS)) continue;
+            const float expected = multicompp::resolveParameter(i,
+                [](const multicompp::Param& d) { return multicompp::hostDefault(d); },
+                [](const multicompp::BandParam& d, int) {
+                    return multicompp::hostDefault(d);
+                });
+            if (!parameterMatches(i, expected)) return false;
+        }
+        return true;
+    }
+
+    int deriveFactoryPreset() const
+    {
+        for (size_t presetIndex = 0;
+             presetIndex < multicompp::kFactoryPresets.size(); ++presetIndex)
+        {
+            bool matches = true;
+            const auto& expanded = multicompp::kExpandedFactoryPresets[presetIndex];
+            for (int parameterIndex = 0;
+                 parameterIndex < multicompp::kMeterMaster && matches;
+                 ++parameterIndex)
+                if (multicompp::presetOwnsParam(
+                        static_cast<int>(presetIndex),
+                        static_cast<uint32_t>(parameterIndex))
+                    && !parameterMatches(
+                        parameterIndex,
+                        expanded.hostValues[static_cast<size_t>(parameterIndex)]))
+                    matches = false;
+            if (matches) return static_cast<int>(presetIndex);
+        }
+        return -1;
+    }
+
+    int deriveUserPreset() const
+    {
+        for (size_t presetIndex = 0; presetIndex < userPresets.size(); ++presetIndex)
+        {
+            bool matches = true;
+            for (int i = 0; i < multicompp::kMeterMaster && matches; ++i)
+                if (i != static_cast<int>(P_BYPASS)
+                    && !parameterMatches(
+                        i, userPresets[presetIndex].values[static_cast<size_t>(i)]))
+                    matches = false;
+            if (matches) return static_cast<int>(presetIndex);
+        }
+        return -1;
+    }
+
+    void syncPresetSelection()
+    {
+        if (matchesDefaults())
+        {
+            clearPresetSelection(true);
+            return;
+        }
+        const int factory = deriveFactoryPreset();
+        if (factory >= 0)
+        {
+            currentPreset = factory;
+            currentUserName.clear();
+            currentUserPath.clear();
+            defaultsActive = false;
+            return;
+        }
+        const int user = deriveUserPreset();
+        if (user >= 0)
+        {
+            currentPreset = -1;
+            currentUserName = userPresets[static_cast<size_t>(user)].name;
+            currentUserPath = userPresets[static_cast<size_t>(user)].path;
+            defaultsActive = false;
+            return;
+        }
+        clearPresetSelection(false);
+    }
 
     void refreshCrossoverMirror()
     {
@@ -328,30 +573,32 @@ private:
 
     void setValue(uint32_t p, float v)
     {
-        currentPreset = -1;
+        clearPresetSelectionForEdit(p);
         editParameter(p, true);
         const float hostValue = hostValueForPlain(p, v);
         values[p] = hostValue;
+        if (p == P_MODE) scheduleModeGeometry(hostValue);
         setParameterValue(p, hostValue);
         editParameter(p, false);
+    }
+
+    void setHostValue(uint32_t p, float hostValue)
+    {
+        clearPresetSelectionForEdit(p);
+        editParameter(p, true);
+        values[p] = hostValue;
+        if (p == P_MODE) scheduleModeGeometry(hostValue);
+        setParameterValue(p, hostValue);
+        editParameter(p, false);
+        if (p >= P_X1 && p <= P_X3) refreshCrossoverMirror();
     }
 
     void drawSection(ImDrawList* dl, float y0, float y1, const char* title)
     {
         dl->AddRectFilled(panel.P(8, y0), panel.P(kDesignW - 8, y1), kPanel, 5.0f * panel.scale());
         dl->AddRect(panel.P(8, y0), panel.P(kDesignW - 8, y1), kLine, 5.0f * panel.scale(), 0, panel.scale());
-        panel.text(dl, 22, y0 + 10, 11, kAccent, title, -1, true);
-    }
-
-    void titleHit(ImDrawList* dl)
-    {
-        panel.text(dl, 22, 11, 24, kText, "Multi-Comp 2", -1, true);
-        panel.text(dl, 24, 40, 10, kDim,
-                   modeName(multicompp::ui_detail::choiceIndex(value(P_MODE), 8)), -1);
-        panel.text(dl, kDesignW - 20, 20, 11, kDim, "Dusk Audio", 1);
-        ImGui::SetCursorScreenPos(panel.P(12, 7));
-        ImGui::InvisibleButton("##mc_title", ImVec2(190 * panel.scale(), 44 * panel.scale()));
-        if (ImGui::IsItemClicked()) showSupporters = true;
+        if (title != nullptr && title[0] != '\0')
+            panel.text(dl, 22, y0 + 10, 11, kAccent, title, -1, true);
     }
 
     bool combo(const char* id, uint32_t p, const char* const* labels, int count,
@@ -393,28 +640,125 @@ private:
         return changed;
     }
 
+    bool headerChevron(ImDrawList* dl, const char* id, float cx, bool left)
+    {
+        constexpr float cy = 24.0f;
+        constexpr float halfH = 12.5f;
+        const ImVec2 b0 = panel.P(cx - 9.5f, cy - halfH);
+        const ImVec2 b1 = panel.P(cx + 9.5f, cy + halfH);
+        ImGui::SetCursorScreenPos(b0);
+        ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+        const bool hovered = ImGui::IsItemHovered();
+        dl->AddRectFilled(b0, b1, hovered ? IM_COL32(54, 54, 58, 255)
+                                          : IM_COL32(38, 38, 41, 255),
+                          2.0f * panel.scale());
+        dl->AddRect(b0, b1, IM_COL32(90, 90, 94, 255), 2.0f * panel.scale(), 0,
+                    panel.scale());
+        const ImVec2 center = panel.P(cx, cy);
+        const float d = 4.3f * panel.scale();
+        const ImU32 ink = hovered ? kText : kDim;
+        if (left)
+            dl->AddTriangleFilled(ImVec2(center.x + d * 0.5f, center.y - d),
+                                  ImVec2(center.x + d * 0.5f, center.y + d),
+                                  ImVec2(center.x - d * 0.7f, center.y), ink);
+        else
+            dl->AddTriangleFilled(ImVec2(center.x - d * 0.5f, center.y - d),
+                                  ImVec2(center.x - d * 0.5f, center.y + d),
+                                  ImVec2(center.x + d * 0.7f, center.y), ink);
+        return ImGui::IsItemClicked();
+    }
+
+    bool headerTextButton(ImDrawList* dl, const char* id, float x0, float x1,
+                          const char* label)
+    {
+        constexpr float y0 = 11.5f, y1 = 36.5f;
+        const ImVec2 b0 = panel.P(x0, y0), b1 = panel.P(x1, y1);
+        ImGui::SetCursorScreenPos(b0);
+        ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+        const bool hovered = ImGui::IsItemHovered();
+        dl->AddRectFilled(b0, b1, hovered ? IM_COL32(54, 54, 58, 255)
+                                          : IM_COL32(38, 38, 41, 255),
+                          2.0f * panel.scale());
+        dl->AddRect(b0, b1, IM_COL32(90, 90, 94, 255), 2.0f * panel.scale(), 0,
+                    panel.scale());
+        panel.text(dl, 0.5f * (x0 + x1), 18.5f, 11.0f,
+                   hovered ? kText : kDim, label, 0, true);
+        return ImGui::IsItemClicked();
+    }
+
+    const char* presetPreview() const
+    {
+        if (currentPreset >= 0
+            && currentPreset < static_cast<int>(multicompp::kFactoryPresets.size()))
+            return multicompp::kFactoryPresets[static_cast<size_t>(currentPreset)].name;
+        if (!currentUserName.empty()) return currentUserName.c_str();
+        return defaultsActive ? "Default" : "Custom";
+    }
+
     void drawHeader(ImDrawList* dl)
     {
-        dl->AddRectFilled(panel.P(0, 0), panel.P(kDesignW, kHeaderH), IM_COL32(18, 19, 22, 255));
-        dl->AddLine(panel.P(0, kHeaderH), panel.P(kDesignW, kHeaderH), kLine, panel.scale());
-        titleHit(dl);
-        combo("mc_mode", P_MODE, multicompp::kModes, 8, 310, 10, 180, "MODE");
-        // Presets use a custom popup because they are programs, not a parameter enum.
-        const ImVec2 p0 = panel.P(505, 26), p1 = panel.P(750, 54);
-        dl->AddRectFilled(p0, p1, IM_COL32(30, 31, 35, 255), 3 * panel.scale());
-        dl->AddRect(p0, p1, kLine, 3 * panel.scale(), 0, panel.scale());
-        const char* presetName = currentPreset >= 0
-            ? multicompp::kFactoryPresets[static_cast<size_t>(currentPreset)].name : "Factory Preset";
-        panel.text(dl, 518, 35, 10.5f, kText, presetName, -1);
-        ImGui::SetCursorScreenPos(p0);
-        ImGui::SetNextItemWidth(p1.x - p0.x);
-        ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0, 0, 0, 0));
-        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(0, 0, 0, 0));
-        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(0, 0, 0, 0));
-        ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IM_COL32(0, 0, 0, 0));
-        const bool presetOpen = ImGui::BeginCombo("##mc_factory", presetName, ImGuiComboFlags_NoArrowButton);
-        ImGui::PopStyleColor(4);
-        if (presetOpen)
+        dl->AddRectFilled(panel.P(0, 0), panel.P(kDesignW, kHeaderH),
+                          IM_COL32(14, 14, 15, 255));
+        dl->AddRectFilledMultiColor(panel.P(0, 0), panel.P(kDesignW, 4),
+                                    IM_COL32(205, 203, 197, 255),
+                                    IM_COL32(155, 154, 151, 255),
+                                    IM_COL32(91, 91, 91, 255),
+                                    IM_COL32(118, 118, 116, 255));
+        dl->AddLine(panel.P(0, 48), panel.P(kDesignW, 48),
+                    IM_COL32(91, 90, 88, 255), 1.2f * panel.scale());
+
+        constexpr float plateX0 = 28.0f, plateX1 = 358.0f;
+        constexpr float plateY0 = 8.0f, plateY1 = 40.0f;
+        dl->AddRectFilledMultiColor(panel.P(plateX0, plateY0), panel.P(plateX1, plateY1),
+                                    IM_COL32(37, 37, 38, 255),
+                                    IM_COL32(29, 29, 30, 255),
+                                    IM_COL32(16, 16, 17, 255),
+                                    IM_COL32(19, 19, 20, 255));
+        dl->AddRect(panel.P(plateX0, plateY0), panel.P(plateX1, plateY1),
+                    IM_COL32(185, 184, 180, 220), 3.5f * panel.scale(), 0,
+                    1.2f * panel.scale());
+        dl->AddLine(panel.P(40, 37), panel.P(348, 37),
+                    IM_COL32(116, 145, 75, 210), 1.2f * panel.scale());
+        panel.text(dl, 42, 10, 24, kText, "MULTI-COMP", -1, true);
+        panel.text(dl, 244, 14, 20, kText, "MC-2", 0, true);
+        panel.text(dl, 346, 20, 11, kDim, "v" MULTICOMP2_VERSION_STRING, 1);
+        panel.text(dl, kDesignW - 34, 12, 22, kText, "DUSK AUDIO", 1, true);
+
+        ImGui::SetCursorScreenPos(panel.P(plateX0, plateY0));
+        if (ImGui::InvisibleButton("##mc_titlecredits",
+                                   ImVec2((plateX1 - plateX0) * panel.scale(),
+                                          (plateY1 - plateY0) * panel.scale())))
+        {
+            supporters.resetInteraction();
+            showSupporters = true;
+        }
+
+        if (headerChevron(dl, "##mc_presetprev", 390.5f, true)) stepPreset(-1);
+        if (headerChevron(dl, "##mc_presetnext", 697.5f, false)) stepPreset(1);
+
+        constexpr float bandY0 = 11.5f, bandY1 = 36.5f;
+        constexpr float bandH = bandY1 - bandY0;
+        ImGui::SetCursorScreenPos(panel.P(404, bandY0));
+        ImGui::SetNextItemWidth(280.0f * panel.scale());
+        ImFont* presetFont = fontSet.pick(13.0f * panel.scale());
+        if (presetFont != nullptr) ImGui::PushFont(presetFont);
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding,
+                            ImVec2(7.0f * panel.scale(),
+                                   std::max(0.0f, 0.5f * (bandH * panel.scale()
+                                                         - ImGui::GetFontSize()))));
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(38, 38, 41, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(48, 48, 51, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IM_COL32(55, 55, 58, 255));
+        ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(24, 24, 26, 255));
+        ImGui::PushStyleColor(ImGuiCol_Header, IM_COL32(76, 103, 48, 255));
+        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, IM_COL32(92, 124, 58, 255));
+        ImGui::PushStyleColor(ImGuiCol_HeaderActive, IM_COL32(62, 85, 39, 255));
+        ImGui::PushStyleColor(ImGuiCol_Button, kHeaderGreenDark);
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, kHeaderGreen);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(40, 58, 27, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, kText);
+        ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0), ImVec2(FLT_MAX, FLT_MAX));
+        if (ImGui::BeginCombo("##mc_factory", presetPreview()))
         {
             for (size_t i = 0; i < multicompp::kFactoryPresets.size(); ++i)
             {
@@ -422,67 +766,301 @@ private:
                 if (ImGui::Selectable(multicompp::kFactoryPresets[i].name, selected))
                 {
                     applyPreset(static_cast<int>(i));
+                    ImGui::CloseCurrentPopup();
                 }
                 if (selected) ImGui::SetItemDefaultFocus();
             }
+            if (!userPresets.empty())
+            {
+                ImGui::SeparatorText("User");
+                for (size_t i = 0; i < userPresets.size(); ++i)
+                {
+                    ImGui::PushID(static_cast<int>(i));
+                    const auto& preset = userPresets[i];
+                    if (ImGui::Selectable(preset.name.c_str(),
+                                          currentPreset < 0
+                                              && preset.path == currentUserPath))
+                    {
+                        loadUserPreset(preset);
+                        ImGui::CloseCurrentPopup();
+                    }
+                    ImGui::PopID();
+                }
+            }
             ImGui::EndCombo();
         }
-        panel.toggle("mc_bypass", P_BYPASS, 780, 20, 875, 50, values[P_BYPASS], "BYPASS");
-    }
+        ImGui::PopStyleColor(11);
+        ImGui::PopStyleVar();
+        if (presetFont != nullptr) ImGui::PopFont();
 
-    void drawGlobal(ImDrawList* dl)
-    {
-        drawSection(dl, kHeaderH + 4, kHeaderH + kGlobalH, "GLOBAL");
-        knob(dl, "mc_mix", P_MIX, 78, 125, "MIX", "%.0f", "%");
-        knob(dl, "mc_link", P_LINK, 166, 125, "STEREO LINK", "%.0f", "%");
-        combo("mc_linkmode", P_LINK_MODE, multicompp::kLinkMode, 3, 270, 103, 112, "LINK MODE");
-        combo("mc_os", P_OS, multicompp::kOversampling, 3, 394, 103, 96, "OVERSAMPLE");
-        knob(dl, "mc_look", P_LOOK, 510, 125, "LOOKAHEAD", "%.1f", " ms");
-        panel.toggle("mc_auto", P_AUTO, 568, 111, 680, 136, values[P_AUTO], "AUTO MAKEUP");
-        panel.toggle("mc_tp", P_TRUE_PEAK, 688, 111, 790, 136, values[P_TRUE_PEAK], "TRUE PEAK");
-        combo("mc_tpq", P_TP_QUALITY, multicompp::kTruePeakQuality, 2, 845, 103, 110, "QUALITY");
-        const bool driveApplicable = multicompp::ui_detail::choiceIndex(value(P_DIST), 4) != 0;
-        knob(dl, "mc_dist", P_DIST_AMT, 1080, 125, "DRIVE", "%.0f", "%",
-             driveApplicable);
-    }
-
-    void drawSidechain(ImDrawList* dl)
-    {
-        drawSection(dl, kHeaderH + kGlobalH + 4, kPanelTop - 4, "SIDECHAIN");
-        panel.toggle("mc_ext", P_EXT_SC, 24, 223, 142, 248, values[P_EXT_SC], "EXTERNAL SC");
-        panel.toggle("mc_listen", P_SC_LISTEN, 24, 255, 142, 280, values[P_SC_LISTEN], "LISTEN");
-        knob(dl, "mc_schp", P_SC_HP, 190, 251, "HP FILTER", "%.0f", " Hz");
-        knob(dl, "mc_sclf", P_SC_LOW_FREQ, 300, 251, "LOW FREQ", "%.0f", " Hz");
-        knob(dl, "mc_sclg", P_SC_LOW_GAIN, 410, 251, "LOW GAIN", "%.1f", " dB");
-        knob(dl, "mc_schf", P_SC_HIGH_FREQ, 520, 251, "HIGH FREQ", "%.0f", " Hz");
-        knob(dl, "mc_schg", P_SC_HIGH_GAIN, 630, 251, "HIGH GAIN", "%.1f", " dB");
-        combo("mc_disttype", P_DIST, multicompp::kDistortion, 4, 954, 230, 130, "DISTORTION");
-        neutralToggle("##mc_noise", P_NOISE, 1000, 270, 1095, 295, "NOISE");
-    }
-
-    // Noise is enabled by default, but it is a utility switch rather than a
-    // compression-state indicator. Keep the same geometry and typography as the
-    // fleet toggles while avoiding the red alarm treatment used for bypass/GR.
-    void neutralToggle(const char* id, uint32_t p, float x0, float y0, float x1, float y1,
-                       const char* label)
-    {
-        const ImVec2 b0 = panel.P(x0, y0), b1 = panel.P(x1, y1);
-        ImGui::SetCursorScreenPos(b0);
-        ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y));
-        if (ImGui::IsItemClicked())
+        if (headerTextButton(dl, "##mc_init", 716, 772, "INIT")) initDefaults();
+        if (headerTextButton(dl, "##mc_save", 780, 836, "SAVE"))
         {
-            const float next = values[p] > 0.5f ? 0.0f : 1.0f;
-            setValue(p, next);
+            std::snprintf(saveBuf, sizeof(saveBuf), "%s", currentUserName.c_str());
+            ImGui::OpenPopup("Save Multi-Comp Preset");
         }
-        ImDrawList* dl = ImGui::GetWindowDrawList();
-        const bool on = values[p] > 0.5f;
-        dl->AddRectFilled(b0, b1, IM_COL32(40, 40, 43, 255), 3.0f * panel.scale());
-        dl->AddRect(b0, b1, kLine, 3.0f * panel.scale(), 0, 1.4f * panel.scale());
-        if (on)
-            dl->AddCircleFilled(panel.P(x0 + 7.0f, 0.5f * (y0 + y1)),
-                                2.6f * panel.scale(), kDim, 12);
-        panel.text(dl, 0.5f * (x0 + x1) + 6.0f, y0 + 0.30f * (y1 - y0), 10.0f,
-                   kText, label, 0, on);
+        drawSaveModal();
+    }
+
+    void drawSaveModal()
+    {
+        ImGui::PushStyleColor(ImGuiCol_PopupBg, IM_COL32(26, 26, 28, 255));
+        ImGui::PushStyleColor(ImGuiCol_Text, kText);
+        ImGui::PushStyleColor(ImGuiCol_Border, IM_COL32(90, 90, 94, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, IM_COL32(40, 40, 43, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, IM_COL32(50, 50, 54, 255));
+        ImGui::PushStyleColor(ImGuiCol_FrameBgActive, IM_COL32(56, 56, 60, 255));
+        ImGui::PushStyleColor(ImGuiCol_Button, kHeaderGreenDark);
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, kHeaderGreen);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(40, 58, 27, 255));
+        if (ImGui::BeginPopupModal("Save Multi-Comp Preset", nullptr,
+                                   ImGuiWindowFlags_AlwaysAutoResize))
+        {
+            const bool appearing = ImGui::IsWindowAppearing();
+            if (appearing)
+                saveFailed = false;
+            ImGui::TextUnformatted("Preset name");
+            ImGui::SetNextItemWidth(260.0f * panel.scale());
+            if (appearing) ImGui::SetKeyboardFocusHere();
+            const bool enter = ImGui::InputText(
+                "##mc_savename", saveBuf, sizeof(saveBuf),
+                ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll);
+            const bool save = ImGui::Button("Save") || enter;
+            ImGui::SameLine();
+            const bool cancel = ImGui::Button("Cancel");
+            if (save && saveBuf[0] != '\0')
+            {
+                if (saveUserPreset(saveBuf))
+                {
+                    saveFailed = false;
+                    ImGui::CloseCurrentPopup();
+                }
+                else
+                {
+                    saveFailed = true;
+                }
+            }
+            if (saveFailed)
+                ImGui::TextColored(ImVec4(0.90f, 0.42f, 0.35f, 1.0f),
+                                   "Could not save. Try a different name.");
+            if (cancel)
+            {
+                saveFailed = false;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
+        ImGui::PopStyleColor(9);
+    }
+
+    void stepPreset(int direction)
+    {
+        int index = currentPreset < 0 ? (direction < 0 ? 0 : -1) : currentPreset;
+        index += direction;
+        index = std::clamp(index, 0,
+                           static_cast<int>(multicompp::kFactoryPresets.size()) - 1);
+        applyPreset(index);
+    }
+
+    void initDefaults()
+    {
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
+        {
+            if (i == static_cast<int>(P_BYPASS)) continue;
+            const float hostDefault = multicompp::resolveParameter(i,
+                [](const multicompp::Param& d) { return multicompp::hostDefault(d); },
+                [](const multicompp::BandParam& d, int) {
+                    return multicompp::hostDefault(d);
+                });
+            setHostValue(static_cast<uint32_t>(i), hostDefault);
+        }
+        clearPresetSelection(true);
+    }
+
+    std::string configDir() const
+    {
+        std::string base;
+       #if defined(_WIN32)
+        for (const char* variable : {"APPDATA", "LOCALAPPDATA"})
+            if (const char* value = std::getenv(variable);
+                value != nullptr && value[0] != '\0')
+            {
+                base = value;
+                break;
+            }
+       #elif defined(__APPLE__)
+        if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0')
+            base = std::string(home) + "/.config";
+       #else
+        if (const char* xdg = std::getenv("XDG_CONFIG_HOME");
+            xdg != nullptr && xdg[0] != '\0')
+            base = xdg;
+        else if (const char* home = std::getenv("HOME");
+                 home != nullptr && home[0] != '\0')
+            base = std::string(home) + "/.config";
+       #endif
+        if (base.empty()) base = ".";
+        return base + "/DuskAudio/MultiComp2/presets";
+    }
+
+    static bool readUserPresetFile(const std::filesystem::path& path, UserPreset& preset)
+    {
+        std::ifstream input(path);
+        if (!input) return false;
+        std::string line;
+        std::string encoded;
+        while (std::getline(input, line))
+        {
+            if (line.compare(0, 5, "name=") == 0)
+                preset.name = line.substr(5);
+            else if (line.compare(0, 6, "state=") == 0)
+                encoded = line.substr(6);
+        }
+        if (preset.name.empty() || encoded.empty()
+            || !multicompp::decodeState(encoded, preset.values))
+            return false;
+        preset.path = path.string();
+        return true;
+    }
+
+    void scanUserPresets()
+    {
+        userPresets.clear();
+        std::error_code error;
+        namespace fs = std::filesystem;
+        for (fs::directory_iterator it(configDir(), error), end;
+             !error && it != end; it.increment(error))
+        {
+            if (it->path().extension() != ".mcpreset") continue;
+            UserPreset preset;
+            if (readUserPresetFile(it->path(), preset))
+                userPresets.push_back(std::move(preset));
+        }
+        std::sort(userPresets.begin(), userPresets.end(),
+                  [](const UserPreset& a, const UserPreset& b) {
+                      return a.name < b.name;
+                  });
+    }
+
+    static std::string storedPresetName(const std::string& path)
+    {
+        UserPreset preset;
+        return readUserPresetFile(path, preset) ? preset.name : std::string();
+    }
+
+    bool saveUserPreset(const char* rawName)
+    {
+        std::string name(rawName);
+        while (!name.empty() && std::isspace(static_cast<unsigned char>(name.front())))
+            name.erase(name.begin());
+        while (!name.empty() && std::isspace(static_cast<unsigned char>(name.back())))
+            name.pop_back();
+        if (name.empty()) return false;
+
+        const std::string directory = configDir();
+        std::error_code error;
+        std::filesystem::create_directories(directory, error);
+        if (error) return false;
+
+        std::string stem;
+        for (const unsigned char character : name)
+            stem += std::isalnum(character) ? static_cast<char>(character) : '_';
+        if (stem.empty()) stem = "Preset";
+
+        std::string path;
+        bool usable = false;
+        for (int suffix = 1; suffix <= 99 && !usable; ++suffix)
+        {
+            path = directory + "/" + stem
+                + (suffix == 1 ? std::string()
+                               : "_" + std::to_string(suffix))
+                + ".mcpreset";
+            error.clear();
+            const bool exists = std::filesystem::exists(path, error);
+            if (!error) usable = !exists || storedPresetName(path) == name;
+        }
+        if (!usable) return false;
+
+        multicompp::StateValues snapshot{};
+        std::copy_n(values.begin(), snapshot.size(), snapshot.begin());
+        snapshot[P_BYPASS] = multicompp::hostDefault(
+            multicompp::kParams[static_cast<size_t>(P_BYPASS)]);
+        std::ofstream output(path, std::ios::trunc);
+        if (!output) return false;
+        output.imbue(std::locale::classic());
+        output << "name=" << name << '\n';
+        output << "state=" << multicompp::encodeState(snapshot) << '\n';
+        output.close();
+        if (!output) return false;
+
+        scanUserPresets();
+        currentPreset = -1;
+        currentUserName = name;
+        currentUserPath = path;
+        defaultsActive = false;
+        return true;
+    }
+
+    void loadUserPreset(const UserPreset& preset)
+    {
+        for (int i = 0; i < multicompp::kMeterMaster; ++i)
+        {
+            if (i == static_cast<int>(P_BYPASS)) continue;
+            setHostValue(static_cast<uint32_t>(i),
+                         preset.values[static_cast<size_t>(i)]);
+        }
+        currentPreset = -1;
+        currentUserName = preset.name;
+        currentUserPath = preset.path;
+        defaultsActive = false;
+    }
+
+    void drawModeToolbar(ImDrawList* dl)
+    {
+        constexpr int modeCount = static_cast<int>(
+            sizeof(multicompp::kModes) / sizeof(multicompp::kModes[0]));
+        static_assert(modeCount == 8,
+                      "the mode toolbar layout must be revisited when modes change");
+        const int selected = multicompp::ui_detail::choiceIndex(value(P_MODE), 8);
+        constexpr float rowLeft = 20.0f;
+        constexpr float rowRight = 996.0f;
+        constexpr float gap = 3.0f;
+        constexpr float buttonWidth =
+            (rowRight - rowLeft - gap * static_cast<float>(modeCount - 1))
+            / static_cast<float>(modeCount);
+        constexpr float y0 = kModeCanvasTop + 3.0f;
+        constexpr float y1 = kModeCanvasTop + 21.0f;
+        for (int mode = 0; mode < modeCount; ++mode)
+        {
+            const float x0 = rowLeft + static_cast<float>(mode) * (buttonWidth + gap);
+            const float x1 = x0 + buttonWidth;
+            const ImVec2 b0 = panel.P(x0, y0);
+            const ImVec2 b1 = panel.P(x1, y1);
+            char id[32];
+            std::snprintf(id, sizeof(id), "##mc_mode_button_%d", mode);
+            ImGui::SetCursorScreenPos(b0);
+            const bool clicked = ImGui::InvisibleButton(
+                id, ImVec2(b1.x - b0.x, b1.y - b0.y));
+            const bool hovered = ImGui::IsItemHovered();
+            const bool active = mode == selected;
+            const ImU32 fill = active ? kHeaderGreenDark
+                : hovered ? kPanelRaised : IM_COL32(24, 25, 29, 255);
+            const ImU32 outline = active
+                ? IM_COL32(103, 132, 75, 255) : kLine;
+            dl->AddRectFilled(b0, b1, fill, 2.0f * panel.scale());
+            dl->AddRect(b0, b1, outline, 2.0f * panel.scale(), 0,
+                        panel.scale());
+            if (active)
+                dl->AddRectFilled(panel.P(x0 + 2.0f, y1 - 2.0f),
+                                  panel.P(x1 - 2.0f, y1), kHeaderGreen);
+            panel.text(dl, 0.5f * (x0 + x1), y0 + 3.0f, 8.8f,
+                       active || hovered ? kText : kDim,
+                       multicompp::kModes[mode], 0, true);
+            if (clicked && !active)
+                setValue(P_MODE, static_cast<float>(mode));
+        }
+        panel.toggle("mc_bypass", P_BYPASS, 1008, kModeCanvasTop + 3,
+                     1098, kModeCanvasTop + 21, values[P_BYPASS], "BYPASS");
     }
 
     void knob(ImDrawList* dl, const char* id, uint32_t p, float x, float y,
@@ -552,15 +1130,16 @@ private:
     void drawModePanel(ImDrawList* dl)
     {
         const int mode = multicompp::ui_detail::choiceIndex(value(P_MODE), 8);
-        drawSection(dl, kPanelTop, kDesignH - 8, modeName(mode));
+        drawSection(dl, kModeCanvasTop, kModeCanvasBottom - 8, "");
+        drawModeToolbar(dl);
         if (mode == 0)
         {
             // Opto owns a panel-integrated analogue GR meter.
         }
         else if (mode == 7)
-            drawMeter(dl, 1062, kPanelTop + 24, 42, 92, meter(kMeterMaster), kAccent, "MASTER GR");
+            drawMeter(dl, 1062, kModeCanvasTop + 42, 42, 92, meter(kMeterMaster), kAccent, "MASTER GR");
         else
-            drawMeter(dl, 28, kPanelTop + 42, 48, 300, meter(kMeterMaster), kAccent, "MASTER GR");
+            drawMeter(dl, 28, kModeCanvasTop + 42, 48, 300, meter(kMeterMaster), kAccent, "MASTER GR");
         // Deliberately exhaustive: adding a ninth mode must force a UI decision.
         switch (mode)
         {
@@ -583,44 +1162,127 @@ private:
         const float top = Layout::top;
         const float bottom = Layout::bottom;
 
-        dl->AddRectFilled(panel.P(left + 4, top + 6), panel.P(right + 4, bottom + 6),
-                          IM_COL32(0, 0, 0, 90), 7.0f * panel.scale());
+        // The face follows the same control contract as the flat Opto panel,
+        // but uses physical rack construction and hardware depth. Keep all
+        // branding original to Dusk rather than reproducing a reference unit.
+        dl->AddRectFilled(panel.P(left + 5, top + 8), panel.P(right + 5, bottom + 8),
+                          IM_COL32(0, 0, 0, 145), 4.0f * panel.scale());
         dl->AddRectFilled(panel.P(left, top), panel.P(right, bottom),
-                          kOptoTrim, 7.0f * panel.scale());
-        dl->AddRectFilled(panel.P(left + 5, top + 5), panel.P(right - 5, bottom - 5),
-                          kOptoFace, 4.0f * panel.scale());
-        dl->AddLine(panel.P(left + 8, top + 8), panel.P(right - 8, top + 8),
-                    IM_COL32(255, 252, 235, 145), panel.scale());
-        dl->AddLine(panel.P(left + 8, bottom - 8), panel.P(right - 8, bottom - 8),
-                    IM_COL32(74, 60, 48, 150), panel.scale());
+                          IM_COL32(21, 23, 24, 255), 3.0f * panel.scale());
 
-        for (const ImVec2 screw : {ImVec2(left + 18, top + 18),
-                                   ImVec2(right - 18, top + 18),
-                                   ImVec2(left + 18, bottom - 18),
-                                   ImVec2(right - 18, bottom - 18)})
+        constexpr float earWidth = 46.0f;
+        const float faceLeft = left + earWidth;
+        const float faceRight = right - earWidth;
+        dl->AddRectFilled(panel.P(left + 3, top + 3), panel.P(faceLeft, bottom - 3),
+                          IM_COL32(143, 147, 147, 255), 2.0f * panel.scale());
+        dl->AddRectFilled(panel.P(faceRight, top + 3), panel.P(right - 3, bottom - 3),
+                          IM_COL32(143, 147, 147, 255), 2.0f * panel.scale());
+        dl->AddRectFilledMultiColor(panel.P(faceLeft, top + 3),
+                                    panel.P(faceRight, bottom - 3),
+                                    IM_COL32(226, 228, 226, 255),
+                                    IM_COL32(193, 196, 195, 255),
+                                    IM_COL32(181, 184, 183, 255),
+                                    IM_COL32(214, 216, 214, 255));
+
+        // Deterministic one-pixel strokes keep the panel feeling like brushed
+        // aluminium without requiring a resolution-specific bitmap texture.
+        for (int row = static_cast<int>(top + 5.0f);
+             row < static_cast<int>(bottom - 4.0f); row += 3)
         {
-            dl->AddCircleFilled(panel.P(screw.x, screw.y), 6.0f * panel.scale(),
-                                IM_COL32(75, 73, 68, 255), 20);
-            dl->AddCircleFilled(panel.P(screw.x - 1.0f, screw.y - 1.0f),
-                                4.2f * panel.scale(), IM_COL32(177, 174, 163, 255), 20);
-            dl->AddLine(panel.P(screw.x - 2.5f, screw.y + 1.0f),
-                        panel.P(screw.x + 2.5f, screw.y - 1.0f),
-                        IM_COL32(72, 69, 63, 255), panel.scale());
+            const int variation = (row * 37) % 5;
+            const ImU32 shade = variation < 2
+                ? IM_COL32(255, 255, 252, 25)
+                : IM_COL32(74, 78, 78, 18);
+            dl->AddLine(panel.P(left + 5.0f, static_cast<float>(row)),
+                        panel.P(right - 5.0f, static_cast<float>(row)),
+                        shade, panel.scale());
+        }
+        dl->AddLine(panel.P(faceLeft, top + 4), panel.P(faceLeft, bottom - 4),
+                    IM_COL32(54, 58, 59, 210), 1.5f * panel.scale());
+        dl->AddLine(panel.P(faceRight, top + 4), panel.P(faceRight, bottom - 4),
+                    IM_COL32(54, 58, 59, 210), 1.5f * panel.scale());
+        dl->AddLine(panel.P(faceLeft + 1, top + 5), panel.P(faceLeft + 1, bottom - 5),
+                    IM_COL32(255, 255, 255, 115), panel.scale());
+        dl->AddLine(panel.P(left + 4, top + 4), panel.P(right - 4, top + 4),
+                    IM_COL32(255, 255, 255, 160), 1.2f * panel.scale());
+        dl->AddLine(panel.P(left + 4, bottom - 4), panel.P(right - 4, bottom - 4),
+                    IM_COL32(23, 25, 26, 220), 2.0f * panel.scale());
+
+        // Rack-ear slots are intentionally clipped by the panel edge, like a
+        // photographed 19-inch unit sitting in a dark rack.
+        for (const float slotY : {top + 72.0f, bottom - 72.0f})
+        {
+            dl->AddRectFilled(panel.P(left - 7.0f, slotY - 9.0f),
+                              panel.P(left + 23.0f, slotY + 9.0f),
+                              IM_COL32(7, 8, 8, 255), 9.0f * panel.scale());
+            dl->AddRectFilled(panel.P(right - 23.0f, slotY - 9.0f),
+                              panel.P(right + 7.0f, slotY + 9.0f),
+                              IM_COL32(7, 8, 8, 255), 9.0f * panel.scale());
+            dl->AddLine(panel.P(left - 2.0f, slotY - 6.0f),
+                        panel.P(left + 19.0f, slotY - 6.0f),
+                        IM_COL32(255, 255, 255, 38), panel.scale());
+            dl->AddLine(panel.P(right - 19.0f, slotY - 6.0f),
+                        panel.P(right + 2.0f, slotY - 6.0f),
+                        IM_COL32(255, 255, 255, 38), panel.scale());
         }
 
-        panel.text(dl, 560, top + 13, 13.0f, kOptoInk, "DUSK OPTO LEVELER", 0, true);
-        panel.text(dl, 560, top + 31, 8.5f, IM_COL32(91, 84, 72, 255),
-                   "PROGRAM-DEPENDENT LEVELING AMPLIFIER", 0, true);
-        optoModeSwitch(dl, 112, 492);
-        optoKnob(dl, "opto_gain", P_OPTO_GAIN, 264, 505, 58.0f, "GAIN");
-        drawOptoMeter(dl, 389, 407, 324, 160, meter(kMeterMaster));
-        optoKnob(dl, "opto_peak", P_OPTO_PEAK, 829, 505, 58.0f,
+        for (const ImVec2 screw : {ImVec2(faceLeft + 28, top + 20),
+                                   ImVec2(faceRight - 28, top + 20),
+                                   ImVec2(faceLeft + 28, bottom - 20),
+                                   ImVec2(560.0f, bottom - 20),
+                                   ImVec2(faceRight - 28, bottom - 20)})
+            drawOptoScrew(dl, screw.x, screw.y, 7.0f);
+
+        panel.text(dl, 156, top + 20, 18.0f, kOptoRed,
+                   "LEVELING AMPLIFIER", -1, true);
+        dl->AddLine(panel.P(156, top + 47), panel.P(354, top + 47),
+                    kOptoRed, 2.0f * panel.scale());
+        panel.text(dl, 953, top + 20, 9.0f, kOptoInk, "OPTO CELL", 0, true);
+        panel.text(dl, 953, top + 36, 7.5f, IM_COL32(75, 78, 77, 255),
+                   "LEVEL CONTROL", 0, true);
+
+        optoModeSwitch(dl, 139, top + 170.0f);
+        optoKnob(dl, "opto_gain", P_OPTO_GAIN, 287, top + 170.0f, 53.0f, "GAIN");
+        drawOptoMeter(dl, 390, top + 54.0f, 348, 196,
+                      optoMeterGainReductionDb);
+        optoKnob(dl, "opto_peak", P_OPTO_PEAK, 838, top + 170.0f, 53.0f,
                  "PEAK REDUCTION");
-        optoKnob(dl, "opto_mix", P_MIX, 1000, 505, 39.0f, "MIX", false);
+        optoKnob(dl, "opto_sc_hp", P_SC_HP, 996, top + 108.0f, 18.0f,
+                 "SC HP", false, "%.0f", " Hz");
+        optoKnob(dl, "opto_mix", P_MIX, 996, top + 224.0f, 18.0f,
+                 "MIX", false);
+    }
+
+    void drawOptoScrew(ImDrawList* dl, float x, float y, float radius)
+    {
+        const float scale = panel.scale();
+        const ImVec2 center = panel.P(x, y);
+        dl->AddCircleFilled(ImVec2(center.x + 2.2f * scale, center.y + 3.2f * scale),
+                            radius * scale, IM_COL32(0, 0, 0, 105), 28);
+        dl->AddCircleFilled(center, radius * scale,
+                            IM_COL32(86, 90, 90, 255), 28);
+        dl->AddCircleFilled(ImVec2(center.x - 0.8f * scale, center.y - 1.0f * scale),
+                            (radius - 1.2f) * scale,
+                            IM_COL32(206, 208, 205, 255), 28);
+        dl->AddCircle(center, (radius - 1.2f) * scale,
+                      IM_COL32(60, 63, 63, 255), 28, 0.9f * scale);
+        const float slot = radius * 0.55f * scale;
+        const ImU32 slotDark = IM_COL32(57, 59, 58, 255);
+        dl->AddLine(ImVec2(center.x - slot, center.y - slot),
+                    ImVec2(center.x + slot, center.y + slot),
+                    slotDark, 1.3f * scale);
+        dl->AddLine(ImVec2(center.x + slot, center.y - slot),
+                    ImVec2(center.x - slot, center.y + slot),
+                    slotDark, 1.3f * scale);
+        dl->AddCircleFilled(ImVec2(center.x - radius * 0.30f * scale,
+                                   center.y - radius * 0.34f * scale),
+                            1.15f * scale, IM_COL32(255, 255, 255, 170), 12);
     }
 
     void optoKnob(ImDrawList* dl, const char* id, uint32_t p, float x, float y,
-                  float radius, const char* label, bool numberedScale = true)
+                  float radius, const char* label, bool numberedScale = true,
+                  const char* format = "%.0f",
+                  const char* suffix = multicompp::ui_detail::optoKnobValueSuffix())
     {
         // Put the shared gesture/editor layer above the custom body while
         // letting it mutate the value first, so the pointer and readout update
@@ -628,10 +1290,11 @@ private:
         optoKnobSplitter.Split(dl, 2);
         optoKnobSplitter.SetCurrentChannel(dl, 1);
         panel.knob(id, p, hostMinimum(p), hostMaximum(p), x, y, radius,
-                   values[p], hostDefaultValue(p), false, false, "%.0f", "%",
+                   values[p], hostDefaultValue(p), false, false, format, suffix,
                    0, true, false, nullptr, false, 1.0f, 0.0f, label, true,
                    nullptr, false, 0.0f, 0.0f, false, true, 9.5f, true, false,
-                   &knobHostToPlain, &knobPlainToHost, this);
+                   &knobHostToPlain, &knobPlainToHost, this,
+                   multicompp::ui_detail::optoKnobUsesPlainDomainDrag(p));
         optoKnobSplitter.SetCurrentChannel(dl, 0);
 
         const float plain = plainValueForHost(p, values[p]);
@@ -642,75 +1305,135 @@ private:
         const ImVec2 center = panel.P(x, y);
         const float scaledRadius = radius * panel.scale();
 
-        for (int tick = 0; tick <= 10; ++tick)
+        if (!numberedScale)
+        {
+            // The original hardware did not have Mix. Treat our required Mix
+            // control as a deliberately small set-screw so it does not compete
+            // with the two primary controls.
+            std::array<ImVec2, 6> nut{};
+            for (int point = 0; point < 6; ++point)
+            {
+                const float angle = kUiPi / 6.0f + static_cast<float>(point)
+                    * kUiPi / 3.0f;
+                nut[static_cast<size_t>(point)] = ImVec2(
+                    center.x + std::cos(angle) * scaledRadius * 1.22f,
+                    center.y + std::sin(angle) * scaledRadius * 1.22f);
+            }
+            std::array<ImVec2, 6> shadow = nut;
+            for (auto& point : shadow)
+            {
+                point.x += 2.0f * panel.scale();
+                point.y += 3.0f * panel.scale();
+            }
+            dl->AddConvexPolyFilled(shadow.data(), 6, IM_COL32(0, 0, 0, 90));
+            dl->AddConvexPolyFilled(nut.data(), 6, IM_COL32(116, 119, 117, 255));
+            dl->AddCircleFilled(center, scaledRadius,
+                                IM_COL32(210, 212, 208, 255), 32);
+            dl->AddCircle(center, scaledRadius, IM_COL32(57, 59, 58, 255),
+                          32, 1.2f * panel.scale());
+            const float slotAngle = duskdaf::DuskPanel::knobAngle(t);
+            const ImVec2 slot(std::sin(slotAngle), -std::cos(slotAngle));
+            dl->AddLine(ImVec2(center.x - slot.x * scaledRadius * 0.63f,
+                               center.y - slot.y * scaledRadius * 0.63f),
+                        ImVec2(center.x + slot.x * scaledRadius * 0.63f,
+                               center.y + slot.y * scaledRadius * 0.63f),
+                        IM_COL32(47, 49, 48, 255), 2.4f * panel.scale());
+            panel.text(dl, x, y - 40.0f, 9.0f, kOptoInk, label, 0, true);
+            panel.text(dl, x - 31.0f, y - 4.0f, 12.0f, kOptoInk, "-", 0, true);
+            panel.text(dl, x + 31.0f, y - 4.0f, 12.0f, kOptoInk, "+", 0, true);
+            if (p == P_SC_HP)
+            {
+                char cutoff[20];
+                if (plain < 1.0f)
+                    std::snprintf(cutoff, sizeof(cutoff), "OFF");
+                else
+                    std::snprintf(cutoff, sizeof(cutoff), "%.0f Hz",
+                                  static_cast<double>(plain));
+                panel.text(dl, x, y + 28.0f, 7.5f, kOptoInk, cutoff, 0, true);
+            }
+            optoKnobSplitter.Merge(dl);
+            return;
+        }
+
+        constexpr std::array<const char*, 11> scaleLabels{{
+            "0", "10", "20", "30", "40", "50",
+            "60", "70", "80", "90", "100"}};
+        for (int tick = 0; tick <= 50; ++tick)
         {
             const float angle = duskdaf::DuskPanel::knobAngle(
-                static_cast<float>(tick) / 10.0f);
+                static_cast<float>(tick) / 50.0f);
             const ImVec2 direction(std::sin(angle), -std::cos(angle));
-            const float inner = scaledRadius + 5.0f * panel.scale();
-            const float outer = scaledRadius
-                + (tick % 5 == 0 ? 13.0f : 9.0f) * panel.scale();
+            const bool major = tick % 5 == 0;
+            const bool medium = tick % 5 == 0 || tick % 5 == 2;
+            const float inner = scaledRadius
+                + (major ? 4.0f : medium ? 6.0f : 8.0f) * panel.scale();
+            const float outer = scaledRadius + 12.0f * panel.scale();
             dl->AddLine(ImVec2(center.x + direction.x * inner,
                                center.y + direction.y * inner),
                         ImVec2(center.x + direction.x * outer,
                                center.y + direction.y * outer),
-                        kOptoInk, (tick % 5 == 0 ? 1.8f : 1.0f) * panel.scale());
+                        kOptoInk, (major ? 1.45f : 0.75f) * panel.scale());
+            if (major)
+            {
+                const int labelIndex = tick / 5;
+                const float labelRadius = radius + 23.0f;
+                panel.text(dl,
+                           x + direction.x * labelRadius,
+                           y + direction.y * labelRadius - 4.0f,
+                           7.8f, kOptoInk,
+                           scaleLabels[static_cast<size_t>(labelIndex)], 0, true);
+            }
         }
 
-        dl->AddCircleFilled(ImVec2(center.x + 2.0f * panel.scale(),
-                                   center.y + 3.0f * panel.scale()),
-                            scaledRadius, IM_COL32(0, 0, 0, 85), 56);
-        dl->AddCircleFilled(center, scaledRadius, IM_COL32(28, 28, 27, 255), 56);
-        for (int ridge = 0; ridge < 24; ++ridge)
+        const ImVec2 shadowCenter(center.x + 3.0f * panel.scale(),
+                                  center.y + 5.0f * panel.scale());
+        dl->AddCircleFilled(shadowCenter, scaledRadius * 1.01f,
+                            IM_COL32(0, 0, 0, 105), 56);
+        for (int lobe = 0; lobe < 14; ++lobe)
         {
-            const float angle = 2.0f * kUiPi
-                * static_cast<float>(ridge) / 24.0f;
+            const float angle = 2.0f * kUiPi * static_cast<float>(lobe) / 14.0f;
             const ImVec2 direction(std::sin(angle), -std::cos(angle));
-            dl->AddLine(ImVec2(center.x + direction.x * scaledRadius * 0.82f,
-                               center.y + direction.y * scaledRadius * 0.82f),
-                        ImVec2(center.x + direction.x * scaledRadius * 0.97f,
-                               center.y + direction.y * scaledRadius * 0.97f),
-                        IM_COL32(116, 112, 102, 150), 1.4f * panel.scale());
+            dl->AddCircleFilled(ImVec2(center.x + direction.x * scaledRadius * 0.81f,
+                                       center.y + direction.y * scaledRadius * 0.81f),
+                                scaledRadius * 0.18f,
+                                IM_COL32(20, 21, 20, 255), 20);
         }
-        dl->AddCircleFilled(center, scaledRadius * 0.72f,
-                            IM_COL32(56, 55, 52, 255), 48);
-        dl->AddCircleFilled(ImVec2(center.x - scaledRadius * 0.12f,
-                                   center.y - scaledRadius * 0.14f),
-                            scaledRadius * 0.57f, IM_COL32(78, 76, 70, 255), 42);
-        dl->AddCircle(center, scaledRadius, IM_COL32(12, 12, 11, 255), 56,
-                      1.5f * panel.scale());
+        dl->AddCircleFilled(center, scaledRadius * 0.92f,
+                            IM_COL32(24, 25, 24, 255), 56);
+        dl->AddCircleFilled(ImVec2(center.x - scaledRadius * 0.09f,
+                                   center.y - scaledRadius * 0.11f),
+                            scaledRadius * 0.70f,
+                            IM_COL32(52, 53, 51, 255), 48);
+        dl->PathArcTo(center, scaledRadius * 0.73f,
+                      -2.75f, -0.32f, 28);
+        dl->PathStroke(IM_COL32(122, 124, 119, 118), 0,
+                       1.6f * panel.scale());
+        dl->PathArcTo(center, scaledRadius * 0.91f,
+                      0.35f, 2.70f, 28);
+        dl->PathStroke(IM_COL32(0, 0, 0, 145), 0, 2.0f * panel.scale());
         const float pointerAngle = duskdaf::DuskPanel::knobAngle(t);
         const ImVec2 pointer(std::sin(pointerAngle), -std::cos(pointerAngle));
         dl->AddLine(ImVec2(center.x + pointer.x * scaledRadius * 0.18f,
                            center.y + pointer.y * scaledRadius * 0.18f),
-                    ImVec2(center.x + pointer.x * scaledRadius * 0.88f,
-                           center.y + pointer.y * scaledRadius * 0.88f),
-                    kOptoFaceLight, 3.2f * panel.scale());
-
-        if (numberedScale)
-        {
-            panel.text(dl, x - radius - 16.0f, y + radius * 0.70f, 8.5f,
-                       kOptoInk, "0", 0, true);
-            panel.text(dl, x, y - radius - 24.0f, 8.5f, kOptoInk, "50", 0, true);
-            panel.text(dl, x + radius + 16.0f, y + radius * 0.70f, 8.5f,
-                       kOptoInk, "100", 0, true);
-        }
-        char readout[16];
-        std::snprintf(readout, sizeof(readout), "%.0f%%", static_cast<double>(plain));
-        dl->AddRectFilled(panel.P(x - 24.0f, y + radius + 10.0f),
-                          panel.P(x + 24.0f, y + radius + 29.0f),
-                          IM_COL32(43, 41, 37, 255), 2.0f * panel.scale());
-        panel.text(dl, x, y + radius + 14.0f, 9.5f, kOptoFaceLight,
-                   readout, 0, true);
-        panel.text(dl, x, y + radius + 35.0f, numberedScale ? 10.0f : 9.0f,
+                    ImVec2(center.x + pointer.x * scaledRadius * 0.84f,
+                           center.y + pointer.y * scaledRadius * 0.84f),
+                    IM_COL32(243, 244, 238, 255), 3.0f * panel.scale());
+        dl->AddLine(ImVec2(center.x + pointer.x * scaledRadius * 0.30f
+                                   - 1.0f * panel.scale(),
+                           center.y + pointer.y * scaledRadius * 0.30f),
+                    ImVec2(center.x + pointer.x * scaledRadius * 0.78f
+                                   - 1.0f * panel.scale(),
+                           center.y + pointer.y * scaledRadius * 0.78f),
+                    IM_COL32(255, 255, 255, 95), panel.scale());
+        panel.text(dl, x, y + radius + 38.0f, 9.5f,
                    kOptoInk, label, 0, true);
         optoKnobSplitter.Merge(dl);
     }
 
     void optoModeSwitch(ImDrawList* dl, float x, float y)
     {
-        const ImVec2 p0 = panel.P(x - 38.0f, y - 82.0f);
-        const ImVec2 p1 = panel.P(x + 38.0f, y + 78.0f);
+        const ImVec2 p0 = panel.P(x - 48.0f, y - 77.0f);
+        const ImVec2 p1 = panel.P(x + 48.0f, y + 74.0f);
         ImGui::SetCursorScreenPos(p0);
         ImGui::InvisibleButton("##opto_comp_limit", ImVec2(p1.x - p0.x, p1.y - p0.y));
         if (ImGui::IsItemClicked())
@@ -718,75 +1441,161 @@ private:
 
         const bool limit = multicompp::ui_detail::choiceIndex(
             values[P_OPTO_LIMIT], 2) == 1;
-        constexpr ImU32 inactiveMode = IM_COL32(111, 103, 88, 255);
-        panel.text(dl, x, y - 74.0f, 9.5f, limit ? kOptoRed : inactiveMode,
-                   multicompp::ui_detail::optoModeLabel(1.0f), 0, true);
-        panel.text(dl, x, y + 65.0f, 9.5f, !limit ? kOptoRed : inactiveMode,
-                   multicompp::ui_detail::optoModeLabel(0.0f), 0, true);
-        dl->AddRectFilled(panel.P(x - 14.0f, y - 42.0f),
-                          panel.P(x + 14.0f, y + 42.0f),
-                          IM_COL32(44, 42, 38, 255), 5.0f * panel.scale());
-        dl->AddRect(panel.P(x - 14.0f, y - 42.0f),
-                    panel.P(x + 14.0f, y + 42.0f),
-                    IM_COL32(18, 18, 17, 255), 5.0f * panel.scale(), 0,
-                    1.5f * panel.scale());
-        const float leverY = y + (limit ? -24.0f : 24.0f);
-        dl->AddLine(panel.P(x, y), panel.P(x, leverY),
-                    IM_COL32(168, 164, 151, 255), 5.0f * panel.scale());
-        dl->AddCircleFilled(panel.P(x, leverY), 8.0f * panel.scale(),
-                            IM_COL32(203, 198, 183, 255), 24);
-        dl->AddCircle(panel.P(x, leverY), 8.0f * panel.scale(),
-                      IM_COL32(34, 33, 30, 255), 24, 1.2f * panel.scale());
-        panel.text(dl, x, y + 93.0f, 8.5f, IM_COL32(91, 84, 72, 255),
-                   multicompp::ui_detail::optoModeLabel(values[P_OPTO_LIMIT]),
-                   0, true);
+
+        auto engravedLabel = [&](float labelY, const char* text, bool active) {
+            dl->AddRectFilled(panel.P(x - 39.0f, labelY - 3.0f),
+                              panel.P(x + 39.0f, labelY + 16.0f),
+                              IM_COL32(28, 29, 28, 255), 1.2f * panel.scale());
+            dl->AddLine(panel.P(x - 36.0f, labelY - 1.0f),
+                        panel.P(x + 36.0f, labelY - 1.0f),
+                        active ? kOptoRed : IM_COL32(115, 118, 115, 120),
+                        (active ? 2.0f : 1.0f) * panel.scale());
+            panel.text(dl, x, labelY, 8.0f,
+                       active ? IM_COL32(248, 247, 238, 255)
+                              : IM_COL32(171, 173, 168, 255),
+                       text, 0, true);
+        };
+        engravedLabel(y - 73.0f, multicompp::ui_detail::optoModeLabel(1.0f), limit);
+        engravedLabel(y + 57.0f, multicompp::ui_detail::optoModeLabel(0.0f), !limit);
+
+        const ImVec2 base = panel.P(x, y);
+        std::array<ImVec2, 6> nut{};
+        for (int point = 0; point < 6; ++point)
+        {
+            const float angle = kUiPi / 6.0f + static_cast<float>(point)
+                * kUiPi / 3.0f;
+            nut[static_cast<size_t>(point)] = ImVec2(
+                base.x + std::cos(angle) * 19.0f * panel.scale(),
+                base.y + std::sin(angle) * 19.0f * panel.scale());
+        }
+        std::array<ImVec2, 6> nutShadow = nut;
+        for (auto& point : nutShadow)
+        {
+            point.x += 2.0f * panel.scale();
+            point.y += 4.0f * panel.scale();
+        }
+        dl->AddConvexPolyFilled(nutShadow.data(), 6, IM_COL32(0, 0, 0, 115));
+        dl->AddConvexPolyFilled(nut.data(), 6, IM_COL32(121, 124, 121, 255));
+        dl->AddCircleFilled(base, 12.5f * panel.scale(),
+                            IM_COL32(49, 51, 50, 255), 32);
+        dl->AddCircle(base, 12.5f * panel.scale(),
+                      IM_COL32(225, 226, 221, 190), 32, panel.scale());
+        const float leverY = y + (limit ? -27.0f : 27.0f);
+        const float leverX = x + (limit ? -3.0f : 4.0f);
+        dl->AddLine(panel.P(x + 2.0f, y + 3.0f),
+                    panel.P(leverX + 2.0f, leverY + 4.0f),
+                    IM_COL32(0, 0, 0, 130), 8.5f * panel.scale());
+        dl->AddLine(base, panel.P(leverX, leverY),
+                    IM_COL32(163, 165, 160, 255), 7.0f * panel.scale());
+        dl->AddLine(panel.P(x - 1.5f, y - 1.5f),
+                    panel.P(leverX - 1.5f, leverY - 1.5f),
+                    IM_COL32(245, 245, 238, 215), 2.0f * panel.scale());
+        dl->AddCircleFilled(panel.P(leverX, leverY), 7.0f * panel.scale(),
+                            IM_COL32(180, 182, 176, 255), 28);
+        dl->AddCircle(panel.P(leverX, leverY), 7.0f * panel.scale(),
+                      IM_COL32(48, 50, 49, 255), 28, 1.0f * panel.scale());
     }
 
     void drawOptoMeter(ImDrawList* dl, float x, float y, float w, float h, float gr)
     {
-        dl->AddRectFilled(panel.P(x + 3.0f, y + 4.0f),
-                          panel.P(x + w + 3.0f, y + h + 4.0f),
-                          IM_COL32(0, 0, 0, 90), 5.0f * panel.scale());
+        const float scale = panel.scale();
+        dl->AddRectFilled(panel.P(x + 5.0f, y + 7.0f),
+                          panel.P(x + w + 5.0f, y + h + 7.0f),
+                          IM_COL32(0, 0, 0, 125), 3.0f * scale);
         dl->AddRectFilled(panel.P(x, y), panel.P(x + w, y + h),
-                          IM_COL32(47, 45, 41, 255), 5.0f * panel.scale());
-        dl->AddRectFilled(panel.P(x + 8.0f, y + 8.0f),
-                          panel.P(x + w - 8.0f, y + h - 8.0f),
-                          kOptoFaceLight, 2.0f * panel.scale());
-        const ImVec2 pivot = panel.P(x + w * 0.5f, y + h - 13.0f);
-        const float radius = 118.0f * panel.scale();
+                          IM_COL32(37, 40, 41, 255), 3.0f * scale);
+        dl->AddRectFilled(panel.P(x + 7.0f, y + 7.0f),
+                          panel.P(x + w - 7.0f, y + h - 7.0f),
+                          IM_COL32(75, 79, 80, 255), 1.5f * scale);
+
+        // Four asymmetric bevel rails give the meter housing a machined depth.
+        dl->AddQuadFilled(panel.P(x + 7, y + 7), panel.P(x + w - 7, y + 7),
+                          panel.P(x + w - 11, y + 11), panel.P(x + 11, y + 11),
+                          IM_COL32(112, 117, 118, 255));
+        dl->AddQuadFilled(panel.P(x + 7, y + h - 7), panel.P(x + 11, y + h - 11),
+                          panel.P(x + w - 11, y + h - 11), panel.P(x + w - 7, y + h - 7),
+                          IM_COL32(26, 28, 29, 255));
+        dl->AddQuadFilled(panel.P(x + 7, y + 7), panel.P(x + 11, y + 11),
+                          panel.P(x + 11, y + h - 11), panel.P(x + 7, y + h - 7),
+                          IM_COL32(88, 93, 94, 255));
+        dl->AddQuadFilled(panel.P(x + w - 7, y + 7), panel.P(x + w - 7, y + h - 7),
+                          panel.P(x + w - 11, y + h - 11), panel.P(x + w - 11, y + 11),
+                          IM_COL32(42, 45, 46, 255));
+
+        dl->AddRectFilledMultiColor(panel.P(x + 11.0f, y + 11.0f),
+                                    panel.P(x + w - 11.0f, y + h - 11.0f),
+                                    IM_COL32(255, 226, 160, 255),
+                                    IM_COL32(249, 214, 141, 255),
+                                    IM_COL32(221, 177, 100, 255),
+                                    IM_COL32(232, 190, 112, 255));
+        dl->AddRectFilled(panel.P(x + 17.0f, y + 16.0f),
+                          panel.P(x + w - 17.0f, y + 50.0f),
+                          IM_COL32(255, 255, 238, 38), 12.0f * scale);
+        dl->AddRect(panel.P(x + 11.0f, y + 11.0f),
+                    panel.P(x + w - 11.0f, y + h - 11.0f),
+                    IM_COL32(75, 61, 39, 220), 1.0f * scale, 0, scale);
+        const float pivotX = x + w * 0.5f;
+        const float pivotY = y + h - 13.0f;
+        constexpr float radiusDesign = 165.0f;
+        const ImVec2 pivot = panel.P(pivotX, pivotY);
+        const float radius = radiusDesign * scale;
+        dl->PathArcTo(pivot, radius * 0.87f, -145.0f * kUiPi / 180.0f,
+                      -35.0f * kUiPi / 180.0f, 40);
+        dl->PathStroke(IM_COL32(92, 70, 38, 185), 0, scale);
         constexpr std::array<const char*, 5> labels{{"20", "15", "10", "5", "0"}};
-        for (size_t tick = 0; tick < labels.size(); ++tick)
+        for (int tick = 0; tick <= 40; ++tick)
         {
-            const float amount = static_cast<float>(tick)
-                / static_cast<float>(labels.size() - 1);
+            const float amount = static_cast<float>(tick) / 40.0f;
             const float angle = (-55.0f + 110.0f * amount)
                 * kUiPi / 180.0f;
             const ImVec2 direction(std::sin(angle), -std::cos(angle));
-            dl->AddLine(ImVec2(pivot.x + direction.x * radius * 0.76f,
-                               pivot.y + direction.y * radius * 0.76f),
+            const bool major = tick % 10 == 0;
+            const bool medium = tick % 5 == 0;
+            dl->AddLine(ImVec2(pivot.x + direction.x * radius
+                                   * (major ? 0.70f : medium ? 0.74f : 0.78f),
+                               pivot.y + direction.y * radius
+                                   * (major ? 0.70f : medium ? 0.74f : 0.78f)),
                         ImVec2(pivot.x + direction.x * radius * 0.88f,
                                pivot.y + direction.y * radius * 0.88f),
-                        kOptoInk, 1.4f * panel.scale());
-            panel.text(dl,
-                       x + w * 0.5f + direction.x * 76.0f,
-                       y + h - 17.0f - std::cos(angle) * 76.0f,
-                       8.0f, kOptoInk, labels[tick], 0, true);
+                        kOptoInk, (major ? 1.45f : 0.70f) * scale);
+            if (major)
+            {
+                const size_t label = static_cast<size_t>(tick / 10);
+                const float labelRadius = radiusDesign * 0.61f;
+                panel.text(dl, pivotX + direction.x * labelRadius,
+                           pivotY + direction.y * labelRadius - 4.0f,
+                           8.5f, kOptoInk, labels[label], 0, true);
+            }
         }
-        panel.text(dl, x + w * 0.5f, y + 16.0f, 11.0f, kOptoRed,
+        panel.text(dl, x + w * 0.5f, y + 17.0f, 8.0f,
+                   IM_COL32(89, 67, 35, 255), "VU LEVEL INDICATOR", 0, true);
+        panel.text(dl, x + 31.0f, y + 54.0f, 12.0f, kOptoInk, "VU", 0, true);
+        panel.text(dl, x + w - 32.0f, y + 54.0f, 12.0f, kOptoRed,
                    multicompp::ui_detail::optoMeterLabel(), 0, true);
+        panel.text(dl, x + w * 0.5f, y + h - 51.0f, 7.0f,
+                   IM_COL32(94, 64, 34, 255), "GAIN REDUCTION", 0, true);
         const float needleAngle = multicompp::ui_detail::optoMeterNeedleAngle(gr);
         const ImVec2 needle(std::sin(needleAngle), -std::cos(needleAngle));
+        dl->AddLine(ImVec2(pivot.x + 1.2f * scale, pivot.y + 1.2f * scale),
+                    ImVec2(pivot.x + needle.x * radius * 0.87f + 1.2f * scale,
+                           pivot.y + needle.y * radius * 0.87f + 1.2f * scale),
+                    IM_COL32(0, 0, 0, 75), 2.8f * scale);
         dl->AddLine(pivot,
                     ImVec2(pivot.x + needle.x * radius * 0.87f,
                            pivot.y + needle.y * radius * 0.87f),
-                    kOptoRed, 2.2f * panel.scale());
-        dl->AddCircleFilled(pivot, 7.0f * panel.scale(), kOptoInk, 24);
-        char reading[24];
-        std::snprintf(reading, sizeof(reading), "%s %.1f dB",
-                      multicompp::ui_detail::optoMeterLabel(),
-                      static_cast<double>(std::clamp(-gr, 0.0f, 99.9f)));
-        panel.text(dl, x + w * 0.5f, y + h + 10.0f, 8.5f, kOptoInk,
-                   reading, 0, true);
+                    IM_COL32(97, 47, 31, 255), 1.8f * scale);
+        dl->AddCircleFilled(pivot, 7.0f * scale, kOptoInk, 24);
+        dl->AddCircleFilled(ImVec2(pivot.x - 1.5f * scale,
+                                   pivot.y - 1.5f * scale),
+                            2.2f * scale, IM_COL32(179, 151, 99, 255), 16);
+
+        // A subtle glass reflection makes the amber illumination read as a
+        // recessed meter rather than a flat painted rectangle.
+        std::array<ImVec2, 4> glass{{
+            panel.P(x + 17.0f, y + 17.0f), panel.P(x + w * 0.58f, y + 17.0f),
+            panel.P(x + w * 0.42f, y + h - 17.0f),
+            panel.P(x + 17.0f, y + h - 17.0f)}};
+        dl->AddConvexPolyFilled(glass.data(), 4, IM_COL32(255, 255, 255, 18));
     }
 
     void drawFet(ImDrawList* dl, bool studio)
@@ -954,19 +1763,16 @@ private:
     void applyPreset(int index)
     {
         if (index < 0 || index >= static_cast<int>(multicompp::kFactoryPresets.size())) return;
-        const auto& q = multicompp::kFactoryPresets[static_cast<size_t>(index)];
-        multicompp::forEachPresetParam(q,
-            [this](multicompp::CoreParameter parameter, float value)
+        multicompp::applyFactoryPresetToHostParameters(
+            static_cast<uint32_t>(index),
+            [this](int parameterIndex, float hostValue)
             {
-                const int index = multicompp::coreParamIndex(parameter);
-                if (index >= 0) setValue(static_cast<uint32_t>(index), value);
-            },
-            [this](int band, int field, float value)
-            {
-                setValue(static_cast<uint32_t>(multicompp::kBandBase + band * 8 + field),
-                         value);
+                setHostValue(static_cast<uint32_t>(parameterIndex), hostValue);
             });
         currentPreset = index;
+        currentUserName.clear();
+        currentUserPath.clear();
+        defaultsActive = false;
     }
 };
 

--- a/plugins/shared-daf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-daf/ui/DuskImGuiWidgets.hpp
@@ -57,6 +57,15 @@ inline int dragDecimalPlaces(float fineStep, const char* fmt) noexcept
     return std::max(resting, fine);
 }
 
+inline float dragKnobCoordinate(float value, float mouseDeltaY,
+                                float minimum, float maximum,
+                                bool fine) noexcept
+{
+    const float speed = fine ? 0.0008f : 0.005f;
+    return std::clamp(value - mouseDeltaY * speed * (maximum - minimum),
+                      minimum, maximum);
+}
+
 #ifndef DUSK_IMGUI_WIDGETS_LOGIC_TEST
 
 // Adapter the UI implements to forward parameter edits to the host.
@@ -316,6 +325,9 @@ public:
     //   toDisplay/fromDisplay: optional nonlinear display transforms. The knob
     //                   still renders and gestures in [minV,maxV], while its
     //                   readout and typed entry use the transformed domain.
+    //   dragInDisplayDomain: opt into gestures and wheel steps in the transformed
+    //                   domain (for example, equal Hz per pixel on a tapered host
+    //                   parameter). The value sent to the host remains [minV,maxV].
     bool knob(const char* id, uint32_t param, float minV, float maxV,
               float cx, float cy, float radius, float& value, float defaultVal,
               bool stepped = false, bool panelTicks = true,
@@ -334,7 +346,8 @@ public:
               bool omitCenterTick = false,
               float (*toDisplay)(float, uint32_t, void*) = nullptr,
               float (*fromDisplay)(float, uint32_t, void*) = nullptr,
-              void* displayContext = nullptr)
+              void* displayContext = nullptr,
+              bool dragInDisplayDomain = false)
     {
         ImDrawList* dl = ImGui::GetWindowDrawList();
         const float R  = radius * s;
@@ -344,6 +357,16 @@ public:
         const auto displayValue = [=](float v) {
             return toDisplay != nullptr ? toDisplay(v, param, displayContext)
                                         : v * dispMul + dispAdd;
+        };
+        const auto valueFromDisplay = [=](float v) {
+            return fromDisplay != nullptr
+                ? fromDisplay(v, param, displayContext)
+                : (v - dispAdd) / (dispMul != 0.0f ? dispMul : 1.0f);
+        };
+        const float dragMinimum = dragInDisplayDomain ? displayValue(minV) : minV;
+        const float dragMaximum = dragInDisplayDomain ? displayValue(maxV) : maxV;
+        const auto beginDragValue = [&]() {
+            dragValue = dragInDisplayDomain ? displayValue(value) : value;
         };
 
         ImGui::SetCursorScreenPos(ImVec2(c.x - R, c.y - R));
@@ -370,18 +393,21 @@ public:
             {
                 if (modKey) // Alt+click (or Cmd on macOS / Ctrl elsewhere): reset, no drag
                 {
-                    host->beginEdit(param); value = defaultVal; dragValue = value;
+                    host->beginEdit(param); value = defaultVal; beginDragValue();
                     host->setParam(param, value); host->endEdit(param); changed = true;
                     modResetActive_ = true;
                 }
-                else { host->beginEdit(param); dragValue = value; modResetActive_ = false; }
+                else { host->beginEdit(param); beginDragValue(); modResetActive_ = false; }
             }
             if (active && !modResetActive_)
             {
-                const float speed = ImGui::GetIO().KeyShift ? 0.0008f : 0.005f;
-                dragValue -= ImGui::GetIO().MouseDelta.y * speed * range;
-                dragValue = dragValue < minV ? minV : (dragValue > maxV ? maxV : dragValue);
-                const float nv = stepped ? std::round(dragValue) : dragValue;
+                dragValue = dragKnobCoordinate(dragValue, ImGui::GetIO().MouseDelta.y,
+                                               dragMinimum, dragMaximum,
+                                               ImGui::GetIO().KeyShift);
+                if (stepped && dragInDisplayDomain) dragValue = std::round(dragValue);
+                float nv = dragInDisplayDomain ? valueFromDisplay(dragValue) : dragValue;
+                nv = nv < minV ? minV : (nv > maxV ? maxV : nv);
+                if (stepped && !dragInDisplayDomain) nv = std::round(nv);
                 if (nv != value) { value = nv; host->setParam(param, nv); changed = true; }
             }
             if (ImGui::IsItemDeactivated()) { if (!modResetActive_) host->endEdit(param); modResetActive_ = false; }
@@ -395,7 +421,7 @@ public:
                 if (doubleClickReset)
                 {
                     value = defaultVal;
-                    dragValue = defaultVal;
+                    beginDragValue();
                     host->setParam(param, value);
                     host->endEdit(param);
                     changed = true;
@@ -415,10 +441,17 @@ public:
                 const float wheel = ImGui::GetIO().MouseWheel;
                 if (wheel != 0.0f)
                 {
-                    const float wheelStep = ImGui::GetIO().KeyShift ? range * 0.004f : range * 0.02f;
-                    float nv = value + wheel * (stepped ? 1.0f : wheelStep);
+                    const float dragRange = dragMaximum - dragMinimum;
+                    const float wheelStep = ImGui::GetIO().KeyShift
+                        ? dragRange * 0.004f : dragRange * 0.02f;
+                    float wheelValue = dragInDisplayDomain ? displayValue(value) : value;
+                    wheelValue += wheel * (stepped ? 1.0f : wheelStep);
+                    wheelValue = wheelValue < dragMinimum ? dragMinimum
+                        : (wheelValue > dragMaximum ? dragMaximum : wheelValue);
+                    if (stepped && dragInDisplayDomain) wheelValue = std::round(wheelValue);
+                    float nv = dragInDisplayDomain ? valueFromDisplay(wheelValue) : wheelValue;
                     nv = nv < minV ? minV : (nv > maxV ? maxV : nv);
-                    nv = stepped ? std::round(nv) : nv;
+                    if (stepped && !dragInDisplayDomain) nv = std::round(nv);
                     if (nv != value)
                     {
                         host->beginEdit(param); value = nv;
@@ -525,9 +558,7 @@ public:
         float typed;
         if (valueEdit(id, cx, cy, radius, typed))
         {
-            typed = fromDisplay != nullptr
-                ? fromDisplay(typed, param, displayContext)
-                : (typed - dispAdd) / (dispMul != 0.0f ? dispMul : 1.0f); // display -> actual
+            typed = valueFromDisplay(typed); // display -> actual
             typed = typed < minV ? minV : (typed > maxV ? maxV : typed);
             if (stepped) typed = std::round(typed);
             if (typed != value)


### PR DESCRIPTION
## Summary

- port the measured Opto campaign onto the current DAF-renamed Multi-Comp 2 tree
- restore the complete 1120x380 machine UI, meters, sidechain controls, program selector, and responsive layout
- cache all 13 expanded factory program records and keep host program changes, the UI mirror, and preset identity coherent
- preserve the selective DAF CI dispatch update and the current mainline bypass/Bus fixes

Closes #212
Closes #214

## Verification

- clean Release configure and full AU/VST3/CLAP/LV2/standalone build
- `ctest --output-on-failure`: 2/2 passed in 13.10 s
- pluginval VST3 strictness level 10: `SUCCESS` across 44.1/48/96 kHz and 64-1024 sample blocks
- exact AU `auval -v aufx DsMc Dusk`: `AU VALIDATION SUCCEEDED`; layouts 4-2, 2-2, and 1-1 passed
- restored the pre-existing installed AU after validation; before/after content digest matched
- preset identity deliberate failure: forcing all parameters into factory ownership failed the ownership assertion; restored suite passed
- host program mirror deliberate failure: omitting the cached Mode write failed the host-program/UI assertion; restored suite passed

## Remaining follow-up

- #213 still needs the final visual check inside Logic
- #217 retains its remaining measurement tasks
- #210 retains the documented dense repeated-burst residuals