### PR TITLE
Multi comp 2/opto campaign snapshot

### DIFF
--- a/.github/workflows/daf-au-test.yml
+++ b/.github/workflows/daf-au-test.yml
@@ -11,7 +11,7 @@ on:
       - 'tape-echo-daf-v*'
 
 env:
-  DAF_SHA: 788eb0193151a3e4afadb187cf72e6e57e6c2f69
+  DAF_SHA: cd445a5080464bc242905063c971b4a23c590cc2
   DAFWIDGETS_SHA: 91e0004e1ece0785d347801925d3e2518b0cbbda
 
 jobs:

--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -66,7 +66,7 @@ on:
 # checkouts on the pinned SHAs (docker/check_daf_pins.sh) so a hand-tested build
 # is the one CI produces.
 env:
-  DAF_REF: 788eb0193151a3e4afadb187cf72e6e57e6c2f69
+  DAF_REF: cd445a5080464bc242905063c971b4a23c590cc2
   DAFWIDGETS_REF: 91e0004e1ece0785d347801925d3e2518b0cbbda
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/.github/workflows/daf-release.yml
+++ b/.github/workflows/daf-release.yml
@@ -42,7 +42,7 @@ on:
 # daf-build.yml, daf-au-test.yml and docker/build_release.sh, and re-run the
 # dispatch matrix before tagging.
 env:
-  DAF_SHA: 788eb0193151a3e4afadb187cf72e6e57e6c2f69
+  DAF_SHA: cd445a5080464bc242905063c971b4a23c590cc2
   DAFWIDGETS_SHA: 91e0004e1ece0785d347801925d3e2518b0cbbda
   PLUGIN_DIR: plugins/sunset-circuits/daf-plugin
   SLUG: sunset-circuits

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -18,7 +18,7 @@ IMAGE_NAME="dusk-plugins-builder"
 # DAF / DAF-Widgets SHAs — keep in sync with daf-build.yml, daf-release.yml and daf-au-test.yml.
 # DAF comes from the dusk-audio/DAF fork (our patches live there); DAF-Widgets
 # stays on upstream DAF (no fork).
-DAF_SHA="788eb0193151a3e4afadb187cf72e6e57e6c2f69"
+DAF_SHA="cd445a5080464bc242905063c971b4a23c590cc2"
 DAFWIDGETS_SHA="91e0004e1ece0785d347801925d3e2518b0cbbda"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -1658,18 +1658,235 @@ void testOptoReferenceOutputMemory()
     {
         const float measured = measureOptoReferenceOutputMemory(gapsMs[row]);
         const float delta = measured - reference[row];
-        std::printf("opto output memory: gap %d ms reference %.3f dB "
-                    "measured %.6f dB delta %+.6f dB\n",
-                    gapsMs[row], reference[row], measured, delta);
         squaredError += delta * delta;
         worstError = std::max(worstError, std::abs(delta));
     }
     const float rmsError = std::sqrt(squaredError / static_cast<float>(gapsMs.size()));
-    std::printf("opto output memory: RMS error %.6f dB worst %.6f dB\n",
-                rmsError, worstError);
     // Reference and implementation both use the same plain-RMS extraction.
     require(rmsError < 0.125f && worstError < 0.26f,
             "Opto end-to-end output memory matches the sixteen-point reference curve");
+}
+
+std::vector<float> makeOptoDenseProgramme()
+{
+    constexpr int kSampleRate = 48000;
+    constexpr int kSeconds = 8;
+    constexpr int kSampleCount = kSeconds * kSampleRate;
+    std::vector<double> programme(static_cast<size_t>(kSampleCount), 0.0);
+    constexpr std::array<std::array<double, 3>, 4> chords{{
+        {{110.0, 164.81, 220.0}}, {{130.81, 196.0, 261.63}},
+        {{98.0, 146.83, 196.0}}, {{82.41, 123.47, 164.81}}
+    }};
+    for (size_t bar = 0; bar < chords.size(); ++bar)
+    {
+        const int start = static_cast<int>(bar) * 2 * kSampleRate;
+        const int stop = std::min(kSampleCount, start + 2 * kSampleRate);
+        for (int sample = start; sample < stop; ++sample)
+        {
+            const double time = static_cast<double>(sample - start) / kSampleRate;
+            const double envelope = std::min(time / 0.03, 1.0)
+                * std::min((2.0 - time) / 0.15, 1.0);
+            for (size_t harmonic = 0; harmonic < chords[bar].size(); ++harmonic)
+                programme[static_cast<size_t>(sample)] += 0.16
+                    / static_cast<double>(harmonic + 1) * envelope
+                    * std::sin(2.0 * static_cast<double>(kPi)
+                        * chords[bar][harmonic] * time);
+        }
+    }
+    const auto uniformNoise = [](uint32_t& state) {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        return static_cast<double>(state) / 4294967295.0 * 2.0 - 1.0;
+    };
+    uint32_t hitState = 0x9e3779b9u;
+    for (int beat = 0; beat < kSeconds * 4; ++beat)
+    {
+        const int start = beat * kSampleRate / 4;
+        const int length = std::min(
+            static_cast<int>(0.18 * kSampleRate), kSampleCount - start);
+        for (int sample = 0; sample < length; ++sample)
+        {
+            const double time = static_cast<double>(sample) / kSampleRate;
+            const double hit = (beat / 2) % 2 == 0
+                ? std::sin(2.0 * static_cast<double>(kPi)
+                    * (55.0 + 45.0 * std::exp(-time / 0.02)) * time)
+                    * std::exp(-time / 0.07)
+                : uniformNoise(hitState) * std::exp(-time / 0.035);
+            programme[static_cast<size_t>(start + sample)] += 0.30 * hit;
+        }
+    }
+    uint32_t bedState = 0x4d433243u;
+    double filteredNoise = 0.0;
+    for (auto& sample : programme)
+    {
+        const double white = uniformNoise(bedState);
+        filteredNoise = 0.985 * filteredNoise + 0.015 * white;
+        sample += 0.025 * (0.65 * white + 0.35 * filteredNoise);
+    }
+    constexpr int kFadeSamples = 20 * kSampleRate / 1000;
+    for (int sample = 0; sample < kFadeSamples; ++sample)
+    {
+        const double fadeIn = static_cast<double>(sample) / kFadeSamples;
+        const double fadeOut = static_cast<double>(kFadeSamples - 1 - sample)
+            / kFadeSamples;
+        programme[static_cast<size_t>(sample)] *= fadeIn;
+        programme[static_cast<size_t>(kSampleCount - kFadeSamples + sample)]
+            *= fadeOut;
+    }
+    double peak = 0.0;
+    for (const double sample : programme)
+        peak = std::max(peak, std::abs(sample));
+    const double scale = static_cast<double>(duskaudio::decibelsToGain(-8.0f))
+        / std::max(peak, 1.0e-12);
+    std::vector<float> result(static_cast<size_t>(kSampleCount));
+    for (size_t sample = 0; sample < result.size(); ++sample)
+        result[sample] = static_cast<float>(programme[sample] * scale);
+    return result;
+}
+
+struct OptoDenseProgrammeMetrics
+{
+    float meanErrorDb = 0.0f;
+    float rmsErrorDb = 0.0f;
+    float correlation = 0.0f;
+};
+
+OptoDenseProgrammeMetrics measureOptoDenseProgramme(
+    const std::vector<float>& programme, float peakReduction,
+    const std::array<float, 80>& referenceEnvelope)
+{
+    constexpr int kBlockSize = 256;
+    constexpr int kFrameSamples = 4800; // Non-overlapping 100 ms RMS frames.
+    MultiCompDSP control;
+    MultiCompDSP active;
+    prepareOptoDynamicsDsp(control, 0.0f);
+    prepareOptoDynamicsDsp(active, peakReduction);
+    control.setParameter(MultiCompDSP::Parameter::OptoGain, 32.1868896f);
+    active.setParameter(MultiCompDSP::Parameter::OptoGain, 32.1868896f);
+    const int latency = control.getLatencySamples();
+    require(active.getLatencySamples() == latency,
+            "Opto dense-programme control and active paths have equal latency");
+    const int totalSamples = static_cast<int>(programme.size()) + latency;
+    std::vector<float> controlOutput(static_cast<size_t>(totalSamples));
+    std::vector<float> activeOutput(static_cast<size_t>(totalSamples));
+    std::array<float, kBlockSize> input{};
+    std::array<float, kBlockSize> controlBlock{};
+    std::array<float, kBlockSize> activeBlock{};
+    for (int blockStart = 0; blockStart < totalSamples; blockStart += kBlockSize)
+    {
+        const int count = std::min(kBlockSize, totalSamples - blockStart);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int sourceSample = blockStart + sample;
+            input[static_cast<size_t>(sample)]
+                = sourceSample < static_cast<int>(programme.size())
+                    ? programme[static_cast<size_t>(sourceSample)] : 0.0f;
+        }
+        const float* inputs[] = {input.data()};
+        float* controlOutputs[] = {controlBlock.data()};
+        float* activeOutputs[] = {activeBlock.data()};
+        control.processBlock(inputs, controlOutputs, 1, count);
+        active.processBlock(inputs, activeOutputs, 1, count);
+        std::copy_n(controlBlock.data(), count, controlOutput.data() + blockStart);
+        std::copy_n(activeBlock.data(), count, activeOutput.data() + blockStart);
+    }
+    std::array<float, 80> measuredEnvelope{};
+    for (size_t frame = 0; frame < measuredEnvelope.size(); ++frame)
+    {
+        const int start = latency + static_cast<int>(frame) * kFrameSamples;
+        double controlPower = 0.0;
+        double activePower = 0.0;
+        for (int sample = 0; sample < kFrameSamples; ++sample)
+        {
+            const float controlSample
+                = controlOutput[static_cast<size_t>(start + sample)];
+            const float activeSample
+                = activeOutput[static_cast<size_t>(start + sample)];
+            controlPower += static_cast<double>(controlSample) * controlSample;
+            activePower += static_cast<double>(activeSample) * activeSample;
+        }
+        measuredEnvelope[frame] = 10.0f * std::log10(static_cast<float>(
+            (controlPower + 1.0e-30) / (activePower + 1.0e-30)));
+    }
+    double referenceMean = 0.0;
+    double measuredMean = 0.0;
+    double squaredError = 0.0;
+    for (size_t frame = 0; frame < referenceEnvelope.size(); ++frame)
+    {
+        referenceMean += referenceEnvelope[frame];
+        measuredMean += measuredEnvelope[frame];
+        const double error = measuredEnvelope[frame] - referenceEnvelope[frame];
+        squaredError += error * error;
+    }
+    referenceMean /= referenceEnvelope.size();
+    measuredMean /= measuredEnvelope.size();
+    double covariance = 0.0;
+    double referenceVariance = 0.0;
+    double measuredVariance = 0.0;
+    for (size_t frame = 0; frame < referenceEnvelope.size(); ++frame)
+    {
+        const double referenceDelta = referenceEnvelope[frame] - referenceMean;
+        const double measuredDelta = measuredEnvelope[frame] - measuredMean;
+        covariance += referenceDelta * measuredDelta;
+        referenceVariance += referenceDelta * referenceDelta;
+        measuredVariance += measuredDelta * measuredDelta;
+    }
+    return {
+        static_cast<float>(measuredMean - referenceMean),
+        static_cast<float>(std::sqrt(squaredError / referenceEnvelope.size())),
+        static_cast<float>(covariance / std::sqrt(
+            std::max(referenceVariance * measuredVariance, 1.0e-30)))
+    };
+}
+
+void testOptoDenseProgrammeParity()
+{
+    // Captured from the live reference AU with matched PR=0 controls, Gain at
+    // 0.321868896, Compress mode, and 2x oversampling.  The deterministic
+    // generator above is shared with the capture recipe; 100 ms RMS frames
+    // retain the envelope defect that remained with wider analysis windows.
+    constexpr std::array<float, 80> referenceAt40{{
+        4.678101f, 4.804975f, 5.371509f, 5.037769f, 4.704782f, 5.310720f, 4.680708f, 5.213288f,
+        4.815061f, 4.546864f, 6.638811f, 5.006345f, 5.698022f, 5.596746f, 4.774736f, 5.515971f,
+        4.687577f, 5.407262f, 4.788301f, 3.326948f, 5.560364f, 5.003565f, 6.150897f, 5.582094f,
+        4.926047f, 5.442073f, 4.682782f, 5.308673f, 4.736460f, 4.463318f, 6.501792f, 4.911393f,
+        5.883970f, 5.463069f, 4.700910f, 5.495205f, 4.649648f, 5.310791f, 4.759596f, 3.340146f,
+        5.165737f, 5.139545f, 5.930709f, 5.516829f, 5.014696f, 5.661359f, 4.955315f, 5.541442f,
+        5.031242f, 4.782400f, 6.543997f, 5.026670f, 5.808061f, 5.619396f, 4.779205f, 5.621126f,
+        4.709073f, 5.268908f, 4.815944f, 3.333637f, 5.753230f, 5.182112f, 5.799463f, 5.638040f,
+        5.147764f, 5.776921f, 5.057772f, 5.807666f, 5.181100f, 4.927483f, 5.726680f, 5.098088f,
+        6.551258f, 5.563705f, 4.832070f, 5.631370f, 4.762319f, 5.514551f, 4.840456f, 3.363744f,
+    }};
+    constexpr std::array<float, 80> referenceAt70{{
+        15.482611f, 16.851750f, 17.896457f, 17.521057f, 17.044112f, 17.847969f, 17.016222f, 17.756700f,
+        17.204546f, 16.949476f, 18.842610f, 17.179530f, 18.070807f, 17.740867f, 17.025793f, 17.979406f,
+        16.990076f, 17.829499f, 16.909756f, 13.463429f, 17.036409f, 17.052952f, 18.357538f, 17.647516f,
+        16.994067f, 17.756139f, 16.906915f, 17.734576f, 17.068864f, 16.868262f, 18.844047f, 17.108888f,
+        18.145505f, 17.647855f, 16.954388f, 17.910899f, 16.888395f, 17.730082f, 16.839019f, 13.477085f,
+        16.947910f, 17.177237f, 17.862250f, 17.554443f, 17.003666f, 17.920045f, 16.988555f, 17.807569f,
+        17.169406f, 16.981416f, 18.699973f, 17.180529f, 17.932969f, 17.722775f, 17.039548f, 18.029931f,
+        16.981497f, 17.745234f, 16.987801f, 13.497576f, 17.138513f, 17.120387f, 17.750245f, 17.683297f,
+        16.990066f, 17.952907f, 16.958054f, 17.823901f, 17.159247f, 16.979283f, 17.944300f, 17.186154f,
+        18.723287f, 17.587928f, 16.948212f, 17.939089f, 16.956146f, 17.839403f, 16.925629f, 13.546612f,
+    }};
+    const auto programme = makeOptoDenseProgramme();
+    const auto low = measureOptoDenseProgramme(programme, 40.0f, referenceAt40);
+    const auto high = measureOptoDenseProgramme(programme, 70.0f, referenceAt70);
+    std::printf("opto dense programme: PR 0.40 mean %+.6f dB RMS %.6f dB "
+                "correlation %.6f; PR 0.70 mean %+.6f dB RMS %.6f dB "
+                "correlation %.6f\n",
+                low.meanErrorDb, low.rmsErrorDb, low.correlation,
+                high.meanErrorDb, high.rmsErrorDb, high.correlation);
+    // The RMS ceilings reject the issue baseline (1.600 / 3.163 dB) with
+    // margin.  Correlation is gated separately so a uniform offset cannot
+    // conceal a flattened or time-inverted gain-reduction envelope.
+    require(std::abs(low.meanErrorDb) < 0.60f && low.rmsErrorDb < 0.75f
+                && low.correlation > 0.75f,
+            "Opto low-PR dense-programme envelope stays inside the reference gate");
+    require(std::abs(high.meanErrorDb) < 1.75f && high.rmsErrorDb < 1.90f
+                && high.correlation > 0.72f,
+            "Opto high-PR dense-programme envelope stays inside the reference gate");
 }
 
 struct OptoAttackCrossings
@@ -4381,6 +4598,7 @@ int main()
     testOptoDetectorFrequencyWeighting();
     testOptoSubBassFloorContinuity();
     testOptoReferenceOutputMemory();
+    testOptoDenseProgrammeParity();
     reportOptoAttackCrossings();
     testOptoLimitDynamics();
     reportOptoReleaseLocalTaus();

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -32,6 +32,7 @@ using duskaudio::MultiCompDSP;
 namespace
 {
 constexpr float kPi = duskaudio::kDuskPi;
+constexpr int kOversampling2xSetting = 1;
 
 void require(bool condition, const char* message)
 {
@@ -604,7 +605,8 @@ void testOptoSampleRateParity()
             "Opto reference residual is invariant from 44.1 to 96 kHz");
 }
 
-void prepareOptoDynamicsDsp(MultiCompDSP& dsp, float peakReduction)
+void prepareOptoDynamicsDsp(MultiCompDSP& dsp, float peakReduction,
+                            int oversamplingSetting = kOversampling2xSetting)
 {
     dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::Opto));
     dsp.setMix(100.0f);
@@ -617,6 +619,7 @@ void prepareOptoDynamicsDsp(MultiCompDSP& dsp, float peakReduction)
     dsp.setParameter(MultiCompDSP::Parameter::OptoPeakReduction, peakReduction);
     dsp.setParameter(MultiCompDSP::Parameter::OptoGain, duskaudio::optoGainDbToKnob(0.0f));
     dsp.setParameter(MultiCompDSP::Parameter::OptoLimit, 0.0f);
+    dsp.setOversampling(oversamplingSetting);
     dsp.prepare(48000.0, 256);
 }
 
@@ -1760,8 +1763,8 @@ OptoDenseProgrammeMetrics measureOptoDenseProgramme(
     constexpr int kFrameSamples = 4800; // Non-overlapping 100 ms RMS frames.
     MultiCompDSP control;
     MultiCompDSP active;
-    prepareOptoDynamicsDsp(control, 0.0f);
-    prepareOptoDynamicsDsp(active, peakReduction);
+    prepareOptoDynamicsDsp(control, 0.0f, kOversampling2xSetting);
+    prepareOptoDynamicsDsp(active, peakReduction, kOversampling2xSetting);
     control.setParameter(MultiCompDSP::Parameter::OptoGain, 32.1868896f);
     active.setParameter(MultiCompDSP::Parameter::OptoGain, 32.1868896f);
     const int latency = control.getLatencySamples();

--- a/plugins/multi-comp/daf-plugin/CMakeLists.txt
+++ b/plugins/multi-comp/daf-plugin/CMakeLists.txt
@@ -38,6 +38,18 @@ if(NOT CMAKE_CROSSCOMPILING)
   target_compile_features(MultiCompPluginLayerTest PRIVATE cxx_std_17)
   add_test(NAME MultiCompPluginLayer COMMAND MultiCompPluginLayerTest)
 
+  if(APPLE)
+    add_executable(MultiCompAUTest MultiCompAUTests.cpp)
+    target_compile_features(MultiCompAUTest PRIVATE cxx_std_17)
+    target_compile_definitions(MultiCompAUTest PRIVATE
+      MULTICOMP_AU_BINARY="$<TARGET_FILE:multi_comp_2-au>")
+    target_link_libraries(MultiCompAUTest PRIVATE
+      "-framework AudioToolbox"
+      "-framework AudioUnit")
+    add_dependencies(MultiCompAUTest multi_comp_2-au)
+    add_test(NAME MultiCompAU COMMAND MultiCompAUTest)
+  endif()
+
   add_executable(DuskUserPresetStoreTest
     ../../shared-daf/ui/tests/DuskUserPresetStoreTest.cpp)
   target_include_directories(DuskUserPresetStoreTest PRIVATE

--- a/plugins/multi-comp/daf-plugin/DafPluginInfo.h
+++ b/plugins/multi-comp/daf-plugin/DafPluginInfo.h
@@ -13,14 +13,11 @@
 // format supports them; JACK exposes all four inputs as named ports.
 #define DAF_PLUGIN_NUM_INPUTS   4
 #define DAF_PLUGIN_NUM_OUTPUTS  2
-// AU hosts filter insert menus by channel layout, and DAF's AU wrapper carries
-// every input channel on ONE element rather than a separate sidechain bus. The
-// base { 4, 2 } entry therefore describes a 4-in insert, which no stereo track
-// offers: without { 2, 2 } here auval reports the handling matrix as 1-1 and 4-2
-// only, and Logic omits the AU from every stereo channel strip. The three
-// entries are the three real layouts -- stereo with external sidechain, plain
-// stereo, and mono -- and run() picks the sidechain path off the input count
-// reported by ioChanged(), not off the output count.
+// The three total-port layouts are stereo with external sidechain, plain
+// stereo, and mono. DAF's AU wrapper projects these onto the main input bus for
+// host channel-capability matching and exposes ports 2-3 on a separate input
+// element. run() still picks the sidechain path from the total active input
+// count reported by ioChanged(), not from the output count.
 #define DAF_PLUGIN_EXTRA_IO     { 2, 2 }, { 1, 1 },
 #define DAF_PLUGIN_HAS_UI       1
 #define DAF_PLUGIN_IS_RT_SAFE   1

--- a/plugins/multi-comp/daf-plugin/MultiCompAUTests.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompAUTests.cpp
@@ -1,0 +1,282 @@
+#include <AudioToolbox/AudioToolbox.h>
+#include <AudioUnit/AudioUnit.h>
+#include <dlfcn.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "MultiCompParams.hpp"
+
+namespace
+{
+void require(bool condition, const char* message)
+{
+    if (! condition)
+    {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        std::exit(1);
+    }
+}
+
+void requireStatus(OSStatus status, const char* message)
+{
+    if (status != noErr)
+    {
+        std::fprintf(stderr, "FAIL: %s (OSStatus %d)\n", message, static_cast<int>(status));
+        std::exit(1);
+    }
+}
+
+constexpr OSType fourcc(char a, char b, char c, char d)
+{
+    return (static_cast<OSType>(a) << 24u) | (static_cast<OSType>(b) << 16u)
+         | (static_cast<OSType>(c) << 8u) | static_cast<OSType>(d);
+}
+
+struct CallbackState
+{
+    UInt32 expectedBus = 0;
+    UInt32 calls = 0;
+};
+
+OSStatus renderInput(void* refCon,
+                     AudioUnitRenderActionFlags*,
+                     const AudioTimeStamp*,
+                     UInt32 bus,
+                     UInt32 frames,
+                     AudioBufferList* data)
+{
+    CallbackState& state = *static_cast<CallbackState*>(refCon);
+    require(bus == state.expectedBus, "input callback receives its destination bus number");
+    ++state.calls;
+
+    for (UInt32 channel = 0; channel < data->mNumberBuffers; ++channel)
+    {
+        require(data->mBuffers[channel].mData != nullptr,
+                "AU supplies allocated storage to each input callback");
+        float* const samples = static_cast<float*>(data->mBuffers[channel].mData);
+        for (UInt32 frame = 0; frame < frames; ++frame)
+            samples[frame] = state.expectedBus == 0 ? 0.1f : 0.8f;
+    }
+    return noErr;
+}
+
+struct StereoBufferList
+{
+    UInt32 numberBuffers;
+    AudioBuffer buffers[2];
+};
+}
+
+int main()
+{
+    void* const image = dlopen(MULTICOMP_AU_BINARY, RTLD_NOW | RTLD_LOCAL);
+    require(image != nullptr, dlerror());
+
+    using Factory = void* (*)(const AudioComponentDescription*);
+    Factory const factory = reinterpret_cast<Factory>(dlsym(image, "PluginAUFactory"));
+    require(factory != nullptr, "AU bundle exports PluginAUFactory");
+
+    const AudioComponentDescription description = {
+        kAudioUnitType_Effect, fourcc('D', 's', 'M', 'c'), fourcc('D', 'u', 's', 'k'), 0, 0
+    };
+    auto* const interface = static_cast<AudioComponentPlugInInterface*>(factory(&description));
+    require(interface != nullptr, "AU factory creates an interface");
+    requireStatus(interface->Open(interface, reinterpret_cast<AudioUnit>(interface)),
+                  "AU interface opens");
+
+    using GetProperty = OSStatus (*)(void*, AudioUnitPropertyID, AudioUnitScope,
+                                     AudioUnitElement, void*, UInt32*);
+    using SetProperty = OSStatus (*)(void*, AudioUnitPropertyID, AudioUnitScope,
+                                     AudioUnitElement, const void*, UInt32);
+    using Lifecycle = OSStatus (*)(void*);
+    using Render = OSStatus (*)(void*, AudioUnitRenderActionFlags*, const AudioTimeStamp*,
+                                UInt32, UInt32, AudioBufferList*);
+    using Reset = OSStatus (*)(void*, AudioUnitScope, AudioUnitElement);
+    using SetParameter = OSStatus (*)(void*, AudioUnitParameterID, AudioUnitScope,
+                                      AudioUnitElement, AudioUnitParameterValue, UInt32);
+
+    const auto getProperty = reinterpret_cast<GetProperty>(interface->Lookup(kAudioUnitGetPropertySelect));
+    const auto setProperty = reinterpret_cast<SetProperty>(interface->Lookup(kAudioUnitSetPropertySelect));
+    const auto initialize = reinterpret_cast<Lifecycle>(interface->Lookup(kAudioUnitInitializeSelect));
+    const auto uninitialize = reinterpret_cast<Lifecycle>(interface->Lookup(kAudioUnitUninitializeSelect));
+    const auto render = reinterpret_cast<Render>(interface->Lookup(kAudioUnitRenderSelect));
+    const auto reset = reinterpret_cast<Reset>(interface->Lookup(kAudioUnitResetSelect));
+    const auto setParameter = reinterpret_cast<SetParameter>(interface->Lookup(kAudioUnitSetParameterSelect));
+    require(getProperty != nullptr && setProperty != nullptr && initialize != nullptr
+                && uninitialize != nullptr && render != nullptr && reset != nullptr
+                && setParameter != nullptr,
+            "AU interface exposes property, lifecycle, and render selectors");
+
+    UInt32 inputBusCount = 0;
+    UInt32 dataSize = sizeof(inputBusCount);
+    requireStatus(getProperty(interface, kAudioUnitProperty_ElementCount,
+                              kAudioUnitScope_Input, 0, &inputBusCount, &dataSize),
+                  "AU reports its input element count");
+    require(inputBusCount == 2, "AU exposes main and sidechain as separate input buses");
+
+    for (UInt32 bus = 0; bus < inputBusCount; ++bus)
+    {
+        AudioStreamBasicDescription format{};
+        dataSize = sizeof(format);
+        requireStatus(getProperty(interface, kAudioUnitProperty_StreamFormat,
+                                  kAudioUnitScope_Input, bus, &format, &dataSize),
+                      "each input bus exposes a stream format");
+        require(format.mChannelsPerFrame == 2, "main and sidechain buses default to stereo");
+    }
+
+    AUChannelInfo channelInfo[3]{};
+    dataSize = sizeof(channelInfo);
+    requireStatus(getProperty(interface, kAudioUnitProperty_SupportedNumChannels,
+                              kAudioUnitScope_Global, 0, channelInfo, &dataSize),
+                  "AU reports supported main-bus layouts");
+    require(dataSize == 2 * sizeof(AUChannelInfo),
+            "duplicate aggregate and main-bus channel layouts are removed");
+    require(channelInfo[0].inChannels == 2 && channelInfo[0].outChannels == 2
+                && channelInfo[1].inChannels == 1 && channelInfo[1].outChannels == 1,
+            "AU channel capabilities describe stereo and mono main buses");
+
+    CallbackState callbackStates[2] = {{0, 0}, {1, 0}};
+    for (UInt32 bus = 0; bus < inputBusCount; ++bus)
+    {
+        const AURenderCallbackStruct callback = {renderInput, &callbackStates[bus]};
+        requireStatus(setProperty(interface, kAudioUnitProperty_SetRenderCallback,
+                                  kAudioUnitScope_Input, bus, &callback, sizeof(callback)),
+                      "each input bus accepts an independent render callback");
+    }
+
+    requireStatus(initialize(interface), "AU initializes with both input buses connected");
+
+    constexpr UInt32 frames = 64;
+    float left[frames]{};
+    float right[frames]{};
+    StereoBufferList storage = {
+        2,
+        {{1, sizeof(left), left}, {1, sizeof(right), right}}
+    };
+    AudioTimeStamp timestamp{};
+    timestamp.mSampleTime = 0.0;
+    timestamp.mFlags = kAudioTimeStampSampleTimeValid;
+    AudioUnitRenderActionFlags flags = 0;
+    requireStatus(render(interface, &flags, &timestamp, 0, frames,
+                         reinterpret_cast<AudioBufferList*>(&storage)),
+                  "AU renders with independent main and sidechain pulls");
+    require(callbackStates[0].calls == 1 && callbackStates[1].calls == 1,
+            "one render pulls both input buses exactly once");
+
+    requireStatus(uninitialize(interface), "AU uninitializes");
+
+    const AURenderCallbackStruct disconnected{};
+    requireStatus(setProperty(interface, kAudioUnitProperty_SetRenderCallback,
+                              kAudioUnitScope_Input, 1, &disconnected, sizeof(disconnected)),
+                  "sidechain callback disconnects independently");
+    requireStatus(initialize(interface), "AU initializes without a sidechain source");
+    requireStatus(render(interface, &flags, &timestamp, 0, frames,
+                         reinterpret_cast<AudioBufferList*>(&storage)),
+                  "AU renders after the sidechain disconnects");
+    require(callbackStates[0].calls == 2 && callbackStates[1].calls == 1,
+            "disconnected sidechain is not pulled and the main bus remains active");
+    requireStatus(reset(interface, kAudioUnitScope_Input, 1),
+                  "reset accepts the sidechain input element");
+    requireStatus(uninitialize(interface), "AU uninitializes after disconnected render");
+
+    AudioStreamBasicDescription monoFormat{};
+    dataSize = sizeof(monoFormat);
+    requireStatus(getProperty(interface, kAudioUnitProperty_StreamFormat,
+                              kAudioUnitScope_Input, 0, &monoFormat, &dataSize),
+                  "main input format can be read before switching to mono");
+    monoFormat.mChannelsPerFrame = 1;
+    requireStatus(setProperty(interface, kAudioUnitProperty_StreamFormat,
+                              kAudioUnitScope_Input, 0, &monoFormat, sizeof(monoFormat)),
+                  "main input bus accepts mono");
+    requireStatus(setProperty(interface, kAudioUnitProperty_StreamFormat,
+                              kAudioUnitScope_Output, 0, &monoFormat, sizeof(monoFormat)),
+                  "output bus accepts matching mono");
+
+    const AURenderCallbackStruct sidechainCallback = {renderInput, &callbackStates[1]};
+    require(setProperty(interface, kAudioUnitProperty_SetRenderCallback,
+                        kAudioUnitScope_Input, 1, &sidechainCallback,
+                        sizeof(sidechainCallback)) == kAudioUnitErr_FormatNotSupported,
+            "unsupported mono-main plus stereo-sidechain layout is rejected");
+
+    requireStatus(initialize(interface), "AU initializes in its advertised mono layout");
+    storage.numberBuffers = 1;
+    requireStatus(render(interface, &flags, &timestamp, 0, frames,
+                         reinterpret_cast<AudioBufferList*>(&storage)),
+                  "AU renders its mono main path");
+    require(callbackStates[0].calls == 3 && callbackStates[1].calls == 1,
+            "mono render pulls only the one-channel main bus");
+    requireStatus(uninitialize(interface), "AU uninitializes after mono render");
+
+    monoFormat.mChannelsPerFrame = 2;
+    requireStatus(setProperty(interface, kAudioUnitProperty_StreamFormat,
+                              kAudioUnitScope_Input, 0, &monoFormat, sizeof(monoFormat)),
+                  "main input bus returns to stereo");
+    requireStatus(setProperty(interface, kAudioUnitProperty_StreamFormat,
+                              kAudioUnitScope_Output, 0, &monoFormat, sizeof(monoFormat)),
+                  "output bus returns to stereo");
+    requireStatus(setParameter(interface,
+                               static_cast<AudioUnitParameterID>(multicompp::ParamId::ExternalSidechain),
+                               kAudioUnitScope_Global, 0, 1.0f, 0),
+                  "external sidechain parameter enables");
+    requireStatus(setParameter(interface,
+                               static_cast<AudioUnitParameterID>(multicompp::ParamId::OptoPeakReduction),
+                               kAudioUnitScope_Global, 0, 80.0f, 0),
+                  "opto peak reduction is set for the routing probe");
+    requireStatus(setParameter(interface,
+                               static_cast<AudioUnitParameterID>(multicompp::ParamId::NoiseEnable),
+                               kAudioUnitScope_Global, 0, 0.0f, 0),
+                  "analogue noise is disabled for the routing probe");
+
+    storage.numberBuffers = 2;
+    requireStatus(initialize(interface), "AU initializes for disconnected routing probe");
+    for (int block = 0; block < 200; ++block)
+        requireStatus(render(interface, &flags, &timestamp, 0, frames,
+                             reinterpret_cast<AudioBufferList*>(&storage)),
+                      "disconnected routing probe renders");
+    const float disconnectedLevel = std::abs(left[frames - 1]);
+    requireStatus(uninitialize(interface), "AU uninitializes after disconnected routing probe");
+
+    requireStatus(setProperty(interface, kAudioUnitProperty_SetRenderCallback,
+                              kAudioUnitScope_Input, 1, &sidechainCallback,
+                              sizeof(sidechainCallback)),
+                  "stereo sidechain reconnects after restoring the stereo main layout");
+    requireStatus(initialize(interface), "AU initializes for connected routing probe");
+    for (int block = 0; block < 200; ++block)
+        requireStatus(render(interface, &flags, &timestamp, 0, frames,
+                             reinterpret_cast<AudioBufferList*>(&storage)),
+                      "connected routing probe renders");
+    const float connectedLevel = std::abs(left[frames - 1]);
+    requireStatus(uninitialize(interface), "AU uninitializes after connected routing probe");
+    std::printf("AU sidechain routing: disconnected %.6f, connected %.6f\n",
+                static_cast<double>(disconnectedLevel), static_cast<double>(connectedLevel));
+    require(connectedLevel < disconnectedLevel * 0.8f,
+            "sidechain bus samples reach the plugin's external detector ports");
+
+    AudioStreamBasicDescription sidechainFormat{};
+    dataSize = sizeof(sidechainFormat);
+    requireStatus(getProperty(interface, kAudioUnitProperty_StreamFormat,
+                              kAudioUnitScope_Input, 1, &sidechainFormat, &dataSize),
+                  "sidechain format can be read before disabling its bus");
+    sidechainFormat.mChannelsPerFrame = 0;
+    requireStatus(setProperty(interface, kAudioUnitProperty_StreamFormat,
+                              kAudioUnitScope_Input, 1, &sidechainFormat,
+                              sizeof(sidechainFormat)),
+                  "sidechain bus accepts the disabled zero-channel format");
+    const UInt32 sidechainCallsBeforeDisabledRender = callbackStates[1].calls;
+    requireStatus(initialize(interface), "AU initializes with its sidechain bus disabled");
+    requireStatus(render(interface, &flags, &timestamp, 0, frames,
+                         reinterpret_cast<AudioBufferList*>(&storage)),
+                  "AU renders with its sidechain bus disabled");
+    require(callbackStates[1].calls == sidechainCallsBeforeDisabledRender,
+            "disabled sidechain bus is not pulled despite retaining its callback");
+    requireStatus(uninitialize(interface), "AU uninitializes after disabled-sidechain render");
+
+    requireStatus(interface->Close(interface), "AU interface closes");
+    dlclose(image);
+
+    std::puts("AU sidechain buses: stereo dual-bus, disconnected, disabled, and mono paths passed");
+    return 0;
+}

--- a/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
@@ -31,10 +31,10 @@ using duskaudio::MultiCompDSP;
 
 namespace
 {
-// DAF prepends { DAF_PLUGIN_NUM_INPUTS, DAF_PLUGIN_NUM_OUTPUTS } to
-// this table, so the entries here are the two layouts narrower than the full
-// sidechain one. Dropping { 2, 2 } takes the AU off every stereo track, since
-// the base entry is a 4-in insert no stereo strip offers.
+// DAF prepends { DAF_PLUGIN_NUM_INPUTS, DAF_PLUGIN_NUM_OUTPUTS } to this table,
+// so the entries here are the two total-port layouts narrower than the full
+// sidechain one. The AU wrapper projects the full layout onto its main bus and
+// deduplicates the resulting { 2, 2 } capability.
 constexpr uint16_t kAdvertisedExtraIo[][2] = {DAF_PLUGIN_EXTRA_IO};
 static_assert(sizeof(kAdvertisedExtraIo) / sizeof(kAdvertisedExtraIo[0]) == 2
               && kAdvertisedExtraIo[0][0] == 2 && kAdvertisedExtraIo[0][1] == 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Multi-Comp builds, automated testing, and releases.

* **Tests**
  * Added macOS Audio Unit coverage for channel layouts, sidechain routing, rendering, reset behavior, and mono/stereo transitions.
  * Added dense-program audio validation for Opto gain-reduction accuracy and consistency.
  * Reduced unnecessary diagnostic output from tests.

* **Documentation**
  * Clarified supported channel layouts, sidechain behavior, and extra-I/O configurations for the Multi-Comp Audio Unit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->