### PR TITLE
Chord Analyzer: correct 6th-chord roots and make the LV2 audio path allocation free

### DIFF
--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -185,9 +185,13 @@ int ChordAnalyzer::findRoot(const std::vector<int>& notes) const
         return uniquePitches[0];
 
     // Try each note as potential root and score the result
+    const int bassPitch = notes[0] % 12;
+
     int bestRoot = uniquePitches[0];
     int bestPriority = -1;
     float bestScore = 0.0f;
+    bool bestIsBass = false;
+    bool found = false;          // a match scoring <= 0 is still a match
 
     for (int candidateRoot : uniquePitches)
     {
@@ -199,18 +203,48 @@ int ChordAnalyzer::findRoot(const std::vector<int>& notes) const
             // Check if intervals match pattern (allowing extra notes)
             if (patternMatches(pattern, intervals))
             {
+                // Penalty for sounding notes the pattern does not explain.
+                // Counted in pitch classes: getIntervals also states a 9th as
+                // 14, an 11th as 17 and a 13th as 21, and charging those
+                // restatements as extra notes penalised exactly the chords
+                // that have them. C E G A scored 19.5 as C6 but 20 as Am7,
+                // purely because the synthetic 21 made C6 look impure.
+                const int patternTones = countPitchClasses(patternPitchClasses(pattern));
+                const int extraNotes   = static_cast<int>(uniquePitches.size()) - patternTones;
+
+                // A shape smaller than a triad may carry at most one added
+                // tone. The two-note power chord fits almost anything, and
+                // without this it "identifies" dense chromatic clusters as
+                // F5(b13,13) and the like. One extra still allows the real
+                // C5add#11 voicing. Bass-independent, so the same notes read
+                // the same way whichever one of them is lowest - previously a
+                // cluster was named or not purely according to its bass.
+                if (patternTones < 3 && extraNotes > 1)
+                    continue;
+
                 float score = static_cast<float>(pattern.priority);
 
                 // Bonus for bass note being the root
-                if (notes[0] % 12 == candidateRoot)
+                const bool isBass = (bassPitch == candidateRoot);
+                if (isBass)
                     score += 5.0f;
 
-                // Bonus for matching interval count closely
-                int extraNotes = static_cast<int>(intervals.size()) - static_cast<int>(pattern.intervals.size());
                 score -= static_cast<float>(extraNotes) * 0.5f;
 
-                if (score > bestScore || (score == bestScore && pattern.priority > bestPriority))
+                // Rank on score, then on the bass, then on pattern priority.
+                // The bass has to outrank priority: C E G A over a C bass is
+                // C6, and only the tie-break tells it from Am7's first
+                // inversion, which scores the same but is not in the bass.
+                const bool better = ! found
+                    || score > bestScore
+                    || (score == bestScore && isBass && ! bestIsBass)
+                    || (score == bestScore && isBass == bestIsBass
+                        && pattern.priority > bestPriority);
+
+                if (better)
                 {
+                    found = true;
+                    bestIsBass = isBass;
                     bestScore = score;
                     bestPriority = pattern.priority;
                     bestRoot = candidateRoot;
@@ -240,6 +274,14 @@ std::set<int> ChordAnalyzer::getIntervals(const std::vector<int>& notes, int roo
     }
 
     return intervals;
+}
+
+int ChordAnalyzer::countPitchClasses(std::uint16_t mask)
+{
+    int n = 0;
+    for (; mask != 0; mask &= static_cast<std::uint16_t>(mask - 1))
+        ++n;
+    return n;
 }
 
 std::uint16_t ChordAnalyzer::patternPitchClasses(const ChordPattern& pattern)
@@ -407,10 +449,7 @@ float ChordAnalyzer::calculateConfidence(const ChordPattern& pattern, const std:
             extraIntervals++;
     }
 
-    int coveredCount = 0;
-    for (int pc = 0; pc < 12; ++pc)
-        if ((covered & (1u << pc)) != 0)
-            ++coveredCount;
+    const int coveredCount = countPitchClasses(covered);
 
     const float patternMatch = static_cast<float>(matchedIntervals) / static_cast<float>(coveredCount);
     const float penalty = static_cast<float>(extraIntervals) * 0.1f;

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -70,10 +70,58 @@ ChordAnalyzer::ChordAnalyzer()
 }
 
 //==============================================================================
+ChordFacts ChordAnalyzer::analyzeFacts(const int* midiNotes, int numNotes) const noexcept
+{
+    ChordFacts facts;
+
+    if (midiNotes == nullptr || numNotes <= 0)
+        return facts;
+
+    // Fold to a pitch-class mask and find the lowest sounding note. Neither
+    // needs the notes sorted or copied.
+    std::uint16_t pitchMask = 0;
+    int lowest = midiNotes[0];
+
+    for (int i = 0; i < numNotes; ++i)
+    {
+        pitchMask = static_cast<std::uint16_t>(pitchMask | (1u << (((midiNotes[i] % 12) + 12) % 12)));
+        lowest = std::min(lowest, midiNotes[i]);
+    }
+
+    facts.bassNote = ((lowest % 12) + 12) % 12;
+
+    if (countPitchClasses(pitchMask) < 2)
+    {
+        // A single pitch class is a note, not a chord
+        facts.rootNote = facts.bassNote;
+        return facts;
+    }
+
+    facts.rootNote = findRoot(pitchMask, facts.bassNote);
+    facts.intervals = intervalsFrom(pitchMask, facts.rootNote);
+    facts.patternIndex = matchPattern(facts.intervals);
+
+    if (facts.patternIndex < 0)
+    {
+        facts.confidence = 0.3f;
+        return facts;
+    }
+
+    facts.quality = chordPatterns[static_cast<size_t>(facts.patternIndex)].quality;
+    facts.inversion = calculateInversion(facts.bassNote, facts.rootNote);
+    facts.slashBass = (facts.bassNote != facts.rootNote);
+    facts.confidence = calculateConfidence(facts.patternIndex, facts.intervals);
+    facts.isValid = true;
+
+    return facts;
+}
+
+//==============================================================================
 ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
 {
     ChordInfo result;
     result.midiNotes = midiNotes;
+    std::sort(result.midiNotes.begin(), result.midiNotes.end());
 
     if (midiNotes.empty())
     {
@@ -82,77 +130,47 @@ ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
         return result;
     }
 
+    const ChordFacts facts = analyzeFacts(midiNotes.data(), static_cast<int>(midiNotes.size()));
+
+    result.rootNote  = facts.rootNote;
+    result.bassNote  = facts.bassNote;
+    result.quality   = facts.quality;
+    result.inversion = facts.inversion;
+    result.slashBass = facts.slashBass;
+    result.confidence = facts.confidence;
+    result.isValid   = facts.isValid;
+
     if (midiNotes.size() == 1)
     {
         // Single note - just show the note name
         result.name = noteToName(midiNotes[0]);
         result.romanNumeral = "-";
-        result.rootNote = midiNotes[0] % 12;
-        result.bassNote = result.rootNote;
         return result;
     }
 
-    // Sort notes for consistent analysis
-    std::vector<int> sortedNotes = midiNotes;
-    std::sort(sortedNotes.begin(), sortedNotes.end());
-
-    // Get bass note
-    result.bassNote = sortedNotes[0] % 12;
-
-    // Find the root
-    result.rootNote = findRoot(sortedNotes);
-
-    if (result.rootNote < 0)
-    {
-        result.name = "?";
-        result.romanNumeral = "?";
-        return result;
-    }
-
-    // Get intervals from root
-    auto intervals = getIntervals(sortedNotes, result.rootNote);
-
-    // Match pattern
-    const ChordPattern* pattern = matchPattern(intervals);
-
-    if (pattern == nullptr)
+    if (facts.patternIndex < 0)
     {
         // No known chord shape fits these notes
         result.name = pitchClassToName(result.rootNote) + "?";
         result.romanNumeral = "?";
-        result.confidence = 0.3f;
         return result;
     }
-
-    result.quality = pattern->quality;
 
     // Build chord name. Any sounding tone the matched pattern does not account
     // for is spelled out instead of dropped, so C E G F# reads "Cadd#11" and
     // not "C" (issue #235).
     result.name = pitchClassToName(result.rootNote)
                 + qualityToSuffix(result.quality)
-                + describeAddedTones(*pattern, intervals);
-
-    // Calculate inversion
-    result.inversion = calculateInversion(sortedNotes, result.rootNote);
+                + describeAddedTones(facts.patternIndex, facts.intervals);
 
     // Slash notation for any bass note other than the root. This covers the
     // classic inversions and also an upper-structure bass such as the #11,
     // which calculateInversion cannot number but must still be shown.
-    result.slashBass = (result.bassNote != result.rootNote);
-
     if (result.slashBass)
-    {
         result.extensions = "/" + pitchClassToName(result.bassNote);
-    }
 
-    // Get Roman numeral and function
     result.romanNumeral = buildRomanNumeral(result.rootNote, result.quality);
     result.function = getHarmonicFunction(result.rootNote, result.quality);
-
-    // Calculate confidence
-    result.confidence = calculateConfidence(*pattern, intervals);
-    result.isValid = true;
 
     return result;
 }
@@ -170,113 +188,34 @@ juce::String ChordAnalyzer::getKeyName() const
 }
 
 //==============================================================================
-int ChordAnalyzer::findRoot(const std::vector<int>& notes) const
+std::vector<ChordAnalyzer::PatternMask> ChordAnalyzer::buildPatternMasks()
 {
-    if (notes.empty()) return -1;
+    std::vector<PatternMask> masks;
+    masks.reserve(chordPatterns.size());
 
-    // Get unique pitch classes
-    std::set<int> pitchClasses;
-    for (int note : notes)
-        pitchClasses.insert(note % 12);
-
-    std::vector<int> uniquePitches(pitchClasses.begin(), pitchClasses.end());
-
-    if (uniquePitches.size() < 2)
-        return uniquePitches[0];
-
-    // Try each note as potential root and score the result
-    const int bassPitch = notes[0] % 12;
-
-    int bestRoot = uniquePitches[0];
-    int bestPriority = -1;
-    float bestScore = 0.0f;
-    bool bestIsBass = false;
-    bool found = false;          // a match scoring <= 0 is still a match
-
-    for (int candidateRoot : uniquePitches)
+    for (const auto& pattern : chordPatterns)
     {
-        auto intervals = getIntervals(uniquePitches, candidateRoot);
+        PatternMask m { 0u, 0u, 0 };
 
-        // Try to match a pattern
-        for (const auto& pattern : chordPatterns)
+        for (int interval : pattern.intervals)
         {
-            // Check if intervals match pattern (allowing extra notes)
-            if (patternMatches(pattern, intervals))
-            {
-                // Penalty for sounding notes the pattern does not explain.
-                // Counted in pitch classes: getIntervals also states a 9th as
-                // 14, an 11th as 17 and a 13th as 21, and charging those
-                // restatements as extra notes penalised exactly the chords
-                // that have them. C E G A scored 19.5 as C6 but 20 as Am7,
-                // purely because the synthetic 21 made C6 look impure.
-                const int patternTones = countPitchClasses(patternPitchClasses(pattern));
-                const int extraNotes   = static_cast<int>(uniquePitches.size()) - patternTones;
-
-                // A shape smaller than a triad may carry at most one added
-                // tone. The two-note power chord fits almost anything, and
-                // without this it "identifies" dense chromatic clusters as
-                // F5(b13,13) and the like. One extra still allows the real
-                // C5add#11 voicing. Bass-independent, so the same notes read
-                // the same way whichever one of them is lowest - previously a
-                // cluster was named or not purely according to its bass.
-                if (patternTones < 3 && extraNotes > 1)
-                    continue;
-
-                float score = static_cast<float>(pattern.priority);
-
-                // Bonus for bass note being the root
-                const bool isBass = (bassPitch == candidateRoot);
-                if (isBass)
-                    score += 5.0f;
-
-                score -= static_cast<float>(extraNotes) * 0.5f;
-
-                // Rank on score, then on the bass, then on pattern priority.
-                // The bass has to outrank priority: C E G A over a C bass is
-                // C6, and only the tie-break tells it from Am7's first
-                // inversion, which scores the same but is not in the bass.
-                const bool better = ! found
-                    || score > bestScore
-                    || (score == bestScore && isBass && ! bestIsBass)
-                    || (score == bestScore && isBass == bestIsBass
-                        && pattern.priority > bestPriority);
-
-                if (better)
-                {
-                    found = true;
-                    bestIsBass = isBass;
-                    bestScore = score;
-                    bestPriority = pattern.priority;
-                    bestRoot = candidateRoot;
-                }
-            }
+            m.intervals |= (1u << interval);
+            m.pitches = static_cast<std::uint16_t>(m.pitches | (1u << (interval % 12)));
         }
+
+        m.pitchCount = countPitchClasses(m.pitches);
+        masks.push_back(m);
     }
 
-    return bestRoot;
+    return masks;
 }
 
-std::set<int> ChordAnalyzer::getIntervals(const std::vector<int>& notes, int root) const
-{
-    std::set<int> intervals;
-    intervals.insert(0);  // Root is always 0
+// Built once at static-init time, after chordPatterns, so no analysis call
+// ever has to allocate this table.
+const std::vector<ChordAnalyzer::PatternMask> ChordAnalyzer::kPatternMasks
+    = ChordAnalyzer::buildPatternMasks();
 
-    for (int note : notes)
-    {
-        int pitchClass = note % 12;
-        int interval = (pitchClass - root + 12) % 12;
-        intervals.insert(interval);
-
-        // Also add compound intervals for extended chords
-        if (interval == 2) intervals.insert(14);  // 9th
-        if (interval == 5) intervals.insert(17);  // 11th
-        if (interval == 9) intervals.insert(21);  // 13th
-    }
-
-    return intervals;
-}
-
-int ChordAnalyzer::countPitchClasses(std::uint16_t mask)
+int ChordAnalyzer::countPitchClasses(std::uint16_t mask) noexcept
 {
     int n = 0;
     for (; mask != 0; mask &= static_cast<std::uint16_t>(mask - 1))
@@ -284,60 +223,151 @@ int ChordAnalyzer::countPitchClasses(std::uint16_t mask)
     return n;
 }
 
-std::uint16_t ChordAnalyzer::patternPitchClasses(const ChordPattern& pattern)
+std::uint32_t ChordAnalyzer::intervalsFrom(std::uint16_t pitchMask, int root) noexcept
 {
-    // Patterns state extensions in compound form (a 9th as 14), while a played
-    // voicing is compared as pitch classes. Reduce once, here, so the matcher,
-    // the tension naming and the confidence score cannot drift apart. Returned
-    // as a bit mask rather than a set: this runs per analysed chord, and the
-    // headless LV2 build calls analyze() straight from its audio callback.
-    std::uint16_t covered = 0;
+    std::uint32_t intervals = 1u;   // the root is always interval 0
 
-    for (int interval : pattern.intervals)
-        covered |= static_cast<std::uint16_t>(1u << (interval % 12));
+    for (int pc = 0; pc < 12; ++pc)
+    {
+        if ((pitchMask & (1u << pc)) == 0)
+            continue;
 
-    return covered;
+        const int interval = ((pc - root) + 12) % 12;
+        intervals |= (1u << interval);
+
+        // Also state compound intervals, so the extended patterns can match
+        if (interval == 2) intervals |= (1u << 14);   // 9th
+        if (interval == 5) intervals |= (1u << 17);   // 11th
+        if (interval == 9) intervals |= (1u << 21);   // 13th
+    }
+
+    return intervals;
 }
 
-bool ChordAnalyzer::patternMatches(const ChordPattern& pattern, const std::set<int>& intervals)
+bool ChordAnalyzer::patternMatches(int patternIndex, std::uint32_t intervals) noexcept
 {
+    const PatternMask& m = kPatternMasks[static_cast<size_t>(patternIndex)];
+
     // Every tone the pattern requires must be sounding (extra notes allowed)
-    for (int interval : pattern.intervals)
-    {
-        if (intervals.find(interval) == intervals.end())
-            return false;
-    }
+    if ((intervals & m.intervals) != m.intervals)
+        return false;
 
     // A b5 or #5 spelling *replaces* the fifth, so it cannot describe a chord
     // that also sounds a perfect fifth - there the altered tone is a #11 or a
     // b13. Without this, C E G Bb F# matched C7b5 and the natural fifth was
     // thrown away.
-    if (intervals.count(7) > 0 && pattern.intervals.count(7) == 0
-        && (pattern.intervals.count(6) > 0 || pattern.intervals.count(8) > 0))
+    const bool soundsFifth  = (intervals   & (1u << 7)) != 0;
+    const bool patternFifth = (m.intervals & (1u << 7)) != 0;
+    const bool patternAltFifth = (m.intervals & ((1u << 6) | (1u << 8))) != 0;
+
+    if (soundsFifth && ! patternFifth && patternAltFifth)
         return false;
 
     return true;
 }
 
-const ChordAnalyzer::ChordPattern* ChordAnalyzer::matchPattern(const std::set<int>& intervals) const
+int ChordAnalyzer::findRoot(std::uint16_t pitchMask, int bassPitch) noexcept
 {
-    const ChordPattern* best = nullptr;
+    const int soundingTones = countPitchClasses(pitchMask);
+    int lowestPitch = 0;
+    while (lowestPitch < 12 && (pitchMask & (1u << lowestPitch)) == 0)
+        ++lowestPitch;
 
-    for (const auto& pattern : chordPatterns)
+    if (soundingTones < 2)
+        return lowestPitch;
+
+    // Try each note as potential root and score the result
+    int bestRoot = lowestPitch;
+    int bestPriority = -1;
+    float bestScore = 0.0f;
+    bool bestIsBass = false;
+    bool found = false;          // a match scoring <= 0 is still a match
+
+    for (int candidateRoot = 0; candidateRoot < 12; ++candidateRoot)
     {
-        if (! patternMatches(pattern, intervals))
+        if ((pitchMask & (1u << candidateRoot)) == 0)
+            continue;
+
+        const std::uint32_t intervals = intervalsFrom(pitchMask, candidateRoot);
+
+        // Try to match a pattern
+        for (size_t i = 0; i < chordPatterns.size(); ++i)
+        {
+            // Check if intervals match pattern (allowing extra notes)
+            if (! patternMatches(static_cast<int>(i), intervals))
+                continue;
+
+            // Penalty for sounding notes the pattern does not explain.
+            // Counted in pitch classes: intervalsFrom also states a 9th as
+            // 14, an 11th as 17 and a 13th as 21, and charging those
+            // restatements as extra notes penalised exactly the chords
+            // that have them. C E G A scored 19.5 as C6 but 20 as Am7,
+            // purely because the synthetic 21 made C6 look impure.
+            const int patternTones = kPatternMasks[i].pitchCount;
+            const int extraNotes   = soundingTones - patternTones;
+
+            // A shape smaller than a triad may carry at most one added
+            // tone. The two-note power chord fits almost anything, and
+            // without this it "identifies" dense chromatic clusters as
+            // F5(b13,13) and the like. One extra still allows the real
+            // C5add#11 voicing. Bass-independent, so the same notes read
+            // the same way whichever one of them is lowest - previously a
+            // cluster was named or not purely according to its bass.
+            if (patternTones < 3 && extraNotes > 1)
+                continue;
+
+            const int priority = chordPatterns[i].priority;
+            float score = static_cast<float>(priority);
+
+            // Bonus for bass note being the root
+            const bool isBass = (bassPitch == candidateRoot);
+            if (isBass)
+                score += 5.0f;
+
+            score -= static_cast<float>(extraNotes) * 0.5f;
+
+            // Rank on score, then on the bass, then on pattern priority.
+            // The bass has to outrank priority: C E G A over a C bass is
+            // C6, and only the tie-break tells it from Am7's first
+            // inversion, which scores the same but is not in the bass.
+            const bool better = ! found
+                || score > bestScore
+                || (score == bestScore && isBass && ! bestIsBass)
+                || (score == bestScore && isBass == bestIsBass && priority > bestPriority);
+
+            if (better)
+            {
+                found = true;
+                bestIsBass = isBass;
+                bestScore = score;
+                bestPriority = priority;
+                bestRoot = candidateRoot;
+            }
+        }
+    }
+
+    return bestRoot;
+}
+
+int ChordAnalyzer::matchPattern(std::uint32_t intervals) noexcept
+{
+    int best = -1;
+
+    for (size_t i = 0; i < chordPatterns.size(); ++i)
+    {
+        if (! patternMatches(static_cast<int>(i), intervals))
             continue;
 
         // Prefer patterns that match more notes (more specific)
         // But also consider priority. A pattern that ties on both keeps the
         // incumbent, so an exact tie resolves to whichever is declared first
         // in chordPatterns - see the ordering contract on that table.
-        if (best == nullptr
-            || pattern.priority > best->priority
-            || (pattern.priority == best->priority
-                && pattern.intervals.size() > best->intervals.size()))
+        if (best < 0
+            || chordPatterns[i].priority > chordPatterns[static_cast<size_t>(best)].priority
+            || (chordPatterns[i].priority == chordPatterns[static_cast<size_t>(best)].priority
+                && chordPatterns[i].intervals.size() > chordPatterns[static_cast<size_t>(best)].intervals.size()))
         {
-            best = &pattern;
+            best = static_cast<int>(i);
         }
     }
 
@@ -366,21 +396,20 @@ const char* ChordAnalyzer::tensionLabel(int semitonesFromRoot)
     }
 }
 
-juce::String ChordAnalyzer::describeAddedTones(const ChordPattern& pattern,
-                                               const std::set<int>& intervals)
+juce::String ChordAnalyzer::describeAddedTones(int patternIndex, std::uint32_t intervals)
 {
-    // Compare as pitch classes: getIntervals states a 9th as both 2 and 14, and
-    // the patterns use the compound form, so a raw set difference would report
+    // Compare as pitch classes: intervalsFrom states a 9th as both 2 and 14,
+    // and the patterns use the compound form, so a raw difference would report
     // every add9/add11/13 chord tone as an extra note.
-    const std::uint16_t covered = patternPitchClasses(pattern);
+    const PatternMask& m = kPatternMasks[static_cast<size_t>(patternIndex)];
 
     // At most one extra per pitch class, so a fixed array suffices.
     const char* extras[12];
     int numExtras = 0;
 
-    for (int interval : intervals)
+    for (int interval = 0; interval < 12; ++interval)
     {
-        if (interval >= 12 || (covered & (1u << interval)) != 0)
+        if ((intervals & (1u << interval)) == 0 || (m.pitches & (1u << interval)) != 0)
             continue;
 
         if (const char* label = tensionLabel(interval))
@@ -392,7 +421,7 @@ juce::String ChordAnalyzer::describeAddedTones(const ChordPattern& pattern,
 
     // A triad carrying one extra tone reads as an add chord ("Cadd#11");
     // anything richer takes parenthesised tensions ("C7(#11)", "C9(b13)").
-    if (numExtras == 1 && pattern.intervals.size() <= 3)
+    if (numExtras == 1 && chordPatterns[static_cast<size_t>(patternIndex)].intervals.size() <= 3)
         return juce::String("add") + extras[0];
 
     juce::String text("(");
@@ -407,19 +436,12 @@ juce::String ChordAnalyzer::describeAddedTones(const ChordPattern& pattern,
     return text;
 }
 
-int ChordAnalyzer::calculateInversion(const std::vector<int>& notes, int root) const
+int ChordAnalyzer::calculateInversion(int bassPitch, int root) noexcept
 {
-    if (notes.empty()) return 0;
+    if (bassPitch == root)
+        return 0;
 
-    int bassNote = notes[0] % 12;
-    if (bassNote == root) return 0;
-
-    // Find which chord tone is in the bass
-    std::set<int> intervals;
-    for (int note : notes)
-        intervals.insert((note % 12 - root + 12) % 12);
-
-    int bassInterval = (bassNote - root + 12) % 12;
+    const int bassInterval = ((bassPitch - root) + 12) % 12;
 
     if (bassInterval == 3 || bassInterval == 4) return 1;  // Third in bass
     if (bassInterval == 7) return 2;  // Fifth in bass
@@ -428,30 +450,28 @@ int ChordAnalyzer::calculateInversion(const std::vector<int>& notes, int root) c
     return 0;
 }
 
-float ChordAnalyzer::calculateConfidence(const ChordPattern& pattern, const std::set<int>& intervals)
+float ChordAnalyzer::calculateConfidence(int patternIndex, std::uint32_t intervals) noexcept
 {
     // Score against the pattern that actually matched. Comparing in pitch
     // classes keeps a compound pattern tone (9th written as 14) from counting
     // its own chord tone as an extra note.
-    const std::uint16_t covered = patternPitchClasses(pattern);
+    const PatternMask& m = kPatternMasks[static_cast<size_t>(patternIndex)];
 
     int matchedIntervals = 0;
     int extraIntervals = 0;
 
-    for (int interval : intervals)
+    for (int interval = 0; interval < 12; ++interval)
     {
-        if (interval >= 12)  // Compound restatement of a tone already counted
+        if ((intervals & (1u << interval)) == 0)
             continue;
 
-        if ((covered & (1u << interval)) != 0)
+        if ((m.pitches & (1u << interval)) != 0)
             matchedIntervals++;
         else if (interval != 0)
             extraIntervals++;
     }
 
-    const int coveredCount = countPitchClasses(covered);
-
-    const float patternMatch = static_cast<float>(matchedIntervals) / static_cast<float>(coveredCount);
+    const float patternMatch = static_cast<float>(matchedIntervals) / static_cast<float>(m.pitchCount);
     const float penalty = static_cast<float>(extraIntervals) * 0.1f;
 
     return juce::jlimit(0.0f, 1.0f, patternMatch - penalty);

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.h
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.h
@@ -69,6 +69,30 @@ enum class SuggestionCategory
 };
 
 //==============================================================================
+// Numeric analysis result: no strings, no heap, safe to compute on an audio
+// thread. The headless LV2 wrapper publishes only these fields.
+struct ChordFacts
+{
+    int rootNote = -1;              // Root pitch class (0-11, C=0)
+    int bassNote = -1;              // Lowest note pitch class
+    ChordQuality quality = ChordQuality::Unknown;
+    int inversion = 0;              // 0=root, 1=first, 2=second, 3=seventh
+    bool slashBass = false;         // Bass is not the root
+    bool isValid = false;
+    float confidence = 0.0f;
+    int patternIndex = -1;          // matched entry, -1 when nothing fitted
+    std::uint32_t intervals = 0;    // interval bit mask from the root
+
+    bool operator==(const ChordFacts& o) const
+    {
+        return rootNote == o.rootNote && bassNote == o.bassNote
+            && quality == o.quality && inversion == o.inversion
+            && isValid == o.isValid;
+    }
+    bool operator!=(const ChordFacts& o) const { return !(*this == o); }
+};
+
+//==============================================================================
 // Chord information structure
 struct ChordInfo
 {
@@ -122,6 +146,11 @@ public:
     // Main analysis function
     ChordInfo analyze(const std::vector<int>& midiNotes);
 
+    // Numeric-only analysis. Allocates nothing and builds no strings, so it is
+    // safe to call from an audio callback - the headless LV2 wrapper does.
+    // analyze() is this plus the display strings.
+    ChordFacts analyzeFacts(const int* midiNotes, int numNotes) const noexcept;
+
     //==========================================================================
     // Key context
     void setKey(int rootNote, bool isMinor);
@@ -167,24 +196,33 @@ private:
     static const std::vector<ChordPattern> chordPatterns;
 
     //==========================================================================
-    // Analysis helpers
-    int findRoot(const std::vector<int>& notes) const;
-    std::set<int> getIntervals(const std::vector<int>& notes, int root) const;
-    static bool patternMatches(const ChordPattern& pattern, const std::set<int>& intervals);
+    // Each pattern reduced to bit masks once, at static-init time, so analysis
+    // touches no heap container. Interval masks carry bits 0-21 (the compound
+    // 14, 17 and 21 included); pitch masks are folded to 12 bits.
+    struct PatternMask
+    {
+        std::uint32_t intervals;
+        std::uint16_t pitches;
+        int           pitchCount;
+    };
 
-    // Pitch classes a pattern covers, as a 12-bit mask (bit n = pitch class n).
-    // analyze() runs on the audio thread in the headless LV2 build, so the
-    // hot helpers below stay free of heap containers.
-    static std::uint16_t patternPitchClasses(const ChordPattern& pattern);
-    static int countPitchClasses(std::uint16_t mask);
-    const ChordPattern* matchPattern(const std::set<int>& intervals) const;
-    int calculateInversion(const std::vector<int>& notes, int root) const;
-    static float calculateConfidence(const ChordPattern& pattern, const std::set<int>& intervals);
+    static const std::vector<PatternMask> kPatternMasks;
+    static std::vector<PatternMask> buildPatternMasks();
+
+    //==========================================================================
+    // Analysis helpers. All operate on masks and allocate nothing.
+    static int findRoot(std::uint16_t pitchMask, int bassPitch) noexcept;
+    static std::uint32_t intervalsFrom(std::uint16_t pitchMask, int root) noexcept;
+    static bool patternMatches(int patternIndex, std::uint32_t intervals) noexcept;
+    static int countPitchClasses(std::uint16_t mask) noexcept;
+    static int matchPattern(std::uint32_t intervals) noexcept;   // -1 if none
+    static int calculateInversion(int bassPitch, int root) noexcept;
+    static float calculateConfidence(int patternIndex, std::uint32_t intervals) noexcept;
 
     //==========================================================================
     // Naming of tones the matched pattern does not account for
     static const char* tensionLabel(int semitonesFromRoot);   // nullptr if none
-    static juce::String describeAddedTones(const ChordPattern& pattern, const std::set<int>& intervals);
+    static juce::String describeAddedTones(int patternIndex, std::uint32_t intervals);
 
     //==========================================================================
     // Roman numeral helpers

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.h
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.h
@@ -176,6 +176,7 @@ private:
     // analyze() runs on the audio thread in the headless LV2 build, so the
     // hot helpers below stay free of heap containers.
     static std::uint16_t patternPitchClasses(const ChordPattern& pattern);
+    static int countPitchClasses(std::uint16_t mask);
     const ChordPattern* matchPattern(const std::set<int>& intervals) const;
     int calculateInversion(const std::vector<int>& notes, int root) const;
     static float calculateConfidence(const ChordPattern& pattern, const std::set<int>& intervals);

--- a/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
@@ -66,14 +66,14 @@ struct ChordAnalyzerLV2
 
     ChordAnalyzer    analyzer;
     std::vector<int> activeNotes;
-    ChordInfo        currentChord;
+    ChordFacts       currentChord;
 
     // Sustain pedal (CC 64) state — single audio thread, no synchronisation needed.
     bool             sustainPedalDown = false;
     std::vector<int> sustainedReleasedNotes;  // notes released while pedal was down
 };
 
-void publishDetectedChord (ChordAnalyzerLV2& self, const ChordInfo& chord)
+void publishDetectedChord (ChordAnalyzerLV2& self, const ChordFacts& chord)
 {
     // Choice index 0 == "no chord / unknown". Indices 1..N follow the same
     // order used by the JUCE-built variant for cross-format consistency.
@@ -246,7 +246,12 @@ void run (LV2_Handle instance, uint32_t /*nSamples*/)
     if (! notesChanged)
         return;
 
-    const ChordInfo newChord = self->analyzer.analyze (self->activeNotes);
+    // analyzeFacts rather than analyze: run() is the audio thread and this
+    // plugin declares lv2:hardRTCapable. The numeric form allocates nothing,
+    // and the display strings analyze() would build are unused here - only
+    // the four detection control ports are published.
+    const ChordFacts newChord = self->analyzer.analyzeFacts (self->activeNotes.data(),
+                                                             static_cast<int> (self->activeNotes.size()));
     if (newChord != self->currentChord)
     {
         self->currentChord = newChord;

--- a/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
+++ b/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
@@ -419,6 +419,49 @@ static void testBassIdentity()
 }
 
 // =====================================================================
+// 9d. Root choice: the bass decides an ambiguous spelling
+//
+// C E G A is both C6 and Am7. findRoot gives the bass a bonus, but the
+// tie-break then preferred the higher pattern priority, so m7 always beat
+// 6 and every root-position 6th chord came out as a 7th chord instead.
+// =====================================================================
+static void testSixthChords()
+{
+    std::cout << "\n--- Sixth Chords / Root Choice ---\n";
+    ChordAnalyzer a;
+
+    check("C E G A over C = C6",     analyzeNotes(a, {60, 64, 67, 69}).name == "C6");
+    check("C Eb G A over C = Cm6",   analyzeNotes(a, {60, 63, 67, 69}).name == "Cm6");
+
+    // The same pitch classes over their other root still read as the 7th chord
+    auto am7 = analyzeNotes(a, {57, 60, 64, 67});
+    check("A C E G over A = Am7",    am7.name == "Am7" && !am7.slashBass);
+    auto am7b5 = analyzeNotes(a, {57, 60, 63, 67});
+    check("A C Eb G over A = Am7b5", am7b5.name == "Am7b5");
+
+    // Every root, both qualities
+    bool allRoots = true;
+    for (int r = 0; r < 12; ++r)
+    {
+        const juce::String root = ChordAnalyzer::pitchClassToName(r);
+        if (analyzeNotes(a, {60 + r, 64 + r, 67 + r, 69 + r}).name != root + "6")  allRoots = false;
+        if (analyzeNotes(a, {60 + r, 63 + r, 67 + r, 69 + r}).name != root + "m6") allRoots = false;
+    }
+    check("all 12 roots, major and minor 6ths", allRoots);
+
+    // A sub-triad shape must not absorb a cluster, and must not depend on the
+    // bass for whether it names anything at all
+    auto cluster     = analyzeNotes(a, {60, 61, 62, 65});   // C C# D F
+    auto clusterAlt  = analyzeNotes(a, {65, 72, 73, 74});   // same notes, F in the bass
+    check("cluster is not a power chord", !cluster.isValid && !clusterAlt.isValid);
+    check("cluster reading is bass-independent", cluster.quality == clusterAlt.quality);
+
+    // ...but a power chord with a single added tone is still named
+    check("C G F# = C5add#11", analyzeNotes(a, {60, 66, 67}).name == "C5add#11");
+    check("C G = C5",          analyzeNotes(a, {60, 67}).name == "C5");
+}
+
+// =====================================================================
 // 10. Static utility functions
 // =====================================================================
 static void testUtilities()
@@ -449,6 +492,7 @@ int main()
     testConfidence();
     testAddedTones();
     testBassIdentity();
+    testSixthChords();
     testUtilities();
 
     std::cout << "\n=== Results: " << passed << " passed, " << failed << " failed ===\n";

--- a/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
+++ b/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
@@ -462,6 +462,58 @@ static void testSixthChords()
 }
 
 // =====================================================================
+// 9e. analyzeFacts is the real-time path
+//
+// The headless LV2 wrapper calls analyzeFacts from run(), which is the
+// audio thread, and the plugin declares lv2:hardRTCapable. It must agree
+// with analyze() on every field that wrapper publishes.
+// =====================================================================
+static void testAnalyzeFacts()
+{
+    std::cout << "\n--- analyzeFacts (real-time path) ---\n";
+    ChordAnalyzer a;
+
+    int checked = 0, mismatches = 0;
+
+    for (int mask = 0; mask < 4096; ++mask)
+    {
+        std::vector<int> pcs;
+        for (int i = 0; i < 12; ++i)
+            if (mask & (1 << i))
+                pcs.push_back(i);
+
+        if (pcs.empty())
+            continue;
+
+        // every rotation, so the bass varies too
+        for (size_t rot = 0; rot < pcs.size(); ++rot)
+        {
+            std::vector<int> notes;
+            for (size_t i = 0; i < pcs.size(); ++i)
+                notes.push_back((i < rot ? 72 : 60) + pcs[i]);
+            std::sort(notes.begin(), notes.end());
+
+            const ChordInfo  full = a.analyze(notes);
+            const ChordFacts fast = a.analyzeFacts(notes.data(), (int) notes.size());
+            ++checked;
+
+            if (full.isValid   != fast.isValid   || full.rootNote  != fast.rootNote
+             || full.bassNote  != fast.bassNote  || full.quality   != fast.quality
+             || full.inversion != fast.inversion || full.slashBass != fast.slashBass)
+                ++mismatches;
+        }
+    }
+
+    std::cout << "       (" << checked << " voicings compared)\n";
+    check("analyzeFacts agrees with analyze", mismatches == 0);
+
+    // Degenerate inputs must not reach into the note pointer
+    check("null notes are safe",  !a.analyzeFacts(nullptr, 0).isValid);
+    const int one = 60;
+    check("single note is not a chord", !a.analyzeFacts(&one, 1).isValid);
+}
+
+// =====================================================================
 // 10. Static utility functions
 // =====================================================================
 static void testUtilities()
@@ -493,6 +545,7 @@ int main()
     testAddedTones();
     testBassIdentity();
     testSixthChords();
+    testAnalyzeFacts();
     testUtilities();
 
     std::cout << "\n=== Results: " << passed << " passed, " << failed << " failed ===\n";


### PR DESCRIPTION
Two defects found by the exhaustive validation pass over PR #236, both pre-existing and neither introduced there.

## The bass now decides an ambiguous root

`C E G A` is both `C6` and `Am7` in first inversion. `findRoot` already gave the bass a +5 bonus to settle exactly this, but two separate defects discarded the result, so **all 24 root-position 6th chords were named as 7th chords**: `C6` came out as `Am7/C`, `Cm6` as `Am7b5/C`. The `Major6` and `Minor6` patterns could never win and were dead entries in the table.

- The extra-note penalty counted raw intervals. `getIntervals` also states a 9th as 14, an 11th as 17 and a 13th as 21, so a chord containing one was charged for the restatement: `C E G A` scored 19.5 as `C6` against 20 as `Am7` purely because of the synthetic 21. Now counted in pitch classes, which is what the penalty always meant.
- The tie-break preferred the higher pattern priority, letting m7 (20) beat 6 (15) after the bass bonus had equalised the scores. The bass now outranks priority; priority only separates two candidates that are both, or neither, in the bass.

Two further `findRoot` defects fell out of testing that:

- `bestScore` started at `0.0f`, so a match scoring zero or less was silently dropped and the analyzer fell back to "lowest pitch class + `?`". Whether that happened depended on the bass bonus, so the same four notes were named or unnamed according to which one was lowest.
- With that fixed, the two-note power chord (which fits almost anything) began naming dense chromatic clusters as `F5(b13,13)`. A shape smaller than a triad may now carry at most one added tone, which still allows the real `C5add#11` voicing and is bass-independent.

## The LV2 audio-thread path allocates nothing

`chord-analyzer-headless.ttl` declares `lv2:hardRTCapable`, but `run()` called `analyze()` directly on the audio thread, allocating 21 to 87 times per chord change: a `std::set` of intervals for each of up to twelve candidate roots, a sorted copy of the notes, another set in `calculateInversion` that was built and never read, and three `juce::String` members on every `ChordInfo`.

The wrapper never needed the strings, publishing four numeric control ports. Analysis is now split into `analyzeFacts()`, which computes only those numbers using bit masks and no heap container, and `analyze()`, which is `analyzeFacts` plus the display strings for the message-thread consumers.

```
chord             analyzeFacts()   analyze()   (was)
C major                 0              2        21
Cmaj7                   0              5        34
Cadd#11                 0              5        34
C13 (7 notes)           0              4        87
12-note cluster         0             11         -
```

## Verification

- **97 tests pass, 0 fail** (was 85 on main), including the 24576-voicing `analyzeFacts`/`analyze` equivalence as a test rather than a one-off check.
- A curated table of **55 real-world chords matches in full** (was 54/55 on main, the miss being `Cm6`).
- An independent oracle that parses each name back into pitch classes reports **zero dropped notes, zero phantom notes, zero root and zero slash errors** across all 4083 pitch-class sets.
- The root-choice change alters 1327 of 24564 readings, of which 446 are chromatic clusters that correctly stop being named as power chords. **No note set containing a real triad lost its name.**
- The allocation refactor is byte-identical to the commit before it across all 24564 readings.
- All six formats build; pluginval clean at strictness 1, 5, 7 and 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chord recognition across a wider range of note combinations, including sixth chords and added tones.
  * More accurate root, inversion, bass-note, slash-chord, and confidence detection.
  * Added reliable handling for single notes, unfamiliar chord shapes, and ambiguous voicings.
* **Performance**
  * Faster, allocation-free analysis supports smoother real-time chord detection.
* **Bug Fixes**
  * Prevented sixth chords from being incorrectly identified as seventh chords.
  * Improved recognition of power chords and reduced incorrect interpretations of small note clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->