### PR TITLE
Shared DAF: deduplicate user preset storage

### DIFF
--- a/plugins/4k-eq/daf-plugin/FourKEQUI.cpp
+++ b/plugins/4k-eq/daf-plugin/FourKEQUI.cpp
@@ -23,6 +23,7 @@
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp" // shared DAF Patreon "Special Thanks" overlay
+#include "DuskUserPresetStore.hpp"
 #include "util/CrashLog.hpp"
 
 #include <algorithm>
@@ -662,32 +663,9 @@ private:
     }
 
     //--- user preset file library (~/.config/DuskAudio/FourKEQ2/presets) --------
-    // Base dir: %APPDATA% (or %LOCALAPPDATA%) on Windows, else $XDG_CONFIG_HOME,
-    // else $HOME/.config. macOS deliberately stays on the ~/.config layout the
-    // other Dusk DAF plugins already write, so the libraries live side by side.
-    // "." is the last resort only: never write relative to the host's CWD while
-    // any supported variable is set.
-    std::string configDir() const
+    std::filesystem::path configDir() const
     {
-        std::string base;
-       #if defined(_WIN32)
-        for (const char* var : { "APPDATA", "LOCALAPPDATA" })
-            if (const char* v = std::getenv(var); v != nullptr && *v != '\0')
-            { base = v; break; }
-       #elif defined(__APPLE__)
-        // XDG_CONFIG_HOME is deliberately NOT read here: a mac with it set in a
-        // dotfile would otherwise stop seeing the library earlier builds wrote.
-        if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0')
-            base = std::string(home) + "/.config";
-       #else
-        if (const char* xdg = std::getenv("XDG_CONFIG_HOME"); xdg != nullptr && *xdg != '\0')
-            base = xdg;
-        else if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0')
-            base = std::string(home) + "/.config";
-       #endif
-        if (base.empty())
-            base = ".";
-        return base + "/DuskAudio/FourKEQ2/presets";
+        return duskdaf::userPresetDirectory("FourKEQ2");
     }
 
     // Strict field parse, shared by the library scan and the loader so a file
@@ -785,97 +763,35 @@ private:
 
     void scanUserPresets()
     {
-        userPresets.clear();
-        namespace fs = std::filesystem;
-        std::error_code ec;
-        for (fs::directory_iterator it(configDir(), ec), end; !ec && it != end; it.increment(ec))
-        {
-            if (it->path().extension() != ".4kpreset")
-                continue;
-            UserPreset up;
-            up.path = it->path().string();
-            up.name = it->path().stem().string();
-            if (readUserPresetFile(up.path, up.name, up.vals))
-                userPresets.push_back(std::move(up));
-        }
-        std::sort(userPresets.begin(), userPresets.end(),
-                  [](const UserPreset& a, const UserPreset& b) { return a.name < b.name; });
-    }
-
-    // Display name stored inside a preset file, or "" when the file is missing
-    // or carries no name= line (a foreign or truncated file in our directory).
-    static std::string storedPresetName(const std::string& path)
-    {
-        std::ifstream f(path);
-        std::string line;
-        while (std::getline(f, line))
-            if (line.compare(0, 5, "name=") == 0)
-                return line.substr(5);
-        return {};
+        duskdaf::scanUserPresets(
+            configDir(), ".4kpreset", userPresets,
+            [](const std::filesystem::path&, UserPreset& preset) {
+                return readUserPresetFile(preset.path, preset.name, preset.vals);
+            });
     }
 
     // Returns false if nothing was written, so the caller can keep the dialog
     // open and say so instead of closing on a save that silently did nothing.
     bool saveUserPreset(const char* rawName)
     {
-        std::string name(rawName);
-        while (!name.empty() && name.back() == ' ')
-            name.pop_back();
-        if (name.empty())
+        const auto saved = duskdaf::writeUserPreset(
+            configDir(), ".4kpreset", rawName,
+            [this](std::ostream& output) {
+                output << "format_version=" << kUserPresetFormatVersion << '\n';
+                output << "frequency_domain=effective_hz\n";
+                output << std::setprecision(std::numeric_limits<float>::max_digits10);
+                for (uint32_t i = 0; i < kParamCount; ++i)
+                    if (fkIsPresetParam(i))
+                        output << kFourKParams[i].key << '='
+                               << (isFrequencyParam(i) ? displayValue(i) : values[i])
+                               << '\n';
+            });
+        if (!saved)
             return false;
-        const std::string dir = configDir();
-        std::error_code ec;
-        std::filesystem::create_directories(dir, ec);
-        if (ec)
-            return false; // no usable library directory (permissions, file in the way)
-        // Filename stem: every non-alphanumeric collapses to '_', so distinct
-        // display names can share a stem ("A B" and "A-B" both give "A_B").
-        // Re-saving the SAME name still overwrites its own file; a stem clash
-        // with a different name takes the next free suffix instead of silently
-        // clobbering that preset.
-        std::string stem;
-        for (char c : name)
-            stem += std::isalnum((unsigned char)c) ? c : '_';
-        std::string path;
-        bool usable = false;
-        for (int n = 1; n <= 99 && !usable; ++n)
-        {
-            path = dir + "/" + stem
-                 + (n == 1 ? std::string() : "_" + std::to_string(n)) + ".4kpreset";
-            // A free path, or one whose file already stores THIS display name.
-            // An existing file without a name= line is not free: the library
-            // lists it under its stem, so overwriting it would drop a preset
-            // the player can see. A path that cannot be probed is never assumed
-            // free either - exists() reports an error as false.
-            ec.clear();
-            const bool present = std::filesystem::exists(path, ec);
-            if (ec)
-                continue;
-            usable = !present || storedPresetName(path) == name;
-        }
-        if (!usable)
-            return false; // 99 colliding stems: refuse rather than overwrite one
-        std::ofstream f(path, std::ios::trunc);
-        if (!f)
-            return false;
-        // Classic locale so the values are written with '.' whatever locale the
-        // host installed, matching parsePresetNumber() on the way back in.
-        f.imbue(std::locale::classic());
-        f << "name=" << name << "\n";
-        f << "format_version=" << kUserPresetFormatVersion << "\n";
-        f << "frequency_domain=effective_hz\n";
-        f << std::setprecision(std::numeric_limits<float>::max_digits10);
-        for (uint32_t i = 0; i < kParamCount; ++i)
-            if (fkIsPresetParam(i))
-                f << kFourKParams[i].key << "="
-                  << (isFrequencyParam(i) ? displayValue(i) : values[i]) << "\n";
-        f.close();
-        if (!f)
-            return false; // flush/close failed: the file on disk is not complete
         scanUserPresets();
         currentPreset = -1;
-        currentUserName = name;
-        currentUserPath = path;
+        currentUserName = saved.name;
+        currentUserPath = saved.path;
         return true;
     }
 

--- a/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
@@ -17,6 +17,7 @@
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp"   // shared DAF Patreon "Special Thanks" overlay (click title)
+#include "DuskUserPresetStore.hpp"
 #include "util/CrashLog.hpp"
 
 #include <cmath>
@@ -229,60 +230,60 @@ private:
     }
 
     //--- user preset file library (~/.config/DuskAudio/TapeMachine2/presets) ---
-    std::string configDir() const
+    std::filesystem::path configDir() const
     {
-        const char* home = std::getenv("HOME");
-        return std::string(home ? home : ".") + "/.config/DuskAudio/TapeMachine2/presets";
+        return duskdaf::userPresetDirectory("TapeMachine2");
     }
 
     void scanUserPresets()
     {
-        userPresets.clear();
-        namespace fs = std::filesystem;
-        std::error_code ec;
-        for (fs::directory_iterator it(configDir(), ec), end; !ec && it != end; it.increment(ec))
-        {
-            if (it->path().extension() != ".tmpreset") continue;
-            UserPreset up;
-            up.path = it->path().string();
-            up.name = it->path().stem().string();
-            for (uint32_t i = 0; i < kParamVuL; ++i) up.vals[i] = kTmParams[i].def;
-            std::ifstream f(it->path());
-            std::string line;
-            while (std::getline(f, line))
-            {
-                const auto eq = line.find('=');
-                if (eq == std::string::npos) continue;
-                const std::string key = line.substr(0, eq);
-                if (key == "name") { up.name = line.substr(eq + 1); continue; }
-                const float v = (float) std::atof(line.c_str() + eq + 1);
+        duskdaf::scanUserPresets(
+            configDir(), ".tmpreset", userPresets,
+            [](const std::filesystem::path& path, UserPreset& preset) {
                 for (uint32_t i = 0; i < kParamVuL; ++i)
-                    if (key == kTmParams[i].id) { up.vals[i] = v; break; }
-            }
-            userPresets.push_back(std::move(up));
-        }
-        std::sort(userPresets.begin(), userPresets.end(),
-                  [](const UserPreset& a, const UserPreset& b) { return a.name < b.name; });
+                    preset.vals[i] = kTmParams[i].def;
+                std::ifstream input(path);
+                std::string line;
+                while (std::getline(input, line))
+                {
+                    const auto equals = line.find('=');
+                    if (equals == std::string::npos) continue;
+                    const std::string key = line.substr(0, equals);
+                    if (key == "name")
+                    {
+                        preset.name = line.substr(equals + 1);
+                        continue;
+                    }
+                    const float value = static_cast<float>(
+                        std::atof(line.c_str() + equals + 1));
+                    for (uint32_t i = 0; i < kParamVuL; ++i)
+                        if (key == kTmParams[i].id)
+                        {
+                            preset.vals[i] = value;
+                            break;
+                        }
+                }
+                // Preserve the existing browser behavior: an unreadable file
+                // still appears under its stem with parameter defaults.
+                return true;
+            });
     }
 
-    void saveUserPreset(const char* rawName)
+    bool saveUserPreset(const char* rawName)
     {
-        std::string name(rawName);
-        while (!name.empty() && name.back() == ' ') name.pop_back();
-        if (name.empty()) return;
-        std::error_code ec;
-        std::filesystem::create_directories(configDir(), ec);
-        std::string fn;
-        for (char c : name) fn += std::isalnum((unsigned char)c) ? c : '_';
-        std::ofstream f(configDir() + "/" + fn + ".tmpreset", std::ios::trunc);
-        if (!f) return;
-        f << "name=" << name << "\n";
-        for (uint32_t i = 0; i < kParamVuL; ++i)
-            if (i != kParamBypass) f << kTmParams[i].id << "=" << values[i] << "\n";
-        f.close();
+        const auto saved = duskdaf::writeUserPreset(
+            configDir(), ".tmpreset", rawName,
+            [this](std::ostream& output) {
+                for (uint32_t i = 0; i < kParamVuL; ++i)
+                    if (i != kParamBypass)
+                        output << kTmParams[i].id << '=' << values[i] << '\n';
+            });
+        if (!saved)
+            return false;
         scanUserPresets();
         currentPreset = -1;
-        currentUserName = name;
+        currentUserName = saved.name;
+        return true;
     }
 
     void loadUserPreset(const std::string& path, const std::string& name)
@@ -739,16 +740,36 @@ private:
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(190, 191, 193, 255));
         if (ImGui::BeginPopupModal("Save Preset", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
+            const bool popupAppearing = ImGui::IsWindowAppearing();
+            if (popupAppearing) saveFailed = false;
             ImGui::TextUnformatted("Preset name");
             ImGui::SetNextItemWidth(240.0f * s);
-            if (ImGui::IsWindowAppearing()) ImGui::SetKeyboardFocusHere();
+            if (popupAppearing) ImGui::SetKeyboardFocusHere();
             const bool enter = ImGui::InputText("##savename", saveBuf, sizeof(saveBuf),
                                                 ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll);
             const bool doSave = ImGui::Button("Save") || enter;
             ImGui::SameLine();
             const bool cancel = ImGui::Button("Cancel");
-            if (doSave && saveBuf[0] != '\0') { saveUserPreset(saveBuf); ImGui::CloseCurrentPopup(); }
-            if (cancel) ImGui::CloseCurrentPopup();
+            if (doSave && saveBuf[0] != '\0')
+            {
+                if (saveUserPreset(saveBuf))
+                {
+                    saveFailed = false;
+                    ImGui::CloseCurrentPopup();
+                }
+                else
+                {
+                    saveFailed = true;
+                }
+            }
+            if (saveFailed)
+                ImGui::TextColored(ImVec4(0.75f, 0.16f, 0.12f, 1.0f),
+                                   "Could not save. Try a different name.");
+            if (cancel)
+            {
+                saveFailed = false;
+                ImGui::CloseCurrentPopup();
+            }
             ImGui::EndPopup();
         }
         ImGui::PopStyleColor(6);
@@ -1220,6 +1241,7 @@ private:
     struct UserPreset { std::string name, path; float vals[kParamVuL]; };
     std::vector<UserPreset> userPresets;
     char    saveBuf[64] = {};
+    bool    saveFailed = false;   // last SAVE wrote nothing; dialog stays open
     bool    showAdvanced = false;   // hidden advanced (Repro EQ) panel toggle
     bool    showSupporters = false; // Patreon "Special Thanks" overlay (click the title nameplate)
     bool    gripCursorSet = false;  // NWSE cursor currently pushed to the window

--- a/plugins/multi-comp/daf-plugin/CMakeLists.txt
+++ b/plugins/multi-comp/daf-plugin/CMakeLists.txt
@@ -37,4 +37,11 @@ if(NOT CMAKE_CROSSCOMPILING)
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared-daf/dsp")
   target_compile_features(MultiCompPluginLayerTest PRIVATE cxx_std_17)
   add_test(NAME MultiCompPluginLayer COMMAND MultiCompPluginLayerTest)
+
+  add_executable(DuskUserPresetStoreTest
+    ../../shared-daf/ui/tests/DuskUserPresetStoreTest.cpp)
+  target_include_directories(DuskUserPresetStoreTest PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../shared-daf/ui")
+  target_compile_features(DuskUserPresetStoreTest PRIVATE cxx_std_17)
+  add_test(NAME DuskUserPresetStore COMMAND DuskUserPresetStoreTest)
 endif()

--- a/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
@@ -134,6 +134,7 @@ inline void refreshCrossoverMirror(std::array<float, N>& values, ReadParameter r
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp"
+#include "DuskUserPresetStore.hpp"
 
 #include <chrono>
 #include <cstdio>
@@ -877,30 +878,9 @@ private:
         clearPresetSelection(true);
     }
 
-    std::string configDir() const
+    std::filesystem::path configDir() const
     {
-        std::string base;
-       #if defined(_WIN32)
-        for (const char* variable : {"APPDATA", "LOCALAPPDATA"})
-            if (const char* value = std::getenv(variable);
-                value != nullptr && value[0] != '\0')
-            {
-                base = value;
-                break;
-            }
-       #elif defined(__APPLE__)
-        if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0')
-            base = std::string(home) + "/.config";
-       #else
-        if (const char* xdg = std::getenv("XDG_CONFIG_HOME");
-            xdg != nullptr && xdg[0] != '\0')
-            base = xdg;
-        else if (const char* home = std::getenv("HOME");
-                 home != nullptr && home[0] != '\0')
-            base = std::string(home) + "/.config";
-       #endif
-        if (base.empty()) base = ".";
-        return base + "/DuskAudio/MultiComp2/presets";
+        return duskdaf::userPresetDirectory("MultiComp2");
     }
 
     static bool readUserPresetFile(const std::filesystem::path& path, UserPreset& preset)
@@ -925,78 +905,34 @@ private:
 
     void scanUserPresets()
     {
-        userPresets.clear();
-        std::error_code error;
-        namespace fs = std::filesystem;
-        for (fs::directory_iterator it(configDir(), error), end;
-             !error && it != end; it.increment(error))
-        {
-            if (it->path().extension() != ".mcpreset") continue;
-            UserPreset preset;
-            if (readUserPresetFile(it->path(), preset))
-                userPresets.push_back(std::move(preset));
-        }
-        std::sort(userPresets.begin(), userPresets.end(),
-                  [](const UserPreset& a, const UserPreset& b) {
-                      return a.name < b.name;
-                  });
-    }
-
-    static std::string storedPresetName(const std::string& path)
-    {
-        UserPreset preset;
-        return readUserPresetFile(path, preset) ? preset.name : std::string();
+        duskdaf::scanUserPresets(
+            configDir(), ".mcpreset", userPresets,
+            [](const std::filesystem::path& path, UserPreset& preset) {
+                return readUserPresetFile(path, preset);
+            });
     }
 
     bool saveUserPreset(const char* rawName)
     {
-        std::string name(rawName);
-        while (!name.empty() && std::isspace(static_cast<unsigned char>(name.front())))
-            name.erase(name.begin());
-        while (!name.empty() && std::isspace(static_cast<unsigned char>(name.back())))
-            name.pop_back();
-        if (name.empty()) return false;
-
-        const std::string directory = configDir();
-        std::error_code error;
-        std::filesystem::create_directories(directory, error);
-        if (error) return false;
-
-        std::string stem;
-        for (const unsigned char character : name)
-            stem += std::isalnum(character) ? static_cast<char>(character) : '_';
-        if (stem.empty()) stem = "Preset";
-
-        std::string path;
-        bool usable = false;
-        for (int suffix = 1; suffix <= 99 && !usable; ++suffix)
-        {
-            path = directory + "/" + stem
-                + (suffix == 1 ? std::string()
-                               : "_" + std::to_string(suffix))
-                + ".mcpreset";
-            error.clear();
-            const bool exists = std::filesystem::exists(path, error);
-            if (!error) usable = !exists || storedPresetName(path) == name;
-        }
-        if (!usable) return false;
-
         multicompp::StateValues snapshot{};
         std::copy_n(values.begin(), snapshot.size(), snapshot.begin());
         snapshot[P_BYPASS] = multicompp::hostDefault(
             multicompp::kParams[static_cast<size_t>(P_BYPASS)]);
-        std::ofstream output(path, std::ios::trunc);
-        if (!output) return false;
-        output.imbue(std::locale::classic());
-        output << "name=" << name << '\n';
-        output << "state=" << multicompp::encodeState(snapshot) << '\n';
-        output.close();
-        if (!output) return false;
+        const auto saved = duskdaf::writeUserPreset(
+            configDir(), ".mcpreset", rawName,
+            [&snapshot](std::ostream& output) {
+                output << "state=" << multicompp::encodeState(snapshot) << '\n';
+            },
+            [](const std::filesystem::path& path) {
+                UserPreset preset;
+                return readUserPresetFile(path, preset) ? preset.name : std::string();
+            });
+        if (!saved) return false;
 
         scanUserPresets();
         currentPreset = -1;
-        currentUserName = name;
-        currentUserPath = path;
+        currentUserName = saved.name;
+        currentUserPath = saved.path;
         defaultsActive = false;
         return true;
     }

--- a/plugins/shared-daf/ui/DuskUserPresetStore.hpp
+++ b/plugins/shared-daf/ui/DuskUserPresetStore.hpp
@@ -1,0 +1,179 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+// Shared message-thread user-preset file handling for DAF plugin UIs.
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <locale>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace duskdaf
+{
+
+// Keep the path used by the shipped DAF plugins. In particular, macOS stays
+// under ~/.config even when XDG_CONFIG_HOME is present, so an update cannot
+// orphan an existing preset library.
+inline std::filesystem::path userPresetDirectory(std::string_view productDirectory)
+{
+    std::filesystem::path base;
+   #if defined(_WIN32)
+    for (const char* variable : {"APPDATA", "LOCALAPPDATA"})
+        if (const char* value = std::getenv(variable);
+            value != nullptr && value[0] != '\0')
+        {
+            base = value;
+            break;
+        }
+   #elif defined(__APPLE__)
+    if (const char* home = std::getenv("HOME"); home != nullptr && home[0] != '\0')
+        base = std::filesystem::path(home) / ".config";
+   #else
+    if (const char* xdg = std::getenv("XDG_CONFIG_HOME");
+        xdg != nullptr && xdg[0] != '\0')
+        base = xdg;
+    else if (const char* home = std::getenv("HOME");
+             home != nullptr && home[0] != '\0')
+        base = std::filesystem::path(home) / ".config";
+   #endif
+    if (base.empty())
+        base = ".";
+    return base / "DuskAudio" / productDirectory / "presets";
+}
+
+inline std::string normaliseUserPresetName(const char* rawName)
+{
+    std::string name(rawName != nullptr ? rawName : "");
+    while (!name.empty()
+           && std::isspace(static_cast<unsigned char>(name.front())) != 0)
+        name.erase(name.begin());
+    while (!name.empty()
+           && std::isspace(static_cast<unsigned char>(name.back())) != 0)
+        name.pop_back();
+    return name;
+}
+
+inline std::string userPresetFilenameStem(const std::string& name)
+{
+    std::string stem;
+    stem.reserve(name.size());
+    for (const unsigned char character : name)
+        stem += std::isalnum(character) != 0 ? static_cast<char>(character) : '_';
+    return stem.empty() ? std::string("Preset") : stem;
+}
+
+// Return only the display name. Format-specific readers remain responsible for
+// deciding whether a complete preset is valid and safe to load.
+inline std::string storedUserPresetName(const std::filesystem::path& path)
+{
+    std::ifstream input(path);
+    std::string line;
+    while (std::getline(input, line))
+        if (line.compare(0, 5, "name=") == 0)
+            return line.substr(5);
+    return {};
+}
+
+struct SavedUserPreset
+{
+    std::string name;
+    std::string path;
+
+    explicit operator bool() const noexcept { return !path.empty(); }
+};
+
+// The writer appends the plugin-specific payload after the shared name= line.
+// nameReader exists because a format may require a complete decode before it
+// considers an existing file eligible for an in-place re-save.
+template <typename Writer, typename NameReader>
+SavedUserPreset writeUserPreset(const std::filesystem::path& directory,
+                                std::string_view extension,
+                                const char* rawName,
+                                Writer&& writer,
+                                NameReader&& nameReader)
+{
+    const std::string name = normaliseUserPresetName(rawName);
+    if (name.empty())
+        return {};
+
+    std::error_code error;
+    std::filesystem::create_directories(directory, error);
+    if (error)
+        return {};
+
+    const std::string stem = userPresetFilenameStem(name);
+    std::filesystem::path selectedPath;
+    for (int suffix = 1; suffix <= 99; ++suffix)
+    {
+        const std::string filename = stem
+            + (suffix == 1 ? std::string() : "_" + std::to_string(suffix))
+            + std::string(extension);
+        const std::filesystem::path candidate = directory / filename;
+        error.clear();
+        const bool exists = std::filesystem::exists(candidate, error);
+        if (!error && (!exists || nameReader(candidate) == name))
+        {
+            selectedPath = candidate;
+            break;
+        }
+    }
+    if (selectedPath.empty())
+        return {};
+
+    std::ofstream output(selectedPath, std::ios::trunc);
+    if (!output)
+        return {};
+    output.imbue(std::locale::classic());
+    output << "name=" << name << '\n';
+    writer(output);
+    output.close();
+    if (!output)
+        return {};
+
+    return {name, selectedPath.string()};
+}
+
+template <typename Writer>
+SavedUserPreset writeUserPreset(const std::filesystem::path& directory,
+                                std::string_view extension,
+                                const char* rawName,
+                                Writer&& writer)
+{
+    return writeUserPreset(
+        directory, extension, rawName, std::forward<Writer>(writer),
+        [](const std::filesystem::path& path) { return storedUserPresetName(path); });
+}
+
+// Preset records intentionally use the common `name` and `path` members. The
+// reader fills or validates the plugin-specific cached parameter payload and
+// returns false for a file that must not appear in the browser.
+template <typename Preset, typename Reader>
+void scanUserPresets(const std::filesystem::path& directory,
+                     std::string_view extension,
+                     std::vector<Preset>& presets,
+                     Reader&& reader)
+{
+    presets.clear();
+    std::error_code error;
+    for (std::filesystem::directory_iterator it(directory, error), end;
+         !error && it != end; it.increment(error))
+    {
+        if (it->path().extension() != extension)
+            continue;
+        Preset preset{};
+        preset.path = it->path().string();
+        preset.name = it->path().stem().string();
+        if (reader(it->path(), preset))
+            presets.push_back(std::move(preset));
+    }
+    std::sort(presets.begin(), presets.end(),
+              [](const Preset& a, const Preset& b) { return a.name < b.name; });
+}
+
+} // namespace duskdaf

--- a/plugins/shared-daf/ui/tests/DuskUserPresetStoreTest.cpp
+++ b/plugins/shared-daf/ui/tests/DuskUserPresetStoreTest.cpp
@@ -1,0 +1,138 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+
+#include "DuskUserPresetStore.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <locale>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+struct CommaDecimal : std::numpunct<char>
+{
+    char do_decimal_point() const override { return ','; }
+};
+
+struct Preset
+{
+    std::string name;
+    std::string path;
+    std::string value;
+};
+
+struct TempDirectory
+{
+    std::filesystem::path path;
+
+    TempDirectory()
+    {
+        const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+        path = std::filesystem::temp_directory_path()
+            / ("dusk-user-preset-store-" + std::to_string(stamp));
+        std::filesystem::create_directories(path);
+    }
+
+    ~TempDirectory()
+    {
+        std::error_code error;
+        std::filesystem::remove_all(path, error);
+    }
+};
+
+std::string fileContents(const std::filesystem::path& path)
+{
+    std::ifstream input(path);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+} // namespace
+
+int main()
+{
+    TempDirectory temporary;
+    const auto library = temporary.path / "library";
+
+    const std::locale previousLocale = std::locale();
+    std::locale::global(std::locale(std::locale::classic(), new CommaDecimal));
+    const auto first = duskdaf::writeUserPreset(
+        library, ".preset", "  Alpha/Beta  ",
+        [](std::ostream& output) { output << "value=" << 1.5 << '\n'; });
+    const auto collision = duskdaf::writeUserPreset(
+        library, ".preset", "Alpha-Beta",
+        [](std::ostream& output) { output << "value=" << 3.0 << '\n'; });
+    const auto overwritten = duskdaf::writeUserPreset(
+        library, ".preset", "Alpha/Beta",
+        [](std::ostream& output) { output << "value=" << 2.5 << '\n'; });
+    std::locale::global(previousLocale);
+
+    {
+        std::ofstream ignored(library / "Ignored.txt");
+        ignored << "name=Ignored\nvalue=9\n";
+    }
+
+    std::vector<Preset> presets;
+    duskdaf::scanUserPresets(
+        library, ".preset", presets,
+        [](const std::filesystem::path& path, Preset& preset)
+        {
+            std::ifstream input(path);
+            if (!input)
+                return false;
+            std::string line;
+            while (std::getline(input, line))
+            {
+                if (line.compare(0, 5, "name=") == 0)
+                    preset.name = line.substr(5);
+                else if (line.compare(0, 6, "value=") == 0)
+                    preset.value = line.substr(6);
+            }
+            return !preset.name.empty() && !preset.value.empty();
+        });
+
+    const auto blocked = temporary.path / "blocked";
+    {
+        std::ofstream file(blocked);
+        file << "not a directory";
+    }
+    const auto failed = duskdaf::writeUserPreset(
+        blocked / "child", ".preset", "Cannot Save",
+        [](std::ostream& output) { output << "value=0\n"; });
+
+    std::ostringstream actual;
+    actual << "first=" << static_cast<bool>(first) << ','
+           << std::filesystem::path(first.path).filename().string() << ','
+           << first.name << '\n';
+    actual << "collision=" << static_cast<bool>(collision) << ','
+           << std::filesystem::path(collision.path).filename().string() << '\n';
+    actual << "overwrite=" << (overwritten.path == first.path) << ','
+           << fileContents(first.path);
+    actual << "stored=" << duskdaf::storedUserPresetName(first.path) << '\n';
+    actual << "scan=" << presets.size();
+    for (const auto& preset : presets)
+        actual << ',' << preset.name << ':' << preset.value;
+    actual << '\n';
+    actual << "failed=" << static_cast<bool>(failed) << '\n';
+
+    const std::string expected =
+        "first=1,Alpha_Beta.preset,Alpha/Beta\n"
+        "collision=1,Alpha_Beta_2.preset\n"
+        "overwrite=1,name=Alpha/Beta\n"
+        "value=2.5\n"
+        "stored=Alpha/Beta\n"
+        "scan=2,Alpha-Beta:3,Alpha/Beta:2.5\n"
+        "failed=0\n";
+    if (actual.str() != expected)
+    {
+        std::cerr << "FAIL: shared user-preset store contract\n"
+                  << "expected:\n" << expected
+                  << "actual:\n" << actual.str();
+        return 1;
+    }
+
+    std::cout << "PASS: shared user-preset store contract\n" << actual.str();
+    return 0;
+}

--- a/plugins/tape-echo/daf-plugin/TapeEchoUI.cpp
+++ b/plugins/tape-echo/daf-plugin/TapeEchoUI.cpp
@@ -14,6 +14,7 @@
 #include "DuskImGuiTextInput.hpp" // Windows host focus while typing values
 #include "DuskImGuiWidgets.hpp"   // shared DuskPanel: chrome knob, LED, text, value bubble
 #include "DuskSupportersOverlay.hpp" // shared DAF Patreon "Special Thanks" overlay
+#include "DuskUserPresetStore.hpp"
 #include "util/CrashLog.hpp"
 #include "TapeEchoFontRegular.inc"
 #include "TapeEchoFontSemiBold.inc"
@@ -929,32 +930,9 @@ private:
     }
 
     //--- user preset file library (~/.config/DuskAudio/TapeEcho2/presets) -------
-    // Base dir: %APPDATA% (or %LOCALAPPDATA%) on Windows, else $XDG_CONFIG_HOME,
-    // else $HOME/.config. macOS deliberately stays on the ~/.config layout the
-    // shipped builds already write, so an update never orphans a user's library.
-    // "." is the last resort only: never write relative to the host's CWD while
-    // any supported variable is set.
-    std::string configDir() const
+    std::filesystem::path configDir() const
     {
-        std::string base;
-       #if defined(_WIN32)
-        for (const char* var : { "APPDATA", "LOCALAPPDATA" })
-            if (const char* v = std::getenv(var); v != nullptr && *v != '\0')
-            { base = v; break; }
-       #elif defined(__APPLE__)
-        // XDG_CONFIG_HOME is deliberately NOT read here: a mac with it set in a
-        // dotfile would otherwise stop seeing the library shipped builds wrote.
-        if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0')
-            base = std::string(home) + "/.config";
-       #else
-        if (const char* xdg = std::getenv("XDG_CONFIG_HOME"); xdg != nullptr && *xdg != '\0')
-            base = xdg;
-        else if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0')
-            base = std::string(home) + "/.config";
-       #endif
-        if (base.empty())
-            base = ".";
-        return base + "/DuskAudio/TapeEcho2/presets";
+        return duskdaf::userPresetDirectory("TapeEcho2");
     }
 
     // Strict field parse, shared by the library scan and the loader so a file can
@@ -986,149 +964,81 @@ private:
         return true;
     }
 
-    void scanUserPresets()
+    struct UserPreset { std::string name, path; float vals[kParamCount]; };
+
+    static bool readUserPresetFile(const std::filesystem::path& path, UserPreset& up)
     {
-        userPresets.clear();
-        namespace fs = std::filesystem;
-        std::error_code ec;
-        for (fs::directory_iterator it(configDir(), ec), end; !ec && it != end; it.increment(ec))
+        for (uint32_t i = 0; i < kParamCount; ++i)
+            up.vals[i] = kTeParams[i].def;
+        std::ifstream input(path);
+        std::string line;
+        bool hasEchoRateNote = false;
+        while (std::getline(input, line))
         {
-            if (it->path().extension() != ".tepreset")
+            const auto equals = line.find('=');
+            if (equals == std::string::npos)
                 continue;
-            UserPreset up;
-            up.path = it->path().string();
-            up.name = it->path().stem().string();
+            const std::string key = line.substr(0, equals);
+            if (key == "name") { up.name = line.substr(equals + 1); continue; }
             for (uint32_t i = 0; i < kParamCount; ++i)
-                up.vals[i] = kTeParams[i].def;
-            std::ifstream f(it->path());
-            std::string line;
-            bool hasEchoRateNote = false;
-            while (std::getline(f, line))
-            {
-                const auto eq = line.find('=');
-                if (eq == std::string::npos)
-                    continue;
-                const std::string key = line.substr(0, eq);
-                if (key == "name") { up.name = line.substr(eq + 1); continue; }
-                for (uint32_t i = 0; i < kParamCount; ++i)
-                    if (teIsPresetParam(i) && key == kTeParams[i].id)
+                if (teIsPresetParam(i) && key == kTeParams[i].id)
+                {
+                    float value = 0.0f;
+                    // Cache the same normalised value loadUserPreset() sends
+                    // through setP(), so preset identity survives hand edits.
+                    if (parsePresetValue(line, equals + 1, i, value))
                     {
-                        float v = 0.0f;
-                        // Normalise on the way in, exactly as loadUserPreset()'s
-                        // setP() will. This cache is compared against values[] to
-                        // recover preset identity, so an un-normalised discrete
-                        // value here (a hand-edited file, or one written before
-                        // the values were quantised) would fail to match the very
-                        // preset that had just been loaded.
-                        if (parsePresetValue(line, eq + 1, i, v))
-                        {
-                            up.vals[i] = normalizeParamValue(i, v);
-                            if (i == kParamEchoRateNote)
-                                hasEchoRateNote = true;
-                        }
-                        break;   // else keep the default already in place
+                        up.vals[i] = normalizeParamValue(i, value);
+                        if (i == kParamEchoRateNote)
+                            hasEchoRateNote = true;
                     }
-            }
-            if (!hasEchoRateNote)
-            {
-                const int leadingHead = teLeadingHeadIndexForMode(
-                    (int)(up.vals[kParamMode] + 0.5f));
-                const int knobPos = teSyncKnobPosForDivision(
-                    (int)(up.vals[kParamSyncDivision] + 0.5f), leadingHead);
-                up.vals[kParamEchoRateNote] = (float)(knobPos + 1);
-            }
-            userPresets.push_back(std::move(up));
+                    break;
+                }
         }
-        std::sort(userPresets.begin(), userPresets.end(),
-                  [](const UserPreset& a, const UserPreset& b) { return a.name < b.name; });
+        if (!hasEchoRateNote)
+        {
+            const int leadingHead = teLeadingHeadIndexForMode(
+                static_cast<int>(up.vals[kParamMode] + 0.5f));
+            const int knobPosition = teSyncKnobPosForDivision(
+                static_cast<int>(up.vals[kParamSyncDivision] + 0.5f), leadingHead);
+            up.vals[kParamEchoRateNote] = static_cast<float>(knobPosition + 1);
+        }
+        return true;
     }
 
-    // Display name stored inside a preset file, or "" when the file is missing or
-    // carries no name= line (a foreign or truncated file in our own directory).
-    static std::string storedPresetName(const std::string& path)
+    void scanUserPresets()
     {
-        std::ifstream f(path);
-        std::string line;
-        while (std::getline(f, line))
-            if (line.compare(0, 5, "name=") == 0)
-                return line.substr(5);
-        return {};
+        duskdaf::scanUserPresets(
+            configDir(), ".tepreset", userPresets,
+            [](const std::filesystem::path& path, UserPreset& preset) {
+                return readUserPresetFile(path, preset);
+            });
     }
 
     // Returns false if nothing was written, so the caller can keep the dialog
     // open and say so instead of closing on a save that silently did nothing.
     bool saveUserPreset(const char* rawName)
     {
-        std::string name(rawName);
-        while (!name.empty() && name.back() == ' ')
-            name.pop_back();
-        if (name.empty())
+        const auto saved = duskdaf::writeUserPreset(
+            configDir(), ".tepreset", rawName,
+            [this](std::ostream& output) {
+                for (uint32_t i = 0; i < kParamCount; ++i)
+                {
+                    if (!teIsPresetParam(i))
+                        continue;
+                    // Preserve an authoritative legacy semantic division by
+                    // omitting its derived physical-detent mirror.
+                    if (i == kParamEchoRateNote && legacySyncDivisionOverride)
+                        continue;
+                    output << kTeParams[i].id << "=" << values[i] << '\n';
+                }
+            });
+        if (!saved)
             return false;
-        const std::string dir = configDir();
-        std::error_code ec;
-        std::filesystem::create_directories(dir, ec);
-        if (ec)
-            return false; // no usable library directory (permissions, file in the way)
-        // Filename stem: every non-alphanumeric collapses to '_', so distinct
-        // display names can share a stem ("A B" and "A-B" both give "A_B").
-        // Re-saving the SAME name still overwrites its own file; a stem clash
-        // with a different name takes the next free suffix instead of silently
-        // clobbering that preset.
-        std::string stem;
-        for (char c : name)
-            stem += std::isalnum((unsigned char)c) ? c : '_';
-        std::string path;
-        bool usable = false;
-        for (int n = 1; n <= 99 && !usable; ++n)
-        {
-            path = dir + "/" + stem
-                 + (n == 1 ? std::string() : "_" + std::to_string(n)) + ".tepreset";
-            // A free path, or one whose file already stores THIS display name.
-            // An existing file without a name= line is not free: the library
-            // lists it under its stem, so overwriting it would drop a preset
-            // the player can see. A path that cannot be probed is never assumed
-            // free either - exists() reports an error as false.
-            ec.clear();
-            const bool present = std::filesystem::exists(path, ec);
-            if (ec)
-                continue;
-            usable = !present || storedPresetName(path) == name;
-        }
-        if (!usable)
-            return false; // 99 colliding stems: refuse rather than overwrite one
-        std::ofstream f(path, std::ios::trunc);
-        if (!f)
-            return false;
-        // Classic locale so the values are written with '.' whatever locale the
-        // host installed, matching parsePresetValue() on the way back in.
-        f.imbue(std::locale::classic());
-        f << "name=" << name << "\n";
-        for (uint32_t i = 0; i < kParamCount; ++i)
-        {
-            if (!teIsPresetParam(i))
-                continue;
-            // Do not write the DERIVED half of the compatibility pair. While an
-            // old project's semantic division owns the delay, Echo Rate Note is
-            // only the nearest physical detent to it, and that division may not
-            // be representable on the current head at all. Writing both would
-            // lose the exact division on reload: the file is read in ascending
-            // index order, so echo_rate_note (21) would land after
-            // sync_division (12) and take ownership. Omitting it leaves
-            // loadUserPreset's default pass followed by the file's
-            // sync_division, which ends with the legacy value authoritative --
-            // and scanUserPresets already derives a detent for files without
-            // the key, so the preset browser still matches.
-            if (i == kParamEchoRateNote && legacySyncDivisionOverride)
-                continue;
-            f << kTeParams[i].id << "=" << values[i] << "\n";
-        }
-        f.close();
-        if (!f)
-            return false; // flush/close failed: the file on disk is not complete
         scanUserPresets();
         currentPreset = -1;
-        currentUserName = name;
-        currentUserPath = path;
+        currentUserName = saved.name;
+        currentUserPath = saved.path;
         return true;
     }
 
@@ -1797,7 +1707,6 @@ private:
     std::string currentUserPath;   // stable identity of the active user preset
 
     // Cached user preset library (file name + display name + every preset param).
-    struct UserPreset { std::string name, path; float vals[kParamCount]; };
     std::vector<UserPreset> userPresets;
     char   saveBuf[64] = {};
     bool   saveFailed = false;      // last SAVE wrote nothing; dialog stays open


### PR DESCRIPTION
Closes #215.

Centralizes the common DAF UI user-preset storage contract in plugins/shared-daf/ui/DuskUserPresetStore.hpp and migrates Multi-Comp 2, Tape Echo 2, 4K EQ 2, and Tape Machine 2. Format-specific decoding and parameter application remain local.

Tape Machine now gets the same collision protection, cross-platform config-root selection, locale-stable writes, and visible save-failure handling as the other UIs.

Verification:
- Deliberate regression: leading-whitespace normalization removed; DuskUserPresetStore failed and exposed wrong filenames, duplicate records, and failed overwrite identity.
- Restored regression: DuskUserPresetStore passed with collision path Alpha_Beta_2.preset, same-name overwrite, sorted scan, extension filter, classic-locale 2.5 serialization, and blocked-directory failure.
- Multi-Comp Release build: AU, VST3, CLAP, LV2, standalone; ctest 3/3 passed.
- Tape Echo Release build: AU, VST3, CLAP, LV2, standalone; ctest 2/2 passed.
- 4K EQ Release build: AU, VST3, CLAP, LV2, standalone.
- Tape Machine Release build: AU, VST3, CLAP, LV2, standalone.
- pluginval strictness 10: SUCCESS for all four VST3 bundles.