### PR TITLE
Guard output parameters against reaching the host as edits

### DIFF
--- a/.github/workflows/daf-au-test.yml
+++ b/.github/workflows/daf-au-test.yml
@@ -11,7 +11,7 @@ on:
       - 'tape-echo-daf-v*'
 
 env:
-  DAF_SHA: 80189fe5e1d1b84536749619a17a719a6a569748
+  DAF_SHA: dfc50729f7a7d31dc0e0740c863bf88dee71c7c2
   DAFWIDGETS_SHA: 91e0004e1ece0785d347801925d3e2518b0cbbda
 
 jobs:

--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -66,7 +66,7 @@ on:
 # checkouts on the pinned SHAs (docker/check_daf_pins.sh) so a hand-tested build
 # is the one CI produces.
 env:
-  DAF_REF: 80189fe5e1d1b84536749619a17a719a6a569748
+  DAF_REF: dfc50729f7a7d31dc0e0740c863bf88dee71c7c2
   DAFWIDGETS_REF: 91e0004e1ece0785d347801925d3e2518b0cbbda
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/.github/workflows/daf-release.yml
+++ b/.github/workflows/daf-release.yml
@@ -42,7 +42,7 @@ on:
 # daf-build.yml, daf-au-test.yml and docker/build_release.sh, and re-run the
 # dispatch matrix before tagging.
 env:
-  DAF_SHA: 80189fe5e1d1b84536749619a17a719a6a569748
+  DAF_SHA: dfc50729f7a7d31dc0e0740c863bf88dee71c7c2
   DAFWIDGETS_SHA: 91e0004e1ece0785d347801925d3e2518b0cbbda
   PLUGIN_DIR: plugins/sunset-circuits/daf-plugin
   SLUG: sunset-circuits

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -18,7 +18,7 @@ IMAGE_NAME="dusk-plugins-builder"
 # DAF / DAF-Widgets SHAs — keep in sync with daf-build.yml, daf-release.yml and daf-au-test.yml.
 # DAF comes from the dusk-audio/DAF fork (our patches live there); DAF-Widgets
 # stays on upstream DAF (no fork).
-DAF_SHA="80189fe5e1d1b84536749619a17a719a6a569748"
+DAF_SHA="dfc50729f7a7d31dc0e0740c863bf88dee71c7c2"
 DAFWIDGETS_SHA="91e0004e1ece0785d347801925d3e2518b0cbbda"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)

--- a/plugins/4k-eq/daf-plugin/CMakeLists.txt
+++ b/plugins/4k-eq/daf-plugin/CMakeLists.txt
@@ -51,3 +51,8 @@ target_compile_definitions(four_k_eq_2 PUBLIC
 # Auto-deploy the built CLAP/VST3/LV2 into the user plugin dirs after each build
 # (disable with -DDUSK_DAF_INSTALL_LOCAL=OFF).
 dusk_daf_install_local(four_k_eq_2 LV2_PROGRAMS)
+
+# Out Peak L/R are output parameters; guard them against reaching the host as
+# parameter edits, in both VST3 (dusk-audio/plugins#233) and CLAP (#231). The
+# harnesses dlopen() the built binaries, so they only run where they are built.
+dusk_daf_add_output_param_tests(four_k_eq_2)

--- a/plugins/TapeMachine/daf-plugin/CMakeLists.txt
+++ b/plugins/TapeMachine/daf-plugin/CMakeLists.txt
@@ -45,3 +45,8 @@ target_compile_definitions(tape_machine_2 PUBLIC
     TM2_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 
 dusk_daf_install_local(tape_machine_2 LV2_PROGRAMS)
+
+# VU L/R are output parameters; guard them against reaching the host as
+# parameter edits, in both VST3 (dusk-audio/plugins#233) and CLAP (#231). The
+# harnesses dlopen() the built binaries, so they only run where they are built.
+dusk_daf_add_output_param_tests(tape_machine_2)

--- a/plugins/shared-daf/cmake/DuskDafPlugin.cmake
+++ b/plugins/shared-daf/cmake/DuskDafPlugin.cmake
@@ -154,3 +154,81 @@ function(dusk_daf_install_local plugin_name)
             VERBATIM)
     endif()
 endfunction()
+
+# Register the shared output-parameter regression tests for a plugin that
+# exposes meters (dusk-audio/plugins#233 for VST3, #231 for CLAP). Each builds a
+# minimal host, runs noise through the plugin's own binary for that format, and
+# fails if any output parameter reaches the host as a parameter event -- or if
+# the meters stopped moving, which is what keeps the first assertion from being
+# satisfiable by simply freezing them.
+#
+# Call AFTER daf_add_plugin, with the plugin base name. Inert where it cannot
+# run: the harnesses dlopen() the plugin binary directly, so Windows and cross
+# builds are skipped rather than failed.
+#
+# Wired for 4k-eq, TapeMachine and tape-echo. multi-comp and sunset-circuits
+# also declare kParameterIsOutput meters and are covered by the same wrapper
+# fixes, but not by these harnesses: multi-comp's gain-reduction meters only
+# move once the compressor is actually compressing, and sunset-circuits is a
+# synth with no audio input at all, so neither can satisfy the "meters still
+# move" assertion from noise at default settings. Driving them would need
+# per-plugin parameter and note setup; the three wired plugins already fail the
+# moment either shared wrapper regresses.
+#
+# A macro, not a function, and deliberately so: enable_testing() called from
+# inside a function() sets nothing -- no CTestTestfile.cmake is written and
+# ctest reports "No tests were found" while the targets still build, which
+# would leave these guards silently dead in a CI job that treats zero tests as a
+# pass. A macro expands into the caller's own directory scope, where
+# enable_testing() takes effect, so callers cannot forget it. Being a macro is
+# also why the body is wrapped in if() rather than guarded with return(): a
+# return() here would return from the caller's CMakeLists.
+macro(dusk_daf_add_output_param_tests _dusk_op_plugin)
+    # A missing target is a typo or a rename, not a platform the harness cannot
+    # run on, and the two must not share a branch: silently skipping it would
+    # register no test, leave enable_testing() uncalled, and let CI -- which
+    # passes a build that reports zero tests -- go green with these guards dead.
+    if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32)
+        foreach(_dusk_op_fmt vst3 clap)
+            if(NOT TARGET ${_dusk_op_plugin}-${_dusk_op_fmt})
+                message(FATAL_ERROR
+                    "dusk_daf_add_output_param_tests(${_dusk_op_plugin}): no target "
+                    "${_dusk_op_plugin}-${_dusk_op_fmt}. Call this after daf_add_plugin, "
+                    "with the plugin base name, and with both formats in TARGETS.")
+            endif()
+        endforeach()
+    endif()
+
+    if(CMAKE_CROSSCOMPILING OR WIN32)
+        message(STATUS "Output-parameter tests skipped for ${_dusk_op_plugin} (unsupported platform)")
+    else()
+        enable_testing()
+
+        # travesty/ and clap/ are DAF's own vendored interfaces; the harnesses
+        # speak the same ABI the wrappers are compiled against rather than a
+        # second copy of either SDK.
+        add_executable(${_dusk_op_plugin}Vst3OutputParamTest
+            "${DUSK_SHARED_DAF_DIR}/tests/DafVst3OutputParamTest.cpp")
+        target_include_directories(${_dusk_op_plugin}Vst3OutputParamTest PRIVATE "${DAF_PATH}/daf/src")
+        target_compile_features(${_dusk_op_plugin}Vst3OutputParamTest PRIVATE cxx_std_17)
+        target_link_libraries(${_dusk_op_plugin}Vst3OutputParamTest PRIVATE ${CMAKE_DL_LIBS})
+        add_dependencies(${_dusk_op_plugin}Vst3OutputParamTest ${_dusk_op_plugin}-vst3)
+
+        add_executable(${_dusk_op_plugin}ClapOutputParamTest
+            "${DUSK_SHARED_DAF_DIR}/tests/DafClapOutputParamTest.cpp")
+        target_include_directories(${_dusk_op_plugin}ClapOutputParamTest PRIVATE "${DAF_PATH}/daf/src")
+        target_compile_features(${_dusk_op_plugin}ClapOutputParamTest PRIVATE cxx_std_17)
+        target_link_libraries(${_dusk_op_plugin}ClapOutputParamTest PRIVATE ${CMAKE_DL_LIBS})
+        add_dependencies(${_dusk_op_plugin}ClapOutputParamTest ${_dusk_op_plugin}-clap)
+
+        # $<TARGET_FILE:...> is the loadable binary itself, so the harnesses
+        # never have to reconstruct Contents/<arch>-linux/ and keep working on
+        # architectures no table here would list.
+        add_test(NAME ${_dusk_op_plugin}Vst3OutputParams
+                 COMMAND ${_dusk_op_plugin}Vst3OutputParamTest
+                         "$<TARGET_FILE:${_dusk_op_plugin}-vst3>" 100 256)
+        add_test(NAME ${_dusk_op_plugin}ClapOutputParams
+                 COMMAND ${_dusk_op_plugin}ClapOutputParamTest
+                         "$<TARGET_FILE:${_dusk_op_plugin}-clap>" 100 256)
+    endif()
+endmacro()

--- a/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
@@ -1,0 +1,497 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// CLAP counterpart of DafVst3OutputParamTest, guarding dusk-audio/plugins#231
+// and the CLAP half of #233.
+//
+// DAF's CLAP wrapper used to push a CLAP_EVENT_PARAM_VALUE, flagged
+// CLAP_EVENT_IS_LIVE and carrying no CLAP_EVENT_DONT_RECORD, for every output
+// parameter whose value had moved since the last block -- one per meter per
+// block. CLAP_EVENT_IS_LIVE means "a user turning a physical knob", so the host
+// was told hundreds of times a second that the user was riding the VU meter.
+// dusk-audio/DAF#18 stopped that; this keeps it stopped.
+//
+// Same two-sided contract as the VST3 harness: no output parameter may reach
+// the host's out_events, and the meters must still move -- read back through
+// clap_plugin_params.get_value(), which clap/ext/params.h lets a host call at
+// any time and is how a host is expected to display them now.
+//
+// Linux and macOS only (dlopen plus the bundle layouts below).
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <dlfcn.h>
+
+// DAF vendors a trimmed CLAP SDK with no umbrella clap.h, so the pieces this
+// harness needs are included individually.
+#include "clap/entry.h"
+#include "clap/plugin.h"
+#include "clap/plugin-features.h"
+#include "clap/ext/audio-ports.h"
+#include "clap/ext/params.h"
+#include "clap/factory/plugin-factory.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// minimal host
+
+static const clap_host_t* gHost = nullptr;
+
+static const void* CLAP_ABI hostGetExtension(const clap_host_t*, const char*) { return nullptr; }
+static void CLAP_ABI hostRequestRestart(const clap_host_t*) {}
+static void CLAP_ABI hostRequestProcess(const clap_host_t*) {}
+static void CLAP_ABI hostRequestCallback(const clap_host_t*) {}
+
+static clap_host_t gHostImpl = {
+    CLAP_VERSION_INIT, nullptr,
+    "DafClapOutputParamTest", "Dusk Audio", "https://dusk-audio.github.io/", "1.0.0",
+    hostGetExtension, hostRequestRestart, hostRequestProcess, hostRequestCallback
+};
+
+// ---- out_events collector -------------------------------------------------------------------------------------------
+
+struct CollectedEvent {
+    uint16_t type;
+    uint32_t flags;
+    clap_id paramId;
+    double value;
+};
+
+struct OutEvents {
+    clap_output_events_t iface;
+    std::vector<CollectedEvent> events;
+
+    OutEvents()
+    {
+        iface.ctx = this;
+        iface.try_push = tryPush;
+    }
+
+    static bool CLAP_ABI tryPush(const clap_output_events_t* const list, const clap_event_header_t* const event)
+    {
+        OutEvents* const self = static_cast<OutEvents*>(list->ctx);
+        CollectedEvent c = { event->type, event->flags, CLAP_INVALID_ID, 0.0 };
+        if (event->type == CLAP_EVENT_PARAM_VALUE)
+        {
+            const clap_event_param_value_t* const pv = (const clap_event_param_value_t*) event;
+            c.paramId = pv->param_id;
+            c.value = pv->value;
+        }
+        else if (event->type == CLAP_EVENT_PARAM_GESTURE_BEGIN || event->type == CLAP_EVENT_PARAM_GESTURE_END)
+        {
+            const clap_event_param_gesture_t* const g = (const clap_event_param_gesture_t*) event;
+            c.paramId = g->param_id;
+        }
+        self->events.push_back(c);
+        return true;
+    }
+};
+
+struct InEvents {
+    clap_input_events_t iface;
+
+    InEvents()
+    {
+        iface.ctx = this;
+        iface.size = size;
+        iface.get = get;
+    }
+
+    static uint32_t CLAP_ABI size(const clap_input_events_t*) { return 0; }
+    static const clap_event_header_t* CLAP_ABI get(const clap_input_events_t*, uint32_t) { return nullptr; }
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+static std::string binaryInsideBundle(const std::string& path)
+{
+   #ifdef __APPLE__
+    // A macOS .clap is a bundle; CMake hands over the binary itself.
+    if (path.size() > 5 && path.compare(path.size() - 5, 5, ".clap") == 0)
+    {
+        std::string name(path);
+        const size_t slash = name.find_last_of('/');
+        if (slash != std::string::npos)
+            name = name.substr(slash + 1);
+        name = name.substr(0, name.size() - 5);
+        const std::string inner = path + "/Contents/MacOS/" + name;
+        if (FILE* const f = std::fopen(inner.c_str(), "rb")) { std::fclose(f); return inner; }
+    }
+   #endif
+    return path;
+}
+
+static bool parsePositiveInt(const char* const text, int& out)
+{
+    char* end = nullptr;
+    const long value = std::strtol(text, &end, 10);
+    if (end == text || *end != '\0' || value < 1 || value > 1000000)
+        return false;
+    out = static_cast<int>(value);
+    return true;
+}
+
+int main(const int argc, const char* const* const argv)
+{
+    bool silent = false;
+    std::vector<const char*> positional;
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--silent") == 0)
+            silent = true;
+        else
+            positional.push_back(argv[i]);
+    }
+
+    if (positional.empty() || positional.size() > 3)
+    {
+        std::fprintf(stderr, "usage: %s <plugin.clap> [blocks] [frames] [--silent]\n", argv[0]);
+        return 2;
+    }
+
+    const std::string path(binaryInsideBundle(positional[0]));
+    int numBlocks = 100, numFrames = 256;
+    if (positional.size() > 1 && ! parsePositiveInt(positional[1], numBlocks))
+    {
+        std::fprintf(stderr, "FAIL: block count %s is not a positive integer\n", positional[1]);
+        return 2;
+    }
+    if (positional.size() > 2 && ! parsePositiveInt(positional[2], numFrames))
+    {
+        std::fprintf(stderr, "FAIL: frame count %s is not a positive integer\n", positional[2]);
+        return 2;
+    }
+
+    // --silent characterises what a plugin does on an idle track. It is a
+    // diagnostic mode, not the regression: the "meters still move" assertion
+    // cannot hold for a plugin whose meters sit still on silence, so a silent
+    // run is expected to report a failure, and the registered ctest always runs
+    // with noise.
+
+    void* const lib = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (lib == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: dlopen(%s): %s\n", path.c_str(), dlerror());
+        return 1;
+    }
+
+    const clap_plugin_entry_t* const entry = (const clap_plugin_entry_t*) dlsym(lib, "clap_entry");
+    if (entry == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: no clap_entry in %s\n", path.c_str());
+        return 1;
+    }
+    if (! entry->init(path.c_str()))
+    {
+        std::fprintf(stderr, "FAIL: clap_entry->init\n");
+        return 1;
+    }
+
+    const clap_plugin_factory_t* const factory =
+        (const clap_plugin_factory_t*) entry->get_factory(CLAP_PLUGIN_FACTORY_ID);
+    if (factory == nullptr || factory->get_plugin_count(factory) == 0)
+    {
+        std::fprintf(stderr, "FAIL: no plugin factory\n");
+        return 1;
+    }
+
+    const clap_plugin_descriptor_t* const desc = factory->get_plugin_descriptor(factory, 0);
+    if (desc == nullptr || desc->id == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: factory returned no descriptor for plugin 0\n");
+        return 1;
+    }
+
+    gHost = &gHostImpl;
+    const clap_plugin_t* const plugin = factory->create_plugin(factory, gHost, desc->id);
+    if (plugin == nullptr || ! plugin->init(plugin))
+    {
+        std::fprintf(stderr, "FAIL: could not create/init the plugin\n");
+        return 1;
+    }
+
+    const clap_plugin_params_t* const paramsExt =
+        (const clap_plugin_params_t*) plugin->get_extension(plugin, CLAP_EXT_PARAMS);
+    if (paramsExt == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: plugin has no params extension\n");
+        return 1;
+    }
+
+    struct P { clap_id id; std::string name; std::string module; uint32_t flags; };
+    std::vector<P> params;
+    const uint32_t paramCount = paramsExt->count(plugin);
+    for (uint32_t i = 0; i < paramCount; ++i)
+    {
+        clap_param_info_t info = {};
+        if (! paramsExt->get_info(plugin, i, &info))
+        {
+            std::fprintf(stderr, "FAIL: get_info(%u); cannot classify every parameter\n", i);
+            return 1;
+        }
+        params.push_back({ info.id, info.name, info.module, info.flags });
+    }
+
+    // DAF stamps CLAP_PARAM_IS_READONLY on output parameters and on the Reset
+    // designation, which is a trigger and is deliberately still reported, so
+    // READONLY alone would call a Reset a meter and fail a correct plugin the
+    // day one is added. Unlike VST3 the wrapper sets no hidden flag to separate
+    // them (getParameterInfo gives Reset exactly STEPPED|READONLY), but it does
+    // stamp the module "daf_reset", which is the designation's own marker and
+    // cannot collide with an ordinary parameter's module. Matching on that
+    // rather than on flags keeps the rule exact for integer and boolean output
+    // parameters, which carry STEPPED too.
+    auto isOutput = [](const P& p) {
+        return (p.flags & CLAP_PARAM_IS_READONLY) != 0 && p.module != "daf_reset";
+    };
+
+    std::vector<size_t> meters;
+    for (size_t i = 0; i < params.size(); ++i)
+        if (isOutput(params[i]))
+            meters.push_back(i);
+
+    std::printf("plugin      : %s\n", positional[0]);
+    std::printf("parameters  : %u (%zu output/read-only)\n", paramCount, meters.size());
+    for (const size_t i : meters)
+        std::printf("  output    : id=%u \"%s\" flags=0x%x\n", params[i].id, params[i].name.c_str(), params[i].flags);
+
+    if (meters.empty())
+    {
+        std::fprintf(stderr, "FAIL: plugin exposes no output parameters; this test would pass vacuously\n");
+        return 1;
+    }
+
+    if (! plugin->activate(plugin, 48000.0, 1, static_cast<uint32_t>(numFrames)))
+    {
+        std::fprintf(stderr, "FAIL: activate\n");
+        return 1;
+    }
+    if (! plugin->start_processing(plugin))
+    {
+        std::fprintf(stderr, "FAIL: start_processing\n");
+        return 1;
+    }
+
+    // Buffers follow the ports the plugin actually declares, so a plugin with a
+    // sidechain gets every port it will index into. Only the main input carries
+    // signal; handing a plugin fewer ports than it declares is how a harness
+    // reads past the end of audio_inputs.
+    const clap_plugin_audio_ports_t* const portsExt =
+        (const clap_plugin_audio_ports_t*) plugin->get_extension(plugin, CLAP_EXT_AUDIO_PORTS);
+    if (portsExt == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: plugin has no audio-ports extension\n");
+        return 1;
+    }
+
+    const uint32_t numInPorts = portsExt->count(plugin, true);
+    const uint32_t numOutPorts = portsExt->count(plugin, false);
+    if (numOutPorts == 0)
+    {
+        std::fprintf(stderr, "FAIL: plugin declares no audio output port\n");
+        return 1;
+    }
+
+    std::vector<uint32_t> inCh(numInPorts), outCh(numOutPorts);
+    for (uint32_t i = 0; i < numInPorts; ++i)
+    {
+        clap_audio_port_info_t info = {};
+        if (! portsExt->get(plugin, i, true, &info)) { std::fprintf(stderr, "FAIL: audio input port %u\n", i); return 1; }
+        inCh[i] = info.channel_count;
+    }
+    for (uint32_t i = 0; i < numOutPorts; ++i)
+    {
+        clap_audio_port_info_t info = {};
+        if (! portsExt->get(plugin, i, false, &info)) { std::fprintf(stderr, "FAIL: audio output port %u\n", i); return 1; }
+        outCh[i] = info.channel_count;
+    }
+
+    std::vector<std::vector<float>> inStore, outStore;
+    std::vector<std::vector<float*>> inPtrs(numInPorts), outPtrs(numOutPorts);
+    std::vector<clap_audio_buffer_t> inBuses(numInPorts), outBuses(numOutPorts);
+
+    for (uint32_t b = 0; b < numInPorts; ++b)
+        for (uint32_t c = 0; c < inCh[b]; ++c)
+            inStore.emplace_back(numFrames, 0.0f);
+    for (uint32_t b = 0; b < numOutPorts; ++b)
+        for (uint32_t c = 0; c < outCh[b]; ++c)
+            outStore.emplace_back(numFrames, 0.0f);
+
+    {
+        size_t next = 0;
+        for (uint32_t b = 0; b < numInPorts; ++b)
+        {
+            for (uint32_t c = 0; c < inCh[b]; ++c)
+                inPtrs[b].push_back(inStore[next++].data());
+            inBuses[b].data32 = inPtrs[b].data();
+            inBuses[b].channel_count = inCh[b];
+        }
+        next = 0;
+        for (uint32_t b = 0; b < numOutPorts; ++b)
+        {
+            for (uint32_t c = 0; c < outCh[b]; ++c)
+                outPtrs[b].push_back(outStore[next++].data());
+            outBuses[b].data32 = outPtrs[b].data();
+            outBuses[b].channel_count = outCh[b];
+        }
+    }
+
+    InEvents inEvents;
+    OutEvents outEvents;
+
+    std::vector<double> meterMin(meters.size()), meterMax(meters.size()), meterFirst(meters.size());
+    for (size_t k = 0; k < meters.size(); ++k)
+    {
+        double v = 0.0;
+        paramsExt->get_value(plugin, params[meters[k]].id, &v);
+        meterFirst[k] = meterMin[k] = meterMax[k] = v;
+    }
+
+    std::mt19937 rng(20260828u);
+    std::uniform_real_distribution<float> noise(-0.5f, 0.5f);
+
+    for (int block = 0; block < numBlocks; ++block)
+    {
+        if (numInPorts > 0)
+        {
+            for (uint32_t c = 0; c < inCh[0]; ++c)
+            {
+                float* const dst = inPtrs[0][c];
+                for (int i = 0; i < numFrames; ++i)
+                    dst[i] = silent ? 0.0f : noise(rng);
+            }
+        }
+
+        clap_process_t process = {};
+        process.frames_count = static_cast<uint32_t>(numFrames);
+        process.audio_inputs = numInPorts > 0 ? inBuses.data() : nullptr;
+        process.audio_inputs_count = numInPorts;
+        process.audio_outputs = outBuses.data();
+        process.audio_outputs_count = numOutPorts;
+        process.in_events = &inEvents.iface;
+        process.out_events = &outEvents.iface;
+        process.steady_time = static_cast<int64_t>(block) * numFrames;
+
+        const clap_process_status status = plugin->process(plugin, &process);
+        if (status == CLAP_PROCESS_ERROR)
+        {
+            std::fprintf(stderr, "FAIL: process() error on block %d\n", block);
+            return 1;
+        }
+
+        for (size_t k = 0; k < meters.size(); ++k)
+        {
+            double v = 0.0;
+            paramsExt->get_value(plugin, params[meters[k]].id, &v);
+            if (v < meterMin[k]) meterMin[k] = v;
+            if (v > meterMax[k]) meterMax[k] = v;
+        }
+    }
+
+    // The second entry point into flushParameters(). It cannot carry meter values
+    // at this point -- the process() above already cached them and d_isEqual
+    // swallows an unchanged value -- so this is a smoke check that flush() emits
+    // nothing of its own, not a second regression gate. The gate is the block
+    // loop above.
+    paramsExt->flush(plugin, &inEvents.iface, &outEvents.iface);
+
+    plugin->stop_processing(plugin);
+
+    size_t outputParamEvents = 0, otherEvents = 0, unknownEvents = 0;
+    for (const CollectedEvent& e : outEvents.events)
+    {
+        int idx = -1;
+        for (size_t i = 0; i < params.size(); ++i)
+            if (params[i].id == e.paramId) { idx = static_cast<int>(i); break; }
+
+        if (e.paramId == CLAP_INVALID_ID)
+            ++otherEvents;
+        else if (idx < 0)
+            ++unknownEvents;
+        else if (isOutput(params[idx]))
+            ++outputParamEvents;
+        else
+            ++otherEvents;
+    }
+
+    std::printf("\nblocks      : %d x %d frames @ 48 kHz, %s\n",
+                numBlocks, numFrames, silent ? "digital silence" : "full-scale noise");
+    std::printf("total out_events                      : %zu\n", outEvents.events.size());
+    std::printf("output-param events reaching the host : %zu\n", outputParamEvents);
+    std::printf("other events reaching the host        : %zu\n", otherEvents);
+    std::printf("events for ids the plugin never listed : %zu\n", unknownEvents);
+
+    bool meterMoved = false;
+    std::printf("\nmeter read-back through clap_plugin_params.get_value (first, min, max):\n");
+    for (size_t k = 0; k < meters.size(); ++k)
+    {
+        const P& p(params[meters[k]]);
+        std::printf("  id=%u \"%s\" first=%.6f min=%.6f max=%.6f\n",
+                    p.id, p.name.c_str(), meterFirst[k], meterMin[k], meterMax[k]);
+        if (meterMax[k] - meterMin[k] > 1.0e-4)
+            meterMoved = true;
+    }
+
+    plugin->deactivate(plugin);
+    plugin->destroy(plugin);
+    entry->deinit();
+
+    std::fflush(stdout);
+    int failures = 0;
+
+    if (! meterMoved)
+    {
+        std::fprintf(stderr, "\nFAIL: no output parameter moved over %d blocks of %s;\n"
+                             "      the meters are not tracking the audio.\n",
+                     numBlocks, silent ? "silence" : "noise");
+        ++failures;
+    }
+    else
+    {
+        std::printf("\nPASS: meters track the audio (at least one output parameter moved).\n");
+    }
+
+    if (outputParamEvents != 0)
+    {
+        std::fprintf(stderr, "FAIL: %zu output-parameter events were pushed to the host's out_events.\n"
+                             "      CLAP gives a host no way to tell these from a user's own edits;\n"
+                             "      Bitwig takes the meter over as last-touched and re-marks the\n"
+                             "      project modified (dusk-audio/plugins#231). Expected 0.\n",
+                     outputParamEvents);
+        // The header flags are the reason these are so damaging: CLAP_EVENT_IS_LIVE
+        // (1 << 0) means "a user turning a physical knob", and without
+        // CLAP_EVENT_DONT_RECORD (1 << 1) the host is invited to record them.
+        for (const CollectedEvent& e : outEvents.events)
+        {
+            int idx = -1;
+            for (size_t i = 0; i < params.size(); ++i)
+                if (params[i].id == e.paramId) { idx = static_cast<int>(i); break; }
+            if (idx >= 0 && isOutput(params[idx]))
+            {
+                std::fprintf(stderr, "      first offender: type=%u flags=0x%x id=%u \"%s\" value=%.6f\n",
+                             e.type, e.flags, e.paramId, params[idx].name.c_str(), e.value);
+                break;
+            }
+        }
+        ++failures;
+    }
+    else
+    {
+        std::printf("PASS: no output-parameter events reached the host.\n");
+    }
+
+    if (unknownEvents != 0)
+    {
+        std::fprintf(stderr, "FAIL: %zu events carried parameter ids the plugin never listed,\n"
+                             "      so they could not be classified.\n", unknownEvents);
+        ++failures;
+    }
+
+    std::printf("\n%s\n", failures == 0 ? "RESULT: PASS" : "RESULT: FAIL");
+    return failures == 0 ? 0 : 1;
+}

--- a/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
@@ -1,0 +1,989 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// Regression test for dusk-audio/plugins#233.
+//
+// DAF simulates VST3 output parameters by pushing every changed one into the
+// host's outputParameterChanges list from process(). A meter moves on nearly
+// every block, so a plugin with two meters hands the host two parameter edits
+// per block for as long as audio flows. Bitwig turns each of those into an
+// undoable plug-in change; the undo history churns fast enough that Undo and
+// Redo stop being offered at all, and the project never stays saved.
+//
+// This is a minimal VST3 host. It instantiates the plugin, runs blocks of
+// noise through it, and records everything the plugin writes to
+// outputParameterChanges. The contract it enforces:
+//
+//   1. No parameter carrying V3_PARAM_READ_ONLY without V3_PARAM_IS_HIDDEN
+//      (DAF's mapping of kParameterIsOutput) may appear in
+//      outputParameterChanges, however much its value moves.
+//   2. No output parameter may reach the host through IComponentHandler either
+//      -- begin_edit/perform_edit/end_edit is the channel a host turns into
+//      undo entries most directly of all, and restart_component must not be
+//      called from the audio callback. Guarding only outputParameterChanges
+//      would leave a regression free to move to the louder channel.
+//   3. The meters must still track the audio: at least one has to move at some
+//      point during the run, sampled every block through
+//      v3_edit_controller::get_parameter_normalised. Without this a "fix" that
+//      simply stopped updating the meters would satisfy 1 and 2, and the
+//      plugin's own embedded UI reads those same cached values.
+//
+// Assertion 3 is what keeps 1 and 2 honest, so all three must hold on the same
+// run. It tests for *movement*, not for non-zero: a gain-reduction meter rests
+// at the top of its range, so "non-zero" would be true of a frozen one. It
+// samples per block rather than at the endpoints, so a meter that moves and
+// decays back to rest still counts as alive.
+//
+// Both of DAF's calls into the code under test are exercised: every iteration
+// sends one zero-frame block (updateParametersFromProcessing on the empty-block
+// early return) and one full block (the normal path). Hosts send zero-frame
+// blocks routinely on transport edges.
+//
+// Linux and macOS only (dlopen plus the two bundle layouts below); the
+// behaviour under test is platform-independent, and the CMake helper that
+// registers this skips the platforms it cannot load a bundle on.
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <dlfcn.h>
+
+#include "travesty/audio_processor.h"
+#include "travesty/base.h"
+#include "travesty/component.h"
+#include "travesty/edit_controller.h"
+#include "travesty/factory.h"
+#include "travesty/host.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+// host-side COM objects
+//
+// travesty's ABI is COM's: a handle is a pointer to a pointer to a block of
+// function pointers, and that same handle is passed back as `self`. Mirroring
+// how the wrapper builds its own objects keeps the two ends in agreement.
+
+template<class T>
+static T* selfOf(void* const self)
+{
+    return *static_cast<T**>(self);
+}
+
+static uint32_t V3_API refStub(void*) { return 1; }
+static uint32_t V3_API unrefStub(void*) { return 1; }
+
+// ---- v3_param_value_queue -------------------------------------------------------------------------------------------
+
+struct HostParamQueue : v3_param_value_queue_cpp {
+    v3_param_id paramId = 0;
+    std::vector<std::pair<int32_t, double>> points;
+
+    // The handle handed to the plugin is the address of this member, so a
+    // queue must never be copied, moved or relocated once the plugin holds
+    // one. Deleting the copy and move operations makes the compiler enforce
+    // that instead of leaving it to a reserve() nobody remembers to keep.
+    HostParamQueue* const selfptr = this;
+    v3_param_value_queue** handle() { return (v3_param_value_queue**) &selfptr; }
+
+    HostParamQueue(const HostParamQueue&) = delete;
+    HostParamQueue& operator=(const HostParamQueue&) = delete;
+    HostParamQueue(HostParamQueue&&) = delete;
+    HostParamQueue& operator=(HostParamQueue&&) = delete;
+
+    HostParamQueue()
+    {
+        query_interface = queryInterface;
+        ref = refStub;
+        unref = unrefStub;
+        queue.get_param_id = getParamId;
+        queue.get_point_count = getPointCount;
+        queue.get_point = getPoint;
+        queue.add_point = addPoint;
+    }
+
+    static v3_result V3_API queryInterface(void* const self, const v3_tuid iid, void** const obj)
+    {
+        if (v3_tuid_match(iid, v3_funknown_iid) || v3_tuid_match(iid, v3_param_value_queue_iid))
+        {
+            *obj = self;
+            return V3_OK;
+        }
+        *obj = nullptr;
+        return V3_NO_INTERFACE;
+    }
+
+    static v3_param_id V3_API getParamId(void* const self)
+    {
+        return selfOf<HostParamQueue>(self)->paramId;
+    }
+
+    static int32_t V3_API getPointCount(void* const self)
+    {
+        return static_cast<int32_t>(selfOf<HostParamQueue>(self)->points.size());
+    }
+
+    static v3_result V3_API getPoint(void* const self, const int32_t idx, int32_t* const offset, double* const value)
+    {
+        HostParamQueue* const q = selfOf<HostParamQueue>(self);
+        if (idx < 0 || static_cast<size_t>(idx) >= q->points.size())
+            return V3_INVALID_ARG;
+        *offset = q->points[idx].first;
+        *value = q->points[idx].second;
+        return V3_OK;
+    }
+
+    static v3_result V3_API addPoint(void* const self, const int32_t offset, const double value, int32_t* const idx)
+    {
+        HostParamQueue* const q = selfOf<HostParamQueue>(self);
+        q->points.emplace_back(offset, value);
+        *idx = static_cast<int32_t>(q->points.size()) - 1;
+        return V3_OK;
+    }
+};
+
+// ---- v3_param_changes -----------------------------------------------------------------------------------------------
+
+struct HostParamChanges : v3_param_changes_cpp {
+    // HostParamQueue is pinned (see above), so the queues are owned through
+    // pointers and reused across blocks rather than reallocated. Reusing them
+    // also means a run is never limited by how many distinct parameters the
+    // plugin decides to report.
+    std::vector<HostParamQueue*> queues;
+    size_t used = 0;
+
+    HostParamChanges* selfptr = this;
+    v3_param_changes** handle() { return (v3_param_changes**) &selfptr; }
+
+    HostParamChanges()
+    {
+        query_interface = queryInterface;
+        ref = refStub;
+        unref = unrefStub;
+        changes.get_param_count = getParamCount;
+        changes.get_param_data = getParamData;
+        changes.add_param_data = addParamData;
+    }
+
+    ~HostParamChanges()
+    {
+        for (HostParamQueue* q : queues)
+            delete q;
+    }
+
+    HostParamChanges(const HostParamChanges&) = delete;
+    HostParamChanges& operator=(const HostParamChanges&) = delete;
+
+    void reset()
+    {
+        for (size_t i = 0; i < used; ++i)
+            queues[i]->points.clear();
+        used = 0;
+    }
+
+    static v3_result V3_API queryInterface(void* const self, const v3_tuid iid, void** const obj)
+    {
+        if (v3_tuid_match(iid, v3_funknown_iid) || v3_tuid_match(iid, v3_param_changes_iid))
+        {
+            *obj = self;
+            return V3_OK;
+        }
+        *obj = nullptr;
+        return V3_NO_INTERFACE;
+    }
+
+    static int32_t V3_API getParamCount(void* const self)
+    {
+        return static_cast<int32_t>(selfOf<HostParamChanges>(self)->used);
+    }
+
+    static v3_param_value_queue** V3_API getParamData(void* const self, const int32_t idx)
+    {
+        HostParamChanges* const c = selfOf<HostParamChanges>(self);
+        if (idx < 0 || static_cast<size_t>(idx) >= c->used)
+            return nullptr;
+        return c->queues[idx]->handle();
+    }
+
+    static v3_param_value_queue** V3_API addParamData(void* const self, const v3_param_id* const id, int32_t* const idx)
+    {
+        HostParamChanges* const c = selfOf<HostParamChanges>(self);
+
+        for (size_t i = 0; i < c->used; ++i)
+        {
+            if (c->queues[i]->paramId == *id)
+            {
+                *idx = static_cast<int32_t>(i);
+                return c->queues[i]->handle();
+            }
+        }
+
+        if (c->used == c->queues.size())
+            c->queues.push_back(new HostParamQueue);
+
+        HostParamQueue* const q = c->queues[c->used];
+        q->paramId = *id;
+        q->points.clear();
+        *idx = static_cast<int32_t>(c->used);
+        ++c->used;
+        return q->handle();
+    }
+};
+
+// ---- v3_component_handler -------------------------------------------------------------------------------------------
+//
+// The channel a host turns into undo entries most directly. DAF only drives it
+// from the UI message path today, so everything recorded here is expected to be
+// zero during processing; that is the point -- a regression that moved meter
+// reporting onto this channel would be invisible to a harness that never
+// installed a handler.
+
+struct HostComponentHandler : v3_component_handler_cpp {
+    std::vector<v3_param_id> beginEdits, performEdits, endEdits;
+    std::vector<int32_t> restarts;
+    bool processing = false;          // set while the block loop runs
+    size_t editsDuringProcessing = 0;
+    size_t restartsDuringProcessing = 0;
+
+    HostComponentHandler* selfptr = this;
+    v3_component_handler** handle() { return (v3_component_handler**) &selfptr; }
+
+    HostComponentHandler()
+    {
+        query_interface = queryInterface;
+        ref = refStub;
+        unref = unrefStub;
+        comp.begin_edit = beginEdit;
+        comp.perform_edit = performEdit;
+        comp.end_edit = endEdit;
+        comp.restart_component = restartComponent;
+    }
+
+    HostComponentHandler(const HostComponentHandler&) = delete;
+    HostComponentHandler& operator=(const HostComponentHandler&) = delete;
+
+    static v3_result V3_API queryInterface(void* const self, const v3_tuid iid, void** const obj)
+    {
+        if (v3_tuid_match(iid, v3_funknown_iid) || v3_tuid_match(iid, v3_component_handler_iid))
+        {
+            *obj = self;
+            return V3_OK;
+        }
+        *obj = nullptr;
+        return V3_NO_INTERFACE;
+    }
+
+    static v3_result V3_API beginEdit(void* const self, const v3_param_id id)
+    {
+        HostComponentHandler* const h = selfOf<HostComponentHandler>(self);
+        h->beginEdits.push_back(id);
+        if (h->processing) ++h->editsDuringProcessing;
+        return V3_OK;
+    }
+
+    static v3_result V3_API performEdit(void* const self, const v3_param_id id, double)
+    {
+        HostComponentHandler* const h = selfOf<HostComponentHandler>(self);
+        h->performEdits.push_back(id);
+        if (h->processing) ++h->editsDuringProcessing;
+        return V3_OK;
+    }
+
+    static v3_result V3_API endEdit(void* const self, const v3_param_id id)
+    {
+        HostComponentHandler* const h = selfOf<HostComponentHandler>(self);
+        h->endEdits.push_back(id);
+        if (h->processing) ++h->editsDuringProcessing;
+        return V3_OK;
+    }
+
+    static v3_result V3_API restartComponent(void* const self, const int32_t flags)
+    {
+        HostComponentHandler* const h = selfOf<HostComponentHandler>(self);
+        h->restarts.push_back(flags);
+        if (h->processing) ++h->restartsDuringProcessing;
+        return V3_OK;
+    }
+};
+
+// ---- v3_host_application --------------------------------------------------------------------------------------------
+
+struct HostApplication : v3_host_application_cpp {
+    HostApplication* selfptr = this;
+    v3_funknown** handle() { return (v3_funknown**) &selfptr; }
+
+    HostApplication()
+    {
+        query_interface = queryInterface;
+        ref = refStub;
+        unref = unrefStub;
+        app.get_name = getName;
+        app.create_instance = createInstance;
+    }
+
+    static v3_result V3_API queryInterface(void* const self, const v3_tuid iid, void** const obj)
+    {
+        if (v3_tuid_match(iid, v3_funknown_iid) || v3_tuid_match(iid, v3_host_application_iid))
+        {
+            *obj = self;
+            return V3_OK;
+        }
+        *obj = nullptr;
+        return V3_NO_INTERFACE;
+    }
+
+    static v3_result V3_API getName(void*, v3_str_128 name)
+    {
+        static const char* const kName = "DafVst3OutputParamTest";
+        int i = 0;
+        for (; kName[i] != '\0'; ++i)
+            name[i] = static_cast<int16_t>(kName[i]);
+        name[i] = 0;
+        return V3_OK;
+    }
+
+    // The wrapper only asks the host to create message and attribute-list
+    // objects, which this test never exercises: it never opens the UI, and the
+    // meter path under test runs entirely inside process().
+    static v3_result V3_API createInstance(void*, v3_tuid, v3_tuid, void** const obj)
+    {
+        *obj = nullptr;
+        return V3_NOT_IMPLEMENTED;
+    }
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+static std::string utf16ToAscii(const v3_str_128 s)
+{
+    std::string out;
+    for (int i = 0; i < 128 && s[i] != 0; ++i)
+        out += static_cast<char>(s[i] & 0x7f);
+    return out;
+}
+
+// CMake passes $<TARGET_FILE:...>, i.e. the loadable binary inside the bundle,
+// so no architecture table is needed here and the harness works wherever DAF
+// builds. A bundle directory is still accepted for running it by hand, on the
+// two layouts this file can be built for; ModuleEntry finds its own bundle
+// through dladdr either way, so nothing downstream depends on which was given.
+static std::string binaryInsideBundle(const std::string& path)
+{
+    if (path.size() <= 5 || path.compare(path.size() - 5, 5, ".vst3") != 0)
+        return path;
+
+    std::string name(path);
+    const size_t slash = name.find_last_of('/');
+    if (slash != std::string::npos)
+        name = name.substr(slash + 1);
+    name = name.substr(0, name.size() - 5);
+
+   #ifdef __APPLE__
+    return path + "/Contents/MacOS/" + name;
+   #else
+    #if defined(__aarch64__)
+     const char* const arch = "aarch64-linux";
+    #else
+     const char* const arch = "x86_64-linux";
+    #endif
+    return path + "/Contents/" + arch + "/" + name + ".so";
+   #endif
+}
+
+struct ParamInfo {
+    v3_param_id id;
+    std::string title;
+    int32_t flags;
+};
+
+// A DAF output parameter (kParameterIsOutput) maps to exactly
+// V3_PARAM_READ_ONLY. Everything else the wrapper marks read-only it also
+// marks hidden: the internal Latency/BufferSize/SampleRate mirrors, and the
+// Reset designation, which is a trigger and is deliberately still reported.
+// "Read-only but not hidden" therefore selects the meters and only the meters,
+// without matching on parameter names.
+static bool isOutputParameter(const ParamInfo& p)
+{
+    return (p.flags & V3_PARAM_READ_ONLY) != 0
+        && (p.flags & V3_PARAM_IS_HIDDEN) == 0;
+}
+
+static bool parsePositiveInt(const char* const text, int& out)
+{
+    char* end = nullptr;
+    const long value = std::strtol(text, &end, 10);
+    if (end == text || *end != '\0' || value < 1 || value > 1000000)
+        return false;
+    out = static_cast<int>(value);
+    return true;
+}
+
+int main(const int argc, const char* const* const argv)
+{
+    // Flags first: leaving --silent to be swallowed by the positional parser
+    // turned a typo into "the meters are not tracking the audio", blaming the
+    // plugin for a command-line mistake.
+    bool silent = false;
+    std::vector<const char*> positional;
+    for (int i = 1; i < argc; ++i)
+    {
+        if (std::strcmp(argv[i], "--silent") == 0)
+            silent = true;
+        else
+            positional.push_back(argv[i]);
+    }
+
+    if (positional.empty() || positional.size() > 3)
+    {
+        std::fprintf(stderr, "usage: %s <plugin.vst3> [blocks] [frames] [--silent]\n", argv[0]);
+        return 2;
+    }
+
+    const std::string bundle(positional[0]);
+    int numBlocks = 100, numFrames = 256;
+    if (positional.size() > 1 && ! parsePositiveInt(positional[1], numBlocks))
+    {
+        std::fprintf(stderr, "FAIL: block count %s is not a positive integer\n", positional[1]);
+        return 2;
+    }
+    if (positional.size() > 2 && ! parsePositiveInt(positional[2], numFrames))
+    {
+        std::fprintf(stderr, "FAIL: frame count %s is not a positive integer\n", positional[2]);
+        return 2;
+    }
+
+    // --silent characterises what a plugin does on an idle track: some of these
+    // emulate tape hiss or a console noise floor, and if that reached the
+    // meters the symptom would appear with no audio playing at all. It is a
+    // diagnostic mode, not the regression -- assertion 2 needs moving meters,
+    // so a silent run is expected to fail for a plugin whose meters do sit
+    // still, and the registered ctest always runs with noise.
+
+    const std::string binary(binaryInsideBundle(bundle));
+
+    void* const lib = dlopen(binary.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (lib == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: dlopen(%s): %s\n", binary.c_str(), dlerror());
+        return 1;
+    }
+
+   #ifdef __APPLE__
+    bool (*moduleEntry)(void*) = (bool (*)(void*)) dlsym(lib, "bundleEntry");
+    bool (*moduleExit)(void) = (bool (*)(void)) dlsym(lib, "bundleExit");
+   #else
+    bool (*moduleEntry)(void*) = (bool (*)(void*)) dlsym(lib, "ModuleEntry");
+    bool (*moduleExit)(void) = (bool (*)(void)) dlsym(lib, "ModuleExit");
+   #endif
+    const void* (*getFactory)(void) = (const void* (*)(void)) dlsym(lib, "GetPluginFactory");
+
+    if (getFactory == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: no GetPluginFactory in %s\n", binary.c_str());
+        return 1;
+    }
+    if (moduleEntry != nullptr && ! moduleEntry(lib))
+    {
+        std::fprintf(stderr, "FAIL: ModuleEntry refused to initialise the bundle\n");
+        return 1;
+    }
+
+    v3_plugin_factory** const factory = (v3_plugin_factory**) getFactory();
+    if (factory == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: GetPluginFactory returned null\n");
+        return 1;
+    }
+
+    HostApplication host;
+
+    // A factory_3 also wants the host context; hand it over when it takes one.
+    v3_plugin_factory_3** factory3 = nullptr;
+    if (v3_cpp_obj_query_interface(factory, v3_plugin_factory_3_iid, &factory3) == V3_OK && factory3 != nullptr)
+        v3_cpp_obj(factory3)->set_host_context(factory3, host.handle());
+
+    v3_tuid componentCid = {};
+    bool haveComponentCid = false;
+
+    const int32_t numClasses = v3_cpp_obj(factory)->num_classes(factory);
+    for (int32_t i = 0; i < numClasses; ++i)
+    {
+        v3_class_info info = {};
+        if (v3_cpp_obj(factory)->get_class_info(factory, i, &info) != V3_OK)
+            continue;
+        if (std::strcmp(info.category, "Audio Module Class") == 0)
+        {
+            std::memcpy(componentCid, info.class_id, sizeof(v3_tuid));
+            haveComponentCid = true;
+            break;
+        }
+    }
+
+    if (! haveComponentCid)
+    {
+        std::fprintf(stderr, "FAIL: no Audio Module Class in factory\n");
+        return 1;
+    }
+
+    v3_component** component = nullptr;
+    if (v3_cpp_obj(factory)->create_instance(factory, componentCid, v3_component_iid, (void**) &component) != V3_OK
+        || component == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: could not create component\n");
+        return 1;
+    }
+
+    if (v3_cpp_obj_initialize(component, host.handle()) != V3_OK)
+    {
+        std::fprintf(stderr, "FAIL: component initialize\n");
+        return 1;
+    }
+
+    // Single-component DAF plugins answer for the controller too, which is what
+    // every plugin in this repository builds. A DAF_VST3_USES_SEPARATE_CONTROLLER
+    // build is refused rather than measured: there the controller keeps its own
+    // parameter cache fed only by the host relaying outputParameterChanges back,
+    // and suppressing those pushes is exactly the fix under test -- so
+    // get_parameter_normalised would read the same value before and after and
+    // the harness would fail a correct plugin.
+    v3_edit_controller** controller = nullptr;
+    if (v3_cpp_obj_query_interface(component, v3_edit_controller_iid, &controller) != V3_OK || controller == nullptr)
+    {
+        std::fprintf(stderr,
+                     "FAIL: the component does not implement v3_edit_controller.\n"
+                     "      This harness reads the meters back through the component's own cache and\n"
+                     "      cannot measure a separate-controller build; teach it the relay path first.\n");
+        return 1;
+    }
+
+    HostComponentHandler handler;
+    if (v3_cpp_obj(controller)->set_component_handler(controller, handler.handle()) != V3_OK)
+    {
+        std::fprintf(stderr, "FAIL: set_component_handler\n");
+        return 1;
+    }
+
+    std::vector<ParamInfo> params;
+    const int32_t paramCount = v3_cpp_obj(controller)->get_parameter_count(controller);
+    for (int32_t i = 0; i < paramCount; ++i)
+    {
+        v3_param_info info = {};
+        if (v3_cpp_obj(controller)->get_parameter_info(controller, i, &info) != V3_OK)
+        {
+            // Not skippable: an unreadable parameter would leave its id
+            // unknown below, and unknown ids are what would let meter events
+            // slip through the classifier unnoticed.
+            std::fprintf(stderr, "FAIL: get_parameter_info(%d) failed; cannot classify every parameter\n", i);
+            return 1;
+        }
+        params.push_back({ info.param_id, utf16ToAscii(info.title), info.flags });
+    }
+
+    auto indexOf = [&params](const v3_param_id id) -> int {
+        for (size_t i = 0; i < params.size(); ++i)
+            if (params[i].id == id)
+                return static_cast<int>(i);
+        return -1;
+    };
+
+    std::vector<int> outputParams;
+    for (size_t i = 0; i < params.size(); ++i)
+        if (isOutputParameter(params[i]))
+            outputParams.push_back(static_cast<int>(i));
+
+    std::printf("plugin      : %s\n", bundle.c_str());
+    std::printf("parameters  : %d (%zu output/read-only)\n", paramCount, outputParams.size());
+    for (const int i : outputParams)
+        std::printf("  output    : id=%u \"%s\" flags=0x%x\n", params[i].id, params[i].title.c_str(), params[i].flags);
+
+    if (outputParams.empty())
+    {
+        std::fprintf(stderr, "FAIL: plugin exposes no output parameters; this test would pass vacuously\n");
+        return 1;
+    }
+
+    v3_audio_processor** processor = nullptr;
+    if (v3_cpp_obj_query_interface(component, v3_audio_processor_iid, &processor) != V3_OK || processor == nullptr)
+    {
+        std::fprintf(stderr, "FAIL: no audio processor\n");
+        return 1;
+    }
+
+    // Buses: give every declared bus the arrangement matching the channel
+    // count it reports, so a plugin with a sidechain (multi-comp) is set up the
+    // way a host sets it up rather than being handed a short array. Only the
+    // main buses are activated, which is what a host does for a plain insert.
+    const int32_t numInBuses = v3_cpp_obj(component)->get_bus_count(component, V3_AUDIO, V3_INPUT);
+    const int32_t numOutBuses = v3_cpp_obj(component)->get_bus_count(component, V3_AUDIO, V3_OUTPUT);
+
+    // DAF matches an arrangement to a bus by channel count, so any mask with the
+    // right population count is accepted. Building one from the low speaker bits
+    // keeps a 4- or 6-channel bus working instead of being forced to stereo and
+    // refused. Mono is spelled with the dedicated V3_SPEAKER_M so a 1-channel
+    // bus is not described as "left only".
+    auto arrangementFor = [](const int32_t channels) -> v3_speaker_arrangement {
+        if (channels <= 0)
+            return 0;
+        if (channels == 1)
+            return V3_SPEAKER_M;
+        v3_speaker_arrangement arr = 0;
+        for (int32_t i = 0; i < channels && i < 64; ++i)
+            arr |= (static_cast<v3_speaker_arrangement>(1) << i);
+        return arr;
+    };
+
+    std::vector<v3_speaker_arrangement> inArr, outArr;
+    std::vector<int32_t> inChannels, outChannels;
+
+    for (int32_t i = 0; i < numInBuses; ++i)
+    {
+        v3_bus_info info = {};
+        if (v3_cpp_obj(component)->get_bus_info(component, V3_AUDIO, V3_INPUT, i, &info) != V3_OK)
+        {
+            std::fprintf(stderr, "FAIL: get_bus_info(input %d)\n", i);
+            return 1;
+        }
+        inChannels.push_back(info.channel_count);
+        inArr.push_back(arrangementFor(info.channel_count));
+    }
+    for (int32_t i = 0; i < numOutBuses; ++i)
+    {
+        v3_bus_info info = {};
+        if (v3_cpp_obj(component)->get_bus_info(component, V3_AUDIO, V3_OUTPUT, i, &info) != V3_OK)
+        {
+            std::fprintf(stderr, "FAIL: get_bus_info(output %d)\n", i);
+            return 1;
+        }
+        outChannels.push_back(info.channel_count);
+        outArr.push_back(arrangementFor(info.channel_count));
+    }
+
+    // A refused arrangement leaves ports disabled, and the run would then
+    // measure a configuration nobody asked for, so this is checked rather than
+    // discarded.
+    const v3_result arrRes = v3_cpp_obj(processor)->set_bus_arrangements(processor,
+                                                                        inArr.empty() ? nullptr : inArr.data(),
+                                                                        numInBuses,
+                                                                        outArr.empty() ? nullptr : outArr.data(),
+                                                                        numOutBuses);
+    if (arrRes != V3_OK)
+    {
+        std::fprintf(stderr, "FAIL: set_bus_arrangements refused the plugin's own reported channel counts (%d)\n",
+                     arrRes);
+        return 1;
+    }
+
+    // Checked, not discarded: a refused main-bus activation makes DAF substitute
+    // a silent dummy buffer, and the meters then legitimately sit still -- which
+    // would surface as "the meters are not tracking the audio", blaming the
+    // plugin for a host-side setup failure.
+    for (int32_t i = 0; i < numInBuses; ++i)
+    {
+        if (v3_cpp_obj(component)->activate_bus(component, V3_AUDIO, V3_INPUT, i, i == 0) != V3_OK && i == 0)
+        {
+            std::fprintf(stderr, "FAIL: could not activate the main input bus\n");
+            return 1;
+        }
+    }
+    for (int32_t i = 0; i < numOutBuses; ++i)
+    {
+        if (v3_cpp_obj(component)->activate_bus(component, V3_AUDIO, V3_OUTPUT, i, i == 0) != V3_OK && i == 0)
+        {
+            std::fprintf(stderr, "FAIL: could not activate the main output bus\n");
+            return 1;
+        }
+    }
+
+    v3_process_setup setup = { V3_REALTIME, V3_SAMPLE_32, numFrames, 48000.0 };
+    if (v3_cpp_obj(processor)->setup_processing(processor, &setup) != V3_OK)
+    {
+        std::fprintf(stderr, "FAIL: setup_processing\n");
+        return 1;
+    }
+
+    if (v3_cpp_obj(component)->set_active(component, true) != V3_OK)
+    {
+        std::fprintf(stderr, "FAIL: set_active\n");
+        return 1;
+    }
+    if (v3_cpp_obj(processor)->set_processing(processor, true) != V3_OK)
+    {
+        std::fprintf(stderr, "FAIL: set_processing(true)\n");
+        return 1;
+    }
+
+    // Channel storage: one contiguous vector per channel, plus the per-bus
+    // pointer arrays VST3 wants. Only the main input bus carries signal.
+    std::vector<std::vector<float>> inStore, outStore;
+    std::vector<std::vector<float*>> inPtrs(numInBuses), outPtrs(numOutBuses);
+    std::vector<v3_audio_bus_buffers> inBuses(numInBuses), outBuses(numOutBuses);
+
+    for (int32_t b = 0; b < numInBuses; ++b)
+        for (int32_t c = 0; c < inChannels[b]; ++c)
+            inStore.emplace_back(numFrames, 0.0f);
+    for (int32_t b = 0; b < numOutBuses; ++b)
+        for (int32_t c = 0; c < outChannels[b]; ++c)
+            outStore.emplace_back(numFrames, 0.0f);
+
+    {
+        size_t next = 0;
+        for (int32_t b = 0; b < numInBuses; ++b)
+        {
+            for (int32_t c = 0; c < inChannels[b]; ++c)
+                inPtrs[b].push_back(inStore[next++].data());
+            inBuses[b].num_channels = inChannels[b];
+            inBuses[b].channel_silence_bitset = 0;
+            inBuses[b].channel_buffers_32 = inPtrs[b].data();
+        }
+        next = 0;
+        for (int32_t b = 0; b < numOutBuses; ++b)
+        {
+            for (int32_t c = 0; c < outChannels[b]; ++c)
+                outPtrs[b].push_back(outStore[next++].data());
+            outBuses[b].num_channels = outChannels[b];
+            outBuses[b].channel_silence_bitset = 0;
+            outBuses[b].channel_buffers_32 = outPtrs[b].data();
+        }
+    }
+
+    // Sampled every block rather than at the two endpoints: a peak meter that
+    // rises and decays back to rest between the first and last sample would
+    // otherwise read as frozen and fail a correct plugin.
+    std::vector<double> meterMin(outputParams.size()), meterMax(outputParams.size());
+    std::vector<double> meterFirst(outputParams.size());
+    for (size_t k = 0; k < outputParams.size(); ++k)
+    {
+        const double v = v3_cpp_obj(controller)->get_parameter_normalised(controller, params[outputParams[k]].id);
+        meterFirst[k] = meterMin[k] = meterMax[k] = v;
+    }
+
+    HostParamChanges inputChanges, outputChanges;
+
+    std::mt19937 rng(20260828u);
+    std::uniform_real_distribution<float> noise(-0.5f, 0.5f);
+
+    size_t outputParamEvents = 0, otherParamEvents = 0, unknownParamEvents = 0;
+    std::vector<size_t> perParamEvents(params.size(), 0);
+
+    auto countEvents = [&](const HostParamChanges& changes) {
+        for (size_t qi = 0; qi < changes.used; ++qi)
+        {
+            const HostParamQueue& q(*changes.queues[qi]);
+            const int idx = indexOf(q.paramId);
+
+            if (idx < 0)
+            {
+                // Never excuse an id the controller did not enumerate: that is
+                // exactly how a drift in the wrapper's id mapping would turn
+                // this gate green with the bug fully present.
+                unknownParamEvents += q.points.size();
+                continue;
+            }
+
+            if (isOutputParameter(params[idx]))
+                outputParamEvents += q.points.size();
+            else
+                otherParamEvents += q.points.size();
+
+            perParamEvents[idx] += q.points.size();
+        }
+    };
+
+    handler.processing = true;
+
+    for (int block = 0; block < numBlocks; ++block)
+    {
+        // DAF reports output parameters from two places: the zero-frame early
+        // return and the normal path. Both run every iteration so a regression
+        // cannot hide on the empty-block branch hosts use at transport edges.
+        {
+            inputChanges.reset();
+            outputChanges.reset();
+
+            v3_process_data empty = {};
+            empty.process_mode = V3_REALTIME;
+            empty.symbolic_sample_size = V3_SAMPLE_32;
+            empty.nframes = 0;
+            empty.num_input_buses = numInBuses;
+            empty.num_output_buses = numOutBuses;
+            empty.inputs = numInBuses > 0 ? inBuses.data() : nullptr;
+            empty.outputs = numOutBuses > 0 ? outBuses.data() : nullptr;
+            empty.input_params = inputChanges.handle();
+            empty.output_params = outputChanges.handle();
+            empty.ctx = nullptr;
+
+            if (v3_cpp_obj(processor)->process(processor, &empty) != V3_OK)
+            {
+                std::fprintf(stderr, "FAIL: process() returned an error on the zero-frame block %d\n", block);
+                return 1;
+            }
+            countEvents(outputChanges);
+        }
+
+        if (numInBuses > 0)
+        {
+            for (int32_t c = 0; c < inChannels[0]; ++c)
+            {
+                float* const dst = inPtrs[0][c];
+                for (int i = 0; i < numFrames; ++i)
+                    dst[i] = silent ? 0.0f : noise(rng);
+            }
+        }
+
+        inputChanges.reset();
+        outputChanges.reset();
+
+        v3_process_data data = {};
+        data.process_mode = V3_REALTIME;
+        data.symbolic_sample_size = V3_SAMPLE_32;
+        data.nframes = numFrames;
+        data.num_input_buses = numInBuses;
+        data.num_output_buses = numOutBuses;
+        data.inputs = numInBuses > 0 ? inBuses.data() : nullptr;
+        data.outputs = numOutBuses > 0 ? outBuses.data() : nullptr;
+        data.input_params = inputChanges.handle();
+        data.output_params = outputChanges.handle();
+        data.input_events = nullptr;
+        data.output_events = nullptr;
+        data.ctx = nullptr;
+
+        if (v3_cpp_obj(processor)->process(processor, &data) != V3_OK)
+        {
+            std::fprintf(stderr, "FAIL: process() returned an error on block %d\n", block);
+            return 1;
+        }
+
+        countEvents(outputChanges);
+
+        for (size_t k = 0; k < outputParams.size(); ++k)
+        {
+            const double v = v3_cpp_obj(controller)->get_parameter_normalised(controller,
+                                                                             params[outputParams[k]].id);
+            if (v < meterMin[k]) meterMin[k] = v;
+            if (v > meterMax[k]) meterMax[k] = v;
+        }
+    }
+
+    handler.processing = false;
+
+    v3_cpp_obj(processor)->set_processing(processor, false);
+
+    std::printf("\nblocks      : %d x %d frames @ 48 kHz, %s\n",
+                numBlocks, numFrames, silent ? "digital silence" : "full-scale noise");
+    std::printf("output-param events reaching the host : %zu\n", outputParamEvents);
+    std::printf("other param events reaching the host  : %zu\n", otherParamEvents);
+    std::printf("events for ids the controller never reported : %zu\n", unknownParamEvents);
+    for (size_t i = 0; i < params.size(); ++i)
+        if (perParamEvents[i] != 0)
+            std::printf("  id=%u \"%s\" flags=0x%x -> %zu events\n",
+                        params[i].id, params[i].title.c_str(), params[i].flags, perParamEvents[i]);
+
+    std::printf("component-handler traffic during processing : %zu parameter edit(s), %zu restart(s)\n",
+                handler.editsDuringProcessing, handler.restartsDuringProcessing);
+
+    // Assertion 3 first: frozen meters would make 1 and 2 meaningless.
+    bool meterMoved = false;
+    std::printf("\nmeter read-back through get_parameter_normalised (first, min, max over the run):\n");
+    for (size_t k = 0; k < outputParams.size(); ++k)
+    {
+        const ParamInfo& p(params[outputParams[k]]);
+        std::printf("  id=%u \"%s\" first=%.6f min=%.6f max=%.6f\n",
+                    p.id, p.title.c_str(), meterFirst[k], meterMin[k], meterMax[k]);
+        if (meterMax[k] - meterMin[k] > 1.0e-4)
+            meterMoved = true;
+    }
+
+    v3_cpp_obj(component)->set_active(component, false);
+
+    // Failures go to stderr: it is unbuffered, so under `ctest --output-on-failure`
+    // they stay next to any plugin diagnostics that explain them instead of being
+    // reordered against block-buffered stdout.
+    std::fflush(stdout);
+    int failures = 0;
+
+    if (! meterMoved)
+    {
+        std::fprintf(stderr,
+                     "\nFAIL: no output parameter moved over %d blocks of %s;\n"
+                     "      the meters are not tracking the audio.\n",
+                     numBlocks, silent ? "silence" : "noise");
+        ++failures;
+    }
+    else
+    {
+        std::printf("\nPASS: meters track the audio (at least one output parameter moved).\n");
+    }
+
+    if (outputParamEvents != 0)
+    {
+        std::fprintf(stderr,
+                     "FAIL: %zu output-parameter events were written to outputParameterChanges.\n"
+                     "      A VST3 host sees these as parameter edits made by the plugin; Bitwig\n"
+                     "      records each as an undoable change and stops offering undo/redo\n"
+                     "      (dusk-audio/plugins#233). Expected 0.\n", outputParamEvents);
+        ++failures;
+    }
+    else
+    {
+        std::printf("PASS: no output-parameter events reached the host.\n");
+    }
+
+    // The IComponentHandler channel. DAF drives it only from the UI message
+    // path, so anything at all arriving here from process() is a regression --
+    // and a worse one than the outputParameterChanges flood, since begin_edit /
+    // perform_edit is unambiguously "the user edited this".
+    size_t outputParamEdits = 0;
+    for (const std::vector<v3_param_id>* list : { &handler.beginEdits, &handler.performEdits, &handler.endEdits })
+        for (const v3_param_id id : *list)
+        {
+            const int idx = indexOf(id);
+            if (idx >= 0 && isOutputParameter(params[idx]))
+                ++outputParamEdits;
+        }
+
+    if (outputParamEdits != 0 || handler.editsDuringProcessing != 0 || handler.restartsDuringProcessing != 0)
+    {
+        std::fprintf(stderr,
+                     "FAIL: the plugin drove IComponentHandler from the audio callback\n"
+                     "      (%zu edit(s) for output parameters, %zu edit(s) and %zu restart_component\n"
+                     "      call(s) during processing). Expected 0 of each.\n",
+                     outputParamEdits, handler.editsDuringProcessing, handler.restartsDuringProcessing);
+        ++failures;
+    }
+    else
+    {
+        std::printf("PASS: no output parameter reached the host through IComponentHandler.\n");
+    }
+
+    if (unknownParamEvents != 0)
+    {
+        std::fprintf(stderr,
+                     "FAIL: %zu events carried parameter ids the edit controller never enumerated,\n"
+                     "      so they could not be classified. Until the id mapping is understood\n"
+                     "      this test cannot tell a meter event from a legitimate one.\n",
+                     unknownParamEvents);
+        ++failures;
+    }
+
+    // Walk the plugin all the way back down, in the reverse order of the way up.
+    // Not housekeeping: DAF refuses to destroy a component whose audio processor
+    // or edit controller is still referenced, parks it in gComponentGarbage and
+    // prints "asked to delete component while audio processor still active", so
+    // skipping any one of these unrefs means the destructor under test never
+    // runs at all.
+    v3_cpp_obj(controller)->set_component_handler(controller, nullptr);
+    v3_cpp_obj_unref(processor);        // query_interface above took a reference
+    v3_cpp_obj_unref(controller);       // and so did that one
+    v3_cpp_obj_terminate(component);
+    v3_cpp_obj_unref(component);
+    if (factory3 != nullptr)
+        v3_cpp_obj_unref(factory3);
+    if (moduleExit != nullptr)
+        moduleExit();
+
+    std::printf("\n%s\n", failures == 0 ? "RESULT: PASS" : "RESULT: FAIL");
+    return failures == 0 ? 0 : 1;
+}

--- a/plugins/tape-echo/daf-plugin/CMakeLists.txt
+++ b/plugins/tape-echo/daf-plugin/CMakeLists.txt
@@ -76,3 +76,8 @@ if(NOT CMAKE_CROSSCOMPILING)
                 -P "${DUSK_SHARED_DAF_CMAKE_DIR}/tests/DuskFixLv2PresetsTest.cmake")
     endif()
 endif()
+
+# Record VU / Record Peak are output parameters; guard them against reaching the
+# host as parameter edits, in both VST3 (dusk-audio/plugins#233) and CLAP
+# (#231). The macro handles the cross-compile skip and enable_testing() itself.
+dusk_daf_add_output_param_tests(tape_echo)


### PR DESCRIPTION
Regression gate for #233 (VST3) and #231 (CLAP). Blocked on dusk-audio/DAF#19,
which carries the VST3 wrapper fix itself.

A meter moves on nearly every block. Both DAF wrappers used to forward that
movement to the host as a parameter edit, so a plugin with two meters handed the
host two edits per block for as long as audio flowed. Bitwig records each as an
undoable plug-in change; the undo history churns until Undo and Redo stop being
offered, and the project goes back to modified the instant it is saved. The CLAP
half was fixed in DAF#18; the VST3 half was never fixed and is still present in
the published 4K EQ 2 v1.0.1, TapeMachine 2 v1.0.7 and Tape Echo 2 v1.0.3
artifacts.

## What this adds

Minimal VST3 and CLAP hosts that instantiate a plugin's own built binary, run
noise through it, and record everything it hands back. Three assertions on the
same run:

1. No output parameter appears in the host's event list (`outputParameterChanges`
   for VST3, `out_events` for CLAP), however much its value moves.
2. No output parameter reaches `IComponentHandler`. `begin_edit` and
   `perform_edit` are the channel a host turns into undo entries most directly,
   so guarding only the first would leave a regression free to move to the louder
   one. `restart_component` from the audio callback fails too.
3. The meters still track the audio, sampled every block through
   `get_parameter_normalised` / `clap_plugin_params.get_value`.

Assertion 3 is what keeps 1 and 2 honest: without it a change that simply stopped
updating the meters would pass. It tests for movement rather than for a non-zero
value, because a gain-reduction meter rests at the top of its range and would
read non-zero while frozen.

## Evidence

Observed failing before the fix and passing after, per plugin, per format:

| plugin | format | before | after |
| --- | --- | --- | --- |
| 4K EQ 2 | VST3 | 200 | 0 |
| 4K EQ 2 | CLAP | 200 | 0 |
| TapeMachine 2 | VST3 | 200 | 0 |
| TapeMachine 2 | CLAP | 0 | 0 |
| Tape Echo 2 | VST3 | 200 | 0 |
| Tape Echo 2 | CLAP | 0 | 0 |

Counts are per 100 blocks by 256 frames of noise. The two CLAP zeroes before the
fix are plugins already built against DAF#18. Reverting each wrapper fix in turn
turns the corresponding guard red and leaves the other green, so neither test
passes for the wrong reason. Freezing the meter cache makes assertion 3 fail while
1 and 2 still pass, which is the check that assertion 3 is not decorative.

On digital silence all counts are 0 before and after, over 8000 blocks. The bug
needs non-silent audio, contrary to the "just open it" wording in #233.

## Coverage

Registered for 4k-eq, TapeMachine and tape-echo. multi-comp and sunset-circuits
also declare `kParameterIsOutput` meters and are covered by the same wrapper fixes
but are deliberately not wired: multi-comp's gain-reduction meters only move once
the compressor is actually compressing, and sunset-circuits is a synth with no
audio input, so neither can satisfy assertion 3 from noise at default settings.
Wiring them needs per-plugin parameter and note setup. The three that are wired
already fail the moment either shared wrapper regresses.

## Note on the CMake helper

`dusk_daf_add_output_param_tests` is a macro, not a function, and that is
deliberate. `enable_testing()` called from inside a CMake `function()` registers
nothing: no `CTestTestfile.cmake` is written and `ctest` reports "No tests were
found" while the targets still build. Since `daf-build.yml` passes a build that
reports zero tests, that would have left these guards silently dead behind a green
check. A macro expands into the caller's own directory scope, where
`enable_testing()` takes effect.

## Before merging

CI on this branch is expected to fail the three `*Vst3OutputParams` tests until
the DAF pin moves, because `DAF_REF` still points at `80189fe5`, which has the
CLAP fix but not the VST3 one. Once DAF#19 merges I will push the pin bump
(`daf-build.yml`, `daf-au-test.yml`, `daf-release.yml`, `docker/build_release.sh`)
to this branch, which is what turns CI green.

4K EQ 2, TapeMachine 2 and Tape Echo 2 then need patch releases to carry the fix
to users; the shipped artifacts are all still affected in VST3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host compatibility for 4K EQ, Tape Machine, and Tape Echo by preventing output meters from being reported as user parameter edits.
  * Preserved accurate meter movement and output-parameter behavior across VST3 and CLAP formats.

* **Tests**
  * Added automated validation for plugin parameters, audio ports, meter updates, and host-facing event behavior.
  * Expanded regression coverage to detect invalid parameter events and confirm meters respond correctly during playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->