### PR TITLE
Multi-Comp 2: PR 0.85/1.00 Opto dense-programme tripwires + campaign doc refresh

### DIFF
--- a/HANDOFF-MC2.md
+++ b/HANDOFF-MC2.md
@@ -5,13 +5,20 @@ You are the planner and reviewer; delegate implementation to Codex via the
 file. The campaign log memory `mc2-la2a-campaign.md` is the long-form record;
 this file is the working state.
 
-**Snapshot authority:** the renamed campaign worktree named in section 2, at
-committed HEAD `d090a7b`, is the current source tree for the measurements below.
-It is based on `origin/main` at `f7edaea`. The measurements were first recorded
-from the historical pre-rename `e0a4f21` worktree plus its listed changes, then
-the campaign state was ported and verified with identical gate output. Do not
-substitute `origin/main`, the historical worktree, or files from the unrelated
-primary checkout.
+**Snapshot authority (updated 2026-08-24):** the campaign branch
+`multi-comp-2/opto-campaign-snapshot` lives in the worktree
+`/private/tmp/dusk-audio-plugins-opto-campaign`. The snapshot has MERGED to
+`origin/main` through PR #228 (`582ab99`: ff57a16 dense-programme parity gate,
+0110ff9 AU sidechain-bus tests, 8d602d7 2x pin); the branch now carries the PR
+0.85/1.00 parity-gate rows. The Opto code paths are unchanged since the
+`d090a7b` state these measurements were taken on, so the gate table below is
+current (Bus/VCA detector fixes landed after it via PR #224). Re-measure
+before using any row as a DSP-decision baseline. The worktree path named in section 2 (`.../mc2-port`) is historical
+and gone. The original authority statement follows for provenance: HEAD
+`d090a7b` was based on `origin/main` at `f7edaea`; the measurements were first
+recorded from the historical pre-rename `e0a4f21` worktree plus its listed
+changes, then the campaign state was ported and verified with identical gate
+output. Do not substitute files from the unrelated primary checkout.
 
 ---
 
@@ -59,9 +66,11 @@ sustained 0.5 ms). Rules earned:
   conform to TapeMachine 2 / Tape Echo 2. That shell change applies across all
   modes; it does not authorise DSP or per-mode panel changes. Keep UI and DSP
   iterations isolated. Bugs found in
-  other modes get issues, not fixes (#220 deferred; same
-  `external ? sidechain : input` dead-link bug likely in VCA ~line 854 and
-  Bus ~line 960 of MultiCompModes.hpp — needs its own issue).
+  other modes get issues, not fixes (#220 was closed 2026-08-23 by the same
+  fix). The
+  `external ? sidechain : input` dead-link bug was fixed for VCA and Bus by
+  452b13b (PR #224); the remaining instance is processStudioVCA
+  (MultiCompModes.hpp:1443) — needs its own issue.
 - **The hardware reference is the only oracle.** Old JUCE implementation is
   not a reference; its Opto golden vectors were deleted deliberately.
 - **Parameter laws follow the reference** ("stick with parity, the goal is to
@@ -73,14 +82,21 @@ sustained 0.5 ms). Rules earned:
 
 ## 2. Repository state
 
-Worktree (all work happens here):
+Worktree (all work happens here): `/private/tmp/dusk-audio-plugins-opto-campaign`
+(branch `multi-comp-2/opto-campaign-snapshot`). The build-recipe,
+measurements-pointer, and DAF-pin bullets below remain CURRENT; the
+worktree/branch lineage bullets are historical provenance for the 2026-08-22
+measurements — the `mc2-port` scratchpad worktree they name is gone; do not
+recreate it.
+
+Historical worktree of the 2026-08-22 snapshot:
 `/private/tmp/claude-502/-Users-marckorte-projects-dusk-audio-plugins/d3a95f36-6e62-4446-9f5b-32717dcb08a6/scratchpad/mc2-port`
 
 - **Authoritative 2026-08-22 campaign snapshot:** worktree branch
   `multi-comp-2/opto-campaign-snapshot` at `d090a7b`, based on `origin/main`
   `f7edaea` (merged PR #223). Its tracked tree contains the faithfully ported
-  campaign changes and the selective DAF build-workflow edit; a clean checkout
-  of `origin/main` does not contain the same gate set.
+  campaign changes and the selective DAF build-workflow edit (historical: since
+  PRs #225-#228, `origin/main` contains the full gate set).
 - **Historical pre-rename 2026-08-22 source:** branch
   `multi-comp-2/review-followups` at `e0a4f21`, plus its five then-uncommitted
   files, with `origin/main` at `c1f9ae4`. This identifies the source from which
@@ -93,33 +109,37 @@ Worktree (all work happens here):
   `MultiCompPluginLayerTests.cpp`, and `MultiCompUI.cpp`. They are committed in
   the authoritative snapshot. The workflow change remains owner-controlled and
   outside the Opto task; do not modify it.
-- Pre-existing untracked `b/` is the configured build directory, not a source
-  change. Preserve it; configure command if needed:
+- (HISTORICAL: the `b/` build directory belonged to the dead mc2-port worktree.
+  The current worktree's build dir is `build-validation/`.) Configure command:
   ```bash
   cmake -U 'SDL2*' -U 'pkgcfg_lib_SDL2*' -S plugins/multi-comp/daf-plugin \
     -B b -DCMAKE_BUILD_TYPE=Release -DDAF_PATH=$HOME/projects/DAF \
     -DDAFWIDGETS_PATH=$HOME/projects/DAF-Widgets -DDUSK_DAF_INSTALL_LOCAL=OFF \
     -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=TRUE
   ```
-- DAF fork `~/projects/DAF`: pinned at `788eb019`; DAF-Widgets is pinned at
-  `91e0004e`. Do not modify either checkout or point builds away from these hard
-  forks.
+- DAF fork pins live in `.github/workflows/daf-build.yml` (`DAF_REF` /
+  `DAFWIDGETS_REF`). Do not modify `~/projects/DAF` / `~/projects/DAF-Widgets`
+  or point builds away from these hard forks.
 - Measurements: `~/projects/dusk-audio-tools/plugins/MultiComp/measurements/`
   (17 JSON + probe scripts). Read before measuring anything new.
 
 ## 3. Where Opto stands — authoritative 2026-08-22 macOS re-run
+
+(2026-08-24: `testOptoDenseProgrammeParity` also carries PR 0.85/1.00
+gap-tripwire rows snapshotting the current build — ceilings and the tightening
+obligation live in that test's comment block, not here.)
 
 | gate | current |
 | --- | --- |
 | static law (sine), 4 deltas | -0.021 / -0.145 / -0.085 / -0.196 dB |
 | broadband static law | fitted RMS 0.073 dB, held-out -24 dBFS +0.016 dB |
 | detector weighting | mean -0.237 dB; shape RMS 0.097 dB |
-| detector memory, 16 pts | RMS 0.070 dB, worst 0.142 dB |
+| detector memory, 16 pts (gate since reworked by bf2e797/1a3e018 into the symmetric 'output memory' probe — re-measure before citing) | RMS 0.070 dB, worst 0.142 dB |
 | make-up taper | worst 0.0029 dB |
 | output ceiling | worst 0.230 dB, peak +4.68 dBFS |
 | burst-rate sweep, 2/5/10/20/40 Hz | +0.407 / +0.563 / +0.187 / +0.384 / +0.792 dB |
 | crest sweep | -0.141 / -0.540 / **+0.615 held out** / -0.709 dB |
-| dense programme, PR 0.4/0.55/0.7/0.85/1.0 | +0.224 / +0.033 / +1.000 / +1.488 / +2.012 dB |
+| dense programme, PR 0.4/0.55/0.7/0.85/1.0 (renderer A/B metric; the in-test gate rows use a different stimulus and scoring — never cross-compare) | +0.224 / +0.033 / +1.000 / +1.488 / +2.012 dB |
 | harmonics | fundamental 0.0002 dB; compressed H2-H5 worst 0.071 dB |
 | sample-rate invariance | 0.002 dB spread |
 | asymmetric stereo | -0.19 / -0.25 dB, symmetric |

--- a/PROMPT-MC2-OPTO-GAPS.md
+++ b/PROMPT-MC2-OPTO-GAPS.md
@@ -1,6 +1,10 @@
 # Task prompt: close the remaining Multi-Comp 2 Opto vs LA-2A gaps
 
 Paste this whole file as the opening message of a fresh session.
+Rewritten 2026-08-24; supersedes every earlier copy of this prompt. Nothing in
+`~/projects/dusk-audio-tools/plugins/MultiComp/handoff/` is authoritative unless
+listed in the mandatory reading below — several files there still assert claims
+from the refuted list in this document.
 
 ---
 
@@ -12,25 +16,19 @@ failure, not a trade.
 
 ## Mandatory reading, before touching anything
 
-First select the campaign worktree, `cd` into it, and verify `git rev-parse HEAD`
-and `git status --short --branch` against the dated snapshot below. Read that
-worktree's `AGENTS.md` and `CLAUDE.md` completely before modifying code. Read
-`HANDOFF-MC2.md` from the same worktree; if it is not present there, use only a
-copy whose snapshot-authority block names the same worktree revision. Do not
-mix repository instructions, handoffs, or source files from the unrelated
-primary checkout into the selected worktree.
+First `cd` into the campaign worktree and verify `git rev-parse HEAD` and
+`git status --short --branch` against the snapshot below. Read that worktree's
+`AGENTS.md` and `CLAUDE.md` completely before modifying code — where the two
+disagree, `CLAUDE.md` wins (AGENTS.md says so itself). Do not mix instructions, handoffs,
+or source files from the unrelated primary checkout into the worktree.
 
 Then read:
 
 1. `~/.claude/projects/-Users-marckorte-projects-dusk-audio-plugins/memory/mc2-la2a-campaign.md`
    — long-form campaign log: decisions, reference facts, refuted claims.
-2. `HANDOFF-MC2.md` from the selected worktree — authoritative working state
-   for the renamed 2026-08-22 snapshot. Its gate table matches "Current measured
-   state" below; pre-rename revision references inside it are explicitly
-   historical.
-3. `~/projects/dusk-audio-tools/plugins/MultiComp/handoff/HANDOFF-2026-08-21.md`
-   — the measurement-side handoff, including the seven excluded hypotheses.
-4. `~/projects/dusk-audio-tools/plugins/MultiComp/tests/reference_comparison/README.md`
+2. `HANDOFF-MC2.md` from the worktree — the working-state record, including the
+   2026-08-22 follow-up audit and its excluded mechanisms.
+3. `~/projects/dusk-audio-tools/plugins/MultiComp/tests/reference_comparison/README.md`
    — harness contract, probe list, the single GR definition.
 
 Treat every root-cause claim in those documents as a **hypothesis**. Six have
@@ -38,30 +36,41 @@ already been refuted by re-measurement (fixed-ratio law, 3.34x release split,
 ~6x exposure stretch, +3.64 dB rebound, even-dominant harmonics, a defective
 memory-curve window). Read per-point data, never a verdict sentence.
 
-## Repository state
+## Repository state (2026-08-24)
 
-- **Authoritative renamed snapshot: 2026-08-22.** `origin/main` = `f7edaea`
-  (DAF rename, #223); campaign branch
-  `multi-comp-2/opto-campaign-snapshot` = `d090a7b`. The branch contains the
-  ported Opto gate set; `origin/main` does not.
-- Existing worktree with the build dir already configured:
-  `/private/tmp/claude-502/-Users-marckorte-projects-dusk-audio-plugins/d3a95f36-6e62-4446-9f5b-32717dcb08a6/scratchpad/mc2-port`
-  (branch `multi-comp-2/opto-campaign-snapshot` @ `d090a7b`). Its tracked tree
-  is the authoritative port; `b/` is its configured, pre-existing untracked
-  build directory and must be preserved. Do not use the unrelated primary
-  checkout or the stale pre-rename worktree.
-- **Historical pre-rename provenance:** `origin/main=c1f9ae4`; campaign branch
-  `multi-comp-2/review-followups=e0a4f21` plus its then-uncommitted changes.
-  These revisions explain where the ported measurements came from but are not
-  valid worktrees for current changes.
-- Opto DSP: `plugins/multi-comp/core/MultiCompModes.hpp` (`processOpto`,
-  `OptoState`, the `opto*` coefficient members) and
-  `plugins/multi-comp/core/MultiCompDSP.cpp`.
-- Gates: `plugins/multi-comp/core/tests/MultiCompCoreTests.cpp` (4110 lines).
+- **The Opto campaign snapshot is MERGED.** `origin/main` = `582ab99` (PR #228;
+  #225-#227 landed earlier the same way). The DSP measured below is what main
+  ships.
+- Campaign branch `multi-comp-2/opto-campaign-snapshot` merged to main through
+  PR #228 (`582ab99`): `ff57a16` dense-programme parity gate, `0110ff9` AU
+  sidechain-bus tests, `8d602d7` 2x pin. The branch now carries the PR
+  0.85/1.00 gate rows and this document refresh (2026-08-24).
+  The OPTO code paths (processOpto, opto coefficients, linked detector) are
+  unchanged since the authoritative `d090a7b` measurement state, so every Opto
+  number below is current; Bus/VCA detector fixes landed after it via PR #224.
+  Re-measure on the current build before using any row as the baseline for a
+  DSP decision — deduction is not measurement.
+- **Worktree (all work happens here):** `/private/tmp/dusk-audio-plugins-opto-campaign`
+  (branch `multi-comp-2/opto-campaign-snapshot`). The worktree path
+  named in older copies of this prompt
+  (`.../d3a95f36-.../scratchpad/mc2-port`) is GONE — do not recreate it.
+- The primary checkout `~/projects/dusk-audio-plugins` has a stale local `main`
+  (`f7edaea`) and sits on an already-merged fix branch. Leave it alone.
+- Opto DSP: `plugins/multi-comp/core/MultiCompModes.hpp` (`processOpto` at
+  ~:646-1105, `OptoState`, the `opto*` coefficient members) and
+  `plugins/multi-comp/core/MultiCompDSP.cpp` (linked detector ~:728).
+- Gates: `plugins/multi-comp/core/tests/MultiCompCoreTests.cpp`; plugin-layer
+  and AU gates in `plugins/multi-comp/daf-plugin/`.
 - Reference measurements (17 JSON + probe scripts):
   `~/projects/dusk-audio-tools/plugins/MultiComp/measurements/`. **Read these
   before generating any new reference render** — most questions are already
   answered on disk.
+- DAF fork pins live in `.github/workflows/daf-build.yml` (`DAF_REF` /
+  `DAFWIDGETS_REF`), mirrored in daf-release.yml and daf-au-test.yml — read
+  them there, do not trust a doc's copy. Hard forks; never read or build
+  against upstream DISTRHO/DPF, never modify `~/projects/DAF` or
+  `~/projects/DAF-Widgets`. Advancing either pin is not part of any Opto task;
+  if a build breaks, fix the plugin code.
 
 Build and run the core suite (verified working, ~4 s compile, macOS):
 
@@ -86,19 +95,13 @@ podman run --rm --arch amd64 -v "$PWD/plugins:/src/plugins:ro" \
 
 Second tripwire on macOS: rebuild with `-ffp-contract=off` and diff the gate
 outputs against the normal build. Any gate that moves is a rounding-difference
-amplifier — find the branch, don't retune around it.
+amplifier — find the branch, don't retune around it. Known baseline exception:
+default macOS differs from Linux/no-contract only in the low-frequency
+weighting rows by up to 0.004563 dB; not permission to widen gates.
 
-Known baseline exception measured on the 2026-08-22 follow-up: all three core
-runs pass, and Linux GCC 12 matches no-contract macOS detector-weighting rows
-within 0.000229 dB. Default macOS differs only in the low-frequency weighting
-rows by up to 0.004563 dB (shape RMS 0.096646 default, 0.098245 no-contract,
-0.098219 Linux). This is not permission to widen gates, and future DSP work
-must still run the full matrix.
+## Current measured state (2026-08-22 macOS clang re-run; Opto DSP verified unchanged since `d090a7b` by diff)
 
-## Current measured state (re-run 2026-08-22, macOS clang, `d090a7b` renamed snapshot)
-
-Suite: **PASS**. These are the same authoritative snapshot recorded in
-`HANDOFF-MC2.md`.
+Suite: **PASS** (macOS default, macOS no-contract, Linux GCC 12).
 
 Steady state, effectively solved — do not spend time here:
 
@@ -109,29 +112,28 @@ Steady state, effectively solved — do not spend time here:
 | broadband static law | fitted RMS 0.073 dB, held-out -24 dBFS +0.016 dB |
 | output ceiling | worst 0.230 dB, max-drive peak +4.68 dBFS |
 | harmonics | fundamental 0.0002 dB; compressed H2-H5 worst 0.071 dB |
+| detector weighting | shape RMS 0.097 dB; mean -0.237 and 1 kHz -0.174 dB anchors gated |
 | detector memory, 16 gaps 1 ms-2 s | RMS 0.070 dB, worst 0.142 dB |
 | sample-rate invariance | 0.002 dB spread |
 | stereo link, asymmetric | -0.19 / -0.25 dB, symmetric |
 
-Open gaps, in the order they should be attacked:
+The Opto UI restyle (#212) is complete and merged: 1120x310 faceplate
+(3.613:1), needle meter with 300 ms display ballistics, COMP/LIMIT lever,
+ridged 0-100 knobs, set-screw Mix and SC-HP trims, preset integration,
+conforming header. `design-qa.md` records the passed visual QA. UI is not part
+of this task except the flagged owner-decision items in the work order.
+
+Open gaps, in attack order:
 
 | # | gap | current numbers |
 |---|---|---|
-| 1 | dense-programme A/B | +0.224 / +0.033 / +1.000 / +1.488 / +2.012 dB at PR 0.4/0.55/0.7/0.85/1.0; material crest 17.795 dB |
-| 2 | crest sweep residuals (structural) | -0.141 / -0.540 / **+0.615 held out** / -0.709 dB |
-| 3 | short-event release decay | RMS 0.701, worst **1.386 dB** |
-| 4 | short-event charge | fitted RMS 0.414 worst 0.716; held-out RMS 0.301 worst 0.401 dB |
-| 5 | burst-rate **one-sided** bias, 2-40 Hz | +0.407 / +0.563 / +0.187 / +0.384 / +0.792 dB (all positive, mean +0.47); arithmetic audit clean, structural gap remains |
-| 6 | detector weighting absolute anchor (resolved) | mean -0.237 dB, 1 kHz -0.174 dB, shape RMS 0.097 dB; all three are now guarded |
-| 7 | Limit-mode charge t90 at the extreme | PR 1.0 @ -3 dBFS / 1 s: ref 36.0 ms vs ours 10.9 ms (-25.1 ms, held out); this is charge, not release |
-| 8 | crest comment block (resolved) | now records -0.141/-0.540/+0.615/-0.709 dB and labels the older trajectory historical |
+| 1 | dense-programme A/B, **monotonic in PR on THIS stimulus — THE gap** (the Step 1 localisation probe, a different stimulus, is non-monotonic in PR — see Step 1) | renderer A/B, unwindowed total-RMS GR residual: +0.224 / +0.033 / **+1.000 / +1.488 / +2.012 dB** at PR 0.4/0.55/0.7/0.85/1.0, crest 17.795 dB. (The in-test 100 ms-frame means read higher — see the test's comment block.) |
+| 2 | crest sweep residuals (structural, same mechanism suspected) | -0.141 / -0.540 / **+0.615 held out** / -0.709 dB |
+| 3 | short-event release decay | RMS 0.701, worst 1.386 dB |
+| 4 | short-event charge (owns the Limit t90 extreme: PR 1.0 / -3 dBFS / 1 s is -25.104 ms, charge not release) | fitted RMS 0.414 worst 0.716; held-out RMS 0.301 worst 0.401 dB |
+| 5 | burst-rate one-sided bias, 2-40 Hz | +0.407 / +0.563 / +0.187 / +0.384 / +0.792 dB (all positive; arithmetic audit clean; do not retune speculatively from the one-sided sign) |
 
-## Work order
-
-### Step 1 — measured baseline (complete; repeat after every DSP change)
-
-The renamed `d090a7b` VST3 was re-run against the live reference AU on material
-with 17.794665 dB crest. The authoritative sweep is:
+Authoritative dense-programme sweep (renderer A/B vs live reference AU):
 
 | PR | reference GR | our GR | total-RMS residual | frame p50 | frame p95 |
 | --- | ---: | ---: | ---: | ---: | ---: |
@@ -141,187 +143,181 @@ with 17.794665 dB crest. The authoritative sweep is:
 | 0.85 | 19.286 | 20.774 | +1.488 | +1.656 | +2.843 |
 | 1.00 | 21.192 | 23.204 | +2.012 | +2.206 | +3.403 |
 
-Total-RMS residual mean/worst/RMS is +0.951/+2.012/1.209 dB. Mine-side
-re-renders independently reproduce our PR-0.55 and PR-0.85 GR as 5.989099 and
-20.774064 dB. The campaign table reports PR 1.0 as +2.012 dB; the earlier
-artifact-level calculation was +2.012752 dB, a 0.000752 dB reporting difference
-with no gate impact. Input-duration-only scoring on the earlier three-row sweep
-differs by at most 0.001445 dB, excluding render tail length as the cause. The
-historical +0.3 to +0.8 dB crest-interpolated prediction is falsified: the near
-match at PR 0.4-0.55 becomes monotonic over-compression above PR 0.55. Repeat
-the five-point measurement after any DSP change.
+Near-parity at PR ≤ 0.55 becoming monotonic over-compression above it makes
+**PR a missing dynamic axis**. The single-PR crest gate structurally cannot
+predict this, and the static-law gates exclude a steady-state curve error.
 
-- renderer: `~/projects/dusk-audio-plugins/build/tests/duskverb_render/duskverb_render`
-- reference: `/Library/Audio/Plug-Ins/Components/uaudio_teletronix_la-2a_tc.component`
-  (PACE-wrapped; instantiates fine under the renderer)
-- harness: `~/projects/dusk-audio-tools/plugins/MultiComp/tests/reference_comparison/`
-  — `gen_stimuli.py` makes `dense_program.wav`; `probe_factory_presets.py`
-  (C1.9) and `compare.py` are the programme paths; `mine_contract.py` runs first
-  for the A/B phase; env prefix `MC2_*`.
-- **Render our build with `--vst3`, never `--au`.** AU resolves through the
-  global registry and will silently measure a stale installed build — this
-  already cost one whole A/B that nearly got recorded as a DSP defect.
-- **GR is always `output(PR=0) - output(PR=x)` at the same Gain**, never
-  input minus output.
-- Report all five programme deltas at PR 0.4/0.55/0.7/0.85/1.0, their frame
-  p50/p95 residuals, and the crest of the material.
+## Work order
 
-### Step 2 — the cheap, provably-bounded items
+### Step 0 — verify state
 
-Do these next; they are small and independent of the structural work.
+In the worktree: branch is `multi-comp-2/opto-campaign-snapshot`;
+`git log --oneline -2` shows "gate Opto dense-programme parity at PR 0.85 and
+1.00" and "refresh the Opto campaign handoff documents" (or descendants); tree
+clean apart from work you were asked to do; and the macOS core suite passes
+before any edit. If any of that disagrees, stop and report.
 
-- **Gap 8 — complete**: the crest comment now records the current residuals and
-  explicitly labels the older trajectory historical. Thresholds were not
-  loosened.
-- **Gap 5 — arithmetic audit complete, gap remains**: all five periods divide
-  48 kHz exactly, each burst is exactly 480 samples, and reference/control use
-  the same stimulus and 6.0-7.5 s scoring window. No divisor, count, or rate
-  mismatch was found; do not retune speculatively from the one-sided sign.
-- **Gap 6 — complete**: the shape score correctly removes its mean, while new
-  absolute assertions pin both the -0.237425 dB mean and -0.174332 dB 1 kHz
-  offsets. The static sine and broadband gates independently own level
-  accuracy. A deliberately broken integration calibration failed the new
-  assertion before the original constant was restored and the suite passed.
-- **Gap 7 — classified**: this gate's t90 is charge/attack, not release. At PR
-  1.0 / -12 dBFS its residual changes from +0.604 ms at 10 ms exposure to
-  -10.437 ms at 100 ms and -12.333 ms at 1 s; the held-out PR 1.0 / -3 dBFS /
-  1 s row is -25.104 ms. Treat it with gap 4, not gap 3.
+### Step 1 — PR-axis localisation: COMPLETE (2026-08-24)
 
-### Step 3 — the structural gap (gaps 2, 3, 4)
+Measured with `probe_pr_axis_localisation.py` (tools repo harness), canonical
+manifests, both devices re-rendered: dynamic residual -0.408/-0.638/+1.041/
++1.867/+1.002 dB at PR 0.4/0.55/0.7/0.85/1.0, stationary -0.038..-0.555,
+attack 0-2 ms up to +2.276, gap 2-10 ms up to +4.946 and 10-30 ms up to
++3.751 dB (PR 1.0); the 30-60 ms band falls to +0.36..+0.69 dB at PR <= 0.85
+but is still +1.467 dB at PR 1.0. **Within the probe's 60 ms inter-event
+window the error is acquired at the event boundary and dissipates — retention
+BEYOND 60 ms is a declared blind spot of this probe, not excluded.** Note the
+probe's dynamic residual is NON-monotonic in PR (+1.867 at 0.85, +1.002 at
+1.0) while the dense-programme gap is monotonic — a stimulus dependence the
+mechanism must explain, not ignore. Full report: harness `report/pr_axis_localisation.{json,md}`,
+including the probe's structural blind spots. Two traps found and handled:
+float-WAV PEAK chunks carry a write timestamp (manifests now hash sample
+bytes), and `MC2_MINE_AU` must be exported explicitly — its default silently
+resolves to the primary checkout's stale VST3 (the 102-parameter readback
+contract catches this).
+
+The original experiment definition, for re-runs at other operating points:
+
+For each PR in {0.4, 0.55, 0.7, 0.85, 1.0}, run the same level- and
+crest-controlled dynamic stimulus and a stationary control, always retaining
+the PR=0 render at the same Gain. Report total-RMS GR, frame p50/p95, and
+**event-aligned attack and inter-event residuals**. The discriminator: does the
+divergence above PR 0.55 appear **while charging** on events, or does it
+**persist through the gaps** (history-dependent retention)?
+
+Division of labour is fixed: **you cannot host the reference AU** (the sandbox
+blocks AudioComponent registration). You write the instruments — stimulus
+generation, event-aligned extraction, residual reporting — as scripts in the
+harness at `~/projects/dusk-audio-tools/plugins/MultiComp/tests/reference_comparison/`
+following its existing conventions (`MC2_*` env, Python 3.9 — no `match`, no
+`X | Y` types, no `zip(strict=)`). Claude runs every reference render and
+returns the outputs. A render failure on your side is not a finding.
+
+Render rules, non-negotiable:
+- our build renders with `--vst3 <path>`, never `--au` (the AU registry
+  silently substitutes installed builds; this once corrupted a whole A/B)
+- our build's VST3 is the worktree's `build-validation/bin/multi_comp_2.vst3`
+  (configure with the cmake recipe in HANDOFF-MC2.md §2, `-B build-validation`);
+  export `MC2_MINE_AU` to that path explicitly — the harness default silently
+  resolves to the primary checkout's stale VST3, and only the 102-parameter
+  readback contract stands between that and a corrupted A/B
+- GR is always `output(PR=0) - output(PR=x)` at the same Gain, never
+  input - output
+- renderer `~/projects/dusk-audio-plugins/build/tests/duskverb_render/duskverb_render`;
+  reference `/Library/Audio/Plug-Ins/Components/uaudio_teletronix_la-2a_tc.component`
+- identical extraction on both sides; any change re-derives the reference side
+
+### Step 2 — the structural mechanism (the first real task; Step 1 is complete)
 
 The reference's crest response is **non-monotonic**: 10.19 → 14.07 → 11.33 →
-8.52 dB GR at constant -24 dBFS RMS. A one-pole integrator into a static law
-cannot produce that shape. Our model reproduces the shape but not the residuals.
+8.52 dB GR at constant -24 dBFS RMS. Our model reproduces the shape but not the
+residuals, and the programme error is PR-dependent on top.
 
-**Already excluded by measurement — do not re-investigate:** stereo linking,
-detector weighting shape, duty cycle at fixed rate, level variation between
-events, metric windowing, the broadband static law, accumulation across repeated
-events, a 0.8 ms integrator, 6000 dB/s cell slew, a 0.4 ms reservoir plus slew,
-shorter reservoirs, a duration-gated charge cap, scaling the repetition blend,
-and a power/RMS rectifier. Scaling repetition blend to 75% raised fitted crest
-RMS from 0.521 to 1.338 dB; the calibrated power rectifier raised short-event
-recovery RMS from 0.701056 to 1.032525 dB and worst error from 1.385892 to
-3.064520 dB. Both were reverted. A dense-stimulus diagnostic then found the
-integrated path already controls `min(peak, integrated)` in 92.0733% of blocks,
-with mean path separation increasing from +1.219 dB in the loudest input-RMS
-quintile to +2.784 dB in the quietest. Parameter-free below-minimum competition
-(`min^2/max`) worsened crest fitted RMS 0.521 -> 1.131 dB and worst error
-0.709 -> 1.903 dB, so nonlinear two-path competition was also reverted.
+**Already excluded by measurement — do not re-investigate or re-try:**
+stereo linking, detector weighting shape, duty cycle at fixed rate, level
+variation between events, metric windowing, the broadband static law,
+accumulation across repeated events, a 0.8 ms integrator, 6000 dB/s cell slew,
+a 0.4 ms reservoir plus slew, shorter reservoirs, a duration-gated charge cap,
+scaling the repetition blend (crest fitted RMS 0.521 → 1.338 dB), a calibrated
+power/RMS rectifier (short-event recovery RMS 0.701 → 1.033, worst 1.386 →
+3.065 dB), parameter-free below-minimum path competition `min²/max` (crest
+fitted RMS 0.521 → 1.131 dB), and a one-knob high-drive fast-rate pivot change
+18 → 15 dB (short-event charge 0.414/0.716 → 0.470/0.995 dB). All were
+reverted with numbers; the details are in `HANDOFF-MC2.md`.
 
-A temporary five-PR dense diagnostic also found cell state above the current
-target in 84.181-87.921% of 16-sample blocks. Mean retained excess was
-0.960528/1.791087/2.097717/2.108555/2.006334 dB at PR
-0.4/0.55/0.7/0.85/1.0. At PR 1.0 the fast/mid/slow contributions were
-0.663660/0.860702/0.534533 dB, and `repetitionBlend` was zero throughout. The
-error is not owned by one charge population or the repetition path; the
-temporary diagnostic scaffolding was reverted.
+Also measured and on file: the integrated path already controls
+`min(peak, integrated)` in 92.07% of dense-stimulus blocks; cell state ends
+above target in 84-88% of blocks with the excess spread across all three
+populations (no single owner); `repetitionBlend` was zero throughout. The
+model already implements capacity-limited charge (`followTarget`, exponents
+5.1/1.5, fast minimum rate 0.150) — **adding another reservoir or fitting
+another correction term on top is explicitly prohibited** until a
+measured mechanism — not merely the event-boundary location — is identified.
 
-The Compress-mode PR-1.0/-24 dBFS/1 s attack report reaches t90 in 9.493 ms
-versus 15.917 ms on the reference. Lowering the existing high-drive fast-rate
-pivot from 18 to 15 dB was tested as a one-knob slowdown, but short-event charge
-fitted RMS/worst worsened from 0.414244/0.716022 to 0.469745/0.994778 dB and
-failed before programme scoring. The pivot was restored; do not repeat this
-simple rate change.
+State the hypothesis and its falsifying experiment **before** editing anything
+structural. One knob per iteration, fresh measurement between. If a change
+improves its own gate and worsens another, it is a symptom fix — revert it and
+say so. A negative result with a root cause is a deliverable.
 
-**Do not fit another correction term on top of the existing model.** A real fix
-now needs a new reference discriminator. The source already implements
-capacity-limited charge in `followTarget`: attack rate depends on remaining
-capacity with fast/slow exponents 5.1/1.5 and a fast minimum rate of 0.150.
-Adding another charge reservoir from the existing single-event and periodic
-burst rows would be an unidentifiable correction, not a measured mechanism.
+### Step 3 — coverage hardening (can interleave with Step 2)
 
-Before another DSP edit, localise the newly measured PR axis. At PR
-0.4/0.55/0.7/0.85/1.0, run the same level- and crest-controlled dynamic
-stimulus and a stationary control, always with a PR=0 render at the same Gain.
-Record total-RMS GR, frame p50/p95, and event-aligned attack/inter-event
-residuals. The discriminator is whether the divergence acquired above PR 0.55
-appears during charge or persists through the gaps. The paired-event
-charge-capacity matrix is deferred unless this PR sweep specifically shows
-history-dependent retention.
+- DONE 2026-08-24: PR 0.85/1.00 envelopes captured (grid validated to
+  0.0005 dB against the 0.40/0.70 constants) and landed in
+  `testOptoDenseProgrammeParity`; verified on macOS clang, macOS
+  -ffp-contract=off, and Linux gcc 12.
+- After the structural fix lands, tighten `testOptoDenseProgrammeParity`'s
+  ceilings — the current values live in that test's comment block. The PR
+  0.40/0.70 rows are parity gates; the PR 0.85/1.00 rows are gap tripwires to
+  be tightened toward parity.
+- Every new gate: state what it structurally cannot see, and break it first —
+  an assertion never seen to fail is not a test.
 
-State the hypothesis and the experiment that would falsify it **before** editing
-anything structural. One knob per iteration, fresh measurement between. If a
-change improves its own gate and worsens another, it is a symptom fix — revert
-it and say so.
+### Step 4 — owner-decision items (flag, do not build)
 
-**A negative result with a root cause is a deliverable.** "Mechanism X is
-excluded, here is the per-point evidence" is a better outcome than a forced
-marginal win, and it belongs in the campaign log where the next session looks.
+Report these for the owner to decide; none is authorised yet:
+
+1. **Meter-mode switch (GR / +4 / +10):** deliberately not implemented — the
+   output bridge publishes block peak and no RMS integration or +4/+10
+   calibration has been specified or measured from the reference.
+2. **Faceplate power switch:** absent; the shell BYPASS covers the function.
+   Cosmetic decision.
+3. **Host-side parameter unit** for Opto Peak Reduction/Gain is still `"%"`
+   (`plugins/multi-comp/daf-plugin/MultiCompParams.hpp:56` — not the core
+   file of the same name) while the faceplate is unitless 0-100 — DAW
+   parameter displays disagree with the panel. Host-visible change; needs a nod.
+4. **#213 geometry fix** is merged but unverified in Logic (AU cache needs a
+   restart/rescan — owner action, not yours).
 
 ## Hard scope walls
 
-- **DSP and per-mode panels: Opto mode only.** Bugs found in the other seven
-  modes get GitHub issues, not fixes. Known and deferred: #220, plus the same
-  `external ? sidechain : input` dead-link bug that likely exists in VCA
-  (~line 854) and Bus (~line 960) of `MultiCompModes.hpp` — that needs its own
-  issue, not a patch in this work. Owner-directed shell conformity is the sole
-  cross-mode UI exception: the visible Global/Sidechain bands are removed and
-  the shared header follows TapeMachine 2 / Tape Echo 2, while their parameters
-  remain available to host state and automation.
-- **Keep UI and DSP iterations isolated.** On 2026-08-22 the owner authorised
-  the Opto panel restyle (#212) to proceed in parallel while reference DSP
-  measurements are pending. The later 2026-08-22 shell-conformity direction is
-  implemented in the working tree as a 1120 x 486 header/layout change; do not
-  treat it as authority to alter the seven other mode panels. Do not mix visual
-  edits into a DSP experiment. Geometry-contract verification (#213) remains a
-  separate host-validation task.
-- **Idle-state harmonics are out of scope.** Worst idle error is 1.86 dB on H5
-  at roughly -110 dBc. Inaudible. Leave it.
-- **Do not touch** `.github/workflows/daf-build.yml` — it carries the owner's
-  selective dispatch edit, committed in the campaign snapshot but outside this
-  task.
-- **DAF and DAF-Widgets are HARD FORKS. `DISTRHO/DPF` and
-  `DISTRHO/DPF-Widgets` are not references — never read, diff, cherry-pick,
-  merge from, or cite upstream, and never point any build or CI at it.** Ours
-  are `dusk-audio/DAF` and `dusk-audio/DAF-Widgets`; CI pins them at
-  `788eb019` and `91e0004e`. There is no "upstream fixed it" path.
-- **Do not modify the fork checkout at `~/projects/DAF`** either. The build
-  consumes it via `-DDAF_PATH=$HOME/projects/DAF`; a local edit makes your build
-  disagree with CI, which clones the pinned ref — you would be measuring a
-  framework nobody else has. If a build breaks, fix the plugin code. The local
-  framework checkouts and CI are currently aligned at `788eb019` and `91e0004e`;
-  advancing either pin is not part of this task.
-- Do not re-apply the review findings that were declined with reasons (UI
-  minimum size, deriving test thresholds from production constants, splitting
-  fast/slow test targets, PR=0 baseline caching). They are listed with rationale
-  in `HANDOFF-MC2.md` §4.
+- **DSP and per-mode panels: Opto only.** Bugs in the other seven modes get
+  issues, not fixes (#220 was closed 2026-08-23 by the same fix). The `external ? sidechain : input`
+  dead-link bug was FIXED for VCA and Bus by 452b13b (PR #224); the one
+  remaining instance is processStudioVCA (`MultiCompModes.hpp:1443`) — audit
+  it via its own issue, not a patch here.
+- Keep UI and DSP iterations isolated; do not mix visual edits into a DSP
+  experiment.
+- Idle-state harmonics are out of scope (worst 1.86 dB on H5 at ~-110 dBc).
+- Do not touch `.github/workflows/daf-build.yml` (owner's dispatch edit).
+- Do not modify `~/projects/DAF` / `~/projects/DAF-Widgets` or point builds
+  anywhere else; upstream DISTRHO is not a reference for anything.
+- Do not re-apply review findings declined with reasons (`HANDOFF-MC2.md` §4:
+  UI minimum size, test thresholds from production constants, split test
+  targets, PR=0 baseline caching).
+- Opto parameters stay as they are. Parameter laws follow the reference
+  ("stick with parity, the goal is to match not deviate"); controls with no
+  reference equivalent (Stereo Link, Mix, Oversampling, Drive) are product
+  decisions.
+- **Never `git commit`, `git push`, `git add`.** The owner makes every commit.
+  Leave work in the working tree and report it. Adversarial review must run
+  clean before any owner-authorised push — every time.
 
 ## Verification obligations
 
-A change is not done until all of these are true and their **real output** is in
-your report:
+A change is not done until all of these are true and their **real output** is
+in your report:
 
-1. Full core suite passes on macOS, with the before/after numbers for every gate
+1. Full core suite passes on macOS, with before/after numbers for every gate
    the change could touch.
-2. Full core suite passes on Linux via the podman recipe, matching macOS to
-   <0.001 dB.
+2. Full core suite passes on Linux via the podman recipe, with per-gate
+   numbers diffed against macOS: agreement within the documented contraction
+   baseline (<=0.005 dB on the weighting rows). A gate that moves more is a
+   rounding-difference amplifier to find, not a tolerance to widen.
 3. The `-ffp-contract=off` macOS build agrees with the normal build.
 4. The dense-programme A/B is re-measured against the reference AU after the
-   change, not predicted from the gates.
+   change (rendered by Claude), not predicted from the gates — the FULL
+   five-point PR sweep (0.4/0.55/0.7/0.85/1.0) with frame p50/p95 and material
+   crest. A single-PR re-measure structurally cannot see the monotonic-in-PR
+   gap.
 5. The seven non-Opto golden vectors are unchanged.
 
 "It builds" and "should be unaffected" are not verification. Bit-null means
 byte-compared renders. Never-worse means a re-measured baseline on the current
 build, not a remembered number.
 
-## Process rules
-
-- **Never commit or push.** The owner makes every commit. The commit
-  authorization granted in the 2026-08-21 session was for that session and is
-  spent.
-- If the owner does authorize a push, an adversarial review must run clean
-  first — every time, not only the first time.
-- Ask what each new gate structurally **cannot** see. That question has already
-  caught four real defects: a dual-mono corpus hid a dead stereo link, sine-only
-  hid a 0.9 dB broadband error, a 13 dB crest ceiling hid the 20 dB crest gap,
-  and macOS-only CI hid a 1.5 dB platform split.
-- Never gate DSP on instantaneous `|sample|` against an absolute epsilon. Use an
-  envelope-relative floor plus a short hold. Any binary branch whose consequence
-  is margin-independent (hold vs discharge) amplifies rounding differences.
-
 ## Report format
 
 Terse. Numbers, not adjectives. For each gap: what you measured, the per-point
 data, what you changed, the before/after on every affected gate, and what is
-still open. Report your own errors plainly and move on. When two gates conflict,
-stop optimising and ask what single mechanism produces both readings.
+still open. Report your own errors plainly and move on. When two gates
+conflict, stop optimising and ask what single mechanism produces both readings.

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -1770,6 +1770,8 @@ OptoDenseProgrammeMetrics measureOptoDenseProgramme(
     const int latency = control.getLatencySamples();
     require(active.getLatencySamples() == latency,
             "Opto dense-programme control and active paths have equal latency");
+    require(static_cast<int>(programme.size()) == 80 * kFrameSamples,
+            "Opto dense-programme frame grid covers the whole stimulus exactly");
     const int totalSamples = static_cast<int>(programme.size()) + latency;
     std::vector<float> controlOutput(static_cast<size_t>(totalSamples));
     std::vector<float> activeOutput(static_cast<size_t>(totalSamples));
@@ -1846,7 +1848,9 @@ OptoDenseProgrammeMetrics measureOptoDenseProgramme(
 void testOptoDenseProgrammeParity()
 {
     // Captured from the live reference AU with matched PR=0 controls, Gain at
-    // 0.321868896, Compress mode, and 2x oversampling.  The deterministic
+    // 0.321868896, Compress mode.  ("2x oversampling" describes OUR DSP
+    // instances below; the reference has no such control and its envelopes are
+    // independent of it.)  The deterministic
     // generator above is shared with the capture recipe; 100 ms RMS frames
     // retain the envelope defect that remained with wider analysis windows.
     constexpr std::array<float, 80> referenceAt40{{
@@ -1873,23 +1877,80 @@ void testOptoDenseProgrammeParity()
         16.990066f, 17.952907f, 16.958054f, 17.823901f, 17.159247f, 16.979283f, 17.944300f, 17.186154f,
         18.723287f, 17.587928f, 16.948212f, 17.939089f, 16.956146f, 17.839403f, 16.925629f, 13.546612f,
     }};
+    constexpr std::array<float, 80> referenceAt85{{
+        20.104985f, 22.494186f, 23.913226f, 23.746440f, 23.250015f, 24.204495f, 23.295250f, 24.129026f,
+        23.534977f, 23.335332f, 24.334897f, 23.455749f, 24.004013f, 23.577777f, 23.408511f, 24.338007f,
+        23.388864f, 24.184784f, 23.246999f, 19.557724f, 21.689873f, 23.154776f, 24.101613f, 23.586273f,
+        23.214226f, 24.130939f, 23.266835f, 24.112291f, 23.461601f, 23.320176f, 24.498404f, 23.459580f,
+        24.013886f, 23.712592f, 23.374801f, 24.276987f, 23.281214f, 24.117632f, 23.167519f, 19.560860f,
+        21.831556f, 22.960261f, 23.593394f, 23.494477f, 23.042502f, 24.192743f, 23.144226f, 24.056533f,
+        23.429952f, 23.294971f, 24.331714f, 23.430099f, 23.711183f, 23.425275f, 23.429654f, 24.358604f,
+        23.380003f, 24.160456f, 23.334399f, 19.629106f, 21.447051f, 22.866222f, 23.362534f, 23.379004f,
+        22.710676f, 24.109749f, 22.891065f, 23.714838f, 23.239478f, 23.083730f, 23.663855f, 23.240345f,
+        24.184290f, 23.385169f, 23.254947f, 24.208047f, 23.312112f, 24.102489f, 23.251892f, 19.708311f,
+    }};
+
+    constexpr std::array<float, 80> referenceAt100{{
+        21.735970f, 23.995080f, 25.559316f, 25.621867f, 25.095696f, 26.063887f, 25.127617f, 25.983373f,
+        25.446505f, 25.255980f, 26.154718f, 25.306286f, 25.741573f, 25.155472f, 25.302920f, 26.298391f,
+        25.288222f, 26.075446f, 25.118816f, 21.396813f, 23.566963f, 24.884442f, 25.765422f, 25.344489f,
+        25.015732f, 26.077456f, 25.198250f, 26.099997f, 25.421426f, 25.300623f, 26.195441f, 25.335950f,
+        25.735408f, 25.461058f, 25.295602f, 26.219607f, 25.209053f, 26.040818f, 25.057249f, 21.393446f,
+        23.623492f, 24.562633f, 25.404302f, 25.377116f, 24.760915f, 26.004137f, 24.899502f, 25.863144f,
+        25.232584f, 25.103475f, 25.990417f, 25.197579f, 25.550791f, 25.016438f, 25.323736f, 26.295938f,
+        25.296739f, 26.067982f, 25.205038f, 21.459274f, 23.141421f, 24.545988f, 25.092825f, 24.972450f,
+        24.350842f, 25.862734f, 24.578558f, 25.445877f, 24.979513f, 24.832923f, 25.267004f, 24.924035f,
+        25.924300f, 25.011722f, 25.029261f, 26.066780f, 25.183565f, 26.022492f, 25.134097f, 21.540473f,
+    }};
     const auto programme = makeOptoDenseProgramme();
     const auto low = measureOptoDenseProgramme(programme, 40.0f, referenceAt40);
     const auto high = measureOptoDenseProgramme(programme, 70.0f, referenceAt70);
+    const auto at85 = measureOptoDenseProgramme(programme, 85.0f, referenceAt85);
+    const auto at100 = measureOptoDenseProgramme(programme, 100.0f, referenceAt100);
     std::printf("opto dense programme: PR 0.40 mean %+.6f dB RMS %.6f dB "
                 "correlation %.6f; PR 0.70 mean %+.6f dB RMS %.6f dB "
+                "correlation %.6f; PR 0.85 mean %+.6f dB RMS %.6f dB "
+                "correlation %.6f; PR 1.00 mean %+.6f dB RMS %.6f dB "
                 "correlation %.6f\n",
                 low.meanErrorDb, low.rmsErrorDb, low.correlation,
-                high.meanErrorDb, high.rmsErrorDb, high.correlation);
-    // The RMS ceilings reject the issue baseline (1.600 / 3.163 dB) with
-    // margin.  Correlation is gated separately so a uniform offset cannot
-    // conceal a flattened or time-inverted gain-reduction envelope.
+                high.meanErrorDb, high.rmsErrorDb, high.correlation,
+                at85.meanErrorDb, at85.rmsErrorDb, at85.correlation,
+                at100.meanErrorDb, at100.rmsErrorDb, at100.correlation);
+    // For the PR 0.40/0.70 rows, the RMS ceilings reject the issue #210
+    // baseline (1.600 / 3.163 dB) with margin.  Correlation is gated separately
+    // so a uniform offset cannot conceal a time-inverted or shape-mismatched
+    // envelope.  (Pearson correlation is invariant to uniform offset AND
+    // uniform positive scaling, so flattening per se is owned by the RMS term,
+    // not this one.)
     require(std::abs(low.meanErrorDb) < 0.60f && low.rmsErrorDb < 0.75f
                 && low.correlation > 0.75f,
             "Opto low-PR dense-programme envelope stays inside the reference gate");
     require(std::abs(high.meanErrorDb) < 1.75f && high.rmsErrorDb < 1.90f
                 && high.correlation > 0.72f,
             "Opto high-PR dense-programme envelope stays inside the reference gate");
+    // The PR 0.85/1.00 rows are different in kind: their ceilings snapshot the
+    // CURRENT build (measured 2026-08-24: PR 0.85 +2.015929 / 2.130637 dB /
+    // 0.774589; PR 1.00 +2.445327 / 2.561165 dB / 0.726289) with 0.269-0.305 dB
+    // and ~0.075 correlation margin.  They document the open PR-dependent gap
+    // and reject regression beyond it; they do NOT certify parity, and they
+    // must be tightened when the event-boundary charge mechanism lands.
+    // Baselines were measured with the manual -O2 clang recipe and also pass
+    // under the ctest -O3 build; the margins cover the documented contraction
+    // baseline.  Hazard noted in review: the two reference envelopes sit only
+    // ~1.8 dB apart while these ceilings span ~2.3-2.9 dB, so a swapped
+    // PR/reference pairing could pass — convert the four rows to a paired
+    // table when these ceilings are next touched.  The mean gates are floored
+    // at -0.30 dB so a sign-flipped (under-compressing) regression cannot hide
+    // inside a two-sided ceiling.  Structural blind spots: these rows run mono
+    // (nCh = 1), so the linked-stereo Opto detector path is never exercised
+    // here (the stereo-link gates own it), and Linux arm64 has not yet run
+    // these rows (matrix: macOS clang, macOS no-contract, Linux gcc 12 x86-64).
+    require(at85.meanErrorDb > -0.30f && at85.meanErrorDb < 2.30f
+                && at85.rmsErrorDb < 2.40f && at85.correlation > 0.70f,
+            "Opto PR 0.85 dense-programme error stays within the documented gap ceiling (tripwire, not parity)");
+    require(at100.meanErrorDb > -0.30f && at100.meanErrorDb < 2.75f
+                && at100.rmsErrorDb < 2.85f && at100.correlation > 0.65f,
+            "Opto PR 1.00 dense-programme error stays within the documented gap ceiling (tripwire, not parity)");
 }
 
 struct OptoAttackCrossings


### PR DESCRIPTION
## What

Two commits on the Opto / LA-2A campaign branch:

1. **Gate Opto dense-programme parity at PR 0.85 and 1.00** — extends `testOptoDenseProgrammeParity` with the two rows where the PR-dependent over-compression is worst, using reference envelopes captured 2026-08-24 from the live reference AU. Capture grid validated by reproducing the existing PR 0.40/0.70 constants to 0.000466 dB. The new ceilings are gap tripwires snapshotting the current build (PR 0.85: mean +2.016 dB / RMS 2.131 dB / corr 0.775; PR 1.00: +2.445 / 2.561 / 0.726) with 0.27-0.30 dB margin — they reject regression, do not certify parity, and carry a documented tightening obligation for when the event-boundary charge mechanism lands. Mean gates floored at -0.30 dB so a sign-flipped under-compression cannot pass; frame-grid coverage asserted; blind spots recorded in the comment block.

2. **Refresh the Opto campaign handoff documents** — HANDOFF-MC2.md and PROMPT-MC2-OPTO-GAPS.md brought up to post-#228 reality: PR-axis localisation results with their blind spots (error acquired at the event boundary within the probe's 60 ms window; >60 ms retention unobserved; probe residual non-monotonic in PR vs the monotonic dense-programme gap — flagged, not smoothed over), verification obligations restored to numeric form, VST3 build + `MC2_MINE_AU` export instructions, DAF pins referenced from the workflows instead of copied, #220 recorded closed, stale paths and rows marked historical.

## Verification

- Full core suite PASS on macOS clang, macOS `-ffp-contract=off`, and Linux gcc 12 (podman, amd64); deltas within the documented contraction baseline (≤0.003 dB on the dense rows).
- Break-first evidence for both new assertions in the delegation report (wrong-PR corruption → FAIL → restore → PASS).
- All 160 reference-array values verified against the captured measurement JSON (tools repo).
- Four adversarial-review rounds ran before push; structural refactor suggestions (table-driven rows, control-render hoist) deliberately deferred to the ceiling-tightening pass and recorded in the test comment.

## Not in this PR

The event-boundary charge mechanism itself (next campaign phase), Linux arm64 on the new rows, and the `setOversampling` clamp hardening noted in review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded dense-programme validation across additional processing ratios.
  - Added reference-envelope comparisons, measurement reporting, and bounded regression checks.
  - Improved stimulus validation to ensure the expected frame count is generated.

- **Documentation**
  - Updated campaign documentation to reflect the merged release state and current verification status.
  - Clarified remaining validation gaps, completed checks, measurement guidance, and follow-up decisions.
  - Documented detector-memory and renderer-comparison considerations for more transparent parity results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->