### PR TITLE
Chord Analyzer: name octaves and unisons, keep doubled dyads named

### DIFF
--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -169,14 +169,18 @@ ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
 
     if (facts.patternIndex < 0)
     {
-        // Two notes are an interval, not a chord, so name the interval rather
-        // than giving up with "C?". The dyads that do imply a chord, the
+        // Two pitch classes are an interval, not a chord, so name the interval
+        // rather than giving up with "C?". The dyads that do imply a chord, the
         // fourth and the fifth, match a pattern above and never reach here.
+        // Counted in pitch classes, not notes, so a doubled dyad still reads as
+        // its interval: C4 E4 C5 is a major third, not three unnamed notes.
         std::uint16_t pitchMask = 0;
         for (int note : midiNotes)
             pitchMask = static_cast<std::uint16_t>(pitchMask | (1u << (((note % 12) + 12) % 12)));
 
-        if (countPitchClasses(pitchMask) == 2)
+        const int distinctPitches = countPitchClasses(pitchMask);
+
+        if (distinctPitches <= 2)
         {
             int upper = result.bassNote;
             for (int pc = 0; pc < 12; ++pc)
@@ -188,8 +192,23 @@ ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
                 }
             }
 
+            // One pitch class is the same note doubled: an octave, or a unison
+            // when every note is literally the same pitch.
+            const char* interval = nullptr;
+
+            if (distinctPitches < 2)
+            {
+                const auto range = std::minmax_element(result.midiNotes.begin(),
+                                                       result.midiNotes.end());
+                interval = (*range.first == *range.second) ? "unison" : "octave";
+            }
+            else
+            {
+                interval = intervalName(((upper - result.bassNote) + 12) % 12);
+            }
+
             result.name = pitchClassToName(result.bassNote) + "+" + pitchClassToName(upper)
-                        + " (" + intervalName(((upper - result.bassNote) + 12) % 12) + ")";
+                        + " (" + interval + ")";
             result.romanNumeral = "-";
             return result;
         }

--- a/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
+++ b/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
@@ -580,6 +580,16 @@ static void testNoFifthAndDyads()
     check("C E = M3 dyad",       analyzeNotes(a, {60, 64}).name == "C+E (M3)");
     check("C F# = tritone dyad", analyzeNotes(a, {60, 66}).name == "C+F# (tritone)");
     check("C Bb = m7 dyad",      analyzeNotes(a, {60, 70}).name == "C+A# (m7)");
+    check("C C = octave dyad",   analyzeNotes(a, {60, 72}).name == "C+C (octave)");
+    check("C C = exact unison",  analyzeNotes(a, {60, 60}).name == "C+C (unison)");
+    check("three octaves of C",  analyzeNotes(a, {60, 72, 84}).name == "C+C (octave)");
+
+    // Doubling a note must not cost the dyad its name: these are two pitch
+    // classes spread over three notes, still a major third
+    check("C E C doubled = M3",  analyzeNotes(a, {60, 64, 72}).name == "C+E (M3)");
+    check("C C E doubled = M3",  analyzeNotes(a, {60, 72, 76}).name == "C+E (M3)");
+    check("C E E doubled = M3",  analyzeNotes(a, {60, 64, 76}).name == "C+E (M3)");
+    check("wide tritone",        analyzeNotes(a, {60, 78}).name == "C+F# (tritone)");
     check("dyad is not a chord", !analyzeNotes(a, {60, 64}).isValid);
 
     // The two dyads that do imply a chord keep their chord names


### PR DESCRIPTION
Picks up local octave/unison handling that was sitting uncommitted in the working tree after #238 merged, and fixes the gate it used.

## What it adds

Two notes an octave apart, or the same note twice, fell through to `C?`. They are a single pitch class, so the dyad naming added in #238 skipped them.

## What it fixes

The gate for that was `midiNotes.size() == 2`, which counts **notes** rather than **pitch classes**, so it lost the doubled dyads #238 did name.

| notes | #238 | uncommitted edit | this PR |
|---|---|---|---|
| `C4 E4 C5` (M3, C doubled) | `C+E (M3)` | `C?` | `C+E (M3)` |
| `C4 C5 E5` (M3, C doubled) | `C+E (M3)` | `C?` | `C+E (M3)` |
| `C4 E4 E5` (M3, E doubled) | `C+E (M3)` | `C?` | `C+E (M3)` |
| `C4 C5` (octave) | `C?` | `C+C (octave)` | `C+C (octave)` |
| `C4 C4` (unison) | `C?` | `C+C (unison)` | `C+C (unison)` |
| `C4 C5 C6` (two octaves) | `C?` | `C?` | `C+C (octave)` |

Counting distinct pitch classes covers both behaviours. Unison is separated from octave by comparing the lowest and highest sounding notes rather than their pitch classes, since those are equal by definition here.

Seven tests now cover the doubling and octave cases, which is what surfaced the regression.

## Verification

- **126 tests pass, 0 fail** (was 119 on main).
- Intervals remain `isValid == false`, so none of this reaches the Roman numeral, the chord history or the recorder.
- `analyzeFacts` is untouched: still agrees with `analyze` on all 24576 voicings and still allocates nothing, so the LV2 audio path from #237 is unaffected.
- The name-parsing oracle still reports zero dropped notes, zero phantom notes, zero root and zero slash errors across all 4083 pitch-class sets; 149 unnamed, unchanged.
- 55/55 curated real-world chords.
- All six formats build; pluginval clean at 1, 5, 7 and 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chord analysis for repeated notes and doubled pitch classes.
  * Octave and unison combinations are now labeled correctly instead of appearing as unknown chords.
  * Dyads with doubled notes continue to receive accurate interval names, including major thirds and tritones.

* **Tests**
  * Added coverage for octave, unison, doubled-note, and wide-interval chord combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->