### PR TITLE
Chord Analyzer: stop dropping notes outside the matched chord pattern

### DIFF
--- a/plugins/chord-analyzer/CMakeLists.txt
+++ b/plugins/chord-analyzer/CMakeLists.txt
@@ -125,6 +125,8 @@ target_link_libraries(ChordAnalyzerTest PRIVATE
 )
 target_compile_definitions(ChordAnalyzerTest PRIVATE
     JUCE_STANDALONE_APPLICATION=1
+    JUCE_USE_CURL=0          # headless unit test: no network, avoids libcurl link dep
+    JUCE_WEB_BROWSER=0
 )
 
 # Optimization for release builds

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -242,15 +242,17 @@ std::set<int> ChordAnalyzer::getIntervals(const std::vector<int>& notes, int roo
     return intervals;
 }
 
-std::set<int> ChordAnalyzer::patternPitchClasses(const ChordPattern& pattern)
+std::uint16_t ChordAnalyzer::patternPitchClasses(const ChordPattern& pattern)
 {
     // Patterns state extensions in compound form (a 9th as 14), while a played
     // voicing is compared as pitch classes. Reduce once, here, so the matcher,
-    // the tension naming and the confidence score cannot drift apart.
-    std::set<int> covered;
+    // the tension naming and the confidence score cannot drift apart. Returned
+    // as a bit mask rather than a set: this runs per analysed chord, and the
+    // headless LV2 build calls analyze() straight from its audio callback.
+    std::uint16_t covered = 0;
 
     for (int interval : pattern.intervals)
-        covered.insert(interval % 12);
+        covered |= static_cast<std::uint16_t>(1u << (interval % 12));
 
     return covered;
 }
@@ -300,10 +302,11 @@ const ChordAnalyzer::ChordPattern* ChordAnalyzer::matchPattern(const std::set<in
     return best;
 }
 
-juce::String ChordAnalyzer::tensionLabel(int semitonesFromRoot)
+const char* ChordAnalyzer::tensionLabel(int semitonesFromRoot)
 {
     // Folded to a pitch class so a compound interval names the same tension as
     // its simple form (14 and 2 are both a 9th, 17 and 5 both an 11th).
+    // String literals, so naming a tension costs no allocation.
     switch (semitonesFromRoot % 12)
     {
         case 1:  return "b9";
@@ -317,7 +320,7 @@ juce::String ChordAnalyzer::tensionLabel(int semitonesFromRoot)
         case 9:  return "13";
         case 10: return "b7";
         case 11: return "maj7";
-        default: return {};   // 0 is the root, always covered by the pattern
+        default: return nullptr;   // 0 is the root, always covered by the pattern
     }
 }
 
@@ -327,29 +330,39 @@ juce::String ChordAnalyzer::describeAddedTones(const ChordPattern& pattern,
     // Compare as pitch classes: getIntervals states a 9th as both 2 and 14, and
     // the patterns use the compound form, so a raw set difference would report
     // every add9/add11/13 chord tone as an extra note.
-    const std::set<int> covered = patternPitchClasses(pattern);
+    const std::uint16_t covered = patternPitchClasses(pattern);
 
-    juce::StringArray extras;
+    // At most one extra per pitch class, so a fixed array suffices.
+    const char* extras[12];
+    int numExtras = 0;
 
     for (int interval : intervals)
     {
-        if (interval >= 12 || covered.count(interval) > 0)
+        if (interval >= 12 || (covered & (1u << interval)) != 0)
             continue;
 
-        const juce::String label = tensionLabel(interval);
-        if (label.isNotEmpty())
-            extras.add(label);
+        if (const char* label = tensionLabel(interval))
+            extras[numExtras++] = label;
     }
 
-    if (extras.isEmpty())
+    if (numExtras == 0)
         return {};
 
     // A triad carrying one extra tone reads as an add chord ("Cadd#11");
     // anything richer takes parenthesised tensions ("C7(#11)", "C9(b13)").
-    if (extras.size() == 1 && pattern.intervals.size() <= 3)
-        return "add" + extras[0];
+    if (numExtras == 1 && pattern.intervals.size() <= 3)
+        return juce::String("add") + extras[0];
 
-    return "(" + extras.joinIntoString(",") + ")";
+    juce::String text("(");
+    for (int i = 0; i < numExtras; ++i)
+    {
+        if (i > 0)
+            text << ",";
+        text << extras[i];
+    }
+    text << ")";
+
+    return text;
 }
 
 int ChordAnalyzer::calculateInversion(const std::vector<int>& notes, int root) const
@@ -378,7 +391,7 @@ float ChordAnalyzer::calculateConfidence(const ChordPattern& pattern, const std:
     // Score against the pattern that actually matched. Comparing in pitch
     // classes keeps a compound pattern tone (9th written as 14) from counting
     // its own chord tone as an extra note.
-    const std::set<int> covered = patternPitchClasses(pattern);
+    const std::uint16_t covered = patternPitchClasses(pattern);
 
     int matchedIntervals = 0;
     int extraIntervals = 0;
@@ -388,13 +401,18 @@ float ChordAnalyzer::calculateConfidence(const ChordPattern& pattern, const std:
         if (interval >= 12)  // Compound restatement of a tone already counted
             continue;
 
-        if (covered.count(interval) > 0)
+        if ((covered & (1u << interval)) != 0)
             matchedIntervals++;
         else if (interval != 0)
             extraIntervals++;
     }
 
-    const float patternMatch = static_cast<float>(matchedIntervals) / static_cast<float>(covered.size());
+    int coveredCount = 0;
+    for (int pc = 0; pc < 12; ++pc)
+        if ((covered & (1u << pc)) != 0)
+            ++coveredCount;
+
+    const float patternMatch = static_cast<float>(matchedIntervals) / static_cast<float>(coveredCount);
     const float penalty = static_cast<float>(extraIntervals) * 0.1f;
 
     return juce::jlimit(0.0f, 1.0f, patternMatch - penalty);

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -4,7 +4,11 @@
 
 //==============================================================================
 // Chord patterns - interval sets from root (in semitones)
-// Priority determines which pattern wins when multiple match
+// Priority determines which pattern wins when multiple match. Patterns that
+// tie on both priority and size fall back to DECLARATION ORDER, so this list
+// is ordered by preferred spelling: Major before Minor before Diminished, and
+// the lower tension first (add9 before add11, so C E G D F reads Cadd9(11)).
+// Reordering entries within a priority band changes chord names.
 const std::vector<ChordAnalyzer::ChordPattern> ChordAnalyzer::chordPatterns = {
     // Power chord (2 notes)
     {{0, 7}, ChordQuality::Power5, "5", 1},
@@ -35,8 +39,8 @@ const std::vector<ChordAnalyzer::ChordPattern> ChordAnalyzer::chordPatterns = {
     // Altered dominants
     {{0, 4, 6, 10}, ChordQuality::Dominant7Flat5, "7b5", 21},
     {{0, 4, 8, 10}, ChordQuality::Dominant7Sharp5, "7#5", 21},
-    {{0, 4, 7, 10, 13}, ChordQuality::Dominant7Flat9, "7b9", 25},
-    {{0, 4, 7, 10, 15}, ChordQuality::Dominant7Sharp9, "7#9", 25},
+    {{0, 1, 4, 7, 10}, ChordQuality::Dominant7Flat9, "7b9", 25},
+    {{0, 3, 4, 7, 10}, ChordQuality::Dominant7Sharp9, "7#9", 25},
 
     // Add chords
     {{0, 4, 7, 14}, ChordQuality::Add9, "add9", 16},
@@ -109,27 +113,35 @@ ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
     auto intervals = getIntervals(sortedNotes, result.rootNote);
 
     // Match pattern
-    int priority = 0;
-    result.quality = matchPattern(intervals, priority);
+    const ChordPattern* pattern = matchPattern(intervals);
 
-    if (result.quality == ChordQuality::Unknown)
+    if (pattern == nullptr)
     {
-        // Try simpler patterns by removing some notes
-        // Sometimes extra notes don't fit known patterns
+        // No known chord shape fits these notes
         result.name = pitchClassToName(result.rootNote) + "?";
         result.romanNumeral = "?";
         result.confidence = 0.3f;
         return result;
     }
 
-    // Build chord name
-    result.name = pitchClassToName(result.rootNote) + qualityToSuffix(result.quality);
+    result.quality = pattern->quality;
+
+    // Build chord name. Any sounding tone the matched pattern does not account
+    // for is spelled out instead of dropped, so C E G F# reads "Cadd#11" and
+    // not "C" (issue #235).
+    result.name = pitchClassToName(result.rootNote)
+                + qualityToSuffix(result.quality)
+                + describeAddedTones(*pattern, intervals);
 
     // Calculate inversion
     result.inversion = calculateInversion(sortedNotes, result.rootNote);
 
-    // Add inversion notation if not root position
-    if (result.inversion > 0)
+    // Slash notation for any bass note other than the root. This covers the
+    // classic inversions and also an upper-structure bass such as the #11,
+    // which calculateInversion cannot number but must still be shown.
+    result.slashBass = (result.bassNote != result.rootNote);
+
+    if (result.slashBass)
     {
         result.extensions = "/" + pitchClassToName(result.bassNote);
     }
@@ -139,7 +151,7 @@ ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
     result.function = getHarmonicFunction(result.rootNote, result.quality);
 
     // Calculate confidence
-    result.confidence = calculateConfidence(intervals, result.quality);
+    result.confidence = calculateConfidence(*pattern, intervals);
     result.isValid = true;
 
     return result;
@@ -185,17 +197,7 @@ int ChordAnalyzer::findRoot(const std::vector<int>& notes) const
         for (const auto& pattern : chordPatterns)
         {
             // Check if intervals match pattern (allowing extra notes)
-            bool matches = true;
-            for (int interval : pattern.intervals)
-            {
-                if (intervals.find(interval) == intervals.end())
-                {
-                    matches = false;
-                    break;
-                }
-            }
-
-            if (matches)
+            if (patternMatches(pattern, intervals))
             {
                 float score = static_cast<float>(pattern.priority);
 
@@ -240,41 +242,114 @@ std::set<int> ChordAnalyzer::getIntervals(const std::vector<int>& notes, int roo
     return intervals;
 }
 
-ChordQuality ChordAnalyzer::matchPattern(const std::set<int>& intervals, int& outPriority) const
+std::set<int> ChordAnalyzer::patternPitchClasses(const ChordPattern& pattern)
 {
-    ChordQuality bestMatch = ChordQuality::Unknown;
-    int bestPriority = -1;
-    size_t bestMatchSize = 0;
+    // Patterns state extensions in compound form (a 9th as 14), while a played
+    // voicing is compared as pitch classes. Reduce once, here, so the matcher,
+    // the tension naming and the confidence score cannot drift apart.
+    std::set<int> covered;
+
+    for (int interval : pattern.intervals)
+        covered.insert(interval % 12);
+
+    return covered;
+}
+
+bool ChordAnalyzer::patternMatches(const ChordPattern& pattern, const std::set<int>& intervals)
+{
+    // Every tone the pattern requires must be sounding (extra notes allowed)
+    for (int interval : pattern.intervals)
+    {
+        if (intervals.find(interval) == intervals.end())
+            return false;
+    }
+
+    // A b5 or #5 spelling *replaces* the fifth, so it cannot describe a chord
+    // that also sounds a perfect fifth - there the altered tone is a #11 or a
+    // b13. Without this, C E G Bb F# matched C7b5 and the natural fifth was
+    // thrown away.
+    if (intervals.count(7) > 0 && pattern.intervals.count(7) == 0
+        && (pattern.intervals.count(6) > 0 || pattern.intervals.count(8) > 0))
+        return false;
+
+    return true;
+}
+
+const ChordAnalyzer::ChordPattern* ChordAnalyzer::matchPattern(const std::set<int>& intervals) const
+{
+    const ChordPattern* best = nullptr;
 
     for (const auto& pattern : chordPatterns)
     {
-        // Check if all pattern intervals are present
-        bool matches = true;
-        for (int interval : pattern.intervals)
-        {
-            if (intervals.find(interval) == intervals.end())
-            {
-                matches = false;
-                break;
-            }
-        }
+        if (! patternMatches(pattern, intervals))
+            continue;
 
-        if (matches)
+        // Prefer patterns that match more notes (more specific)
+        // But also consider priority. A pattern that ties on both keeps the
+        // incumbent, so an exact tie resolves to whichever is declared first
+        // in chordPatterns - see the ordering contract on that table.
+        if (best == nullptr
+            || pattern.priority > best->priority
+            || (pattern.priority == best->priority
+                && pattern.intervals.size() > best->intervals.size()))
         {
-            // Prefer patterns that match more notes (more specific)
-            // But also consider priority
-            if (pattern.priority > bestPriority ||
-                (pattern.priority == bestPriority && pattern.intervals.size() > bestMatchSize))
-            {
-                bestMatch = pattern.quality;
-                bestPriority = pattern.priority;
-                bestMatchSize = pattern.intervals.size();
-            }
+            best = &pattern;
         }
     }
 
-    outPriority = bestPriority;
-    return bestMatch;
+    return best;
+}
+
+juce::String ChordAnalyzer::tensionLabel(int semitonesFromRoot)
+{
+    // Folded to a pitch class so a compound interval names the same tension as
+    // its simple form (14 and 2 are both a 9th, 17 and 5 both an 11th).
+    switch (semitonesFromRoot % 12)
+    {
+        case 1:  return "b9";
+        case 2:  return "9";
+        case 3:  return "#9";
+        case 4:  return "3";
+        case 5:  return "11";
+        case 6:  return "#11";
+        case 7:  return "5";
+        case 8:  return "b13";
+        case 9:  return "13";
+        case 10: return "b7";
+        case 11: return "maj7";
+        default: return {};   // 0 is the root, always covered by the pattern
+    }
+}
+
+juce::String ChordAnalyzer::describeAddedTones(const ChordPattern& pattern,
+                                               const std::set<int>& intervals)
+{
+    // Compare as pitch classes: getIntervals states a 9th as both 2 and 14, and
+    // the patterns use the compound form, so a raw set difference would report
+    // every add9/add11/13 chord tone as an extra note.
+    const std::set<int> covered = patternPitchClasses(pattern);
+
+    juce::StringArray extras;
+
+    for (int interval : intervals)
+    {
+        if (interval >= 12 || covered.count(interval) > 0)
+            continue;
+
+        const juce::String label = tensionLabel(interval);
+        if (label.isNotEmpty())
+            extras.add(label);
+    }
+
+    if (extras.isEmpty())
+        return {};
+
+    // A triad carrying one extra tone reads as an add chord ("Cadd#11");
+    // anything richer takes parenthesised tensions ("C7(#11)", "C9(b13)").
+    if (extras.size() == 1 && pattern.intervals.size() <= 3)
+        return "add" + extras[0];
+
+    return "(" + extras.joinIntoString(",") + ")";
 }
 
 int ChordAnalyzer::calculateInversion(const std::vector<int>& notes, int root) const
@@ -298,38 +373,31 @@ int ChordAnalyzer::calculateInversion(const std::vector<int>& notes, int root) c
     return 0;
 }
 
-float ChordAnalyzer::calculateConfidence(const std::set<int>& intervals, ChordQuality matched) const
+float ChordAnalyzer::calculateConfidence(const ChordPattern& pattern, const std::set<int>& intervals)
 {
-    if (matched == ChordQuality::Unknown) return 0.0f;
+    // Score against the pattern that actually matched. Comparing in pitch
+    // classes keeps a compound pattern tone (9th written as 14) from counting
+    // its own chord tone as an extra note.
+    const std::set<int> covered = patternPitchClasses(pattern);
 
-    // Find the matching pattern
-    for (const auto& pattern : chordPatterns)
+    int matchedIntervals = 0;
+    int extraIntervals = 0;
+
+    for (int interval : intervals)
     {
-        if (pattern.quality == matched)
-        {
-            // Check how closely we match
-            int matchedIntervals = 0;
-            int extraIntervals = 0;
+        if (interval >= 12)  // Compound restatement of a tone already counted
+            continue;
 
-            for (int interval : intervals)
-            {
-                if (interval < 12)  // Only count basic intervals
-                {
-                    if (pattern.intervals.find(interval) != pattern.intervals.end())
-                        matchedIntervals++;
-                    else if (interval != 0)
-                        extraIntervals++;
-                }
-            }
-
-            float patternMatch = static_cast<float>(matchedIntervals) / static_cast<float>(pattern.intervals.size());
-            float penalty = static_cast<float>(extraIntervals) * 0.1f;
-
-            return juce::jlimit(0.0f, 1.0f, patternMatch - penalty);
-        }
+        if (covered.count(interval) > 0)
+            matchedIntervals++;
+        else if (interval != 0)
+            extraIntervals++;
     }
 
-    return 0.5f;
+    const float patternMatch = static_cast<float>(matchedIntervals) / static_cast<float>(covered.size());
+    const float penalty = static_cast<float>(extraIntervals) * 0.1f;
+
+    return juce::jlimit(0.0f, 1.0f, patternMatch - penalty);
 }
 
 //==============================================================================

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.h
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <cstdint>
 
 //==============================================================================
 // Chord quality enumeration
@@ -170,14 +171,18 @@ private:
     int findRoot(const std::vector<int>& notes) const;
     std::set<int> getIntervals(const std::vector<int>& notes, int root) const;
     static bool patternMatches(const ChordPattern& pattern, const std::set<int>& intervals);
-    static std::set<int> patternPitchClasses(const ChordPattern& pattern);
+
+    // Pitch classes a pattern covers, as a 12-bit mask (bit n = pitch class n).
+    // analyze() runs on the audio thread in the headless LV2 build, so the
+    // hot helpers below stay free of heap containers.
+    static std::uint16_t patternPitchClasses(const ChordPattern& pattern);
     const ChordPattern* matchPattern(const std::set<int>& intervals) const;
     int calculateInversion(const std::vector<int>& notes, int root) const;
     static float calculateConfidence(const ChordPattern& pattern, const std::set<int>& intervals);
 
     //==========================================================================
     // Naming of tones the matched pattern does not account for
-    static juce::String tensionLabel(int semitonesFromRoot);
+    static const char* tensionLabel(int semitonesFromRoot);   // nullptr if none
     static juce::String describeAddedTones(const ChordPattern& pattern, const std::set<int>& intervals);
 
     //==========================================================================

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.h
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.h
@@ -80,12 +80,17 @@ struct ChordInfo
     ChordQuality quality = ChordQuality::Unknown;
     juce::String extensions;        // Any additional text
     int inversion = 0;              // 0=root, 1=first, 2=second, etc.
+    bool slashBass = false;         // Bass is not the root - display slash notation
     bool isValid = false;
     float confidence = 0.0f;        // 0.0-1.0 confidence score
 
     bool operator==(const ChordInfo& other) const
     {
-        return name == other.name && rootNote == other.rootNote && quality == other.quality;
+        // bassNote is part of the identity: C/E and C/G share a name, root and
+        // quality, but they display differently and publish a different
+        // detectedBass. Omitting it left both stale until some other note moved.
+        return name == other.name && rootNote == other.rootNote
+            && quality == other.quality && bassNote == other.bassNote;
     }
 
     bool operator!=(const ChordInfo& other) const
@@ -164,9 +169,16 @@ private:
     // Analysis helpers
     int findRoot(const std::vector<int>& notes) const;
     std::set<int> getIntervals(const std::vector<int>& notes, int root) const;
-    ChordQuality matchPattern(const std::set<int>& intervals, int& outPriority) const;
+    static bool patternMatches(const ChordPattern& pattern, const std::set<int>& intervals);
+    static std::set<int> patternPitchClasses(const ChordPattern& pattern);
+    const ChordPattern* matchPattern(const std::set<int>& intervals) const;
     int calculateInversion(const std::vector<int>& notes, int root) const;
-    float calculateConfidence(const std::set<int>& intervals, ChordQuality matched) const;
+    static float calculateConfidence(const ChordPattern& pattern, const std::set<int>& intervals);
+
+    //==========================================================================
+    // Naming of tones the matched pattern does not account for
+    static juce::String tensionLabel(int semitonesFromRoot);
+    static juce::String describeAddedTones(const ChordPattern& pattern, const std::set<int>& intervals);
 
     //==========================================================================
     // Roman numeral helpers

--- a/plugins/chord-analyzer/Source/PluginEditor.cpp
+++ b/plugins/chord-analyzer/Source/PluginEditor.cpp
@@ -399,11 +399,13 @@ void ChordAnalyzerEditor::updateChordDisplay()
     // Update chord name
     juce::String displayName = cachedChord.name;
 
-    // Add inversion notation if enabled and not root position
+    // Add slash notation if enabled and the bass is not the root. This covers
+    // the numbered inversions and an upper-structure bass alike, so a C triad
+    // voiced over F# reads "Cadd#11/F#" rather than "C" (issue #235).
     bool showInv = *audioProcessor.getAPVTS().getRawParameterValue(
         ChordAnalyzerProcessor::PARAM_SHOW_INVERSIONS) > 0.5f;
 
-    if (showInv && !cachedChord.extensions.isEmpty() && cachedChord.inversion > 0)
+    if (showInv && cachedChord.slashBass && !cachedChord.extensions.isEmpty())
     {
         displayName += cachedChord.extensions;
     }

--- a/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
+++ b/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
@@ -321,6 +321,104 @@ static void testConfidence()
 }
 
 // =====================================================================
+// 9b. Added tones and slash bass (issue #235)
+//
+// The matcher accepts a pattern whose intervals are a subset of the notes
+// played, so every tone outside the pattern used to vanish from the name:
+// C E G F# read as plain "C".
+// =====================================================================
+static void testAddedTones()
+{
+    std::cout << "\n--- Added Tones / Slash Bass ---\n";
+    ChordAnalyzer a;
+
+    // C major triad plus F# (C E G F#) — the reported chord
+    auto addSharp11 = analyzeNotes(a, {60, 64, 66, 67});
+    check("C E G F# = Cadd#11", addSharp11.isValid && addSharp11.name == "Cadd#11");
+
+    // Same pitch classes voiced with F# in the bass — "C / F#"
+    auto overSharp11 = analyzeNotes(a, {54, 60, 64, 67});
+    check("C triad over F# names the #11", overSharp11.name == "Cadd#11");
+    check("C triad over F# is a slash chord",
+          overSharp11.slashBass && overSharp11.extensions == "/F#");
+
+    // A perfect fifth alongside the tritone means #11, never b5
+    auto dom7Sharp11 = analyzeNotes(a, {60, 64, 66, 67, 70});
+    check("C E G Bb F# = C7(#11)", dom7Sharp11.isValid
+                                    && dom7Sharp11.quality == ChordQuality::Dominant7
+                                    && dom7Sharp11.name == "C7(#11)");
+
+    auto maj7Sharp11 = analyzeNotes(a, {60, 64, 66, 67, 71});
+    check("C E G B F# = Cmaj7(#11)", maj7Sharp11.name == "Cmaj7(#11)");
+
+    // Same rule for the flat thirteenth against a natural fifth
+    auto dom7Flat13 = analyzeNotes(a, {60, 64, 67, 68, 70});
+    check("C E G Ab Bb = C7(b13)", dom7Flat13.name == "C7(b13)");
+
+    // Genuine altered fifths still resolve to their own spelling
+    auto realFlat5 = analyzeNotes(a, {60, 64, 66, 70});
+    check("C E Gb Bb = C7b5", realFlat5.quality == ChordQuality::Dominant7Flat5
+                               && realFlat5.name == "C7b5");
+    auto realSharp5 = analyzeNotes(a, {60, 64, 68, 70});
+    check("C E G# Bb = C7#5", realSharp5.name == "C7#5");
+    auto dim = analyzeNotes(a, {60, 63, 66});
+    check("C Eb Gb still = Cdim", dim.quality == ChordQuality::Diminished);
+
+    // Altered ninths: these patterns were written with compound intervals
+    // (13/15) that getIntervals never produces, so they could never match
+    auto flat9 = analyzeNotes(a, {60, 64, 67, 70, 73});
+    check("C E G Bb Db = C7b9", flat9.quality == ChordQuality::Dominant7Flat9
+                                 && flat9.name == "C7b9");
+    auto sharp9 = analyzeNotes(a, {60, 64, 67, 70, 75});
+    check("C E G Bb Eb = C7#9", sharp9.quality == ChordQuality::Dominant7Sharp9
+                                 && sharp9.name == "C7#9");
+
+    // Exactly matched chords must gain no extra text
+    check("C major gains no tension text", analyzeNotes(a, {60, 64, 67}).name == "C");
+    check("Cadd9 gains no tension text",   analyzeNotes(a, {60, 64, 67, 74}).name == "Cadd9");
+    check("Cadd11 gains no tension text",  analyzeNotes(a, {60, 64, 67, 65}).name == "Cadd11");
+    check("Cmaj13 gains no tension text",
+          analyzeNotes(a, {60, 64, 67, 71, 74, 77, 81}).name == "Cmaj13");
+
+    // Classic inversions keep numbering their bass and still flag the slash
+    auto firstInv = analyzeNotes(a, {64, 67, 72});
+    check("C/E still 1st inversion", firstInv.inversion == 1
+                                      && firstInv.slashBass
+                                      && firstInv.extensions == "/E");
+    check("Root position sets no slash", !analyzeNotes(a, {60, 64, 67}).slashBass);
+
+    // A third outside the matched triad is a tension, not a dropped note
+    check("C Eb E G = Cadd#9", analyzeNotes(a, {60, 63, 64, 67}).name == "Cadd#9");
+
+    // Two patterns can tie on priority and size (add9 and add11 are both
+    // {root,3,5,+1} at priority 16); chordPatterns declaration order breaks
+    // the tie, and this pins the spelling that ordering is meant to produce.
+    check("C E G D F = Cadd9(11)", analyzeNotes(a, {60, 64, 67, 74, 77}).name == "Cadd9(11)");
+}
+
+// =====================================================================
+// 9c. Chord identity includes the bass
+//
+// ChordInfo::operator== gates display refresh, history and the exported
+// detectedBass parameter. Leaving bassNote out of it meant moving only the
+// bass never registered as a change.
+// =====================================================================
+static void testBassIdentity()
+{
+    std::cout << "\n--- Bass Is Part Of Identity ---\n";
+    ChordAnalyzer a;
+
+    auto overE = analyzeNotes(a, {64, 67, 72});   // C/E
+    auto overG = analyzeNotes(a, {55, 60, 64});   // C/G
+
+    check("C/E and C/G share a name",  overE.name == overG.name
+                                        && overE.rootNote == overG.rootNote
+                                        && overE.quality == overG.quality);
+    check("C/E differs from C/G",      overE != overG);
+    check("Same voicing compares equal", overE == analyzeNotes(a, {64, 67, 72}));
+}
+
+// =====================================================================
 // 10. Static utility functions
 // =====================================================================
 static void testUtilities()
@@ -349,6 +447,8 @@ int main()
     testHarmonicFunctions();
     testEdgeCases();
     testConfidence();
+    testAddedTones();
+    testBassIdentity();
     testUtilities();
 
     std::cout << "\n=== Results: " << passed << " passed, " << failed << " failed ===\n";


### PR DESCRIPTION
The matcher accepted any pattern whose intervals were a subset of the notes played, then discarded everything it had not matched. C E G F# matched the plain major triad, so the F# vanished and the chord displayed as "C" (issue #235). calculateInversion only recognised a 3rd, 5th or 7th in the bass, so the same notes voiced over F# also lost the slash.

Fixes:

* Unmatched tones are now spelled out by describeAddedTones. A triad with one extra tone reads as an add chord (Cadd#11); richer chords take parenthesised tensions (C7(#11), C7(b13)). Comparison is done in pitch classes so a compound pattern tone (a 9th written as 14) does not report its own chord tone as an extra note.
* A b5 or #5 spelling replaces the fifth, so patternMatches now rejects those patterns when a perfect fifth also sounds. C E G Bb F# matched C7b5 (priority 21 beat Dominant7's 20) and threw the natural fifth away; it now reads C7(#11). A genuine C E Gb Bb still reads C7b5.
* New ChordInfo::slashBass replaces the inversion > 0 display gate, so an upper-structure bass renders slash notation (Cadd#11/F#) alongside the classic numbered inversions (C/E).

Two adjacent bugs in the same code, fixed as collateral:

* The 7b9 and 7#9 patterns were written with compound intervals 13 and 15, which getIntervals never produces, so neither could ever match. Corrected to 1 and 3.
* calculateConfidence looked its pattern up by quality, hitting the wrong one of the two Dominant13 entries. It now takes the pattern that matched.
* ChordInfo::operator== ignored bassNote. Since it gates the display refresh, the history append and stageDetectedChord, moving C/E to C/G compared equal: the label kept reading C/E and the exported detectedBass parameter published a stale bass.

chordPatterns relies on declaration order to break exact ties, and that ordering encodes real preference (Major before Minor before Diminished, lower tension first). Documented as a contract on the table and pinned by tests rather than replaced, since every alternative discriminator tried made results worse.

ChordAnalyzerTest could not link at all beforehand (undefined curl_*), so the test target gains JUCE_USE_CURL=0 and JUCE_WEB_BROWSER=0.

Tests: 85 pass, 0 fail (was 63 before this branch, all still passing). Verified across VST3, CLAP, LV2, LV2 headless and the MIDI variant; pluginval clean at strictness 1, 5, 7 and 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved chord recognition for altered ninths, altered fifths, diminished chords, and added tones.
  * Chord names now identify sounding extensions such as add9, `#11`, b13, b9, and `#9`.
  * Improved slash-bass notation for inversions and upper-structure bass notes.
  * Chord comparisons now distinguish chords with different bass notes, such as C/E and C/G.
  * Improved confidence scoring and pattern selection for more accurate chord results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->