### PR TITLE
240: fix resizing issues

### DIFF
--- a/plugins/TapeMachine/Source/PluginEditor.cpp
+++ b/plugins/TapeMachine/Source/PluginEditor.cpp
@@ -236,7 +236,7 @@ TapeMachineAudioProcessorEditor::TapeMachineAudioProcessorEditor(TapeMachineAudi
 
     // Initialize scalable resize helper with persistence
     // Base size: 800x580, Min: 640x464 (80%), Max: 1200x870 (150%)
-    resizeHelper.initialize(this, &audioProcessor, 800, 580, 640, 464, 1200, 870, false);
+    resizeHelper.initialize(this, &audioProcessor, 800, 580, 640, 464, 1200, 870, true);
     setSize(resizeHelper.getStoredWidth(), resizeHelper.getStoredHeight());
 }
 

--- a/plugins/chord-analyzer/Source/PluginEditor.cpp
+++ b/plugins/chord-analyzer/Source/PluginEditor.cpp
@@ -10,7 +10,7 @@ ChordAnalyzerEditor::ChordAnalyzerEditor(ChordAnalyzerProcessor& p)
     // Default 800x580 (was 520) to fit the recent-chord history strip
     // below the main display. Min 460 (was 400) preserves a usable
     // chord-display area at the smallest size.
-    resizeHelper.initialize(this, &audioProcessor, 800, 580, 600, 460, 1200, 840, false);
+    resizeHelper.initialize(this, &audioProcessor, 800, 580, 600, 460, 1200, 840, true);
     setSize(resizeHelper.getStoredWidth(), resizeHelper.getStoredHeight());
 
     setupChordDisplay();

--- a/plugins/convolution-reverb/PluginEditor.cpp
+++ b/plugins/convolution-reverb/PluginEditor.cpp
@@ -333,7 +333,7 @@ ConvolutionReverbEditor::ConvolutionReverbEditor(ConvolutionReverbProcessor& p)
     updateIRNameLabel();
 
     // Initialize resizable UI (900x700 base, range 720-1350 width)
-    resizeHelper.initialize(this, &audioProcessor, 900, 700, 720, 560, 1350, 1050, false);
+    resizeHelper.initialize(this, &audioProcessor, 900, 700, 720, 560, 1350, 1050, true);
     setSize(resizeHelper.getStoredWidth(), resizeHelper.getStoredHeight());
 
     // User preset manager (no factory presets — IR-dependent plugin)

--- a/plugins/multi-comp/CMakeLists.txt
+++ b/plugins/multi-comp/CMakeLists.txt
@@ -250,6 +250,9 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32)
     # --- State-restore integrity (pluginval L10 bool-param flake, deterministic) ---
     multicomp_add_functional_test(MultiCompStateRestoreTest tests/test_state_restore.cpp)
 
+    # --- Issue #240: host-edge resizing must preserve the proportional UI ---
+    multicomp_add_functional_test(MultiCompEditorResizeTest tests/test_editor_resize.cpp)
+
     # --- Parameter fuzz (pluginval "Fuzz parameters" replica; run under ASan) ---
     multicomp_add_functional_test(MultiCompParamFuzzTest tests/test_param_fuzz.cpp)
 endif()

--- a/plugins/multi-comp/EnhancedCompressorEditor.cpp
+++ b/plugins/multi-comp/EnhancedCompressorEditor.cpp
@@ -304,7 +304,7 @@ EnhancedCompressorEditor::EnhancedCompressorEditor(UniversalCompressor& p)
     
     // Initialize resizable UI using shared helper with persistence
     // Base size: 750x500, Min: 500x350, Max: 1400x1000
-    resizeHelper.initialize(this, &processor, 750, 500, 500, 350, 1400, 1000, false);
+    resizeHelper.initialize(this, &processor, 750, 500, 500, 350, 1400, 1000, true);
     setSize(resizeHelper.getStoredWidth(), resizeHelper.getStoredHeight());
 }
 

--- a/plugins/multi-comp/tests/test_editor_resize.cpp
+++ b/plugins/multi-comp/tests/test_editor_resize.cpp
@@ -1,0 +1,91 @@
+#include <JuceHeader.h>
+
+#include "../UniversalCompressor.h"
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+class MultiCompEditorResizeTest final : public juce::JUCEApplicationBase
+{
+public:
+    const juce::String getApplicationName() override { return "MultiCompEditorResizeTest"; }
+    const juce::String getApplicationVersion() override { return "1.0"; }
+    bool moreThanOneInstanceAllowed() override { return true; }
+    void anotherInstanceStarted(const juce::String&) override {}
+    void suspended() override {}
+    void resumed() override {}
+    void systemRequestedQuit() override { quit(); }
+    void shutdown() override {}
+    void unhandledException(const std::exception*, const juce::String&, int) override {}
+
+    void initialise(const juce::String&) override
+    {
+        UniversalCompressor processor;
+        std::unique_ptr<juce::AudioProcessorEditor> editor(processor.createEditor());
+
+        if (editor == nullptr)
+        {
+            fail("processor did not create an editor");
+            finish();
+            return;
+        }
+
+        constexpr int baseWidth = 750;
+        constexpr int baseHeight = 500;
+        constexpr double expectedAspect = static_cast<double>(baseWidth) / baseHeight;
+        const auto initialBounds = editor->getBounds();
+
+        auto* constrainer = editor->getConstrainer();
+        check("editor exposes a resize constrainer", constrainer != nullptr);
+        if (constrainer != nullptr)
+        {
+            check("host constrainer advertises the editor aspect ratio",
+                  std::abs(constrainer->getFixedAspectRatio() - expectedAspect) < 0.0001);
+        }
+
+        // Reproduce the issue's REAPER/Linux gesture: move the top edge down
+        // while dragging the right edge out. The bottom edge remains anchored.
+        editor->setBounds(0, 0, baseWidth, baseHeight);
+        editor->setBoundsConstrained({ 0, 150, 1125, 350 });
+
+        check("host-edge resize preserves proportional bounds",
+              editor->getWidth() == 1125 && editor->getHeight() == 750);
+        check("top-edge resize keeps the bottom edge anchored", editor->getBottom() == baseHeight);
+
+        // EnhancedCompressorEditor persists its size on destruction. Restore
+        // the value loaded at startup so this test does not alter user state.
+        editor->setBounds(initialBounds);
+        processor.editorBeingDeleted(editor.get());
+        editor.reset();
+        finish();
+    }
+
+private:
+    int failures = 0;
+
+    void check(const char* name, bool condition)
+    {
+        if (condition)
+            std::cout << "[PASS] " << name << '\n';
+        else
+            fail(name);
+    }
+
+    void fail(const char* name)
+    {
+        std::cout << "[FAIL] " << name << '\n';
+        ++failures;
+    }
+
+    void finish()
+    {
+        std::cout << (failures == 0 ? "PASS" : "FAIL")
+                  << ": Multi-Comp editor resize regression ("
+                  << failures << " failures)\n";
+        setApplicationReturnValue(failures == 0 ? 0 : 1);
+        quit();
+    }
+};
+
+START_JUCE_APPLICATION(MultiCompEditorResizeTest)

--- a/plugins/multi-comp/tests/test_editor_resize.cpp
+++ b/plugins/multi-comp/tests/test_editor_resize.cpp
@@ -3,7 +3,6 @@
 #include "../UniversalCompressor.h"
 
 #include <cmath>
-#include <iostream>
 #include <memory>
 
 class MultiCompEditorResizeTest final : public juce::JUCEApplicationBase
@@ -64,25 +63,19 @@ public:
 private:
     int failures = 0;
 
-    void check(const char* name, bool condition)
+    void check(const char*, bool condition)
     {
-        if (condition)
-            std::cout << "[PASS] " << name << '\n';
-        else
-            fail(name);
+        if (!condition)
+            ++failures;
     }
 
-    void fail(const char* name)
+    void fail(const char*)
     {
-        std::cout << "[FAIL] " << name << '\n';
         ++failures;
     }
 
     void finish()
     {
-        std::cout << (failures == 0 ? "PASS" : "FAIL")
-                  << ": Multi-Comp editor resize regression ("
-                  << failures << " failures)\n";
         setApplicationReturnValue(failures == 0 ? 0 : 1);
         quit();
     }

--- a/plugins/shared/ScalableEditorHelper.h
+++ b/plugins/shared/ScalableEditorHelper.h
@@ -9,7 +9,18 @@ class ScalableEditorHelper
 {
 public:
     ScalableEditorHelper() = default;
-    ~ScalableEditorHelper() = default;
+    ~ScalableEditorHelper()
+    {
+        // The editor does not own a custom constrainer. Detach it while both
+        // objects are still alive so the editor cannot retain a dangling
+        // pointer during base-class teardown.
+        resizer.reset();
+        if (parentEditor != nullptr && parentEditor->getConstrainer() == &constrainer)
+        {
+            parentEditor->setResizable(false, false);
+            parentEditor->setConstrainer(nullptr);
+        }
+    }
 
     // uiVersion (default 0 = no version check, backwards-compatible) bumps
     // the persistence "uiVersion" key. If the stored uiVersion is lower
@@ -26,6 +37,7 @@ public:
     {
         parentEditor = editor;
         audioProcessor = processor;
+        persistenceEnabled = true;
         baseWidth = static_cast<float>(defaultWidth);
         baseHeight = static_cast<float>(defaultHeight);
         defaultW = defaultWidth;
@@ -36,19 +48,22 @@ public:
         maxH = maxHeight;
         currentUiVersion = uiVersion;
 
-        loadStoredSize();
-
         constrainer.setMinimumSize(minWidth, minHeight);
         constrainer.setMaximumSize(maxWidth, maxHeight);
-        if (fixedAspectRatio)
-            constrainer.setFixedAspectRatio(baseWidth / baseHeight);
+        constrainer.setFixedAspectRatio(fixedAspectRatio ? baseWidth / baseHeight : 0.0);
+
+        loadStoredSize();
 
         resizer = std::make_unique<juce::ResizableCornerComponent>(editor, &constrainer);
         editor->addAndMakeVisible(resizer.get());
         resizer->setAlwaysOnTop(true);
 
-        editor->setResizable(true, true);
-        editor->setResizeLimits(minWidth, minHeight, maxWidth, maxHeight);
+        // The host and the in-editor corner must share this constrainer.
+        // setResizeLimits() configures AudioProcessorEditor's separate default
+        // constrainer, which allowed host-window edge drags to bypass the
+        // fixed aspect ratio used by the corner component.
+        editor->setResizable(true, false);
+        editor->setConstrainer(&constrainer);
     }
 
     // Overload without processor — no size persistence, fixed aspect ratio.
@@ -79,8 +94,8 @@ public:
         editor->addAndMakeVisible(resizer.get());
         resizer->setAlwaysOnTop(true);
 
-        editor->setResizable(true, true);
-        editor->setResizeLimits(minWidth, minHeight, maxWidth, maxHeight);
+        editor->setResizable(true, false);
+        editor->setConstrainer(&constrainer);
     }
 
     int getStoredWidth() const { return storedWidth; }
@@ -175,6 +190,20 @@ private:
 
         storedWidth = juce::jlimit(minW, maxW, storedWidth);
         storedHeight = juce::jlimit(minH, maxH, storedHeight);
+
+        // setSize() intentionally bypasses an editor constrainer. Normalise a
+        // previously persisted free-aspect size here so an editor fixed by a
+        // newer build cannot reopen in the clipped shape saved by an older one.
+        if (constrainer.getFixedAspectRatio() > 0.0)
+        {
+            juce::Rectangle<int> storedBounds(0, 0, storedWidth, storedHeight);
+            const juce::Rectangle<int> defaultBounds(0, 0, defaultW, defaultH);
+            const juce::Rectangle<int> limits(0, 0, maxW, maxH);
+            constrainer.checkBounds(storedBounds, defaultBounds, limits,
+                                    false, false, true, true);
+            storedWidth = storedBounds.getWidth();
+            storedHeight = storedBounds.getHeight();
+        }
     }
 
     void saveCurrentSize()

--- a/plugins/tape-echo/Source/PluginEditor.cpp
+++ b/plugins/tape-echo/Source/PluginEditor.cpp
@@ -192,7 +192,7 @@ TapeEchoEditor::TapeEchoEditor(TapeEchoProcessor& p)
     startTimerHz(30);
 
     // Initialize resizable UI (600x450 base, range 480-900 width)
-    resizeHelper.initialize(this, &processor, 600, 450, 480, 360, 900, 675, false);
+    resizeHelper.initialize(this, &processor, 600, 450, 480, 360, 900, 675, true);
     setSize(resizeHelper.getStoredWidth(), resizeHelper.getStoredHeight());
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin window sizes are now remembered and restored across sessions.
  * Resizable plugin interfaces better maintain their proportions and positioning during host-edge resizing.

* **Bug Fixes**
  * Improved handling of fixed-aspect resizing and persisted window dimensions across supported plugins.

* **Tests**
  * Added coverage for proportional resizing, edge anchoring, and restoration of saved editor bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->