### PR TITLE
Chord Analyzer: name voicings without the fifth, and two-note intervals

### DIFF
--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -62,6 +62,25 @@ const std::vector<ChordAnalyzer::ChordPattern> ChordAnalyzer::chordPatterns = {
     // Simplified extended chords (without all tensions)
     {{0, 4, 7, 10, 21}, ChordQuality::Dominant13, "13", 28},  // 13 without 9/11
     {{0, 4, 7, 10, 17}, ChordQuality::Dominant11, "11", 28},  // 11 without 9
+
+    // Voicings that drop the fifth. Standard practice on guitar and piano -
+    // the fifth adds no colour, so it is the first tone to go - and the shell
+    // voicing (root, third, seventh) is the backbone of jazz comping.
+    //
+    // These sit BELOW every pattern that contains a fifth, not just below
+    // their own full counterparts. findRoot compares priorities across
+    // candidate roots, so a high-priority incomplete shape wins at the wrong
+    // root: at 28, maj9(no5) rooted on Ab beat a plain C7 rooted on the bass
+    // and C E G Ab Bb came out as G#maj9(no5,b13)/C. Ranked here only against
+    // each other, they win when, and only when, no fifth is sounding.
+    {{0, 4, 14},         ChordQuality::Add9,        "add9",   3, true},
+    {{0, 4, 10},         ChordQuality::Dominant7,   "7",      5, true},
+    {{0, 4, 11},         ChordQuality::Major7,      "maj7",   5, true},
+    {{0, 3, 10},         ChordQuality::Minor7,      "m7",     5, true},
+    {{0, 3, 11},         ChordQuality::MinorMajor7, "mMaj7",  5, true},
+    {{0, 4, 10, 14},     ChordQuality::Dominant9,   "9",      7, true},
+    {{0, 4, 11, 14},     ChordQuality::Major9,      "maj9",   7, true},
+    {{0, 3, 10, 14},     ChordQuality::Minor9,      "m9",     7, true},
 };
 
 //==============================================================================
@@ -150,6 +169,31 @@ ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
 
     if (facts.patternIndex < 0)
     {
+        // Two notes are an interval, not a chord, so name the interval rather
+        // than giving up with "C?". The dyads that do imply a chord, the
+        // fourth and the fifth, match a pattern above and never reach here.
+        std::uint16_t pitchMask = 0;
+        for (int note : midiNotes)
+            pitchMask = static_cast<std::uint16_t>(pitchMask | (1u << (((note % 12) + 12) % 12)));
+
+        if (countPitchClasses(pitchMask) == 2)
+        {
+            int upper = result.bassNote;
+            for (int pc = 0; pc < 12; ++pc)
+            {
+                if (pc != result.bassNote && (pitchMask & (1u << pc)) != 0)
+                {
+                    upper = pc;
+                    break;
+                }
+            }
+
+            result.name = pitchClassToName(result.bassNote) + "+" + pitchClassToName(upper)
+                        + " (" + intervalName(((upper - result.bassNote) + 12) % 12) + ")";
+            result.romanNumeral = "-";
+            return result;
+        }
+
         // No known chord shape fits these notes
         result.name = pitchClassToName(result.rootNote) + "?";
         result.romanNumeral = "?";
@@ -396,6 +440,25 @@ const char* ChordAnalyzer::tensionLabel(int semitonesFromRoot)
     }
 }
 
+const char* ChordAnalyzer::intervalName(int semitones)
+{
+    switch (((semitones % 12) + 12) % 12)
+    {
+        case 0:  return "octave";
+        case 1:  return "m2";
+        case 2:  return "M2";
+        case 3:  return "m3";
+        case 4:  return "M3";
+        case 5:  return "P4";
+        case 6:  return "tritone";
+        case 7:  return "P5";
+        case 8:  return "m6";
+        case 9:  return "M6";
+        case 10: return "m7";
+        default: return "M7";
+    }
+}
+
 juce::String ChordAnalyzer::describeAddedTones(int patternIndex, std::uint32_t intervals)
 {
     // Compare as pitch classes: intervalsFrom states a 9th as both 2 and 14,
@@ -403,9 +466,15 @@ juce::String ChordAnalyzer::describeAddedTones(int patternIndex, std::uint32_t i
     // every add9/add11/13 chord tone as an extra note.
     const PatternMask& m = kPatternMasks[static_cast<size_t>(patternIndex)];
 
-    // At most one extra per pitch class, so a fixed array suffices.
-    const char* extras[12];
+    // At most one extra per pitch class, plus the "no5" marker.
+    const char* extras[13];
     int numExtras = 0;
+
+    // Announce a missing fifth first, so it reads C9(no5,#11) rather than
+    // splitting the parenthesis into two groups.
+    const bool omitsFifth = chordPatterns[static_cast<size_t>(patternIndex)].omitsFifth;
+    if (omitsFifth)
+        extras[numExtras++] = "no5";
 
     for (int interval = 0; interval < 12; ++interval)
     {
@@ -421,7 +490,9 @@ juce::String ChordAnalyzer::describeAddedTones(int patternIndex, std::uint32_t i
 
     // A triad carrying one extra tone reads as an add chord ("Cadd#11");
     // anything richer takes parenthesised tensions ("C7(#11)", "C9(b13)").
-    if (numExtras == 1 && chordPatterns[static_cast<size_t>(patternIndex)].intervals.size() <= 3)
+    // An absent fifth is never an "add", so those always take the parens.
+    if (! omitsFifth && numExtras == 1
+        && chordPatterns[static_cast<size_t>(patternIndex)].intervals.size() <= 3)
         return juce::String("add") + extras[0];
 
     juce::String text("(");

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.h
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.h
@@ -191,6 +191,12 @@ private:
         ChordQuality quality;
         juce::String suffix;
         int priority;               // Higher = preferred match
+
+        // Set on the shapes that deliberately leave the fifth out. The fifth
+        // is the most disposable chord tone, so these voicings are everywhere
+        // in practice, but the name has to say the fifth is absent or it would
+        // claim a note that is not sounding.
+        bool omitsFifth = false;
     };
 
     static const std::vector<ChordPattern> chordPatterns;
@@ -222,6 +228,7 @@ private:
     //==========================================================================
     // Naming of tones the matched pattern does not account for
     static const char* tensionLabel(int semitonesFromRoot);   // nullptr if none
+    static const char* intervalName(int semitones);           // "M3", "tritone", ...
     static juce::String describeAddedTones(int patternIndex, std::uint32_t intervals);
 
     //==========================================================================

--- a/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
+++ b/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
@@ -449,12 +449,30 @@ static void testSixthChords()
     }
     check("all 12 roots, major and minor 6ths", allRoots);
 
-    // A sub-triad shape must not absorb a cluster, and must not depend on the
-    // bass for whether it names anything at all
-    auto cluster     = analyzeNotes(a, {60, 61, 62, 65});   // C C# D F
-    auto clusterAlt  = analyzeNotes(a, {65, 72, 73, 74});   // same notes, F in the bass
-    check("cluster is not a power chord", !cluster.isValid && !clusterAlt.isValid);
-    check("cluster reading is bass-independent", cluster.quality == clusterAlt.quality);
+    // A two-note shape must never absorb a cluster, and whether a set can be
+    // named at all must not depend on which of its notes is lowest. Which
+    // root wins may legitimately change with the bass - that is the rule
+    // above - so only namability and the power-chord exclusion are asserted.
+    const int clusterPcs[4] = { 0, 1, 2, 5 };   // C C# D F
+    bool anyPowerChord = false;
+    bool allSameValidity = true;
+    bool firstValid = false;
+
+    for (int rot = 0; rot < 4; ++rot)
+    {
+        std::vector<int> notes;
+        for (int i = 0; i < 4; ++i)
+            notes.push_back((i < rot ? 72 : 60) + clusterPcs[i]);
+        std::sort(notes.begin(), notes.end());
+
+        const auto c = a.analyze(notes);
+        if (rot == 0) firstValid = c.isValid;
+        if (c.isValid != firstValid) allSameValidity = false;
+        if (c.quality == ChordQuality::Power5) anyPowerChord = true;
+    }
+
+    check("cluster is never a power chord", !anyPowerChord);
+    check("cluster namability is bass-independent", allSameValidity);
 
     // ...but a power chord with a single added tone is still named
     check("C G F# = C5add#11", analyzeNotes(a, {60, 66, 67}).name == "C5add#11");
@@ -514,6 +532,62 @@ static void testAnalyzeFacts()
 }
 
 // =====================================================================
+// 9f. Voicings without the fifth, and two-note intervals
+//
+// Every pattern used to require the perfect fifth, so the shell voicings
+// that are standard on guitar and piano either went unnamed (C E Bb) or
+// were read as nonsense (C E B came out as "E5addb13/C").
+// =====================================================================
+static void testNoFifthAndDyads()
+{
+    std::cout << "\n--- No-Fifth Voicings / Dyads ---\n";
+    ChordAnalyzer a;
+
+    // Shells: root, third, seventh
+    check("C E Bb = C7(no5)",       analyzeNotes(a, {60, 64, 70}).name == "C7(no5)");
+    check("C E B = Cmaj7(no5)",     analyzeNotes(a, {60, 64, 71}).name == "Cmaj7(no5)");
+    check("C Eb Bb = Cm7(no5)",     analyzeNotes(a, {60, 63, 70}).name == "Cm7(no5)");
+    check("C Eb B = CmMaj7(no5)",   analyzeNotes(a, {60, 63, 71}).name == "CmMaj7(no5)");
+    check("C E D = Cadd9(no5)",     analyzeNotes(a, {60, 64, 74}).name == "Cadd9(no5)");
+
+    // ...and the same with the ninth
+    check("C E Bb D = C9(no5)",     analyzeNotes(a, {60, 64, 70, 74}).name == "C9(no5)");
+    check("C E B D = Cmaj9(no5)",   analyzeNotes(a, {60, 64, 71, 74}).name == "Cmaj9(no5)");
+    check("C Eb Bb D = Cm9(no5)",   analyzeNotes(a, {60, 63, 70, 74}).name == "Cm9(no5)");
+
+    // The quality is the real one, so Roman numerals and the exported
+    // detected-quality port stay correct without new enum values
+    auto shell = analyzeNotes(a, {60, 64, 70});
+    check("shell keeps its quality", shell.quality == ChordQuality::Dominant7 && shell.isValid);
+
+    // A complete chord must still prefer the complete spelling
+    check("C7 with a fifth is plain C7",       analyzeNotes(a, {60, 64, 67, 70}).name == "C7");
+    check("Cmaj7 with a fifth is plain Cmaj7", analyzeNotes(a, {60, 64, 67, 71}).name == "Cmaj7");
+    check("C9 with a fifth is plain C9",       analyzeNotes(a, {60, 64, 67, 70, 74}).name == "C9");
+
+    // An incomplete shape must not outrank a complete one at another root.
+    // At priority 28 maj9(no5) rooted on Ab beat C7 rooted on the bass, and
+    // C E G Ab Bb came out as G#maj9(no5,b13)/C.
+    check("C E G Ab Bb = C7(b13)", analyzeNotes(a, {60, 64, 67, 68, 70}).name == "C7(b13)");
+    check("C Eb E G = Cadd#9",     analyzeNotes(a, {60, 63, 64, 67}).name == "Cadd#9");
+    check("C E G D F = Cadd9(11)", analyzeNotes(a, {60, 64, 67, 74, 77}).name == "Cadd9(11)");
+
+    // An omitted fifth joins the tension list rather than opening a second
+    // parenthesis, so it never reads C7(no5)(13)
+    check("C E Bb A = C7(no5,13)", analyzeNotes(a, {60, 64, 70, 81}).name == "C7(no5,13)");
+
+    // Two notes are an interval, not a chord
+    check("C E = M3 dyad",       analyzeNotes(a, {60, 64}).name == "C+E (M3)");
+    check("C F# = tritone dyad", analyzeNotes(a, {60, 66}).name == "C+F# (tritone)");
+    check("C Bb = m7 dyad",      analyzeNotes(a, {60, 70}).name == "C+A# (m7)");
+    check("dyad is not a chord", !analyzeNotes(a, {60, 64}).isValid);
+
+    // The two dyads that do imply a chord keep their chord names
+    check("C G is still C5",   analyzeNotes(a, {60, 67}).name == "C5");
+    check("C F is still F5/C", analyzeNotes(a, {60, 65}).name == "F5");
+}
+
+// =====================================================================
 // 10. Static utility functions
 // =====================================================================
 static void testUtilities()
@@ -546,6 +620,7 @@ int main()
     testBassIdentity();
     testSixthChords();
     testAnalyzeFacts();
+    testNoFifthAndDyads();
     testUtilities();
 
     std::cout << "\n=== Results: " << passed << " passed, " << failed << " failed ===\n";


### PR DESCRIPTION
Follow-up to #237. Investigating the note sets the analyzer still could not name turned up something larger than the dyads and clusters I expected: **every pattern in the chord table required the perfect fifth.**

The fifth is the most disposable chord tone, so leaving it out is standard on guitar and piano, and the shell voicing (root, third, seventh) is the backbone of jazz comping. Those voicings either went unnamed or were read as nonsense:

| notes | before | after |
|---|---|---|
| `C E Bb` (C7 shell) | *unnamed* | `C7(no5)` |
| `C E B` (Cmaj7 shell) | `E5addb13/C` | `Cmaj7(no5)` |
| `C Eb Bb` (Cm7 shell) | `D#5add13/C` | `Cm7(no5)` |
| `C Eb B` (CmMaj7 no 5) | *unnamed* | `CmMaj7(no5)` |
| `C E D` (Cadd9 no 5) | *unnamed* | `Cadd9(no5)` |
| `C E Bb D` (C9 no 5) | *unnamed* | `C9(no5)` |
| `C E B D` (Cmaj9 no 5) | *unnamed* | `Cmaj9(no5)` |
| `C Eb Bb D` (Cm9 no 5) | *unnamed* | `Cm9(no5)` |

## How it is done

Eight patterns flagged with `ChordPattern::omitsFifth`. The omission is announced through the **existing added-tone mechanism** rather than baked into the suffix, so it merges into one parenthesis (`C7(no5,13)`, not `C7(no5)(13)`), and each pattern keeps its real `ChordQuality`. Roman numerals, harmonic function and the exported detected-quality port stay correct with **no new enum values and no LV2 TTL change**.

Priority placement matters more than it looks. `findRoot` compares priorities *across candidate roots*, so an incomplete shape ranked near its full counterpart wins at the wrong root: at 28, `maj9(no5)` rooted on Ab beat a plain `C7` rooted on the bass, and `C E G Ab Bb` came out as `G#maj9(no5,b13)/C`. They now sit below every pattern containing a fifth, ranked only against each other, so they win when and only when no fifth is sounding. Three regression tests pin that.

## Two-note input

Two notes are an interval, not a chord, and now say so: `C E` reads `C+E (M3)` instead of `C?`. `isValid` stays false, so an interval still gets no Roman numeral and stays out of the chord history and the recorder. The fourth and fifth still match a pattern and are untouched (`C5`, `F5/C`).

## Verification

- **119 tests pass, 0 fail** (was 97 on main).
- Unnamed note sets fall **433 to 149**, all of them three- and four-note chromatic clusters with no fifth and no triad, where a question mark is the honest answer.
- The independent name-parsing oracle, taught that `(no5)` removes the fifth from what a name claims, still reports **zero dropped notes, zero phantom notes, zero root and zero slash errors** across all 4083 pitch-class sets. No new name claims a fifth that is not sounding.
- `analyzeFacts` still agrees with `analyze` on all 24576 voicings and **still allocates nothing**, so the LV2 audio path from #237 is unaffected.
- 55/55 curated real-world chords; 0 of 24 6th chords misnamed.
- All six formats build; pluginval clean at 1, 5, 7 and 10.

One test changed meaning: the cluster `C C# D F` is no longer unnamed, because `Db F C` is a genuine Dbmaj7 shell and the D is its b9, giving `C#maj7(no5,b9)`. That is an accurate reading rather than the power-chord absorption the test was guarding against, so the test now asserts what it actually meant: a two-note shape must never absorb a cluster, and whether a set can be named must not depend on which note is lowest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recognition and display of shell voicings that omit the fifth, including seventh, ninth, add9, major, and minor chord variations.
  - Chord names now clearly show omitted fifths and combine added-tone details in a readable format.
  - Unmatched two-note combinations are now identified by their musical intervals, such as major thirds, tritones, and minor sevenths.

- **Bug Fixes**
  - Improved chord identification across different bass-note arrangements.
  - Prevented incomplete voicings from being mislabeled as power chords or unknown chords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->