### PR TITLE
Complete Multi-Comp 2 FET parity and validation fixes

### DIFF
--- a/CODEX-DAF-RENAME-NOTICE.md
+++ b/CODEX-DAF-RENAME-NOTICE.md
@@ -1,0 +1,158 @@
+# Notice for in-flight Multi-Comp 2 work: DPF is now DAF
+
+Paste this to Codex mid-task. It supersedes any path, macro, or repository name
+in your current brief.
+
+## What happened
+
+While you were working, the framework was renamed and its public API forked.
+This landed on `main` as `f7edaea` (PR #223) and CI is green across all four
+platforms. **Your working tree almost certainly references paths and macros
+that no longer exist.** Before continuing, run `git status` and preserve any
+uncommitted work you have (commit it on your branch, or stash it). For unrelated
+work, rebase onto `origin/main`. For Multi-Comp 2 Opto campaign work, switch to
+`multi-comp-2/opto-campaign-snapshot` instead so validation uses the campaign's
+intended gate set.
+
+## The substitution table
+
+Apply this to every file you have touched and to every path in your brief.
+
+| old | new |
+|---|---|
+| `github.com/dusk-audio/DPF` | `github.com/dusk-audio/DAF` |
+| `github.com/dusk-audio/DPF-Widgets` | `github.com/dusk-audio/DAF-Widgets` |
+| `~/projects/DPF`, `~/projects/DPF-Widgets` | `~/projects/DAF`, `~/projects/DAF-Widgets` |
+| `../DPF`, `../DPF-Widgets` | `../DAF`, `../DAF-Widgets` |
+| `plugins/<name>/dpf-plugin/` | `plugins/<name>/daf-plugin/` |
+| `plugins/shared-dpf/` | `plugins/shared-daf/` |
+| `PatreonBackersDpf.hpp` | `PatreonBackersDaf.hpp` |
+| `DistrhoPluginInfo.h` | `DafPluginInfo.h` |
+| `DistrhoPlugin.hpp`, `DistrhoUI.hpp` | `DafPlugin.hpp`, `DafUI.hpp` |
+| `#include "distrho/..."` | `#include "daf/..."` |
+| `DISTRHO_*` (every macro) | `DAF_*` |
+| `START_NAMESPACE_DISTRHO` | `START_NAMESPACE_DAF` |
+| `END_NAMESPACE_DISTRHO` | `END_NAMESPACE_DAF` |
+| `USE_NAMESPACE_DISTRHO` | `USE_NAMESPACE_DAF` |
+| `namespace DISTRHO` | `namespace DAF` |
+| `duskdpf::` | `duskdaf::` |
+| `dpf_add_plugin(...)` | `daf_add_plugin(...)` |
+| `DuskDpfPlugin.cmake` | `DuskDafPlugin.cmake` |
+| `-DDPF_PATH`, `-DDPFWIDGETS_PATH` | `-DDAF_PATH`, `-DDAFWIDGETS_PATH` |
+| `-DDUSK_DPF_*` | `-DDUSK_DAF_*` |
+| `DPF_REF` | `DAF_REF` |
+| `DPF_SHA` | `DAF_SHA` |
+| `DPFWIDGETS_*` | `DAFWIDGETS_*` |
+| `.github/workflows/dpf-*.yml` | `.github/workflows/daf-*.yml` |
+| `docker/check_dpf_pins.sh` | `docker/check_daf_pins.sh` |
+| `.github/scripts/dpf_clap_validate.py` | `.github/scripts/daf_clap_validate.py` |
+| `docs/dpf-migration/` | `docs/daf-migration/` |
+
+## What deliberately did NOT change. Do not "finish the rename" on these.
+
+1. **`d_cconst('D','P','F',' ')` in `daf/src/DafPluginVST3.cpp`** (in the DAF
+   repo). Those four characters are hashed into every VST3 class UID the
+   framework emits. Changing them to `'D','A','F',' '` rewrites the UID of every
+   shipped VST3 and orphans every saved session that references one. The line
+   carries a comment saying so. Leave it.
+2. **Per-file licence headers.** Every framework file still opens with
+   `DISTRHO Plugin Framework (DPF)` above the copyright line and the ISC notice.
+   That is required attribution, not a leftover.
+3. **Plugin identity.** `DAF_PLUGIN_URI`, `DAF_PLUGIN_CLAP_ID`,
+   `DAF_PLUGIN_UNIQUE_ID` and `DAF_PLUGIN_BRAND_ID` values are unchanged
+   (`https://dusk-audio.github.io/plugins/...`, `com.duskaudio.*`, `DsMc`,
+   `Dusk`). Only the macro names moved. Do not touch the values.
+4. **Example plugins' own `"DISTRHO"` brand strings and `distrho.sf.net` URIs**
+   inside the DAF repo's `examples/`.
+
+## Hard rule about upstream
+
+DAF and DAF-Widgets are **hard forks**. `DISTRHO/DPF` and `DISTRHO/DPF-Widgets`
+are not references: do not read, fetch, diff, cherry-pick, or merge from them,
+and do not cite upstream to explain a behaviour here. The `upstream` remote has
+been removed from the local checkout. If inherited code has a bug, it is our bug
+and it gets fixed here. Attribution lives in README.md and
+`plugins/shared-daf/THIRD_PARTY_LICENSES.md` and is not up for revision.
+
+## Your Multi-Comp 2 Opto campaign state moved
+
+The uncommitted Opto work that lived in the `/private/tmp/.../scratchpad/mc2`
+worktree (Opto detector changes in `MultiCompModes.hpp`, the extra gates in
+`MultiCompCoreTests.cpp`, the knob-splitter UI work) has been ported onto the
+renamed tree and pushed:
+
+    branch: multi-comp-2/opto-campaign-snapshot   (off main, f7edaea)
+
+**Branch from that, not from `main`, and not from the old worktree.** `main`
+does not contain the extra Opto gates; if you branch from `main` you will be
+measuring against a smaller gate set and your numbers will not be comparable to
+the campaign log. The old worktree is now stale: two of its five files sit at
+deleted paths.
+
+The port is verified faithful. Every gate reports the same numbers as before
+the rename, to the digit: crest sweep -0.141 / -0.540 / +0.615 held out /
+-0.709 dB, burst rate fitted RMS 0.561 dB, detector weighting shape RMS
+0.097 dB, short-event release worst 1.386 dB.
+
+## Commands, updated
+
+Core suite (fast, this is the one that carries the Opto gates):
+
+```bash
+c++ -O2 -std=c++17 -Iplugins/multi-comp/core -Iplugins/shared-daf/dsp \
+  plugins/multi-comp/core/tests/MultiCompCoreTests.cpp \
+  plugins/multi-comp/core/MultiCompDSP.cpp -o /tmp/mc2tests && /tmp/mc2tests
+```
+
+Full plugin build plus both ctest targets:
+
+```bash
+cmake -U 'SDL2*' -U 'pkgcfg_lib_SDL2*' \
+  -S plugins/multi-comp/daf-plugin -B build-mc2 \
+  -DCMAKE_BUILD_TYPE=Release -DDAF_PATH=$HOME/projects/DAF \
+  -DDAFWIDGETS_PATH=$HOME/projects/DAF-Widgets -DDUSK_DAF_INSTALL_LOCAL=OFF \
+  -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=TRUE
+cmake --build build-mc2 -j8 && ctest --test-dir build-mc2 --output-on-failure
+```
+
+Linux parity check, still mandatory before declaring a DSP change done:
+
+```bash
+podman run --rm --arch amd64 -v "$PWD/plugins:/src/plugins:ro" \
+  docker.io/library/gcc:12 bash -c \
+  'g++ -O3 -std=c++17 -I/src/plugins/multi-comp/core \
+   -I/src/plugins/shared-daf/dsp \
+   /src/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp \
+   /src/plugins/multi-comp/core/MultiCompDSP.cpp -o /tmp/t && /tmp/t'
+```
+
+Framework pins are `DAF 788eb019` and `DAF-Widgets 91e0004e`. Confirm your
+checkouts match with `./docker/check_daf_pins.sh` (exits 0 when they do).
+
+## One trap worth knowing
+
+A blanket search-and-replace over this rename silently disarmed two guard
+scripts, because their whole job was to match the old name:
+
+- `check_fork_sources.sh` grepped for `DISTRHO/(DPF|DPF-Widgets|pugl)`; the
+  rename rewrote that to `DISTRHO/(DAF|...)`, which matches nothing upstream, so
+  the check that stops a build fetching from DISTRHO would have passed on a real
+  leak.
+- A stale CMake include path, `shared-dpf/dsp`, survived inside a quoted string
+  in `target_include_directories`. CMake does not validate include directories,
+  so nothing complains at configure time; the directory is simply absent from
+  the compiler's header search path, and the first symptom is a header that
+  fails to resolve when that target compiles. It was caught by grepping for the
+  old token, not by a build.
+
+If you run any bulk substitution, grep afterwards for the old tokens — but read
+the hits against the allowlist above before changing any of them. The DPF tokens
+listed under "What deliberately did NOT change" are supposed to still be there:
+`d_cconst('D','P','F',' ')`, the per-file `DISTRHO Plugin Framework (DPF)`
+licence headers, and the examples' own `"DISTRHO"` brand strings and
+`distrho.sf.net` URIs. "Finishing" those rewrites every shipped VST3's class UID
+and strips required attribution. Treat only hits outside that allowlist as
+leftovers to fix.
+
+Then re-run `./docker/check_daf_pins.sh` and
+`./.github/scripts/check_fork_sources.sh ~/projects/DAF`. Both must exit 0.

--- a/HANDOFF-MC2.md
+++ b/HANDOFF-MC2.md
@@ -356,3 +356,360 @@ Declined, with reasons — do not silently re-apply:
 Terse. Numbers, not adjectives. Report your own errors plainly and move on.
 When two gates conflict, stop optimising and ask what single mechanism
 produces both readings.
+
+## 9. Logic "black box" AU investigation — 2026-08-28, OPEN
+
+Symptom: the `aufx DsMc Dusk` AU opens in Logic Pro as an empty dark rectangle
+with the plugin name centred. Same `.component` renders in REAPER.
+
+**The plugin is exonerated in every configuration reproducible outside Logic.**
+Measured with `plugins/shared-daf/tests/DafAUViewProbe.mm` (new, untracked)
+against the Aug 28 14:38 build, which is byte-identical to the installed bundle:
+
+| configuration | result |
+|---|---|
+| in-process, view instantiated | renders, 666 distinct colours in the GL front buffer |
+| out of process (`LoadOutOfProcess`) | renders; host gets `_RemoteAUv2ViewFactory` + `NSRemoteView` |
+| host `setFrameSize` 1012x257 and 700x200 right after creation | renders |
+| 1000 blocks rendered through both input buses with the editor open | renders, `worstStatus=0` |
+| the above under `MallocGuardEdges`/`MallocScribble`/`MallocCheckHeapEach` | clean, disposes cleanly |
+
+Do not re-derive these. In particular the OpenGL-over-ViewBridge theory is dead:
+out-of-process hosting composites the GL view correctly.
+
+Also ruled out by evidence: Info.plist shape, linked frameworks, exported symbols
+and ObjC class names (identical to `tape_machine_2`); code signing (the broken
+plugin verifies clean, the *working* `tape_machine_2` does not); the uncommitted
+`MultiCompAUComponentBundlePath.mm`, which produces the same string as DAF's own
+fallback and is a no-op in the normal case; `scanUserPresets`, which uses the
+`std::error_code` overloads throughout and cannot throw out of the view factory.
+
+Logic's own scan is clean: `~/Library/Caches/AudioUnitCache/Logs/AUScan*.plist`
+records `Multi-Comp 2 start` / `took 0.000000 seconds`, no error.
+
+**`auval` cannot catch this class of bug.** Its `Cocoa Views Available: 1` comes
+from enumerating the class name; it never calls `uiViewForAudioUnit:`. That is
+why `DafAUViewProbe.mm` exists, and why it belongs in `daf-au-test.yml`.
+
+**Next step, and the only one left:** Logic running with the plugin inserted and
+the blank window open, then `lsof` across the `Logic Pro` and
+`AUHostingServiceXPC_arrow` pids to see which process maps the bundle. Note that
+`AUHostingServiceXPC_arrow` loading a component is NOT proof of out-of-process
+hosting — Logic's startup scan runs there too, and was observed loading
+known-good `tape_machine_2` alongside Multi-Comp 2.
+
+### Two real defects found alongside, both unfixed
+
+1. `DAF::PluginAU::reallocAudioBufferList(bool)` heap-corrupts on `Uninitialize`
+   (`~/Library/Logs/DiagnosticReports/REAPER-2026-08-28-110312.ips`, imageIndex 24
+   is this bundle), and auval prints ~20 `AU Reports Processing in Place; Input
+   buffer[0] ... and Output buffer[0] ... are not the same` on the same path.
+   Multi-Comp 2 is the only DAF plugin with two AU input elements. The probe's
+   render path does not trip it; the bus-reconfiguration sequences in
+   `MultiCompAUTests.cpp` are the better vehicle.
+2. `docker/check_daf_pins.sh:84-90` and `.github/scripts/check_fork_sources.sh`
+   both decide pugl's provenance from `.gitmodules`, never from the checkout.
+   Local `DAF/dgl/src/pugl-upstream` origin is `https://github.com/DISTRHO/pugl.git`
+   on `5e2621d` while DAF HEAD pins `43d8e34` (object not even fetched), and both
+   guards report OK. Every local AU build compiled upstream DISTRHO pugl.
+   `DAF-Widgets` is also off-pin (local `1c09e1ef`, CI `91e0004e`).
+
+## 10. Milestone #2 closeout audit — 2026-08-30
+
+The live milestone had two open issues at audit time: #200 (DAF AU true
+sidechain bus) and #210 (Opto dense-programme parity).
+
+- #200's requested production path is present in the pinned DAF checkout at
+  `dfc50729` (the grouped-input-bus implementation is `cd445a50`). The committed
+  `MultiCompAUTest` sees two AU input elements and passes stereo, mono,
+  disconnected, disabled and routed-sidechain cases. Both the normal and
+  `-ffp-contract=off` CTest runs passed 4/4, including `MultiCompAU`.
+- #210's old issue-body figures (RMS 1.600/3.163 dB at PR 0.85/1.00) no longer
+  describe current production. The current paired results are PR 0.40:
+  mean -0.019567 dB, RMS 0.427058 dB, correlation 0.870237; PR 0.70:
+  +0.440839/0.742100/0.854521; PR 0.85:
+  +0.584630/0.921499/0.811253; PR 1.00:
+  +0.616529/0.987459/0.822303. The four-row parity gate now constrains all
+  three metrics at every PR. Removing the production startup-attack scale made
+  PR 1.00 correlation fall to 0.734804 and the gate fail; restoring it returns
+  the figures above and passes.
+- The FET/1176 lifecycle test previously poisoned a dead sentinel rather than
+  the state used by the callback. The sentinel is removed and the test now
+  poisons/checks both input peaks and both active/silent counters across
+  repeated prepare, reset, mode exit and settled bypass. Removing the bypass
+  active-counter reset produces the expected focused failure; restoring it
+  passes with the counter saturated at 24 and post-window blend exactly 0.
+- Current FET audio DSP remains the accepted Wave 27/30 state. No scalar DSP
+  candidate survived the recorded controls, so no speculative audio change was
+  made in this closeout. The meter-film comparison is still measurement-blocked:
+  UAD independent repeats exceed the 0.5-degree repeatability limit at 27/504
+  points, with a 22.172-degree maximum. Collect continuous timestamped,
+  nonblocking film before scoring another visual-meter candidate.
+- Verification on this source: native CTest 4/4 in 40.21 seconds; no-FMA CTest
+  4/4 in 43.49 seconds. The Linux GCC 12 tripwire could not run because the
+  existing Podman VM returned to `stopped` immediately after reporting a
+  successful start; this is an unverified platform, not a test failure.
+
+## 11. FET Wave 31: shallow-knee parity — 2026-08-30
+
+Wave 28 identified the next measurable frontier: the accepted detector entered
+the 4:1 knee too early, and its 100 Hz/1 kHz split contradicted the reference.
+The new `--fet-knee-onset` gate uses nine independently captured points per
+frequency from -14 through -6 dB driven level, plus held-out 40 and 60 Hz
+endpoints from Wave 24. On the pre-change production path it failed with
+0.724184 dB worst absolute error and 0.120661 dB worst frequency split. The
+accepted path reads 0.011842 dB and 0.000574 dB respectively; the bounds are
+0.04 and 0.03 dB.
+
+The implemented mechanism is a shallow, raw-input peak cell for vintage 4:1
+only. It holds peaks for 30 ms, releases over 250 ms, and applies the difference
+between the existing colour-envelope reduction and the measured onset table as
+a post-colour scalar, bounded to +/-0.85 dB (the measured pre-change miss tops
+out at 0.724 dB). The original transformed detector and FET envelope remain the
+harmonic lookup coordinate. The auxiliary cell fades over -5 to -4 dB and clears
+immediately at the accepted-law join, leaving deeper reduction, other ratios,
+Studio FET, All-buttons and the established harmonic surface on their existing
+paths. Its state is part of `FETState`, so repeated prepare and reset clear it
+with the rest of that aggregate.
+
+Controls that shaped the result:
+
+- Replacing the main envelope target passed the onset rows but moved the
+  harmonic coordinate; low-frequency H3 missed by as much as 5.895 dB.
+- A post-colour scalar without a true peak hold amplitude-modulated the
+  harmonics; low-frequency H3/H5 errors reached 22 dB/0.806 dB.
+- Linear frequency compensation fixed 100 Hz but over-corrected the held-out
+  40 Hz endpoint by 0.090826 dB. The final common cell needs no frequency fit.
+- Letting the cell release above the accepted-law join made the -42 dBFS attack
+  curve miss by 0.0832 RMS (bound 0.038) and read 2.052x the reference fitted
+  tau. Ending it at the join restored the attack gate to 0.0289 RMS worst-case
+  without moving the knee result.
+- The opposite deep-to-shallow control exposed a second failure in that draft:
+  after 33.757294 dB of main-envelope reduction the auxiliary cell cancelled
+  14.446922 dB of retained release memory (3.229736 dB still cancelled after
+  four seconds). Bounding the cell to its measured domain reduces the observed
+  maximum/final correction to 0.849715/0.849714 dB while leaving the static and
+  harmonic gates unchanged. Removing the bound reproduces the focused failure.
+
+Neighbour verification passed for static and maximum reduction, all ratios,
+All-buttons and measured-curve arms, attack drive/knob, startup peak/lifecycle,
+deep-to-shallow release memory, block-size invariance (maximum delta 0), reset
+determinism (maximum delta 0), stereo link/phase, and sample rates
+44.1/48/88.2/96 kHz (worst flat-gain delta 0.003448 dB). The six colour gates
+remain within their established bounds:
+low H5 0.117296 dB, low H3 0.646858/0.104789 dB at 100 Hz/1 kHz, LF colour
+0.232735 dB, broadband H2 0.103566 dB, H3 0.059604 dB and H5 0.068170 dB.
+
+Final release builds produced JACK, LV2, VST3, CLAP and AU. Native CTest passed
+4/4 in 46.96 seconds; no-FMA CTest passed 4/4 in 50.70 seconds. The Linux retry
+again reported a successful Podman-machine start and then immediately returned
+to `Running: false`; the unverified platform gap recorded in section 10 remains.
+
+## 12. FET Wave 32: complex shallow-knee H3 parity — 2026-08-30
+
+Wave 25's retained 33-point, quarter-dB 100 Hz sweep remained a real hole after
+the Wave 31 transfer fix because that post-colour scalar deliberately left the
+harmonic ratio unchanged. The new `--fet-low-h3-dense` gate renders the same
+12-second stimuli and 9.0-10.5 second coherent window in process. On the
+unchanged Wave 31 path it failed at 1.756796 dB worst H3/H1 error and 0.855123
+dB worst adjacent error step. The retained UAD WAVs also expose the missing
+complex constraint: reference H3 phase moves smoothly from 164.574 to 90.682
+degrees, while Wave 31 moved from 167.171 to 54.322 degrees and missed by up to
+73.758 degrees. A magnitude-only scalar fit can therefore match the reference
+only by jumping between two coefficient roots; it is not a parity mechanism.
+
+The accepted mechanism is confined to vintage 4:1 and the measured -15 to -4
+dB driven-input window. It makes pure Chebyshev T3 and T5 bases from the raw
+input normalised by Wave 31's held peak, then passes each through one and two
+300 Hz low-pass poles. Four real coefficients jointly match UAD H3 real/imaginary
+while holding the prior H5 real/imaginary vector. Half-dB rows from -14 through
+-6 dB are fit anchors; all intervening quarter-dB rows remain held out, with
+cubic interpolation used only across the uniformly spaced fit anchors. The
+unequal -15/-14 and -6/-4 endpoint fades stay linear. The four pole states live
+in `FETState`, so aggregate prepare/reset clearing covers both channels without
+allocation or callback locking.
+
+The accepted dense result is 0.194420 dB worst H3/H1 error, 0.194702 dB worst
+adjacent error step and 2.587519 degrees worst phase error, against 0.75/0.20/3.0
+bounds. A disabled-cell control across the same 33 rows measures maximum
+movement of 0.000000475 dB raw GR, 0.000034092 dB H1, 0.000090070 dB H2 and
+0.004332182 dB H5, all below the predeclared 0.02 dB isolation bound.
+
+Controls that shaped and prove the result:
+
+- Re-keying only low-frequency K3 from raw to net knee reduction was rejected:
+  it worsened the dense result to 3.908683 dB error and 2.320884 dB adjacent
+  step. The Wave 31 scalar is not the hidden harmonic coordinate.
+- A raw-input direct-plus-lag draft closed dense H3 and fixed H5, but leaked
+  into the established 1 kHz H3 guard (0.846793 dB worst versus about 0.10 dB
+  before). Replacing the direct branch with the first 300 Hz pole and using the
+  second pole as its independent vector restores the 1 kHz guard to 0.097896
+  dB.
+- Scaling the accepted direct coefficient to 99 percent leaves magnitude and
+  continuity green at 0.225589/0.199254 dB, but phase rises to 3.022585 degrees
+  and the combined assertion fails. Restoring it returns 2.587519 degrees.
+- Removing only the two T5 hold terms leaves H3 green at 0.194526 dB error,
+  0.194710 dB adjacent step and 2.585369 degrees, but moves H5 by 0.032555608
+  dB and produces the focused neighbour failure. Restoring them reduces that
+  movement to 0.004332182 dB.
+
+Neighbour verification passed for static and maximum reduction, all ratios,
+All-buttons and measured-curve arms, the Wave 31 knee/onset and deep-release
+cell, attack drive/knob, startup peak/lifecycle, block-size invariance (maximum
+delta 0), reset determinism (maximum delta 0), stereo link/phase and flat gain
+at 44.1/48/88.2/96 kHz (0.003448 dB worst). The established colour gates read:
+low H5 0.117306 dB, low H3 0.619408/0.097896 dB at 100 Hz/1 kHz, LF colour
+0.232732 dB, broadband H2 0.103566 dB, H3 0.076874 dB and H5 0.068170 dB.
+
+Final release builds again produced JACK, LV2, VST3, CLAP and AU. Native CTest
+passed 4/4 in 58.98 seconds; no-FMA CTest passed 4/4 in 62.87 seconds. The full
+Milestone #2 sidechain/Opto gates from section 10 remain green. Linux GCC 12 was
+not re-run in this wave; the stopped-Podman platform gap remains unverified.
+
+## 13. FET Wave 33: broadband complex H3 parity — 2026-08-30
+
+Wave 27's scalar-rate experiment had compared different Release controls and
+therefore rejected a coordinate the experiment did not hold constant. Its
+matched-reduction rows used Release 0.5; the original harmonic campaign used
+0.66595459. Once that distinction is retained, the sparse broadband-K3 fit is
+shown to match its anchor magnitudes but miss the UAD vector between them: at
+Input 0.8 the reference H3 phase rotates by more than 120 degrees while the
+reduction-only cubic remains near 135 degrees.
+
+The new `--fet-broadband-h3-dense` gate contains 17 same-stimulus UAD rows at
+48 kHz and 13 at 96 kHz. Nine Release-0.5 rows per rate are the long-window
+calibration surface; the original Release-0.66595459 campaign rows are the
+opposite-control validation surface. Wave 32 failed this gate at 4.441893 dB
+worst magnitude error, 85.829597 degrees worst phase error and 4.479455 dB
+worst adjacent error step. The accepted Wave 33 result was 0.174096 dB,
+0.528112 degrees and 0.172962 dB against 0.25/3.0/0.20 bounds.
+
+The mechanism uses raw Chebyshev T3 and its first three 300 Hz pole states.
+Four real coefficients solve the complex 1 kHz H3 residual while forcing the
+same cell's complex 100 Hz H3 contribution to zero. Release interpolates
+between separately measured 0.5 and 0.66595459 coefficient tables; Input uses
+a triangular measured-cell weight centred at 0.8. The 96 kHz normalisation was
+fit only from the Release-0.5 rows; four untouched 96 kHz campaign-Release rows
+then validated within 0.075 dB / 0.42 degrees. `shallowT3Lowest` is part of
+`FETState`, so aggregate prepare/reset clearing covers it without allocation or
+callback locking.
+
+The neighbour gate measured 0.000000496 dB GR, 0.000011050 dB H1,
+0.000099685 dB H2 and 0.002120043 dB H5 movement at acceptance. Injecting
+`0.0001 * shallowT5Lag` left the H3 gate green but moved H5 by 7.060746814 dB
+and produced the intended isolation failure; removing the fault restored the
+figures above. Native/no-FMA focused gates and both 4/4 full suites passed
+(73.82/78.42 seconds). Wave 34's independently intended H5 correction changes
+the stored H5 neighbour anchors; with those accepted anchors the current H3
+gate reads 0.183746 dB / 0.504795 degrees / 0.160003 dB natively and
+0.184155 / 0.503875 / 0.160423 without FMA.
+
+## 14. FET Wave 34: broadband complex H5 parity — 2026-08-30
+
+The remaining broadband H5 problem was larger than Wave 26's 0.372948 dB
+96 kHz magnitude failure. Retained same-stimulus Release-0.5 captures expose a
+5.131136 dB / 137.482381-degree miss, while the sparse campaign magnitudes hid
+the phase error. A new `--fet-broadband-h5-dense` gate now carries 31 scoreable
+same-stimulus UAD vectors: Release 0.5 at 48/96 kHz, the original
+Release-0.66595459 grid at 48/96 kHz, and three independently retained 48 kHz
+campaign midpoints at -30, -18 and -9 dBFS.
+
+The old scalar proposal is conclusively rejected, not tuned around. Zero/full
+source controls confirm complex linearity, but the best real scale still leaves
+0.739-2.513 dB and 8.735-33.615 degrees residual. The accepted mechanism is a
+raw Chebyshev T5 plus its first three 300 Hz pole states. Four real coefficients
+solve the 1 kHz H5 vector and force the joint 100 Hz H5 contribution to zero.
+Tables retain drive, Input, Release and 48/96 kHz as measured coordinates;
+zero guards keep the correction dormant below the -92 dBc scoring onset, and
+triangular Input weights leave neighbouring measured positions on their prior
+paths. The added `shallowT5Lowest` state is cleared by the existing aggregate
+prepare/reset paths.
+
+The three initially unscored 48 kHz campaign midpoint magnitude errors were
+0.779003, 1.450880 and 0.493261 dB. They now read +0.000019, -0.000021 and
+-0.000019 dB, with phase errors +0.000016, +0.000093 and +0.000089
+degrees.
+Across all 31 rows the native worst result is 0.001763 dB / 0.007186 degrees;
+the no-FMA result is 0.002256 dB / 0.021547 degrees, against 0.25 dB / 3.0
+degree bounds. The pre-existing sparse broadband H5 gate improves to 0.055018
+dB worst, and the constrained opposite-frequency path remains 0.117324 dB
+worst at 100 Hz.
+
+Neighbour verification passed for broadband H2 (0.103559 dB), LF colour
+(0.232734 dB), both dense H3 gates, static and maximum reduction, knee onset
+(0.011713 dB worst and 0.000446 dB frequency split), deep-release memory,
+startup lifecycle (counter 24, blend 0), stereo phase, reset determinism and
+block-size invariance (both maximum delta 0), and 44.1/48/88.2/96 kHz flat
+gain (0.003448 dB worst). After updating the H3 gate's H5 anchors to this
+independently accepted surface, a deliberate `0.00001 * shallowT5` leak left
+H3 within its bounds but moved H5 by 11.682719686 dB and produced the expected
+neighbour failure; restoring production returns native H5 movement to exactly
+0 in that gate (0.002006967 dB without FMA).
+
+Final release builds produced standalone/JACK, LV2, VST3, CLAP and signed AU in
+both variants. Native CTest passed 4/4 in 86.78 seconds; no-FMA CTest passed
+4/4 in 92.00 seconds. This includes the Milestone #2 AU sidechain and Opto
+dense-programme gates from section 10. A final live GitHub audit confirms both
+milestone issues, #200 and #210, are CLOSED (closed 2026-08-30 at 14:51 UTC).
+Linux GCC 12 was not re-run; the stopped Podman platform gap remains explicitly
+unverified.
+
+## 15. FET Wave 35: final stereo/recovery audio parity — 2026-08-30
+
+The two retained Wave 27 audio holdouts are now measured gates and both pass.
+This closes the known FET audio-parity surface; it does not manufacture a claim
+for the still-unrepeatable visual meter film or the unavailable Linux runner.
+
+The new `--fet-stereo-dense` gate replays the exact 48/96 kHz UAD phase rows:
+the exposed 96 kHz equal-level quarter-cycle cell, its two adjacent phases, the
+same 48 kHz cell, and the unequal-level opposite arm. The pre-change path failed
+at 0.059104905 dB worst. A common oversampled detector was rejected at
+0.199462399 dB and native winner selection with an oversampled maximum was
+rejected at 0.345179409 dB. The control experiment was decisive: evaluating the
+link at 1x reduced the whole falsifier set to 0.006510735 dB. The accepted path
+therefore evaluates the internal signed-maximum link control once per host
+sample and holds it through the oversampling phases, while leaving audio,
+colour, and external-sidechain interpolation oversampled. It reads 0.009922296
+dB native and 0.010486871 dB without FMA against the 0.020 dB bound. The older
+in-phase/antiphase law, asymmetric stereo reference, block and reset gates all
+remain green.
+
+The new `--fet-recovery-dense` gate covers all 16 retained recovery conditions
+and five declared windows per condition: 48/96 kHz, 1/4 kHz carriers, -30/-18/-6
+dBFS drive, Attack 0/0.5/1, 4:1/8:1, and the 90-degree terminal-phase falsifier.
+The current pre-change binary failed at 3.404430389 dB. It also exposed a newer
+neighbor regression: after a loud burst, the shallow-knee helper treated a
+retained envelope as live knee programme and produced a false +0.85 dB gain
+hump, reaching +0.915519714 dB error in the 48 kHz phase-90 4.5 s window. The
+helper now requires the existing 2 ms live-programme support, so carrier zero
+crossings remain supported while the post-burst false arm cannot engage.
+
+The remaining recovery difference is a finite terminal-charge population, not
+a new asymptotic release scalar. Its measured coordinates are maximum
+reduction, Attack, Release, ratio, host rate, and terminal level drop; the last
+coordinate supplies the phase/time-order degree of freedom that Wave 27 proved
+was missing. A compact positive terminal arm plus the independently measured
+small bipolar tail reaches 0.140045166 dB worst over all 80 native points and
+the same 0.140045166 dB without FMA, against the 0.150 dB bound. Static and
+sustained programme never enter this arm. Ratio/Attack/Release automation
+clears a pending event instead of reinterpreting it under new controls.
+
+The recovery state is aggregate-initialized in prepare/reset and explicitly
+cleared on repeated prepare, reset, FET mode exit, settled bypass, and the
+unused channel of a mono render. `--fet-recovery-state` measures an exercised
+gain of 1.491761/1.491761 and exactly 1.000000/1.000000 after prepare, reset,
+mode exit, and bypass; mono clears channel 1 to exactly 1.000000. Removing only
+the settled-bypass clear left 1.482260/1.482260 and produced the expected test
+failure; restoring it returns the gate to green.
+
+Focused neighbors passed for knee onset/release, static and maximum reduction,
+All-buttons settling, attack drive/knob, startup peak/lifecycle/neighbors,
+stereo, reset and block invariance, sample-rate gain, and every broadband/LF
+H2/H3/H5 gate. Final production builds again generated standalone/JACK, LV2,
+VST3, CLAP, and signed AU in both variants. Native CTest passed 4/4 in 109.23
+seconds; no-FMA CTest passed 4/4 in 116.06 seconds. These suites include the
+Milestone #2 AU-sidechain and Opto dense-programme gates; the live closeout in
+section 14 remains valid with issues #200 and #210 CLOSED. Linux GCC 12 was not
+re-run because the Podman platform remains unavailable, and visual meter-film
+parity remains measurement-blocked by the reference's failed repeatability
+control.

--- a/design-qa.md
+++ b/design-qa.md
@@ -90,3 +90,96 @@ full-view scale.
 No P3 visual follow-up is required for this scope.
 
 final result: passed
+
+---
+
+# Multicomp-2 FET Design QA
+
+**Source visual truth**
+
+- User-supplied 1176-style front-panel reference, locally grounded at `build-multi-comp-1176/qa/1176ln-reference.jpg`.
+- Source pixels: 2560 × 532.
+
+**Implementation evidence**
+
+- Final hosted-AU screenshot: `build-multi-comp-1176/qa/au-fet-one-db-meter.png`.
+- Captured pixels: 2240 × 760 at a 2× backing scale; native editor viewport:
+  1120 × 380 design pixels.
+- State: FET mode, default FET controls, ratio 4:1, meter fixed to GR.
+- Internal product precedent: the shipping Opto face and its `drawOptoMeter`
+  renderer in `MultiCompUI.cpp`.
+
+**Normalization and comparison**
+
+- Full-view inspection used the final 2240 × 760 hosted-AU screenshot.
+- Focused same-input comparison:
+  `build-multi-comp-1176/qa/fet-one-db-comparison.png` (2240 × 310).
+- Focused meter comparison:
+  `build-multi-comp-1176/qa/fet-one-db-meter-focused.png` (1280 × 390),
+  with the hardware reference on the left and final AU meter on the right.
+- For the focused comparison, the source face was cropped to 2350 × 430,
+  scaled proportionally to 1120 px wide, and vertically padded to 1120 × 310.
+  The 2240 × 620 implementation face was cropped from the 2× capture and
+  downsampled to 1120 × 310. Neither face was stretched.
+
+**Findings**
+
+- No actionable P0, P1, or P2 visual differences remain.
+- Fonts and typography: the compact industrial hierarchy, calibrated scales,
+  uppercase labels, and centered rack branding follow the source. Dusk's
+  existing crisp font replaces the photographed manufacturer's type intentionally.
+- Spacing and layout rhythm: the primary order matches the source—Input,
+  Output, stacked Attack/Release, Ratio, VU, Meter. Threshold, Transient, and
+  Curve are no longer visible on the vintage face. Mix remains as the only
+  small product extension, placed at the lower-right edge.
+- Colors and visual tokens: black brushed face, restrained off-white markings, dark switch banks, machined silver controls, and amber VU treatment match the source palette.
+- Image quality and asset fidelity: the FET face now calls the exact Opto VU
+  renderer rather than maintaining a weaker FET-only approximation. Both large
+  and timing knobs use center-aligned metal layers; the prior upper-left gray
+  crescent is absent in the final capture. The photographed UA logo and branding
+  were intentionally not reproduced; original FET 76 / MC-2 branding is used.
+- Meter scale and copy: the shared Opto/FET VU contains 21 marks across its
+  0–20 dB gain-reduction span, producing one mark per dB. Five-dB marks remain
+  longer and numbered for hierarchy. The redundant `VU LEVEL INDICATOR` legend
+  is absent in both final AU captures; `VU`, `GR`, and `GAIN REDUCTION` remain.
+- Copy and content: hardware labels and ratio ordering match the source while
+  preserving the All-buttons option. Meter +8/+4/Off positions are decorative
+  because this plugin exposes only GR metering; GR is visibly fixed as active.
+
+**Comparison history**
+
+1. `fet-before-vst3.png`: P1—generic compressor row, wrong control order, small uniform knobs, no integrated hardware identity.
+   Fix: rebuilt the black face, added large gain knobs, stacked timing controls, vertical ratio bank, and amber analogue meter.
+2. `fet-pass-1.png` / `fet-pass-2.png`: P1—hardware row was closer, but an
+   always-visible MC-2 extension row made the mode taller and unlike the real
+   panel. Fix: followed the existing Opto pattern, removed the second row, and
+   returned FET to 1120 × 380.
+3. `fet-pass-3-opto-layout.png`: P1—Threshold, Transient, and Curve still added
+   faceplate clutter; the FET-only VU was visually weaker than the proven Opto
+   VU; offset opaque knob disks created gray upper-left crescents.
+4. `fet-pass-4-opto-meter.png`: removed those three visible controls, reused the
+   Opto VU renderer, and rebuilt each gray knob from concentric metal layers.
+   The final source/implementation comparison shows the requested hardware order,
+   clean knob silhouettes, shallow rack format, and original Dusk identity.
+5. `au-fet-one-db-meter.png` and `au-opto-one-db-meter.png`: reduced the shared
+   VU from 41 half-dB marks to 21 one-dB marks and removed its top legend. The
+   revised FET/reference comparison shows the calmer scale; the direct AU
+   captures confirm that the same renderer is used in both modes.
+
+**Implementation checklist**
+
+- [x] Use exactly one gain-reduction tick per dB in Opto and FET.
+- [x] Remove the `VU LEVEL INDICATOR` legend from the shared meter.
+- [x] Render and inspect both modes through the AU component.
+- [x] Compare the revised FET face with the source at matched dimensions.
+
+**Verification gaps / follow-up polish**
+
+- P3: a manual DAW pass can still judge hover bubbles and very small-label
+  readability at the minimum resize scale. The shared knob interaction path and
+  FET ratio source contract compile and pass the plugin-layer test, but pointer
+  interaction was not automated in the screenshot host.
+
+**Final result**
+
+final result: passed

--- a/plugins/multi-comp/core/MultiCompDSP.cpp
+++ b/plugins/multi-comp/core/MultiCompDSP.cpp
@@ -14,6 +14,129 @@ void copyParameter(std::atomic<T>& destination, const std::atomic<T>& source) no
 {
     destination.store(source.load(std::memory_order_relaxed), std::memory_order_relaxed);
 }
+
+float fetAttackPositionFromPlain(float legacyMilliseconds) noexcept
+{
+    const float proportion = std::clamp(
+        (legacyMilliseconds - 0.02f) / (80.0f - 0.02f), 0.0f, 1.0f);
+    return std::pow(proportion, 0.3f);
+}
+
+// The installed unit's first-cycle output peak SATURATES. Twelve dB of extra
+// input moves it +8.83 dB from -30 to -18 dBFS but only +1.63 dB from -18 to
+// -6 dBFS (Attack 0.00, 4 kHz reference peaks 0.9672 / 2.6765 / 3.2279). That
+// is a ceiling signature, not a detector one, and it is the mechanism the
+// vintage path was missing: our own peaks ran 6.69-7.01 dB high across the
+// whole -6 dBFS row and +3.39/+6.62 dB at Attack 1.00 lower down.
+//
+// This is deliberately a LEVEL-domain soft ceiling and not the time-windowed
+// output gain an earlier attempt used, because the two gates that constrain it
+// overlap in time and cannot both be satisfied by any choice of window. The
+// 4 kHz attack estimator fits from half a carrier period (0.125 ms) out to
+// 20 ms, while the measured first-cycle peaks sit at 0.0208-0.2500 ms. A gain
+// held across a fixed window multiplies the estimator's exponential by a
+// non-exponential envelope, which moved the fitted tau by up to 26 percentage
+// points on two rows -- proven by disabling the stage outright on diagnostic
+// binary 28dd845b6adf, which restored the pre-stage 23.487 % worst exactly.
+//
+// A ceiling has the property the window cannot buy: it is inert on every
+// sample already below the target, so it stops acting the moment the envelope
+// has decayed past it. At -30 dBFS/Attack 1.00 that is 0.065 ms after onset,
+// before the estimator's first fitted sample.
+float fetStartupPeakTarget(float sourcePeakDbfs, float attackPosition,
+                           int ratioIndex) noexcept
+{
+    // Reference whole-capture peaks, each entry fitted to the gated 1 kHz
+    // dynamics campaign where that measurement exists and to the 4 kHz
+    // high-carrier probe where it does not. `testFetStartupPeakSurface` asserts
+    // the 1 kHz Attack 0.00/0.50/1.00 knots of the -6 dBFS row (and the ratio
+    // rows at 0.50); nothing was ever captured at 1 kHz for Attack 0.25 or
+    // 0.75, so those two take the 4 kHz numbers rather than an interpolation
+    // between the knots either side. An earlier revision did interpolate them,
+    // and the 4 kHz probe rejected it: Attack 0.75 came out 3.847 dB low with
+    // its curve RMS up from 0.01808 to 0.04877, because the invented target
+    // (1.3554) sat far under the measured one (2.5606).
+    //
+    // That leaves the row non-monotonic in Attack, and the non-monotonicity is
+    // real rather than a fitting artefact: the installed unit's first-cycle
+    // peak is CARRIER dependent wherever its own detector wins the race to the
+    // first crest, so 1 kHz reads 2.4892 at Attack 0.50 where 4 kHz reads
+    // 3.1495. A single carrier-independent ceiling cannot serve both, and the
+    // gated carrier wins. The cost is recorded in the scorecard: the 4 kHz
+    // Attack 1.00 row keeps a -3.394 dB residual, where the reference is
+    // detector-bound (its peaks are 0.9113 at 1 kHz against 1.3908 at 4 kHz)
+    // while ours is ceiling-bound and therefore nearly carrier independent.
+    //
+    // The -18 and -30 rows are 4 kHz throughout; no 1 kHz row was ever
+    // captured at those drives.
+    constexpr std::array<float, 3> sourceDbfs{{-30.0f, -18.0f, -6.0f}};
+    constexpr std::array<float, 5> attackKnots{{
+        0.0f, 0.25f, 0.5f, 0.75f, 1.0f}};
+    // Stored knee-compensated, NOT as the raw reference peak: the soft knee
+    // below passes `startupCeilingSlope` of the excess, so a table holding the
+    // target itself lands high by exactly that fraction (measured: +0.444 to
+    // +1.007 dB, core c9281fa8bc9b). Each entry is the C solving
+    // `T = C + (P - C) * slope` for the measured reference peak T and our own
+    // measured raw peak P, i.e. `C = (T - slope * P) / (1 - slope)`.
+    constexpr std::array<std::array<float, 5>, 3> peaks{{
+        {{0.9677f, 0.9350f, 0.8921f, 0.8034f, 0.5058f}},
+        {{2.7337f, 2.3762f, 2.1709f, 1.8299f, 0.7835f}},
+        {{2.7164f, 2.6670f, 2.3360f, 2.5606f, 0.7865f}},
+    }};
+    // Ratio scaling, measured at Attack 0.50 / -6 dBFS on the 1 kHz reference
+    // (2.4892 / 2.1281 / 1.8324 / 1.4771 / 2.5832), knee-compensated the same
+    // way and expressed against the 4:1 entry. The 8:1 entry is the reference
+    // peak itself rather than a solved C, because our raw 8:1 peak (2.1056)
+    // already sits BELOW the reference (2.1281): that row needs the ceiling to
+    // stay inert, and solving it would have pulled the target under our own
+    // peak and started clipping a row that was already within 0.092 dB. Held
+    // flat in Attack because no other ratio row was captured, and faded out
+    // towards -30 dBFS where no ratio row was captured at all.
+    constexpr std::array<float, 5> ratioScale{{
+        1.0f, 0.910999f, 0.772807f, 0.603782f, 1.029946f}};
+
+    size_t sourceHigh = 1;
+    if (sourcePeakDbfs >= sourceDbfs.back())
+        sourceHigh = sourceDbfs.size() - 1;
+    else
+        while (sourceHigh < sourceDbfs.size() - 1
+               && sourcePeakDbfs > sourceDbfs[sourceHigh])
+            ++sourceHigh;
+    const size_t sourceLow = sourceHigh - 1;
+    const float sourceFraction = std::clamp(
+        (sourcePeakDbfs - sourceDbfs[sourceLow])
+            / (sourceDbfs[sourceHigh] - sourceDbfs[sourceLow]),
+        0.0f, 1.0f);
+
+    size_t attackHigh = 1;
+    if (attackPosition >= attackKnots.back())
+        attackHigh = attackKnots.size() - 1;
+    else
+        while (attackHigh < attackKnots.size() - 1
+               && attackPosition > attackKnots[attackHigh])
+            ++attackHigh;
+    const size_t attackLow = attackHigh - 1;
+    const float attackFraction = std::clamp(
+        (attackPosition - attackKnots[attackLow])
+            / (attackKnots[attackHigh] - attackKnots[attackLow]),
+        0.0f, 1.0f);
+    const auto interpolateAttack = [&](size_t sourceIndex) noexcept {
+        return peaks[sourceIndex][attackLow]
+            + attackFraction
+                * (peaks[sourceIndex][attackHigh]
+                    - peaks[sourceIndex][attackLow]);
+    };
+    const float low = interpolateAttack(sourceLow);
+    const float high = interpolateAttack(sourceHigh);
+    const float target = low + sourceFraction * (high - low);
+
+    const float ratioDepth = std::clamp(
+        (sourcePeakDbfs + 30.0f) / 24.0f, 0.0f, 1.0f);
+    const float scale = 1.0f + ratioDepth
+        * (ratioScale[static_cast<size_t>(std::clamp(ratioIndex, 0, 4))]
+            - 1.0f);
+    return target * scale;
+}
 }
 
 void MultiCompDSP::prepare(double sr, int blockSize)
@@ -24,6 +147,10 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     const int initialOversampling = oversamplingSetting == 2 ? 4
                                   : oversamplingSetting == 1 ? 2 : 1;
     modes.prepare(sampleRate, maxBlock, initialOversampling);
+    // MultiCompModes::prepare deliberately preserves state when its rate and
+    // factor are unchanged. A host prepare is nevertheless a lifecycle reset
+    // for the finite FET post-burst helper, including repeated prepare calls.
+    modes.clearFetPostBurstRecovery();
     truePeakDetector.prepare();
     truePeakDetector.setQuality(MultiCompTruePeakDetector::Quality::Standard4x);
     for (auto& os : oversamplers) { os.setFactor(4); os.prepare(maxBlock); os.reset(); }
@@ -42,6 +169,8 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     for (auto& v : crossoverCurves) v.assign(static_cast<size_t>(maxBlock), 0.0f);
     dry.assign(static_cast<size_t>(maxBlock * kMaxChannels), 0.0f);
     bypassDry.assign(static_cast<size_t>(maxBlock * kMaxChannels), 0.0f);
+    fetStartupInput.assign(
+        static_cast<size_t>(maxBlock * kMaxChannels), 0.0f);
     mixCurve.assign(static_cast<size_t>(maxBlock), 1.0f);
     bypassCurve.assign(static_cast<size_t>(maxBlock), 0.0f);
     autoGainCurve.assign(static_cast<size_t>(maxBlock), 1.0f);
@@ -55,6 +184,9 @@ void MultiCompDSP::prepare(double sr, int blockSize)
     previousOptoOwnSidechainValid = {{false, false}};
     previousBusSidechain = {{0.0f, 0.0f}};
     previousBusSidechainValid = {{false, false}};
+    fetStartupInputPeak = {{0.0f, 0.0f}};
+    fetStartupActiveSamples = {{0, 0}};
+    fetStartupSilentSamples = {{0, 0}};
     const size_t dryDelaySize = static_cast<size_t>(std::max(1, antiAliasLatency + static_cast<int>(std::ceil(sampleRate * 0.01)) + 1));
     for (auto& line : dryPathDelay) line.assign(dryDelaySize, 0.0f);
     dryPathWrite = {{0, 0}};
@@ -105,6 +237,7 @@ void MultiCompDSP::reset()
     for (auto& v : modeInput) std::fill(v.begin(), v.end(), 0.0f);
     std::fill(dry.begin(), dry.end(), 0.0f);
     std::fill(bypassDry.begin(), bypassDry.end(), 0.0f);
+    std::fill(fetStartupInput.begin(), fetStartupInput.end(), 0.0f);
     for (auto& line : delayedInput) std::fill(line.begin(), line.end(), 0.0f);
     for (auto& line : globalLookahead) std::fill(line.begin(), line.end(), 0.0f);
     globalLookaheadWrite = {{0, 0}};
@@ -114,6 +247,9 @@ void MultiCompDSP::reset()
     previousOptoOwnSidechainValid = {{false, false}};
     previousBusSidechain = {{0.0f, 0.0f}};
     previousBusSidechainValid = {{false, false}};
+    fetStartupInputPeak = {{0.0f, 0.0f}};
+    fetStartupActiveSamples = {{0, 0}};
+    fetStartupSilentSamples = {{0, 0}};
     for (auto& line : dryPathDelay) std::fill(line.begin(), line.end(), 0.0f);
     dryPathWrite = {{0, 0}};
     for (auto& line : bypassDelay) std::fill(line.begin(), line.end(), 0.0f);
@@ -239,6 +375,20 @@ void MultiCompDSP::processBlock(const float* const* in, float* const* out, int n
     processBlockExternal(in, nullptr, out, nCh, nSamples);
 }
 
+float MultiCompDSP::advanceFetStartupBlend(
+    int& activeSamples, int fullCorrectionSamples,
+    int correctionEndSamples) noexcept
+{
+    if (activeSamples < correctionEndSamples)
+        ++activeSamples;
+    if (activeSamples <= fullCorrectionSamples)
+        return 1.0f;
+    return std::clamp(static_cast<float>(correctionEndSamples - activeSamples)
+                          / static_cast<float>(correctionEndSamples
+                                               - fullCorrectionSamples),
+                      0.0f, 1.0f);
+}
+
 void MultiCompDSP::processBlockExternal(const float* const* in, const float* const* sidechain,
                                         float* const* out, int nCh, int nSamples)
 {
@@ -270,6 +420,20 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
             blockInputPeak = std::max(blockInputPeak, std::abs(in[ch][i]));
     const MultiCompMode mode = static_cast<MultiCompMode>(
         std::clamp(params.mode.load(std::memory_order_relaxed), 0, 7));
+    if (mode != MultiCompMode::FET)
+    {
+        fetStartupInputPeak = {{0.0f, 0.0f}};
+        fetStartupActiveSamples = {{0, 0}};
+        fetStartupSilentSamples = {{0, 0}};
+        modes.clearFetPostBurstRecovery();
+    }
+    else
+    {
+        if (nCh == 1) modes.clearFetPostBurstRecovery(1);
+        for (int ch = 0; ch < nCh; ++ch)
+            std::copy_n(in[ch], nSamples,
+                fetStartupInput.data() + static_cast<size_t>(ch * maxBlock));
+    }
     const int linkMode = std::clamp(params.stereoLinkMode.load(std::memory_order_relaxed), 0, 2);
     const int oversamplingSetting = params.oversampling.load(std::memory_order_relaxed);
     const int actualOversampling = oversamplingSetting == 2 ? 4 : oversamplingSetting == 1 ? 2 : 1;
@@ -322,6 +486,10 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
     processLatencyHistory(in, out, nCh, nSamples, blockLatency, requestedBypass && bypassSettled);
     if (requestedBypass && bypassSettled)
     {
+        fetStartupInputPeak = {{0.0f, 0.0f}};
+        fetStartupActiveSamples = {{0, 0}};
+        fetStartupSilentSamples = {{0, 0}};
+        modes.clearFetPostBurstRecovery();
         previousBusSidechainValid = {{false, false}};
         processSidechainListenHistory(filteredSidechain, nCh, nSamples, blockLatency);
         for (int i = 0; i < nSamples; ++i) (void)sidechainListenRamp.next();
@@ -412,6 +580,130 @@ void MultiCompDSP::processBlockExternal(const float* const* in, const float* con
                 dry[rightIndex] = dryMid - drySide;
             }
         }
+    }
+    if (mode == MultiCompMode::FET)
+    {
+        // The installed unit's first reconstructed cycle has a short output-
+        // stage memory that depends on source peak, Attack, and Ratio. Apply
+        // its measured surface here, after AA reconstruction: the current raw
+        // input then leads the delayed output by `antiAliasLatency`, matching
+        // the reference signal path without adding lookahead or changing PDC.
+        // The correction is gone 0.5 ms after the aligned output onset. The
+        // higher-carrier gate resolves and separately constrains the small
+        // overlap with its first attack-shape samples.
+        const float attackPosition = fetAttackPositionFromPlain(
+            params.fetAttack.load(std::memory_order_relaxed));
+        const int ratioIndex = std::clamp(
+            params.fetRatio.load(std::memory_order_relaxed), 0, 4);
+        const float outputPosition = std::clamp(
+            (params.fetOutput.load(std::memory_order_relaxed) + 20.0f) / 40.0f,
+            0.0f, 1.0f);
+        const float outputControlBlend = std::clamp(
+            (0.90f - outputPosition) / (0.90f - 0.625915527f),
+            0.0f, 1.0f);
+        const float activeThreshold = decibelsToGain(-60.0f);
+        const int silenceResetSamples = std::max(
+            1, static_cast<int>(std::lround(0.002 * sampleRate)));
+        const int fullCorrectionSamples = antiAliasLatency
+            + std::max(1, static_cast<int>(std::lround(0.00025 * sampleRate)));
+        const int correctionEndSamples = antiAliasLatency
+            + std::max(2, static_cast<int>(std::lround(0.00050 * sampleRate)));
+        const float peakRelease = std::exp(
+            -1.0f / static_cast<float>(0.010 * sampleRate));
+        constexpr float startupCeilingSlope = 0.10f;
+        for (int ch = 0; ch < nCh; ++ch)
+            for (int i = 0; i < nSamples; ++i)
+            {
+                const float inputMagnitude = std::abs(fetStartupInput[
+                    static_cast<size_t>(ch * maxBlock + i)]);
+                if (inputMagnitude > activeThreshold)
+                {
+                    if (fetStartupInputPeak[static_cast<size_t>(ch)] <= 0.0f
+                        || fetStartupSilentSamples[static_cast<size_t>(ch)]
+                            >= silenceResetSamples)
+                    {
+                        fetStartupInputPeak[static_cast<size_t>(ch)]
+                            = inputMagnitude;
+                        fetStartupActiveSamples[static_cast<size_t>(ch)] = 0;
+                    }
+                    else
+                        fetStartupInputPeak[static_cast<size_t>(ch)] = std::max(
+                            inputMagnitude,
+                            fetStartupInputPeak[static_cast<size_t>(ch)]
+                                * peakRelease);
+                    fetStartupSilentSamples[static_cast<size_t>(ch)] = 0;
+                }
+                else if (fetStartupInputPeak[static_cast<size_t>(ch)] > 0.0f)
+                {
+                    fetStartupInputPeak[static_cast<size_t>(ch)] *= peakRelease;
+                    fetStartupSilentSamples[static_cast<size_t>(ch)] = std::min(
+                        fetStartupSilentSamples[static_cast<size_t>(ch)] + 1,
+                        silenceResetSamples + 1);
+                    if (fetStartupSilentSamples[static_cast<size_t>(ch)]
+                        >= silenceResetSamples)
+                    {
+                        fetStartupInputPeak[static_cast<size_t>(ch)] = 0.0f;
+                        fetStartupActiveSamples[static_cast<size_t>(ch)] = 0;
+                    }
+                }
+
+                float startupBlend = 0.0f;
+                if (fetStartupInputPeak[static_cast<size_t>(ch)] > 0.0f)
+                {
+                    // Saturate at the end of the correction window: the blend is
+                    // already 0 there and stays 0, so counting past it changes
+                    // nothing audible and only risks int overflow on a long
+                    // sustained input.
+                    int& activeSamples
+                        = fetStartupActiveSamples[static_cast<size_t>(ch)];
+                    startupBlend = advanceFetStartupBlend(
+                        activeSamples, fullCorrectionSamples,
+                        correctionEndSamples);
+                }
+                const float magnitude = std::abs(out[ch][i]);
+                if (startupBlend > 0.0f && outputControlBlend > 0.0f
+                    && magnitude > 0.0f)
+                {
+                    const float sourcePeakDbfs = gainToDecibels(std::max(
+                        fetStartupInputPeak[static_cast<size_t>(ch)], 1.0e-12f));
+                    const float startupCeiling = fetStartupPeakTarget(
+                        sourcePeakDbfs, attackPosition, ratioIndex);
+                    // Inert below the target -- that is the property the old
+                    // time-windowed gain lacked. Only samples ABOVE the
+                    // installed unit's measured first-cycle peak are touched,
+                    // so the estimator window is left alone the instant the
+                    // envelope has decayed past it.
+                    if (magnitude > startupCeiling)
+                    {
+                        const float limited = startupCeiling
+                            + (magnitude - startupCeiling)
+                                * startupCeilingSlope;
+                        out[ch][i] += outputControlBlend * startupBlend
+                            * (std::copysign(limited, out[ch][i]) - out[ch][i]);
+                    }
+                }
+            }
+
+        // The reference's base-rate output stage compresses only the largest
+        // reconstructed startup peaks. Its steady ceiling sweep stays below
+        // this knee, so static gain and harmonic measurements remain untouched.
+        // Runs after the mid/side decode above: the hardware limits the
+        // physical left/right outputs, so the ceiling must see decoded L/R
+        // samples in both link modes (identical result for mono and for pure
+        // mid or pure side content; differs only for mixed stereo material).
+        constexpr float outputCeilingKnee = 6.39712761f;
+        constexpr float outputCeilingSlope = 0.46720009f;
+        for (int ch = 0; ch < nCh; ++ch)
+            for (int i = 0; i < nSamples; ++i)
+            {
+                const float magnitude = std::abs(out[ch][i]);
+                if (magnitude > outputCeilingKnee)
+                    out[ch][i] = std::copysign(
+                        outputCeilingKnee
+                            + (magnitude - outputCeilingKnee)
+                                * outputCeilingSlope,
+                        out[ch][i]);
+            }
     }
     const float targetMix = std::clamp((isMulti ? params.mbMix.load(std::memory_order_relaxed) : params.mix.load(std::memory_order_relaxed)) * 0.01f, 0.0f, 1.0f);
     globalMixSmoother.setTarget(targetMix);
@@ -779,13 +1071,90 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
             previousOptoOwnSidechainValid = {{false, false}};
             continue;
         }
+        if (mode == MultiCompMode::FET && link)
+        {
+            // The installed 1176's stereo link is an arithmetic signed
+            // maximum, not a magnitude maximum or a power sum. Its internal
+            // link control is evaluated once per host sample and held across
+            // the oversampling phases; the audio and colour path remain fully
+            // oversampled. Recomputing the maximum on interpolated sub-samples
+            // creates a false time-order arm at 96 kHz: the equal-level
+            // quarter-cycle response moves by 0.059 dB while its adjacent and
+            // complementary phases do not. A full 1x control proved the rate
+            // coordinate (0.0065 dB worst); this held control reproduces it
+            // without disabling audio oversampling (0.0099 dB worst).
+            std::array<float, 4> inputLeftPhases{}, inputRightPhases{};
+            std::array<float, 4> outputLeftPhases{}, outputRightPhases{};
+            oversamplers[0].upsampleSample(in[0][i], inputLeftPhases.data());
+            oversamplers[1].upsampleSample(in[1][i], inputRightPhases.data());
+            for (int ch = 0; ch < 2; ++ch)
+                if (!previousOversampledSidechainValid[static_cast<size_t>(ch)])
+                {
+                    previousOversampledSidechain[static_cast<size_t>(ch)]
+                        = ch == 0 ? sc0 : sc1;
+                    previousOversampledSidechainValid[static_cast<size_t>(ch)] = true;
+                }
+            const float nativeSignedMaximum = std::max(sc0, sc1);
+            const bool nativeLeftUsesLinkedDetector = external
+                || sc0 < nativeSignedMaximum - 1.0e-12f;
+            const bool nativeRightUsesLinkedDetector = external
+                || sc1 < nativeSignedMaximum - 1.0e-12f;
+            for (int phase = 0; phase < actualOs; ++phase)
+            {
+                const float phaseSc0 = external
+                    ? actualOs == 1 ? sc0
+                        : interpolateOversampledSidechain(
+                            previousOversampledSidechain[0], sc0,
+                            phase, actualOs)
+                    : inputLeftPhases[static_cast<size_t>(phase)];
+                const float phaseSc1 = external
+                    ? actualOs == 1 ? sc1
+                        : interpolateOversampledSidechain(
+                            previousOversampledSidechain[1], sc1,
+                            phase, actualOs)
+                    : inputRightPhases[static_cast<size_t>(phase)];
+                // External sidechains retain their existing interpolated path;
+                // only the measured internal link has a native-rate control.
+                const float detectorSc0 = external ? phaseSc0 : sc0;
+                const float detectorSc1 = external ? phaseSc1 : sc1;
+                const float signedMaximum = std::max(detectorSc0, detectorSc1);
+                constexpr float fetLinkDetectorGain = 1.0285f;
+                const float leftSidechain = detectorSc0
+                    + (fetLinkDetectorGain * signedMaximum - detectorSc0)
+                        * linkAmount;
+                const float rightSidechain = detectorSc1
+                    + (fetLinkDetectorGain * signedMaximum - detectorSc1)
+                        * linkAmount;
+                outputLeftPhases[static_cast<size_t>(phase)] = applyCoreDistortion(
+                    modes.process(
+                        mode, inputLeftPhases[static_cast<size_t>(phase)], 0,
+                        leftSidechain, modeParams, localBusMix, external, 0.0f,
+                        nativeLeftUsesLinkedDetector),
+                    distortionType, distortionAmount);
+                outputRightPhases[static_cast<size_t>(phase)] = applyCoreDistortion(
+                    modes.process(
+                        mode, inputRightPhases[static_cast<size_t>(phase)], 1,
+                        rightSidechain, modeParams, localBusMix, external, 0.0f,
+                        nativeRightUsesLinkedDetector),
+                    distortionType, distortionAmount);
+            }
+            out[0][i] = oversamplers[0].downsampleSample(outputLeftPhases.data());
+            out[1][i] = oversamplers[1].downsampleSample(outputRightPhases.data());
+            previousOversampledSidechain = {{sc0, sc1}};
+            previousOptoOwnSidechain = {{sc0, sc1}};
+            previousOptoOwnSidechainValid = {{true, true}};
+            previousBusSidechainValid = {{false, false}};
+            continue;
+        }
         for (int ch = 0; ch < nCh; ++ch)
         {
             const float input = in[ch][i];
             const float ownSc = ch == 0 ? sc0 : sc1;
             const float midSideSc = ch == 0 ? (sc0 + sc1) * 0.5f : (sc0 - sc1) * 0.5f;
-            const float sc = link ? std::abs(ownSc) * (1.0f - linkAmount) + scLevel * linkAmount
-                                  : linkMode == 1 ? midSideSc : ownSc;
+            const float sc = link
+                ? std::abs(ownSc) * (1.0f - linkAmount)
+                    + scLevel * linkAmount
+                : linkMode == 1 ? midSideSc : ownSc;
             // Interpolate causally from the previous native detector sample to
             // this one.  The carried endpoint makes the same detector curve
             // independent of where the host divides blocks.
@@ -803,15 +1172,26 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
             }
             const float previousOptoOwnSc = previousOptoOwnSidechain[channelIndex];
             const float localMix = mode == MultiCompMode::Digital ? localDigitalMix : localBusMix;
+            const bool fetOwnDetectorIsLinkedMaximum
+                = std::abs(ownSc) >= scLevel - 1.0e-12f;
+            const bool modeUsesLinkedDetector = mode == MultiCompMode::FET
+                ? link && (external || !fetOwnDetectorIsLinkedMaximum) : link;
             if (actualOs == 1)
             {
                 out[ch][i] = oversamplers[ch].processSample(input, [&](float sample) noexcept {
                     const float optoOwnDetector = external ? ownSc : sample;
                     const float optoDetector = optoOwnDetector
                         + (optoLinkedPhases[0] - optoOwnDetector) * linkAmount;
+                    const float modeSidechain = mode == MultiCompMode::FET && link
+                        ? external ? sc
+                        : fetOwnDetectorIsLinkedMaximum ? std::abs(sample)
+                        : std::abs(sample) * (1.0f - linkAmount)
+                            + std::abs(optoLinkedPhases[0]) * linkAmount
+                        : sc;
                     return applyCoreDistortion(modes.process(
-                                                   mode, sample, ch, sc, modeParams,
-                                                   localMix, external, optoDetector, link),
+                                                   mode, sample, ch, modeSidechain, modeParams,
+                                                   localMix, external, optoDetector,
+                                                   modeUsesLinkedDetector),
                                                distortionType, distortionAmount);
                 });
             }
@@ -829,9 +1209,17 @@ void MultiCompDSP::processRange(const float* const* in, const float* const* side
                     const float optoDetector = optoOwnDetector
                         + (optoLinkedPhases[static_cast<size_t>(phase)]
                            - optoOwnDetector) * linkAmount;
+                    const float modeSidechain = mode == MultiCompMode::FET && link
+                        ? external ? osSc
+                        : fetOwnDetectorIsLinkedMaximum ? std::abs(sample)
+                        : std::abs(sample) * (1.0f - linkAmount)
+                            + std::abs(optoLinkedPhases[static_cast<size_t>(phase)])
+                                * linkAmount
+                        : osSc;
                     return applyCoreDistortion(modes.process(
-                                                   mode, sample, ch, osSc, modeParams,
-                                                   localMix, external, optoDetector, link),
+                                                   mode, sample, ch, modeSidechain, modeParams,
+                                                   localMix, external, optoDetector,
+                                                   modeUsesLinkedDetector),
                                                distortionType, distortionAmount);
                 });
             }

--- a/plugins/multi-comp/core/MultiCompDSP.hpp
+++ b/plugins/multi-comp/core/MultiCompDSP.hpp
@@ -115,6 +115,9 @@ private:
     void processSidechainListenHistory(const float* const* sidechain, int nCh,
                                        int nSamples, int delay) noexcept;
     void resetAutoGainMeasurement() noexcept;
+    static float advanceFetStartupBlend(int& activeSamples,
+                                        int fullCorrectionSamples,
+                                        int correctionEndSamples) noexcept;
     int latencySamplesForMode(MultiCompMode mode, float globalLookaheadMs,
                               float digitalLookaheadMs) const noexcept;
 
@@ -136,7 +139,8 @@ private:
     std::array<std::array<std::vector<float>, kMaxChannels>, kMultiCompBands> bands, sidechainBands;
     std::array<std::vector<float>, kMaxChannels> processedSidechain;
     std::array<std::vector<float>, kMaxChannels> modeInput;
-    std::vector<float> dry, bypassDry, mixCurve, bypassCurve, autoGainCurve;
+    std::vector<float> dry, bypassDry, fetStartupInput;
+    std::vector<float> mixCurve, bypassCurve, autoGainCurve;
     std::array<std::vector<float>, kMaxChannels> dryPathDelay;
     std::array<int, kMaxChannels> dryPathWrite{{0, 0}};
     std::array<std::vector<float>, kMaxChannels> bypassDelay;
@@ -153,6 +157,9 @@ private:
     std::array<float, kMaxChannels> previousBusSidechain{{0.0f, 0.0f}};
     std::array<bool, kMaxChannels> previousBusSidechainValid{{false, false}};
     std::array<float, kMultiCompBands * kMaxChannels> multibandEnvelopes{};
+    std::array<float, kMaxChannels> fetStartupInputPeak{{0.0f, 0.0f}};
+    std::array<int, kMaxChannels> fetStartupActiveSamples{{0, 0}};
+    std::array<int, kMaxChannels> fetStartupSilentSamples{{0, 0}};
     std::uint8_t activeBandMask = 0x0f;
     std::array<int, kMultiCompBands> enabledBandIndices{{0, 1, 2, 3}};
     std::array<int, kMultiCompBands - 1> stageBoundaryIndices{{0, 1, 2}};

--- a/plugins/multi-comp/core/MultiCompModes.hpp
+++ b/plugins/multi-comp/core/MultiCompModes.hpp
@@ -2730,7 +2730,8 @@ private:
                 -1.0f / (0.250f * sr));
             constexpr float kneeHoldSeconds = 0.030f;
             const float sampleSeconds = 1.0f / sr;
-            const auto advanceHeldPeak = [kneePeakRelease, sampleSeconds](
+            const auto advanceHeldPeak = [kneePeakRelease, kneeHoldSeconds,
+                                          sampleSeconds](
                 float inputLevel, float& peak,
                 float& holdSeconds) noexcept {
                 if (inputLevel >= peak)

--- a/plugins/multi-comp/core/MultiCompModes.hpp
+++ b/plugins/multi-comp/core/MultiCompModes.hpp
@@ -136,10 +136,12 @@ public:
         {
             case MultiCompMode::Opto: return processOpto(
                 input, ch, sc, p, external, optoDetector, useOptoDetector);
-            case MultiCompMode::FET: return processFET(input, ch, sc, p, false, external);
+            case MultiCompMode::FET: return processFET(
+                input, ch, sc, p, false, external, useOptoDetector);
             case MultiCompMode::VCA: return processVCA(input, ch, sc, p, external);
             case MultiCompMode::Bus: return processBus(input, ch, sc, p, localMix, external);
-            case MultiCompMode::StudioFET: return processFET(input, ch, sc, p, true, external);
+            case MultiCompMode::StudioFET: return processFET(
+                input, ch, sc, p, true, external, false);
             case MultiCompMode::StudioVCA: return processStudioVCA(input, ch, sc, p, external);
             case MultiCompMode::Digital: return processDigital(input, ch, sc, p, localMix, external);
             case MultiCompMode::Multiband: return input;
@@ -153,7 +155,9 @@ public:
         switch (mode)
         {
             case MultiCompMode::Opto: return gainToDecibels(opto[ch].gain);
-            case MultiCompMode::FET: return gainToDecibels(fet[ch].envelope);
+            case MultiCompMode::FET: return gainToDecibels(
+                fet[ch].envelope * fet[ch].kneeGain
+                    * fet[ch].recoveryGain);
             case MultiCompMode::VCA: return gainToDecibels(vca[ch].envelope);
             case MultiCompMode::Bus: return gainToDecibels(bus[ch].envelope);
             case MultiCompMode::StudioFET: return gainToDecibels(studioFet[ch].envelope);
@@ -162,6 +166,44 @@ public:
             case MultiCompMode::Multiband: break;
         }
         return 0.0f;
+    }
+
+    float fetColourGainReduction(int ch) const noexcept
+    {
+        ch = std::clamp(ch, 0, 1);
+        return gainToDecibels(fet[ch].envelope);
+    }
+
+    float fetPostBurstRecoveryGain(int ch) const noexcept
+    {
+        return fet[static_cast<size_t>(std::clamp(ch, 0, 1))].recoveryGain;
+    }
+
+    void clearFetPostBurstRecovery(int channel = -1) noexcept
+    {
+        const auto clear = [](auto& d) noexcept {
+            d.programmeExposureSeconds = 0.0f;
+            d.programmeMaximumGrDb = 0.0f;
+            d.programmeSilentSamples = 0;
+            d.kneePeak = 0.0f;
+            d.kneeBaseReductionDb = 0.0f;
+            d.kneeCorrectionDb = 0.0f;
+            d.kneeGain = 1.0f;
+            d.recoveryPreviousInstantLevel = 0.0f;
+            d.recoveryMaximumLevelDrop = 0.0f;
+            d.recoveryMaximumGrDb = 0.0f;
+            d.recoveryElapsedSeconds = 0.0f;
+            d.recoveryTerminalWeight = 0.0f;
+            d.recoveryReleasePosition = 0.5f;
+            d.recoveryAttackPosition = 0.5f;
+            d.recoveryGain = 1.0f;
+            d.recoveryRatioIndex = 0;
+            d.recoveryWasSupported = false;
+        };
+        if (channel >= 0 && channel < 2)
+            clear(fet[static_cast<size_t>(channel)]);
+        else
+            for (auto& d : fet) clear(d);
     }
 
     void setBusSidechainControls(float highPassFrequency,
@@ -239,9 +281,30 @@ private:
     struct FETState
     {
         float envelope = 1, previous = 0, dc = 0, prevSq = 0, peak = 0;
+        float kneePeak = 0;
+        float kneeBaseReductionDb = 0;
+        float kneeCorrectionDb = 0, kneeGain = 1;
+        float recoveryPreviousInstantLevel = 0;
+        float recoveryMaximumLevelDrop = 0;
+        float recoveryMaximumGrDb = 0, recoveryElapsedSeconds = 0;
+        float recoveryTerminalWeight = 0, recoveryReleasePosition = 0.5f;
+        float recoveryAttackPosition = 0.5f;
+        float recoveryGain = 1;
+        int recoveryRatioIndex = 0;
+        float kneePeakHoldSeconds = 0;
+        float kneeBaseHoldSeconds = 0;
+        float fastGrDb = 0, intermediateGrDb = 0, slowGrDb = 0;
+        float programmeExposureSeconds = 0, programmeMaximumGrDb = 0;
         float releaseMemory = 0, sag = 0, hf = 0, tilt = 0, subBass = 0;
+        float colourPeak = 0, colourHighPassLow = 0, colourHighPassLower = 0;
+        float colourLow = 0, colourLower = 0, colourLowPeak = 0;
+        float shallowT3Lag = 0, shallowT3Lower = 0, shallowT3Lowest = 0;
+        float shallowT5Lag = 0, shallowT5Lower = 0, shallowT5Lowest = 0;
+        float colourLowDc = 0, colourLowPrevSq = 0;
+        float colourLowHarmonicDc = 0;
         float previousLevel = 0.0f, voltageSag = 0.0f, subBassHpState = 0.0f;
-        int transient = 0, sagCounter = 0;
+        int transient = 0, sagCounter = 0, programmeSilentSamples = 0;
+        bool recoveryWasSupported = false;
     };
     struct VCAState
     {
@@ -511,6 +574,1088 @@ private:
         9.6964f, 11.7394f, 13.5249f, 15.2602f, 17.4341f, 19.2438f,
         21.5010f, 23.3864f, 25.7863f, 27.9270f, 30.0609f, 32.0834f,
         34.7103f, 36.8851f, 38.8184f, 40.5691f, 40.9082f}};
+
+    // Installed UADx 1176 v1.0.3 control laws, measured from three source
+    // levels at each position so neither compression nor the low-level floor
+    // can masquerade as pot taper. Values are relative to the clockwise stop.
+    // Multi-Comp's existing host ranges remain unchanged: saved/automated
+    // values retain their knob position and are mapped only inside vintage FET.
+    inline static constexpr std::array<float, 12> kFetControlPositions{{
+        0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.625915527f,
+        0.7f, 0.8f, 0.9f, 1.0f}};
+    inline static constexpr std::array<float, 12> kFetInputRelativeDb{{
+        -120.0f, -38.892933f, -33.678216f, -25.932386f, -20.790574f,
+        -13.389983f, -8.620572f, -7.996695f, -6.054538f, -1.246802f,
+        -0.066005f, 0.0f}};
+    inline static constexpr std::array<float, 12> kFetOutputRelativeDb{{
+        -120.0f, -76.428106f, -55.024575f, -41.535576f, -30.782583f,
+        -21.810000f, -14.485545f, -12.846387f, -8.604931f, -4.012500f,
+        -0.978134f, 0.0f}};
+
+    // Vintage-FET attack drive law. Six measured points, no extrapolation:
+    // see the note at the use site in processFET. The abscissa is the SETTLED
+    // reduction in dB, which is what `positiveReduction` carries; the ordinate
+    // multiplies the base attack time. Both ends are held, so the domain is
+    // exactly the span the reference was rendered at.
+    inline static constexpr std::array<float, 6> kFetDriveReductionDb{{
+        4.2865f, 6.6572f, 9.1406f, 14.1087f, 24.0669f, 34.0261f}};
+    inline static constexpr std::array<float, 6> kFetDriveAttackScale{{
+        14.8651f, 10.6649f, 7.8264f,
+        5.0588f, 2.9199f, 2.3322f}};
+
+    static float fetDriveAttackScale(float positiveReductionDb) noexcept
+    {
+        // Geometric interpolation: a multiplier on a time constant is a ratio,
+        // so the natural interpolant between two anchors is the constant-ratio
+        // one, and the required curve is strongly convex across a factor of six
+        // -- linear interpolation of the same anchors reads 3.8 % high at the
+        // middle of the widest gap. The independent check on the interpolant is
+        // the held-out -24 dBFS row (19.0 dB settled, in that widest gap, never
+        // an anchor): curve RMS 0.0291, between its neighbours' 0.0309 and
+        // 0.0262.
+        //
+        // A NaN argument falls through every comparison to the last entry,
+        // which is finite and positive. The clamp it replaced passed NaN
+        // straight through to the attack coefficient.
+        if (positiveReductionDb <= kFetDriveReductionDb.front())
+            return kFetDriveAttackScale.front();
+        for (size_t i = 1; i < kFetDriveReductionDb.size(); ++i)
+            if (positiveReductionDb <= kFetDriveReductionDb[i])
+            {
+                const float fraction
+                    = (positiveReductionDb - kFetDriveReductionDb[i - 1])
+                    / (kFetDriveReductionDb[i] - kFetDriveReductionDb[i - 1]);
+                return kFetDriveAttackScale[i - 1] * std::pow(
+                    kFetDriveAttackScale[i] / kFetDriveAttackScale[i - 1],
+                    fraction);
+            }
+        return kFetDriveAttackScale.back();
+    }
+
+    static float fetControlLaw(float position,
+                               const std::array<float, 12>& values) noexcept
+    {
+        position = std::clamp(position, 0.0f, 1.0f);
+        for (size_t i = 1; i < kFetControlPositions.size(); ++i)
+            if (position <= kFetControlPositions[i])
+            {
+                const float low = kFetControlPositions[i - 1];
+                const float high = kFetControlPositions[i];
+                const float fraction = (position - low) / (high - low);
+                return values[i - 1] + fraction * (values[i] - values[i - 1]);
+            }
+        return values.back();
+    }
+
+    static float fetInputGainDb(float legacyValueDb) noexcept
+    {
+        const float position = (legacyValueDb + 20.0f) / 60.0f;
+        // 39.850671 = 40.0 - 0.149329. The vintage chain carried a
+        // frequency-flat +0.149329 dB (x1.017341) gain excess against the
+        // reference: ten zero-gain-reduction operating points spanning 89 dB of
+        // output level reproduce it to 2.6e-05 dB, and the zero-GR frequency
+        // sweep reproduces it to 0.008 dB from 100 Hz to 16 kHz.
+        //
+        // It is removed here, ahead of the detector, rather than from the
+        // output trim, because that is where it was measured to live. Removing
+        // it post-compressor translates all 80 static cells by exactly
+        // -0.149334 dB (measured spread 1.7e-07 dB) and leaves a residual
+        // proportional to each cell's reduction slope: regressing that residual
+        // on the measured per-cell slope gives -0.146893 dB per unit slope
+        // against the -0.149334 a pure pre-detector error predicts, and the
+        // correlation between residual and slope falls from -0.76 to +0.02 once
+        // the excess is taken out here instead. The solved split is therefore
+        // +0.1469 dB pre / +0.0025 dB post, i.e. all of it pre within the
+        // measurement -- not the +0.093/+0.056 that four static rows suggested.
+        // The 64 non-All-buttons static cells land within 0.082 dB this way
+        // against 0.195 dB the other way.
+        //
+        // `inputGain` scales the audio and the detector together, so this also
+        // lowers every settled reduction by slope x 0.149329 dB (0.124 dB at
+        // 4:1). The attack drive table and the `fetBroadbandK2` lookup are both
+        // reduction-indexed and therefore both moved with it. The attack drive
+        // table was re-measured against that shift when it was written;
+        // `fetBroadbandK2` was NOT, and this sentence used to claim both were.
+        // It has since been re-fitted in its own right against a dense measured
+        // surface -- see the note there.
+        return 39.850671f + fetControlLaw(position, kFetInputRelativeDb);
+    }
+
+    static float fetOutputGainDb(float legacyValueDb) noexcept
+    {
+        const float position = (legacyValueDb + 20.0f) / 40.0f;
+        // Absolute trim includes the measured linear convolution-chain loss;
+        // the relative pot law above remains the independently fitted result.
+        return 4.360566f + fetControlLaw(position, kFetOutputRelativeDb);
+    }
+
+    static float fetBroadbandK2(float gainReductionDb) noexcept
+    {
+        // The black-face unit's even-order path is programme dependent rather
+        // than a monotonic polynomial drive: its equivalent coefficient falls
+        // from 0.0042 at the compression onset to a minimum of 0.0020 near 7 dB
+        // of reduction, then rises by a factor of nine to 0.0163 by 28 dB.
+        //
+        // COORDINATE. The argument is what the call site passes:
+        // `-gainToDecibels(envelope + 0.001f)`, per sample. That is NOT the
+        // settled output-referred reduction the render probes report -- the
+        // +0.001 offset alone costs 0.087 dB at 20 dB -- and every anchor below
+        // is stated in the call site's coordinate, measured there by
+        // `MultiCompCoreTest --fet-h2-surface`. Do not re-fit these against a
+        // reduction read anywhere else without moving the abscissa first.
+        //
+        // MEASUREMENT. 39 operating points at 1 kHz spanning Input 0.2-1.0 and
+        // source -48 to -6 dBFS (`probe_h2_surface.py`, campaign
+        // reference_comparison_1176), each giving the coefficient that lands
+        // the reference unit's own H2: rows reaching the same reduction from
+        // different knob/level combinations agree to about 0.1 dB, which is
+        // what makes a reduction-indexed law the right shape here. Every
+        // segment below contains at least two of those rows. The sixteen-row
+        // campaign harmonic grid, which is all the previous anchor set ever had,
+        // reaches eight distinct depths -- four of them zero -- so it left two of
+        // that table's seven segments with no point at all and gave four more
+        // exactly one, never in the interior. That is how a non-monotonic wiggle
+        // (0.0027 at 2.8 dB, 0.0020 at 7.2, then 3x to 0.0059 at 13.0) survived:
+        // its widest segment was sampled once, near the bottom edge, and read
+        // 5.14 dB high in the middle. Worst residual of this fit over the 39
+        // rows: 0.191 dB.
+        //
+        // Above 33.5 dB nothing is measured: the reference's own reduction law
+        // collapses past roughly +37 dB internal (a separate, unfixed defect),
+        // so the last segment is a straight-line extension of the fitted
+        // 28-33.5 dB trend, not data.
+        //
+        // 100 Hz is deliberately not in the fit. There `lowFrequencyK2 *
+        // colourLowH2` supplies most of the even order, so a 100 Hz row's
+        // implied coefficient belongs to that mechanism, not to this one.
+        constexpr std::array<float, 14> reductionDb{{
+            0.0f, 0.6f, 1.5f, 3.2f, 5.0f, 7.0f, 9.0f,
+            13.0f, 17.5f, 20.0f, 23.0f, 25.5f, 28.0f, 40.0f}};
+        constexpr std::array<float, 14> coefficients{{
+            0.003912f, 0.004212f, 0.003316f, 0.002510f, 0.002094f, 0.001966f,
+            0.002194f, 0.003210f, 0.005215f, 0.006591f, 0.009206f, 0.012971f,
+            0.016280f, 0.018549f}};
+        gainReductionDb = std::clamp(gainReductionDb, 0.0f, 40.0f);
+        for (size_t i = 1; i < reductionDb.size(); ++i)
+            if (gainReductionDb <= reductionDb[i])
+            {
+                const float fraction = (gainReductionDb - reductionDb[i - 1])
+                    / (reductionDb[i] - reductionDb[i - 1]);
+                return coefficients[i - 1]
+                    + fraction * (coefficients[i] - coefficients[i - 1]);
+            }
+        return coefficients.back();
+    }
+
+    static float fetBroadbandK3(float gainReductionDb) noexcept
+    {
+        // The black-face unit's broadband third harmonic is not reproduced by
+        // one constant cubic. Its equivalent coefficient grows modestly from
+        // compression onset to 8 dB of reduction, then falls to roughly one
+        // third of the old -0.006 coefficient by 33 dB.
+        //
+        // COORDINATE. As for `fetBroadbandK2`, every anchor is expressed in the
+        // call site's `-gainToDecibels(envelope + 0.001f)` coordinate, measured
+        // in process by `MultiCompCoreTest --fet-h2-surface`. It is not the
+        // settled output-referred reduction printed by the VST render probe.
+        //
+        // MEASUREMENT. The zero and full cubic builds identify the complex 3f
+        // contribution over the dense 1 kHz surface. Separate half-cubic builds
+        // reproduce their complex midpoint to 0.003712 dB before, and 0.003494
+        // dB after, the independently fitted low-frequency T3 correction. That
+        // establishes this coefficient as a scalable source rather than a
+        // magnitude coincidence. The first fit landed at 0.089538 dB measured
+        // worst over the 36 reference rows above the -92 dBc floor. Changing
+        // low T3 then exposed this path's finite 1 kHz leakage, so the same
+        // zero/half/full inversion was repeated on top of it. Retaining anchors
+        // until piecewise interpolation is within 0.10 dB now predicts 0.097975
+        // dB worst at 1 kHz while preserving 100 Hz at 0.631009 dB worst.
+        //
+        // This table fits H3 only. The same control predicts up to 4.93 dB H5
+        // error, which remains assigned to the separately measured fifth-order
+        // path rather than being hidden in this coefficient.
+        constexpr std::array<float, 13> reductionDb{{
+            0.0f, 0.3543f, 1.0175f, 3.2496f, 6.9921f, 10.0089f, 12.6634f,
+            19.8974f, 22.6659f, 27.5467f, 31.0579f, 33.4397f, 40.0f}};
+        constexpr std::array<float, 13> coefficients{{
+            -0.004527116f, -0.004527116f, -0.005052484f, -0.005072347f,
+            -0.005519443f, -0.005649644f, -0.005065947f, -0.003015710f,
+            -0.002580895f, -0.002362978f, -0.001939411f, -0.001867239f,
+            -0.001867239f}};
+        gainReductionDb = std::clamp(gainReductionDb, 0.0f, 40.0f);
+        for (size_t i = 1; i < reductionDb.size(); ++i)
+            if (gainReductionDb <= reductionDb[i])
+            {
+                const float fraction = (gainReductionDb - reductionDb[i - 1])
+                    / (reductionDb[i] - reductionDb[i - 1]);
+                return coefficients[i - 1]
+                    + fraction * (coefficients[i] - coefficients[i - 1]);
+            }
+        return coefficients.back();
+    }
+
+    static float fetLowFrequencyK3(float gainReductionDb) noexcept
+    {
+        // The low-frequency third-order transformer path is separately
+        // reduction-dependent. A constant -0.0058 coefficient leaves the
+        // installed unit's 100 Hz H3 up to 5.51 dB away, but this path is not
+        // perfectly band-limited: fitting 100 Hz alone moves 1 kHz H3 by more
+        // than 1 dB and undoes the broadband cubic fit above.
+        //
+        // COORDINATE. These are anchors in the same call-site internal-GR
+        // coordinate as the broadband K2/K3 tables, measured by
+        // `MultiCompCoreTest --fet-h2-surface`.
+        //
+        // MEASUREMENT. Zero, half, and full low-T3 builds prove complex
+        // superposition to 0.000226 dB worst over scoreable H3. A constrained
+        // fit uses all 96 scoreable 100 Hz H3 rows while bounding all 36
+        // scoreable 1 kHz rows, then removes anchors until either frequency's
+        // predeclared guard would fail. This eight-anchor result predicts
+        // 0.606240 dB worst at 100 Hz and 0.897453 dB at 1 kHz, compared with
+        // 5.510934 and 0.089538 dB for the constant coefficient. The broadband
+        // residual is intentionally closed again by that mechanism's own fit;
+        // it is kept visible here rather than hidden in an unconstrained
+        // low-frequency table.
+        //
+        // H5 is not part of this fit and remains assigned to the independent
+        // fifth-order term below.
+        constexpr std::array<float, 8> reductionDb{{
+            0.0f, 0.2378f, 0.5373f, 0.7234f, 1.3622f, 2.5753f, 13.8515f,
+            40.0f}};
+        constexpr std::array<float, 8> coefficients{{
+            -0.002084180f, -0.004712892f, -0.003397340f, -0.003469579f,
+            -0.005932644f, -0.006994165f, -0.004806491f, -0.006058491f}};
+        gainReductionDb = std::clamp(gainReductionDb, 0.0f, 40.0f);
+        for (size_t i = 1; i < reductionDb.size(); ++i)
+            if (gainReductionDb <= reductionDb[i])
+            {
+                const float fraction = (gainReductionDb - reductionDb[i - 1])
+                    / (reductionDb[i] - reductionDb[i - 1]);
+                return coefficients[i - 1]
+                    + fraction * (coefficients[i] - coefficients[i - 1]);
+            }
+        return coefficients.back();
+    }
+
+    static std::array<float, 4> fetShallowKneeOddCorrection(
+        float drivenInputDb) noexcept
+    {
+        // The 100 Hz shallow-knee H3 is complex: the installed unit's phase
+        // moves from 164.6 to 90.7 degrees while the reduction cell engages.
+        // A scalar correction can match magnitude only by jumping between two
+        // coefficient roots. These two coefficients instead scale the first
+        // and second 300 Hz low-pass poles of a pure T3 basis made from the
+        // held raw input. The matching pair of filtered T5 bases jointly holds
+        // the prior H5 complex vector, preventing the T3 correction from
+        // inheriting fifth harmonic from reconstruction ripple. Using the
+        // detector input rather than the already-compressed colour waveform
+        // and retaining both poles prevents H5 leakage; omitting the poles
+        // moved the established 1 kHz H3 guard by 0.74 dB. Even
+        // half-dB rows from -14 through -6 dB are the fit anchors; the
+        // intervening quarter-dB reference rows are held out. The endpoints
+        // fade the cell to zero outside the measured 4:1 knee and preserve the
+        // established deeper-reduction harmonic surface.
+        constexpr std::array<float, 19> driveDb{{
+            -15.0f, -14.0f, -13.5f, -13.0f, -12.5f, -12.0f, -11.5f,
+            -11.0f, -10.5f, -10.0f, -9.5f, -9.0f, -8.5f, -8.0f,
+            -7.5f, -7.0f, -6.5f, -6.0f, -4.0f}};
+        constexpr std::array<float, 19> direct{{
+            0.0f, 0.000000147296f, -0.000012437259f, -0.000035329776f,
+            -0.000073386195f, -0.000116595019f, -0.000146058870f,
+            -0.000167959659f, -0.000201904590f, -0.000242491601f,
+            -0.000318190851f, -0.000423721595f, -0.000564032270f,
+            -0.000698676667f, -0.000822144740f, -0.000966098630f,
+            -0.001131396372f, -0.001393907435f, 0.0f}};
+        constexpr std::array<float, 19> lag{{
+            0.0f, -0.000004630468f, 0.000020562542f, 0.000067365078f,
+            0.000146981010f, 0.000236175923f, 0.000293332999f,
+            0.000334985008f, 0.000396516160f, 0.000387766529f,
+            0.000409416966f, 0.000448438044f, 0.000549813571f,
+            0.000622585136f, 0.000659935770f, 0.000737630182f,
+            0.000851202512f, 0.001211519530f, 0.0f}};
+        constexpr std::array<float, 19> fifthLag{{
+            0.0f, -0.000000015059f, -0.000000011610f, -0.000000001779f,
+            0.000000020677f, 0.000000045071f, 0.000000046848f,
+            0.000000042798f, 0.000000028838f, -0.000000269259f,
+            -0.000000699823f, -0.000001267242f, -0.000001847419f,
+            -0.000002489201f, -0.000003196090f, -0.000003875615f,
+            -0.000004587354f, -0.000005053848f, 0.0f}};
+        constexpr std::array<float, 19> fifthLower{{
+            0.0f, -0.000000019836f, 0.000000139720f, 0.000000432226f,
+            0.000000928802f, 0.000001480890f, 0.000001844100f,
+            0.000002119219f, 0.000002523170f, 0.000002663537f,
+            0.000003078891f, 0.000003709499f, 0.000004741675f,
+            0.000005619440f, 0.000006332498f, 0.000007265373f,
+            0.000008476385f, 0.000011060490f, 0.0f}};
+        if (drivenInputDb <= driveDb.front()
+            || drivenInputDb >= driveDb.back())
+            return {{0.0f, 0.0f, 0.0f, 0.0f}};
+        for (size_t i = 1; i < driveDb.size(); ++i)
+            if (drivenInputDb <= driveDb[i])
+            {
+                const float fraction = (drivenInputDb - driveDb[i - 1])
+                    / (driveDb[i] - driveDb[i - 1]);
+                // The fitted -14..-6 dB anchors are uniformly spaced. Cubic
+                // interpolation keeps their measured curvature without using
+                // any of the intervening quarter-dB validation rows. The two
+                // unequal endpoint fades remain linear.
+                if (i - 1 >= 2 && i <= 16)
+                {
+                    const auto cubic = [fraction](float p0, float p1,
+                                                  float p2, float p3) noexcept {
+                        const float t2 = fraction * fraction;
+                        const float t3 = t2 * fraction;
+                        return 0.5f * (2.0f * p1
+                            + (-p0 + p2) * fraction
+                            + (2.0f * p0 - 5.0f * p1 + 4.0f * p2 - p3)
+                                * t2
+                            + (-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
+                    };
+                    return {{
+                        cubic(direct[i - 2], direct[i - 1], direct[i],
+                              direct[i + 1]),
+                        cubic(lag[i - 2], lag[i - 1], lag[i], lag[i + 1]),
+                        cubic(fifthLag[i - 2], fifthLag[i - 1], fifthLag[i],
+                              fifthLag[i + 1]),
+                        cubic(fifthLower[i - 2], fifthLower[i - 1],
+                              fifthLower[i], fifthLower[i + 1])}};
+                }
+                return {{
+                    direct[i - 1] + fraction
+                        * (direct[i] - direct[i - 1]),
+                    lag[i - 1] + fraction * (lag[i] - lag[i - 1]),
+                    fifthLag[i - 1] + fraction
+                        * (fifthLag[i] - fifthLag[i - 1]),
+                    fifthLower[i - 1] + fraction
+                        * (fifthLower[i] - fifthLower[i - 1])}};
+            }
+        return {{0.0f, 0.0f, 0.0f, 0.0f}};
+    }
+
+    static std::array<float, 4> fetBroadbandComplexH3Correction(
+        float inputPosition, float releasePosition,
+        float drivenInputDb, double hostSampleRate) noexcept
+    {
+        // The sparse reduction-only K3 fit gets the original campaign anchors'
+        // magnitudes right, but misses the UAD vector between them: at Input
+        // 0.8 its H3 phase rotates by more than 120 degrees while the cubic
+        // stays near 135 degrees. A pure raw-input T3 and its first three
+        // 300 Hz poles provide four real degrees of freedom: two solve the
+        // reference's complex 1 kHz H3 and two force the same cell's complex
+        // 100 Hz H3 contribution to zero. T3 contributes no H1/H2/H5.
+        //
+        // The Wave 27 scalar contradiction was a missing coordinate, not a
+        // rate law: its matched-reduction probe used Release 0.5, while the
+        // original harmonic grid used 0.66595459. The required lag coefficient
+        // changes sign between those controls. Both tables below are fitted at
+        // 48 kHz. Release-0.5 rows set a 0.9826 source normalisation at 96 kHz;
+        // four untouched campaign-Release rows then validate to 0.075 dB / 0.42
+        // degrees. Release interpolation holds its measured endpoints.
+        constexpr std::array<float, 9> halfReleaseDriveDb{{
+            -10.0f, -6.0f, 0.0f, 6.0f, 12.0f, 18.0f, 24.0f, 30.0f, 34.0f}};
+        constexpr std::array<std::array<float, 9>, 4> halfRelease{{
+            {{-0.000001129286f, 0.000005640098f, 0.000020928763f,
+               0.000015788718f, 0.000013878506f, 0.000017151017f,
+               0.000011323861f, 0.000009239721f, 0.000010164660f}},
+            {{0.000126741287f, 0.000260478093f, 0.000207309249f,
+              0.000174141674f, 0.000104720559f, 0.000050368387f,
+              0.000024496578f, 0.000013932452f, 0.000010243772f}},
+            {{-0.000253599807f, -0.000537741764f, -0.000462143430f,
+              -0.000384481333f, -0.000240319580f, -0.000137359480f,
+              -0.000073002796f, -0.000047337873f, -0.000041811016f}},
+            {{0.000248913519f, 0.000543718419f, 0.000499131315f,
+              0.000412038918f, 0.000265486269f, 0.000170002288f,
+              0.000094725879f, 0.000065180976f, 0.000061539456f}},
+        }};
+        constexpr std::array<float, 8> campaignReleaseDriveDb{{
+            -9.396131f, 2.603869f, 8.603869f, 14.603869f,
+            20.603869f, 26.603869f, 29.603869f, 32.603869f}};
+        constexpr std::array<std::array<float, 8>, 4> campaignRelease{{
+            {{-0.000001761571f, 0.000028899354f, 0.000019785929f,
+               0.000020777596f, 0.000019925249f, 0.000010698004f,
+               0.000010906451f, 0.000010859942f}},
+            {{0.000048332712f, -0.000289051296f, -0.000162517054f,
+              -0.000130925980f, -0.000093221427f, -0.000059479269f,
+              -0.000046187095f, -0.000036586152f}},
+            {{-0.000093944202f, 0.000523663427f, 0.000287074460f,
+              0.000221217220f, 0.000146846412f, 0.000097882236f,
+              0.000070606261f, 0.000051314367f}},
+            {{0.000089547765f, -0.000461366619f, -0.000245113153f,
+              -0.000177927938f, -0.000105963674f, -0.000075748103f,
+              -0.000048322742f, -0.000029309312f}},
+        }};
+        const auto tableValue = [drivenInputDb](const auto& positions,
+                                                const auto& values) noexcept {
+            if (drivenInputDb <= positions.front()) return values.front();
+            for (size_t i = 1; i < positions.size(); ++i)
+                if (drivenInputDb <= positions[i])
+                {
+                    const float fraction
+                        = (drivenInputDb - positions[i - 1])
+                        / (positions[i] - positions[i - 1]);
+                    return values[i - 1]
+                        + fraction * (values[i] - values[i - 1]);
+                }
+            return values.back();
+        };
+        const float releaseBlend = std::clamp(
+            (releasePosition - 0.5f) / (0.66595459f - 0.5f),
+            0.0f, 1.0f);
+        std::array<float, 4> coefficients{};
+        for (size_t basis = 0; basis < coefficients.size(); ++basis)
+        {
+            const float half = tableValue(
+                halfReleaseDriveDb, halfRelease[basis]);
+            coefficients[basis] = half + releaseBlend * (tableValue(
+                campaignReleaseDriveDb, campaignRelease[basis]) - half);
+        }
+        // Only Input 0.8 has the dense complex oracle. The nearest measured
+        // Input 0.7/0.9 rows retain the established reduction-only surface;
+        // interpolate continuously between those three measured positions.
+        const float positionWeight = std::clamp(
+            1.0f - std::abs(inputPosition - 0.8f) / 0.1f, 0.0f, 1.0f);
+        const float rateBlend = std::clamp(
+            static_cast<float>((hostSampleRate - 48000.0) / 48000.0),
+            0.0f, 1.0f);
+        const float rateScale = 1.0f - 0.0174f * rateBlend;
+        for (float& coefficient : coefficients)
+            coefficient *= positionWeight * rateScale;
+        return coefficients;
+    }
+
+    static std::array<float, 4> fetBroadbandComplexH5Correction(
+        float inputPosition, float releasePosition,
+        float drivenInputDb, double hostSampleRate) noexcept
+    {
+        // The reduction-only broadband-T5 table matches the sparse campaign
+        // magnitudes, but not their complex vectors, and it misses the dense
+        // Release-0.5 surface by 5.13 dB / 137.48 degrees. Scaling that source
+        // cannot close the gap: its least-squares optimum still leaves up to
+        // 2.51 dB / 33.62 degrees. A raw T5 plus its first three 300 Hz poles
+        // supplies four real degrees of freedom. Two solve the complex 1 kHz
+        // H5 residual and two force the same cell's complex 100 Hz H5 to zero.
+        // T5 contributes no H1-H4 for the settled calibration sine.
+        //
+        // The tables are same-stimulus UAD fits at Release 0.5 and the original
+        // campaign Release 0.66595459, separately at 48/96 kHz. Zero guards
+        // below the -92 dBc scoring onset keep the correction dormant where
+        // the reference fifth harmonic is not measurable. Input 0.2 and 0.8
+        // are the only campaign positions with a scoreable complex oracle;
+        // triangular weights leave their measured neighbours unchanged.
+        constexpr std::array<float, 9> halfDriveDb{{
+            -10.0f, -6.0f, 0.0f, 6.0f, 12.0f, 18.0f, 24.0f, 30.0f, 34.0f}};
+        constexpr std::array<std::array<float, 4>, 9> half48{{
+            {{0.0f, 0.0f, 0.0f, 0.0f}},
+            {{-2.496762303e-05f, -6.385083138e-04f, 1.322520898e-03f, -2.605647916e-03f}},
+            {{-3.514863744e-05f, -9.802532544e-04f, 2.028960828e-03f, -3.975562361e-03f}},
+            {{-2.844470984e-05f, -7.681089883e-04f, 1.590256165e-03f, -3.122185053e-03f}},
+            {{-1.812680163e-05f, -4.895134041e-04f, 1.013464766e-03f, -1.989751412e-03f}},
+            {{-1.124180239e-05f, -3.045824937e-04f, 6.305764770e-04f, -1.237766028e-03f}},
+            {{-6.849515997e-06f, -1.858045370e-04f, 3.846670558e-04f, -7.550101469e-04f}},
+            {{-4.103466552e-06f, -1.111874142e-04f, 2.301909137e-04f, -4.518421406e-04f}},
+            {{-2.953060083e-06f, -7.837672966e-05f, 1.622897785e-04f, -3.189758675e-04f}},
+        }};
+        constexpr std::array<std::array<float, 4>, 9> half96{{
+            {{0.0f, 0.0f, 0.0f, 0.0f}},
+            {{-2.199947933e-05f, -6.955178209e-04f, 1.417204358e-03f, -2.795922969e-03f}},
+            {{-3.178495081e-05f, -1.039834703e-03f, 2.118426437e-03f, -4.171582779e-03f}},
+            {{-2.495754847e-05f, -8.237529328e-04f, 1.678135300e-03f, -3.303008516e-03f}},
+            {{-1.597939544e-05f, -5.263453760e-04f, 1.072272524e-03f, -2.110740121e-03f}},
+            {{-9.907290171e-06f, -3.287461995e-04f, 6.696985743e-04f, -1.317771421e-03f}},
+            {{-6.047465184e-06f, -2.011216196e-04f, 4.097062525e-04f, -8.060867201e-04f}},
+            {{-3.672773926e-06f, -1.206963874e-04f, 2.458859059e-04f, -4.840796946e-04f}},
+            {{-2.616770294e-06f, -8.514188609e-05f, 1.734619187e-04f, -3.416789155e-04f}},
+        }};
+        constexpr std::array<float, 8> campaignEightDriveDb{{
+            -10.0f, 2.603869f, 8.603869f, 14.603869f, 20.603869f,
+            26.603869f, 29.603869f, 32.603869f}};
+        constexpr std::array<std::array<float, 4>, 8> campaignEight48{{
+            {{0.0f, 0.0f, 0.0f, 0.0f}},
+            {{-3.392391092e-05f, -1.252005652e-03f, 2.586600369e-03f, -4.992588415e-03f}},
+            {{-2.295591452e-05f, -8.489944705e-04f, 1.753971953e-03f, -3.385138287e-03f}},
+            {{-1.444476717e-05f, -5.389668373e-04f, 1.113416694e-03f, -2.147990378e-03f}},
+            {{-8.945497246e-06f, -3.353536706e-04f, 6.927667765e-04f, -1.336185579e-03f}},
+            {{-5.372873574e-06f, -2.021097288e-04f, 4.175060493e-04f, -8.051449580e-04f}},
+            {{-4.179771556e-06f, -1.565668807e-04f, 3.234341623e-04f, -6.238524233e-04f}},
+            {{-3.254192256e-06f, -1.217262133e-04f, 2.514626946e-04f, -4.850624161e-04f}},
+        }};
+        constexpr std::array<std::array<float, 4>, 8> campaignEight96{{
+            {{0.0f, 0.0f, 0.0f, 0.0f}},
+            {{-2.853863582e-05f, -1.331864879e-03f, 2.709335030e-03f, -5.249923320e-03f}},
+            {{-2.058420386e-05f, -9.509113032e-04f, 1.934452523e-03f, -3.749883227e-03f}},
+            {{-1.262977189e-05f, -5.699577274e-04f, 1.159570016e-03f, -2.249843134e-03f}},
+            {{-8.677201044e-06f, -3.902275582e-04f, 7.939217905e-04f, -1.540609249e-03f}},
+            {{-4.724630197e-06f, -2.104973889e-04f, 4.282735793e-04f, -8.313753642e-04f}},
+            {{-3.800751490e-06f, -1.683110645e-04f, 3.424497924e-04f, -6.649333896e-04f}},
+            {{-2.876872782e-06f, -1.261247400e-04f, 2.566260055e-04f, -4.984914149e-04f}},
+        }};
+        constexpr std::array<float, 3> campaignTwoDriveDb{{
+            -10.0f, -5.827545f, 0.172455f}};
+        constexpr std::array<std::array<float, 4>, 3> campaignTwo48{{
+            {{0.0f, 0.0f, 0.0f, 0.0f}},
+            {{-2.400488442e-05f, -9.349371226e-04f, 1.930961527e-03f, -3.717920381e-03f}},
+            {{-3.593272669e-05f, -1.310352387e-03f, 2.707331605e-03f, -5.228575893e-03f}},
+        }};
+        constexpr std::array<std::array<float, 4>, 3> campaignTwo96{{
+            {{0.0f, 0.0f, 0.0f, 0.0f}},
+            {{-2.104118307e-05f, -9.690486077e-04f, 1.971370845e-03f, -3.821899905e-03f}},
+            {{-3.033543485e-05f, -1.386319642e-03f, 2.820318067e-03f, -5.469396430e-03f}},
+        }};
+        const auto tableValue = [drivenInputDb](const auto& positions,
+                                                const auto& values) noexcept {
+            if (drivenInputDb <= positions.front()) return values.front();
+            for (size_t i = 1; i < positions.size(); ++i)
+                if (drivenInputDb <= positions[i])
+                {
+                    const float fraction = (drivenInputDb - positions[i - 1])
+                        / (positions[i] - positions[i - 1]);
+                    std::array<float, 4> result{};
+                    for (size_t basis = 0; basis < result.size(); ++basis)
+                        result[basis] = values[i - 1][basis]
+                            + fraction * (values[i][basis]
+                                - values[i - 1][basis]);
+                    return result;
+                }
+            return values.back();
+        };
+        const float rateBlend = std::clamp(
+            static_cast<float>((hostSampleRate - 48000.0) / 48000.0),
+            0.0f, 1.0f);
+        const auto rateValue = [rateBlend](const auto& low,
+                                           const auto& high) noexcept {
+            std::array<float, 4> result{};
+            for (size_t basis = 0; basis < result.size(); ++basis)
+                result[basis] = low[basis]
+                    + rateBlend * (high[basis] - low[basis]);
+            return result;
+        };
+        const auto halfEight = rateValue(
+            tableValue(halfDriveDb, half48),
+            tableValue(halfDriveDb, half96));
+        const auto campaignEight = rateValue(
+            tableValue(campaignEightDriveDb, campaignEight48),
+            tableValue(campaignEightDriveDb, campaignEight96));
+        const auto campaignTwo = rateValue(
+            tableValue(campaignTwoDriveDb, campaignTwo48),
+            tableValue(campaignTwoDriveDb, campaignTwo96));
+        const float releaseBlend = std::clamp(
+            (releasePosition - 0.5f) / (0.66595459f - 0.5f),
+            0.0f, 1.0f);
+        const float eightWeight = std::clamp(
+            1.0f - std::abs(inputPosition - 0.8f) / 0.1f, 0.0f, 1.0f);
+        const float twoWeight = std::clamp(
+            1.0f - std::abs(inputPosition - 0.2f) / 0.1f, 0.0f, 1.0f);
+        std::array<float, 4> result{};
+        for (size_t basis = 0; basis < result.size(); ++basis)
+        {
+            const float eight = halfEight[basis]
+                + releaseBlend * (campaignEight[basis] - halfEight[basis]);
+            result[basis] = eightWeight * eight
+                + twoWeight * releaseBlend * campaignTwo[basis];
+        }
+        return result;
+    }
+
+    static float fetLowFrequencyK5(float gainReductionDb) noexcept
+    {
+        // The low-frequency fifth-order transformer contribution also changes
+        // with reduction. The former constant 0.00255 coefficient leaves the
+        // installed unit's 100 Hz H5 up to 6.35 dB away.
+        //
+        // COORDINATE. These anchors use the same per-sample internal-GR
+        // coordinate as the other FET harmonic tables. Zero, half, and full
+        // low-T5 builds reproduce their complex H5 midpoint to 0.000280 dB,
+        // establishing a scalable source. The constant-coefficient fit uses
+        // every scoreable 100 Hz H5 row and retains anchors until piecewise
+        // interpolation is within 0.10 dB. Production evaluates the table per
+        // sample, however, and detector ripple traverses the steep onset
+        // segment: recalibrating only the 0.8882 dB anchor from 0.001205130 to
+        // 0.001150000 changes its measured error from +0.259219 to -0.079061
+        // dB. The guard at 0.7234 dB keeps the already fitted 100 Hz H3
+        // residual below its declared bound near compression onset.
+        //
+        // The finite 1 kHz leakage is deliberately not hidden in this table;
+        // it belongs to the separately measured broadband fifth-order path.
+        constexpr std::array<float, 18> reductionDb{{
+            0.0f, 0.7234f, 0.8882f, 0.9345f, 1.1328f, 1.3622f, 1.7057f,
+            2.1781f, 2.5753f, 3.1896f, 3.9931f, 6.9247f, 9.8790f,
+            12.0660f, 13.8515f, 24.6525f, 34.3368f, 40.0f}};
+        constexpr std::array<float, 18> coefficients{{
+            0.002167500f, 0.002167500f, 0.001150000f, 0.001378785f,
+            0.001957890f, 0.002406180f, 0.002787915f, 0.003019200f,
+            0.002900880f, 0.002935050f, 0.002883795f, 0.002550765f,
+            0.002316930f, 0.002024700f, 0.001853085f, 0.002283525f,
+            0.002515575f, 0.002515575f}};
+        gainReductionDb = std::clamp(gainReductionDb, 0.0f, 40.0f);
+        for (size_t i = 1; i < reductionDb.size(); ++i)
+            if (gainReductionDb <= reductionDb[i])
+            {
+                const float fraction = (gainReductionDb - reductionDb[i - 1])
+                    / (reductionDb[i] - reductionDb[i - 1]);
+                return coefficients[i - 1]
+                    + fraction * (coefficients[i] - coefficients[i - 1]);
+            }
+        return coefficients.back();
+    }
+
+    static float fetBroadbandK5(float gainReductionDb) noexcept
+    {
+        // The remaining 1 kHz fifth harmonic is a distinct, high-passed
+        // contribution. An unfiltered T5 source is measurably the wrong
+        // mechanism: at half strength it improves 1 kHz but worsens the
+        // already fitted 100 Hz H5 residual from 0.079061 to 0.717420 dB.
+        // Two 250 Hz high-pass poles reduce that leakage while preserving the
+        // mid-band contribution.
+        //
+        // COORDINATE. These anchors use the same per-sample internal-GR
+        // coordinate as the other FET harmonic tables. Zero, half, and full
+        // high-passed T5 controls reproduce their complex midpoint to
+        // 0.000357 dB for H3 and 0.000165 dB for H5. The fit uses all 32
+        // scoreable 1 kHz H5 rows and removes anchors until the predicted
+        // piecewise-interpolation error reaches 0.10 dB. Its independent
+        // guards predict 0.107523 dB worst at 100 Hz H5, 0.099039 dB at
+        // 1 kHz H3, and 0.728298 dB at 100 Hz H3.
+        constexpr std::array<float, 8> reductionDb{{
+            0.0f, 2.6305f, 3.2496f, 4.5656f, 6.9921f, 13.9253f,
+            33.4397f, 40.0f}};
+        constexpr std::array<float, 8> coefficients{{
+            -0.000098400f, -0.000098400f, -0.000104240f,
+            -0.000101680f, -0.000086860f, -0.000062020f,
+            -0.000093440f, -0.000093440f}};
+        gainReductionDb = std::clamp(gainReductionDb, 0.0f, 40.0f);
+        for (size_t i = 1; i < reductionDb.size(); ++i)
+            if (gainReductionDb <= reductionDb[i])
+            {
+                const float fraction = (gainReductionDb - reductionDb[i - 1])
+                    / (reductionDb[i] - reductionDb[i - 1]);
+                return coefficients[i - 1]
+                    + fraction * (coefficients[i] - coefficients[i - 1]);
+            }
+        return coefficients.back();
+    }
+
+    static float fetLowFrequencyK2(float gainReductionDb) noexcept
+    {
+        // The vintage unit's second even-order path: the low-frequency
+        // transformer asymmetry, generated at the call site from a 250 Hz
+        // two-pole copy of the saturated signal. This is its coefficient.
+        //
+        // COORDINATE. Same as `fetBroadbandK2` above and for the same reason:
+        // the argument is the call site's own `-gainToDecibels(envelope +
+        // 0.001f)`, per sample, and every anchor here was measured in exactly
+        // that coordinate by `MultiCompCoreTest --fet-h2-surface`.
+        //
+        // MEASUREMENT. 91 compressing operating points at 100 Hz, Input
+        // 0.2-1.0 x source -48 to -6 dBFS (`probe_h2_surface.py`, campaign
+        // reference_comparison_1176). At 100 Hz mine's 2f output is the sum of
+        // TWO contributions, this one and `fetBroadbandK2`, and they arrive
+        // nearly in QUADRATURE -- the two-pole low pass turns -21.8 deg per
+        // pole at 100 Hz and squaring doubles it, measured -78 to -86 deg
+        // across the axis. So the coefficient each row asks for is the positive
+        // root of |B + v C| = target, not a ratio of magnitudes; B and C are
+        // the broadband and low-frequency complex second harmonics, read
+        // separately by rebuilding with the other coefficient zeroed.
+        // Superposition was verified rather than assumed: a build at half this
+        // coefficient reproduces B + 0.5 C over 198 operating points to
+        // 2.7e-05 dB.
+        //
+        // The result is a clean single-valued function of the reduction.
+        // Triplets that reach the same depth from three different (Input,
+        // source) combinations agree to 0.07-0.35 %: 9.88/9.89/9.94 dB ask
+        // 0.030548/0.030563/0.030574, and 14.83/14.84/14.88 dB ask
+        // 0.032141/0.032165/0.032153. That last triplet is the point. The law
+        // this replaced was `0.0400 * clamp(grDb / 12) * saturation`, whose
+        // charge term SATURATES at 12 dB, so every row above it got the same
+        // coefficient; the reference keeps asking for 3.7 % more between 12.6
+        // and 18.8 dB, and the campaign read that as a mysterious second
+        // GR-dependent term the charge did not carry. It is not a second term.
+        // It is the reduction axis the clamp threw away.
+        //
+        // Every segment holds at least one measured row INSIDE it, not only at
+        // its edges -- the hole that let `fetBroadbandK2`'s predecessor read
+        // 5.14 dB high. Above 34.35 dB nothing is measured and the last anchor
+        // holds rather than extrapolating.
+        //
+        // Worst residual over the 91 rows: 0.189 dB, and the six worst all sit
+        // below 1.4 dB of reduction. That band is NOT this table's to fix: with
+        // this coefficient at zero the broadband term alone still reads
+        // +0.06 to +0.14 dB high there, because `fetBroadbandK2` is fitted at
+        // 1 kHz. Driving this table negative is not physical and is not the
+        // answer; the floor moves when that table gains 100 Hz support.
+        constexpr std::array<float, 14> reductionDb{{
+            0.0f, 0.9f, 1.4f, 2.0f, 2.6f, 4.0f, 7.0f, 8.9f, 12.6f, 18.0f,
+            22.0f, 28.0f, 31.0f, 40.0f}};
+        constexpr std::array<float, 14> coefficients{{
+            0.000000f, 0.000497f, 0.005382f, 0.009019f, 0.011509f, 0.016751f,
+            0.024972f, 0.029460f, 0.032097f, 0.032621f, 0.032929f, 0.032396f,
+            0.031305f, 0.031302f}};
+        gainReductionDb = std::clamp(gainReductionDb, 0.0f, 40.0f);
+        for (size_t i = 1; i < reductionDb.size(); ++i)
+            if (gainReductionDb <= reductionDb[i])
+            {
+                const float fraction = (gainReductionDb - reductionDb[i - 1])
+                    / (reductionDb[i] - reductionDb[i - 1]);
+                return coefficients[i - 1]
+                    + fraction * (coefficients[i] - coefficients[i - 1]);
+            }
+        return coefficients.back();
+    }
+
+    static float fetReferenceReductionDb(float inputLevelDb, int ratioIndex,
+                                         float thresholdControlDb) noexcept
+    {
+        // The installed 1176's settled sine transfer collapses onto one input
+        // axis regardless of whether the level is reached with the source or
+        // Input control. A conventional quadratic knee fits that surface to
+        // 0.032 dB or better for every button. Because this is a feed-forward
+        // equivalent of the hardware feedback law, these are reduction slopes
+        // (1 - 1/R), not the nominal faceplate ratios.
+        constexpr std::array<float, 5> reductionSlopes{{
+            0.82857823f, 0.90319133f, 0.93707197f, 0.96619657f, 0.95953144f}};
+        constexpr std::array<float, 5> measuredThresholdsDb{{
+            -8.34012099f, -5.90065303f, -4.47645544f, -2.66788769f,
+            -4.74344379f}};
+        constexpr std::array<float, 5> kneeWidthsDb{{
+            14.12963324f, 7.19106925f, 1.87103644f, 4.83803856f,
+            4.87980041f}};
+        ratioIndex = std::clamp(ratioIndex, 0, 4);
+        const float slope = reductionSlopes[static_cast<size_t>(ratioIndex)];
+        // -10 dB is the reference-compatible extension setting. Moving the
+        // extension shifts the measured transfer without changing its shape.
+        const float threshold = measuredThresholdsDb[static_cast<size_t>(ratioIndex)]
+            + thresholdControlDb + 10.0f;
+        const float width = kneeWidthsDb[static_cast<size_t>(ratioIndex)];
+        const float kneeStart = threshold - width * 0.5f;
+        if (inputLevelDb <= kneeStart) return 0.0f;
+        // At the clockwise Input stop the installed unit stops adding reduction
+        // near the top of every ratio's detector domain. Dense 4:1 measurements
+        // resolve output slopes of 0.98--1.00 after the bend; ten-row sibling
+        // controls find the same plateau at progressively higher levels for
+        // 8:1, 12:1, and 20:1. All-buttons reaches it at the 4:1 coordinate.
+        // Holding the detector coordinate, rather than the computed reduction,
+        // leaves the knee and every previously fitted row below +38.7 dB intact.
+        constexpr std::array<float, 5> maximumDetectorLevelsDb{{
+            38.72f, 38.85f, 39.00f, 39.09f, 38.23f}};
+        inputLevelDb = std::min(
+            inputLevelDb,
+            maximumDetectorLevelsDb[static_cast<size_t>(ratioIndex)]);
+        if (inputLevelDb >= threshold + width * 0.5f)
+            return slope * (inputLevelDb - threshold);
+        const float position = inputLevelDb - kneeStart;
+        return slope * position * position / (2.0f * width);
+    }
+
+    static float fetReferenceKneeOnsetDb(float inputLevelDb,
+                                         float thresholdControlDb) noexcept
+    {
+        // The earlier five-point static grid did not resolve the bottom half
+        // of the 4:1 knee. Independent 100 Hz and 1 kHz quarter-dB sweeps do:
+        // the installed unit remains below 0.003 dB reduction through -10.75
+        // dB driven level, then joins the established static law. The two
+        // reference sweeps collapse within 0.00564 dB, so this is a common
+        // low-level cell rather than the deeper LF detector-response surface.
+        // Values are the 1 kHz reference reduction; the 100 Hz sweep is the
+        // held-out frequency and is gated separately in the core test.
+        constexpr std::array<float, 33> reductionDb{{
+            0.001054679f, 0.001119700f, 0.001188390f, 0.001261232f,
+            0.001338008f, 0.001419694f, 0.001506451f, 0.001597734f,
+            0.001694829f, 0.001797734f, 0.001906877f, 0.002021984f,
+            0.002144161f, 0.002273709f, 0.010022404f, 0.055453550f,
+            0.129645571f, 0.224473074f, 0.335152209f, 0.456996590f,
+            0.589745641f, 0.724483669f, 0.866982937f, 1.015019298f,
+            1.167031527f, 1.323735118f, 1.482176304f, 1.643956780f,
+            1.808799028f, 1.968619347f, 2.138448954f, 2.309558868f,
+            2.483170986f,
+        }};
+        // Move the table with the existing Threshold extension control. At
+        // its reference-compatible -10 dB setting this offset is exactly zero.
+        const float thresholdShift = thresholdControlDb + 10.0f;
+        const float level = inputLevelDb - thresholdShift;
+        constexpr float firstLevelDb = -14.0f;
+        constexpr float lastLevelDb = -6.0f;
+        constexpr float referenceKneeFloorDb = -15.404937f;
+        if (level <= referenceKneeFloorDb) return 0.0f;
+        if (level < firstLevelDb)
+            return reductionDb.front()
+                * (level - referenceKneeFloorDb)
+                / (firstLevelDb - referenceKneeFloorDb);
+        if (level <= lastLevelDb)
+        {
+            const float tablePosition = (level - firstLevelDb) * 4.0f;
+            const size_t low = static_cast<size_t>(std::min(
+                static_cast<int>(reductionDb.size()) - 2,
+                std::max(0, static_cast<int>(std::floor(tablePosition)))));
+            const float fraction = tablePosition - static_cast<float>(low);
+            return reductionDb[low]
+                + fraction * (reductionDb[low + 1] - reductionDb[low]);
+        }
+        // The measured onset is almost tangent to the established curve by
+        // -4 dB. Join there and leave every deeper static/maximum-GR anchor on
+        // the accepted law rather than extrapolating the new table.
+        constexpr float joinLevelDb = -4.0f;
+        const float shiftedJoinLevelDb = joinLevelDb + thresholdShift;
+        const float joinedReduction = fetReferenceReductionDb(
+            shiftedJoinLevelDb, 0, thresholdControlDb);
+        if (level < joinLevelDb)
+        {
+            const float fraction = (level - lastLevelDb)
+                / (joinLevelDb - lastLevelDb);
+            return reductionDb.back()
+                + fraction * (joinedReduction - reductionDb.back());
+        }
+        return fetReferenceReductionDb(inputLevelDb, 0, thresholdControlDb);
+    }
+
+    static float fetAllProcessorCorrectionDb(float inputLevelDb) noexcept
+    {
+        // All-buttons has a separate 1.20 dB small-signal gain and a curved
+        // transition into limiting. This correction was measured after the
+        // common analog stages, on a dense 997 Hz grid, so the target below
+        // accounts for their level-dependent residual instead of applying a
+        // second output trim. Positions are in `detectorLevelDb` and are
+        // consumed as passed; the recurring .145 fraction in them is inherited
+        // from the grid the original measurement was laid out on and is NOT an
+        // offset to be applied to or removed from the argument (see the note on
+        // the coordinate below). Intermediate points are linearly interpolated.
+        //
+        // The first FIVE entries are the small-signal plateau: below the
+        // All-buttons knee no reduction is generated, so -(entry) IS the
+        // small-signal gain and it must be the reference's measured 1.20 dB.
+        // The flat +0.15 dB that used to be added to this function's result at
+        // the call site is a fit constant belonging to the compressing region
+        // only, and is now carried by the entries from -6.145 dB upward --
+        // where it was fitted -- instead of by every entry. Applied to the
+        // plateau it made the small-signal gain 1.048 dB. That was invisible
+        // while the chain carried the +0.149329 dB excess removed in
+        // fetInputGainDb, which very nearly cancelled it; the scalar-immune
+        // measurement is the All-buttons-minus-4:1 output difference at Input
+        // 0.4 / -36 dBFS, where both laws are below their knees: reference
+        // +1.19992 dB, this plugin +1.04601 dB before the change.
+        //
+        // -7.224 dB ends the plateau. The 2 dB sweep the table was originally
+        // fitted on samples this transition at exactly the knot spacing, so it
+        // could not see the segment interiors; a 0.5 dB sweep of the same
+        // operating point (Input 0.4, All buttons, Modern curve) shows the
+        // reference producing NO reduction at all up to -7.5 dB internal --
+        // consecutive 0.5 dB steps come back +0.499629 / +0.499584 / +0.499533
+        // / +0.499476 / +0.499412 dB -- and then knee-ing hard. A single
+        // straight segment from -8.145 to -6.145 starts compressing 0.9 dB too
+        // early and read -0.206 / -0.334 / -0.272 dB against the reference at
+        // -7.5 / -7.0 / -6.5. Extending the plateau and re-fitting the -6.145
+        // entry against that sweep leaves at worst 0.022 dB across the whole
+        // transition.
+        //
+        // The knot's value came out of least squares, but the best-determined
+        // thing at that abscissa is this plugin's OWN slope break: with the
+        // campaign's pinned -10 dB threshold `fetReferenceReductionDb` starts
+        // generating All-buttons reduction at -4.74344 - 10 + 10 - 4.87980/2 =
+        // -7.18334 dB, which the fit landed 0.041 dB from. The reference's own
+        // knee onset is only bounded to (-7.65, -7.15) by the 0.5 dB grid, so
+        // it does not pin the knot nearly as well; do not re-derive this
+        // position from "where the reference knees" alone.
+        //
+        // The argument is `detectorLevelDb` as passed, with no offset. A
+        // reference-free inversion pins that: the only difference between the
+        // two builds either side of this re-fit is this table, so the measured
+        // output difference over the 0.5 dB grid IS the difference of the two
+        // tables sampled at the consumption argument, and solving the one
+        // unknown gives detectorLevelDb - 0.008 (+/-0.03). An earlier note here
+        // claimed a +0.130 dB effective offset from detector ripple; that was
+        // the Wave 5 -0.149329 dB input-gain correction subtracted twice in the
+        // analysis coordinate, not a property of the chain. It cost the fit
+        // 0.009 dB, which is far inside what the grid resolves, but do not
+        // carry that offset into a fit of the segments above.
+        constexpr std::array<float, 23> positions{{
+            -30.145f, -20.145f, -12.145f, -8.145f, -7.224f, -6.145f,
+            -4.145f, -2.145f, -0.145f, 1.855f, 2.608f, 3.855f,
+            7.149f, 13.064f, 14.608f, 15.855f, 19.234f, 25.234f,
+            26.608f, 27.855f, 32.608f, 33.855f, 40.0f}};
+        constexpr std::array<float, 23> corrections{{
+            -1.20005f, -1.19849f, -1.19245f, -1.18313f, -1.18313f,
+            -0.55515f, 0.48398f, 0.67817f, 0.57889f, 0.51182f,
+            0.49441f, 0.46731f, 0.41443f, 0.42950f, 0.46340f,
+            0.44900f, 0.48120f, 0.51680f, 0.51190f, 0.50250f,
+            0.54200f, 0.54070f, 0.54070f}};
+        if (inputLevelDb <= positions.front()) return corrections.front();
+        for (size_t i = 1; i < positions.size(); ++i)
+            if (inputLevelDb <= positions[i])
+            {
+                const float fraction = (inputLevelDb - positions[i - 1])
+                    / (positions[i] - positions[i - 1]);
+                return corrections[i - 1]
+                    + fraction * (corrections[i] - corrections[i - 1]);
+            }
+        return corrections.back();
+    }
+
+    static float fetAllOverloadMemoryDb(float baseReductionDb) noexcept
+    {
+        // The Modern All-buttons arm carries an additional slow high-level
+        // population below its maximum-reduction plateau. A 9--11.5 second
+        // sweep measures +0.312 / +0.345 / +0.228 dB missing reduction at
+        // nominal internal levels +34 / +37 / +38 dB, falling to zero when the
+        // overload cap engages. The coordinate here is the reduction produced
+        // by the existing static law at the call site, before this correction.
+        constexpr std::array<float, 5> reductionDb{{
+            36.00f, 37.65f, 40.53f, 41.49f, 41.78f}};
+        constexpr std::array<float, 5> memoryDb{{
+            0.000f, 0.312f, 0.345f, 0.228f, 0.000f}};
+        if (baseReductionDb <= reductionDb.front()) return memoryDb.front();
+        for (size_t i = 1; i < reductionDb.size(); ++i)
+            if (baseReductionDb <= reductionDb[i])
+            {
+                const float fraction = (baseReductionDb - reductionDb[i - 1])
+                    / (reductionDb[i] - reductionDb[i - 1]);
+                return memoryDb[i - 1]
+                    + fraction * (memoryDb[i] - memoryDb[i - 1]);
+            }
+        return memoryDb.back();
+    }
+
+    static float fetAttackPosition(float legacyMilliseconds) noexcept
+    {
+        // Invert the existing descriptor's 0.3 skew to recover the host knob
+        // position without changing its saved-state or automation domain.
+        const float proportion = std::clamp(
+            (legacyMilliseconds - 0.02f) / (80.0f - 0.02f), 0.0f, 1.0f);
+        return std::pow(proportion, 0.3f);
+    }
+
+    static float fetAttackKnobScale(float attackPosition,
+                                    float positiveReductionDb) noexcept
+    {
+        // A 4 kHz carrier resolves the installed unit's slow half of the Attack
+        // knob without the 1 kHz estimator's 0.5 ms floor. The correction is
+        // programme dependent: a single multiplier fixed the shallow row but
+        // made the deep row slower even though it needed to move in the other
+        // direction. Interpolate the independently measured shallow and deep
+        // corrections, holding both ends outside the measured 14--34 dB span.
+        // The midpoint and upper half retain the established drive-axis law.
+        const float depth = std::clamp(
+            (positiveReductionDb - 14.0f) / 20.0f, 0.0f, 1.0f);
+        const float atSlowStop = 1.45f - 0.20f * depth;
+        const float atQuarter = 1.25f - 0.25f * depth;
+        if (attackPosition <= 0.25f)
+            return atSlowStop
+                + 4.0f * attackPosition * (atQuarter - atSlowStop);
+        if (attackPosition < 0.50f)
+            return atQuarter
+                + 4.0f * (attackPosition - 0.25f) * (1.0f - atQuarter);
+        return 1.0f;
+    }
+
+    static float fetReleasePosition(float legacyMilliseconds) noexcept
+    {
+        return std::clamp(
+            (legacyMilliseconds - 50.0f) / (1100.0f - 50.0f), 0.0f, 1.0f);
+    }
+
+    static float fetReleaseExposureScale(float exposureSeconds,
+                                         float maximumGrDb) noexcept
+    {
+        constexpr std::array<float, 4> exposures{{0.01f, 0.10f, 1.0f, 5.0f}};
+        constexpr std::array<float, 4> lowDrive{{0.42f, 0.46f, 0.65f, 0.80f}};
+        constexpr std::array<float, 4> midDrive{{0.51f, 0.56f, 0.82f, 1.00f}};
+        constexpr std::array<float, 4> highDrive{{0.10f, 0.70f, 1.00f, 1.24f}};
+        const auto interpolateExposure = [&exposures, exposureSeconds](
+            const std::array<float, 4>& values) noexcept {
+            if (exposureSeconds <= exposures.front()) return values.front();
+            for (size_t i = 1; i < exposures.size(); ++i)
+                if (exposureSeconds <= exposures[i])
+                {
+                    const float lowLog = std::log(exposures[i - 1]);
+                    const float highLog = std::log(exposures[i]);
+                    const float fraction = (std::log(exposureSeconds) - lowLog)
+                        / (highLog - lowLog);
+                    return values[i - 1]
+                        + fraction * (values[i] - values[i - 1]);
+                }
+            return values.back();
+        };
+        const float low = interpolateExposure(lowDrive);
+        const float mid = interpolateExposure(midDrive);
+        const float high = interpolateExposure(highDrive);
+        const float drive = std::clamp((maximumGrDb - 14.0f) / 20.0f,
+                                       0.0f, 1.0f);
+        return drive <= 0.5f
+            ? low + drive * 2.0f * (mid - low)
+            : mid + (drive - 0.5f) * 2.0f * (high - mid);
+    }
+
+    static float fetPostBurstRecoveryAssistDb(
+        float elapsedSeconds, float maximumGrDb, int ratioIndex,
+        float terminalWeight, float attackPosition, float releasePosition,
+        float hostSampleRate) noexcept
+    {
+        // The installed cell sheds a finite terminal-charge population after
+        // programme support disappears. It is separate from the ordinary
+        // asymptotic release: the candidate/UAD difference is 1.1--3.4 dB in
+        // the first 250 ms recovery window and has crossed zero by 3.25 s.
+        // Maximum reduction owns the population size/shape; the final active
+        // detector sample supplies the measured phase coordinate that a
+        // phase-blind release scalar could not reproduce.
+        const float drive = std::clamp(
+            (maximumGrDb - 14.0f) / 20.0f, 0.0f, 1.0f);
+        if (maximumGrDb < 8.0f || elapsedSeconds < 0.0f) return 0.0f;
+        const float lowerDrive = std::min(drive * 2.0f, 1.0f);
+        const float upperDrive = std::max(drive * 2.0f - 1.0f, 0.0f);
+        float amplitudeDb = 1.93f
+            + lowerDrive * (2.85f - 1.93f)
+            + upperDrive * (3.38f - 2.85f);
+        float exponent = 4.00f
+            + lowerDrive * (2.87f - 4.00f)
+            + upperDrive * (1.50f - 2.87f);
+        const float rate = std::clamp(
+            (hostSampleRate - 48000.0f) / 48000.0f, 0.0f, 1.0f);
+        const float phase = std::clamp(terminalWeight, 0.0f, 1.0f);
+        amplitudeDb += phase * drive * (0.69f + 0.13f * rate);
+        exponent += phase * drive * (0.25f - 0.07f * rate);
+        amplitudeDb += 0.20f * drive
+            * (1.0f - std::clamp(attackPosition, 0.0f, 1.0f));
+        if (ratioIndex == 1)
+        {
+            amplitudeDb *= 1.15f;
+            exponent += 0.70f;
+        }
+        else if (ratioIndex != 0)
+            return 0.0f;
+        const float nominalReleaseSeconds
+            = 2.00f - 1.82f * releasePosition
+                + 0.12f * releasePosition * releasePosition;
+        const float durationSeconds = 3.0f
+            * nominalReleaseSeconds / 1.12f;
+        const float position = 1.0f - elapsedSeconds
+            / std::max(durationSeconds, 0.05f);
+        const float terminalAssist = position > 0.0f
+            ? amplitudeDb * std::pow(position, exponent) : 0.0f;
+        // The slow tail crosses the reference after the terminal population
+        // has discharged. This small bipolar arm is independently constrained
+        // by the 1.875/3.375/4.875/5.875 s windows, where a positive-only
+        // assist would leave up to +0.164 dB of over-recovery.
+        float tailAmplitudeDb = drive <= 0.5f
+            ? 0.17f
+            : 0.17f + (drive - 0.5f) * 2.0f * (0.03f - 0.17f);
+        if (ratioIndex == 1) tailAmplitudeDb += 0.08f;
+        const float tailSeconds = elapsedSeconds * 1.12f
+            / std::max(nominalReleaseSeconds, 0.05f);
+        float tailShape = 0.0f;
+        if (tailSeconds > 0.375f && tailSeconds <= 1.875f)
+            tailShape = (tailSeconds - 0.375f) / 1.5f * 0.40f;
+        else if (tailSeconds <= 3.375f && tailSeconds > 1.875f)
+            tailShape = 0.40f
+                + (tailSeconds - 1.875f) / 1.5f * 0.60f;
+        else if (tailSeconds <= 4.875f && tailSeconds > 3.375f)
+            tailShape = 1.0f
+                - (tailSeconds - 3.375f) / 1.5f * 0.70f;
+        else if (tailSeconds <= 5.875f && tailSeconds > 4.875f)
+            tailShape = 0.30f
+                - (tailSeconds - 4.875f) * 0.20f;
+        else if (tailSeconds <= 6.5f && tailSeconds > 5.875f)
+            tailShape = 0.10f
+                * (1.0f - (tailSeconds - 5.875f) / 0.625f);
+        return terminalAssist - tailAmplitudeDb
+            * std::max(tailShape, 0.0f);
+    }
 
     static float optoThresholdDb(float peakReduction, bool limit) noexcept
     {
@@ -1345,14 +2490,26 @@ private:
         return optoOutputStage(out);
     }
 
-    float processFET(float input, int ch, float sidechain, const MultiCompParameterState& p, bool studio, bool external) noexcept
+    float processFET(float input, int ch, float sidechain,
+                     const MultiCompParameterState& p, bool studio,
+                     bool external, bool linked) noexcept
     {
         auto& d = studio ? static_cast<FETState&>(studioFet[ch]) : fet[ch];
         const float sr = static_cast<float>(fs * osFactor);
         auto& inT = studio ? inputTransformerStudioFet[ch] : inputTransformerFet[ch];
         auto& outT = studio ? outputTransformerStudioFet[ch] : outputTransformerFet[ch];
-        const float inputGain = decibelsToGain(p.fetInput.load(std::memory_order_relaxed));
-        const float gained = inT.processSample(input, ch) * inputGain;
+        const float inputValue = p.fetInput.load(std::memory_order_relaxed);
+        const float inputGain = decibelsToGain(
+            studio ? inputValue : fetInputGainDb(inputValue));
+        // Equivalent source-level/Input combinations have the same measured
+        // vintage output spectrum. The generic transformer saturates far
+        // earlier than this unit when driven by its 40 dB Input range, so the
+        // calibrated vintage coloration below owns the audio stage. Its subtly
+        // shaped signal remains useful to the unlinked detector. Studio FET
+        // retains its established transformer-before-gain audio topology.
+        const float transformedInput = inT.processSample(input, ch);
+        const float gained = studio ? transformedInput * inputGain
+                                    : input * inputGain;
         const int ratioIndex = std::clamp(p.fetRatio.load(std::memory_order_relaxed), 0, 4);
         const float ratios[5] = {studio ? 4.0f : 3.85f, studio ? 8.0f : 7.40f, studio ? 12.0f : 12.50f, studio ? 20.0f : 21.50f, studio ? 20.0f : 21.50f};
         const float ratio = ratios[ratioIndex];
@@ -1363,17 +2520,171 @@ private:
             // Vintage FET saturation is inside the feedback loop.  The
             // sidechain must see this signal, not the post-envelope shortcut.
             const float grDb = -gainToDecibels(d.envelope + 0.001f);
-            const float grNorm = std::clamp(grDb / 20.0f, 0.0f, 1.0f);
-            const float k2 = ratioIndex == 4 ? 0.04f + grNorm * 0.04f
-                                             : 0.024f + grNorm * 0.026f;
-            const float k3 = ratioIndex == 4 ? 0.005f + grNorm * 0.010f
-                                             : 0.004f + grNorm * 0.008f;
+            const float k2 = fetBroadbandK2(grDb);
+            const float k3 = fetBroadbandK3(grDb);
+            // `fetBroadbandK3` is a settled small-signal fit. On the first
+            // uncompressed cycle, Input can drive this internal node tens of
+            // times beyond every fitted row; extrapolating x^3 there creates
+            // a false rectified crest and even reverses the 1 kHz fundamental.
+            // The installed unit bounds that cell before its output stage.
+            // Keep the fitted polynomial bit-identical throughout its measured
+            // domain and bound only the out-of-domain source that it consumes.
+            // An 8.0 source limit is the measured compromise across the 1 kHz
+            // startup surface, the 0.5-20 ms attack curve, and the independent
+            // 4 kHz Attack-knob surface; see the Wave 21 evidence note.
+            constexpr float kFetBroadbandK3SourceLimit = 8.0f;
+            const float k3Source = std::clamp(
+                saturated, -kFetBroadbandK3SourceLimit,
+                kFetBroadbandK3SourceLimit);
             const float sq = saturated * saturated;
             const float alpha = 1.0f / (1.0f + kDuskTwoPi * 10.0f / sr);
             const float h2 = alpha * (d.dc + sq - d.prevSq);
             d.dc = h2;
             d.prevSq = sq;
-            saturated += k2 * h2 + k3 * saturated * saturated * saturated;
+            // High-pass and normalise the broadband colour source so its
+            // Chebyshev T5 term contributes fifth harmonic without folding a
+            // large cubic back into the independently fitted K3 surface or
+            // duplicating the low-frequency transformer term.
+            const float colourHighPassCoeff = 1.0f
+                - std::exp(-2.0f * kDuskPi * 250.0f / sr);
+            d.colourHighPassLow += colourHighPassCoeff
+                * (saturated - d.colourHighPassLow);
+            float colourHighPassed = saturated - d.colourHighPassLow;
+            d.colourHighPassLower += colourHighPassCoeff
+                * (colourHighPassed - d.colourHighPassLower);
+            colourHighPassed -= d.colourHighPassLower;
+            const float colourPeakRelease = std::exp(-1.0f / (0.1f * sr));
+            const float colourHighPassedAbs = std::abs(colourHighPassed);
+            d.colourPeak = colourHighPassedAbs >= d.colourPeak
+                ? colourHighPassedAbs
+                : colourHighPassedAbs + (d.colourPeak - colourHighPassedAbs)
+                    * colourPeakRelease;
+            const float colourNormalised = std::clamp(
+                colourHighPassed / std::max(d.colourPeak, 1.0e-9f),
+                -1.0f, 1.0f);
+            const float colour2 = colourNormalised * colourNormalised;
+            const float colour3 = colour2 * colourNormalised;
+            const float colour5 = colour2 * colour3;
+            const float broadbandHarmonicDrive = std::clamp(
+                grDb / 14.0f, 0.0f, 1.0f);
+            const float broadbandH5 = d.colourPeak * broadbandHarmonicDrive
+                * fetBroadbandK5(grDb)
+                * (16.0f * colour5 - 20.0f * colour3
+                    + 5.0f * colourNormalised);
+            // The hardware's low-frequency transformer asymmetry grows with
+            // gain reduction. Generate that even harmonic from a 250 Hz
+            // two-pole low-passed copy; `fetLowFrequencyK2` above is its
+            // measured coefficient.
+            //
+            // The two poles put this path 49 dB down at 1 kHz once squared,
+            // which is NOT negligible against `fetBroadbandK2` and must not be
+            // treated as if it were: measured by rebuilding with the
+            // coefficient zeroed, the term moves the 1 kHz second harmonic by
+            // up to 0.175 dB (Input 0.6, -24 dBFS). Any change here has to be
+            // scored on the 1 kHz surface as well as the 100 Hz one -- the
+            // Wave 9 fit carries the 39-row 1 kHz set as a constraint for
+            // exactly this reason, and lands it at 0.2335 dB worst against the
+            // 0.2625 dB it inherited.
+            const float colourLowCoeff = 1.0f
+                - std::exp(-2.0f * kDuskPi * 250.0f / sr);
+            d.colourLow += colourLowCoeff * (saturated - d.colourLow);
+            d.colourLower += colourLowCoeff * (d.colourLow - d.colourLower);
+            const float colourLowSq = d.colourLower * d.colourLower;
+            const float colourLowH2 = alpha
+                * (d.colourLowDc + colourLowSq - d.colourLowPrevSq);
+            d.colourLowDc = colourLowH2;
+            d.colourLowPrevSq = colourLowSq;
+            const float lowFrequencyK2 = fetLowFrequencyK2(grDb);
+            const float colourLowPeakRelease = std::exp(-1.0f / (0.1f * sr));
+            const float colourLowerAbs = std::abs(d.colourLower);
+            d.colourLowPeak = colourLowerAbs >= d.colourLowPeak
+                ? colourLowerAbs
+                : colourLowerAbs
+                    + (d.colourLowPeak - colourLowerAbs)
+                        * colourLowPeakRelease;
+            const float lowNormalised = std::clamp(
+                d.colourLower / std::max(d.colourLowPeak, 1.0e-9f),
+                -1.0f, 1.0f);
+            const float low2 = lowNormalised * lowNormalised;
+            const float low3 = low2 * lowNormalised;
+            const float low4 = low2 * low2;
+            const float low5 = low4 * lowNormalised;
+            const float lowHarmonicDrive = std::clamp(grDb / 14.0f, 0.0f, 1.0f);
+            const float lowFrequencyK3 = fetLowFrequencyK3(grDb);
+            const float lowFrequencyK5 = fetLowFrequencyK5(grDb);
+            const float lowT3 = 4.0f * low3 - 3.0f * lowNormalised;
+            const float shallowNormalised = std::clamp(
+                gained / std::max(d.kneePeak, 1.0e-9f), -1.0f, 1.0f);
+            const float shallowNormalised2
+                = shallowNormalised * shallowNormalised;
+            const float shallowNormalised3
+                = shallowNormalised2 * shallowNormalised;
+            const float shallowT3 = 4.0f * shallowNormalised2
+                * shallowNormalised - 3.0f * shallowNormalised;
+            const float shallowT5 = 16.0f * shallowNormalised3
+                    * shallowNormalised2
+                - 20.0f * shallowNormalised3
+                + 5.0f * shallowNormalised;
+            const float lowT3LagCoeff = 1.0f
+                - std::exp(-2.0f * kDuskPi * 300.0f / sr);
+            d.shallowT3Lag += lowT3LagCoeff
+                * (shallowT3 - d.shallowT3Lag);
+            d.shallowT3Lower += lowT3LagCoeff
+                * (d.shallowT3Lag - d.shallowT3Lower);
+            d.shallowT3Lowest += lowT3LagCoeff
+                * (d.shallowT3Lower - d.shallowT3Lowest);
+            d.shallowT5Lag += lowT3LagCoeff
+                * (shallowT5 - d.shallowT5Lag);
+            d.shallowT5Lower += lowT3LagCoeff
+                * (d.shallowT5Lag - d.shallowT5Lower);
+            d.shallowT5Lowest += lowT3LagCoeff
+                * (d.shallowT5Lower - d.shallowT5Lowest);
+            const float shallowDriveDb = gainToDecibels(
+                std::max(d.kneePeak, 1.0e-12f));
+            const std::array<float, 4> shallowOddCorrection
+                = ratioIndex == 0
+                    ? fetShallowKneeOddCorrection(shallowDriveDb)
+                    : std::array<float, 4>{{0.0f, 0.0f, 0.0f, 0.0f}};
+            const float inputPosition = std::clamp(
+                (inputValue + 20.0f) / 60.0f, 0.0f, 1.0f);
+            const float releasePosition = fetReleasePosition(
+                p.fetRelease.load(std::memory_order_relaxed));
+            const std::array<float, 4> broadbandComplexH3Correction
+                = ratioIndex == 0
+                    ? fetBroadbandComplexH3Correction(
+                        inputPosition, releasePosition, shallowDriveDb, fs)
+                    : std::array<float, 4>{{0.0f, 0.0f, 0.0f, 0.0f}};
+            const std::array<float, 4> broadbandComplexH5Correction
+                = ratioIndex == 0
+                    ? fetBroadbandComplexH5Correction(
+                        inputPosition, releasePosition, shallowDriveDb, fs)
+                    : std::array<float, 4>{{0.0f, 0.0f, 0.0f, 0.0f}};
+            float lowHarmonics = d.colourLowPeak * lowHarmonicDrive
+                * (lowFrequencyK3 * lowT3
+                    + 0.0037f * (8.0f * low4 - 8.0f * low2)
+                    + lowFrequencyK5 * (16.0f * low5 - 20.0f * low3
+                        + 5.0f * lowNormalised));
+            lowHarmonics += d.colourLowPeak
+                * (shallowOddCorrection[0] * d.shallowT3Lag
+                    + shallowOddCorrection[1] * d.shallowT3Lower
+                    + shallowOddCorrection[2] * d.shallowT5Lag
+                    + shallowOddCorrection[3] * d.shallowT5Lower);
+            lowHarmonics += d.kneePeak
+                * (broadbandComplexH3Correction[0] * shallowT3
+                    + broadbandComplexH3Correction[1] * d.shallowT3Lag
+                    + broadbandComplexH3Correction[2] * d.shallowT3Lower
+                    + broadbandComplexH3Correction[3] * d.shallowT3Lowest);
+            lowHarmonics += d.kneePeak
+                * (broadbandComplexH5Correction[0] * shallowT5
+                    + broadbandComplexH5Correction[1] * d.shallowT5Lag
+                    + broadbandComplexH5Correction[2] * d.shallowT5Lower
+                    + broadbandComplexH5Correction[3] * d.shallowT5Lowest);
+            d.colourLowHarmonicDc += (1.0f - alpha)
+                * (lowHarmonics - d.colourLowHarmonicDc);
+            lowHarmonics -= d.colourLowHarmonicDc;
+            saturated += k2 * h2 + lowFrequencyK2 * colourLowH2
+                + k3 * k3Source * k3Source * k3Source
+                + broadbandH5 + lowHarmonics;
         }
 
         // FET junction capacitance choke in the feedback path.  Studio FET
@@ -1385,7 +2696,59 @@ private:
         const float chokeCoeff = 1.0f - std::exp(-2.0f * kDuskPi * corner / sr);
         d.hf += chokeCoeff * (feedbackInput - d.hf);
         float detect = 0.0f;
-        if (external)
+        float kneeDetect = 0.0f;
+        float vintageInstantLevel = 0.0f;
+        bool vintageProgrammeActive = false;
+        bool vintageProgrammeSupported = false;
+        if (!studio)
+        {
+            // The static reference law above is expressed on the signal driven
+            // by Input, before gain reduction. Its feedback topology has the
+            // same settled transfer, but using the already-reduced signal with
+            // a feed-forward slope produces a second, incorrect ratio. The
+            // fast peak detector supplies a stable level to the timing stage.
+            // The ordinary internal path follows the oversampled audio and its
+            // measured reconstruction latency. Only an external detector or
+            // an active vintage stereo link consumes the sidechain prepared by
+            // MultiCompDSP; using it unconditionally erased the first-cycle
+            // overshoot by giving the detector unintended lookahead.
+            const float instantLevel = std::abs(
+                (external || linked) ? sidechain * inputGain
+                                     : transformedInput * inputGain);
+            vintageInstantLevel = instantLevel;
+            vintageProgrammeActive = instantLevel > 0.03f;
+            const float peakReleaseCoeff = std::exp(-1.0f / (0.040f * sr));
+            if (instantLevel > d.peak)
+                d.peak = instantLevel;
+            else
+                d.peak += (1.0f - peakReleaseCoeff) * (instantLevel - d.peak);
+            detect = d.peak;
+            const float kneeInstantLevel = std::abs(
+                (external || linked) ? sidechain * inputGain
+                                     : input * inputGain);
+            const float kneePeakRelease = std::exp(
+                -1.0f / (0.250f * sr));
+            constexpr float kneeHoldSeconds = 0.030f;
+            const float sampleSeconds = 1.0f / sr;
+            const auto advanceHeldPeak = [kneePeakRelease, sampleSeconds](
+                float inputLevel, float& peak,
+                float& holdSeconds) noexcept {
+                if (inputLevel >= peak)
+                {
+                    peak = inputLevel;
+                    holdSeconds = kneeHoldSeconds;
+                }
+                else if (holdSeconds > 0.0f)
+                    holdSeconds = std::max(0.0f, holdSeconds - sampleSeconds);
+                else
+                    peak = inputLevel
+                        + (peak - inputLevel) * kneePeakRelease;
+            };
+            advanceHeldPeak(kneeInstantLevel, d.kneePeak,
+                            d.kneePeakHoldSeconds);
+            kneeDetect = d.kneePeak;
+        }
+        else if (external)
             detect = std::abs(sidechain * inputGain);
         else if (ratioIndex == 4)
         {
@@ -1409,9 +2772,71 @@ private:
         // JUCE applies the all-buttons threshold shift exactly once below via
         // abiThreshold = threshold * 0.5f.  Do not fold a second -6.0206 dB
         // offset into the base threshold here.
-        const float threshold = decibelsToGain(studio ? -10.0f : p.fetThreshold.load(std::memory_order_relaxed));
+        const float thresholdControlDb = studio
+            ? -10.0f : p.fetThreshold.load(std::memory_order_relaxed);
+        const float threshold = decibelsToGain(thresholdControlDb);
         float reduction = 0.0f;
-        if (ratioIndex == 4)
+        float kneeTargetReduction = 0.0f;
+        float kneeHandoff = 1.0f;
+        if (!studio)
+        {
+            const float detectorLevelDb = gainToDecibels(
+                std::max(detect, 1.0e-12f));
+            const bool measuredExtension
+                = p.fetCurve.load(std::memory_order_relaxed) != 0;
+            if (ratioIndex == 4 && measuredExtension)
+            {
+                const float abiThreshold = threshold * 0.5f;
+                if (detect > abiThreshold)
+                    reduction = lookupTables.getAllButtonsReduction(
+                        gainToDecibels(detect / abiThreshold), true);
+            }
+            else
+            {
+                if (ratioIndex == 0)
+                {
+                    // The installed unit's shallow knee is frequency-flat even
+                    // though its deeper feedback detector is not. A second,
+                    // raw-input peak cell supplies only this onset interval;
+                    // it hands back to the transformed detector before the
+                    // accepted LF response and harmonic anchors. Its release
+                    // spans many 100 Hz half-cycles, preventing rectifier ripple
+                    // from turning the common static curve into a frequency law.
+                    const float kneeLevelDb = gainToDecibels(
+                        std::max(kneeDetect, 1.0e-12f));
+                    const float onsetReduction = fetReferenceKneeOnsetDb(
+                        kneeLevelDb, thresholdControlDb);
+                    const float normalisedKneeLevel = kneeLevelDb
+                        - (thresholdControlDb + 10.0f);
+                    // The onset table itself rejoins the accepted detector law
+                    // at -4 dB. Fade this auxiliary cell out over the preceding
+                    // decibel; carrying it above that join adds a second,
+                    // 100 ms trajectory to the already-matched -42 dBFS attack.
+                    const float handoff = std::clamp(
+                        (normalisedKneeLevel + 5.0f) / 1.0f,
+                        0.0f, 1.0f);
+                    const float smoothHandoff = handoff * handoff
+                        * (3.0f - 2.0f * handoff);
+                    kneeTargetReduction = onsetReduction;
+                    kneeHandoff = smoothHandoff;
+                    // Keep the established detector/envelope trajectory as the
+                    // coloration coordinate. The shallow auxiliary gain cell
+                    // below supplies only the difference to the measured knee,
+                    // so every harmonic ratio remains on its fitted axis.
+                    reduction = fetReferenceReductionDb(
+                        detectorLevelDb, ratioIndex, thresholdControlDb);
+                }
+                else
+                    reduction = fetReferenceReductionDb(
+                        detectorLevelDb, ratioIndex, thresholdControlDb);
+                if (ratioIndex == 4)
+                    reduction += fetAllProcessorCorrectionDb(detectorLevelDb);
+            }
+            if (p.fetTransient.load(std::memory_order_relaxed) > 0.01f)
+                reduction /= std::max(1.0f, transientShaper.process(
+                    input, ch, p.fetTransient.load(std::memory_order_relaxed)));
+        }
+        else if (ratioIndex == 4)
         {
             const float abiThreshold = threshold * 0.5f;
             if (detect > abiThreshold)
@@ -1434,52 +2859,378 @@ private:
             reduction = std::min(over * (1.0f - 1.0f / ratio), 60.0f);
         }
         // Studio FET allows the JUCE expansion bump to survive below threshold.
-        reduction = std::clamp(reduction, -1.0f, 60.0f);
-        const float minRelease = 0.05f, maxRelease = 1.1f;
-        float attack = std::max(0.0001f, p.fetAttack.load(std::memory_order_relaxed) * 0.001f);
-        const float releaseNorm = std::clamp(p.fetRelease.load(std::memory_order_relaxed) / 1100.0f, 0.0f, 1.0f);
-        float release = minRelease * std::pow(maxRelease / minRelease, releaseNorm);
-        if (ratioIndex == 4)
+        const float minimumReduction = !studio && ratioIndex == 4 ? -1.3f : -1.0f;
+        reduction = std::clamp(reduction, minimumReduction, 60.0f);
+        if (!studio)
         {
-            attack = std::max(0.0002f, attack * 2.0f);
-            release *= 1.0f + std::clamp(reduction / 20.0f, 0.0f, 1.0f) * 0.5f;
-            const float memoryDecay = std::exp(-1.0f / (0.5f * sr));
-            d.releaseMemory *= memoryDecay;
-            if (d.transient == 0 && reduction > 3.0f) d.releaseMemory = std::min(1.0f, d.releaseMemory + 0.15f);
-            release *= 1.0f + d.releaseMemory * 0.3f;
-        }
-        const float programFactor = std::clamp(1.0f + reduction * 0.05f, 0.5f, 2.0f);
-        const float signalDelta = std::abs(detect - d.previousLevel);
-        d.previousLevel = detect;
-        if (signalDelta > 0.1f) { attack *= 0.8f; release *= 1.2f; }
-        else { attack *= programFactor; release *= programFactor; }
-        const float target = decibelsToGain(-reduction);
-        const float attackCoeff = std::exp(-1.0f / (std::max(1.0e-5f, attack * sr)));
-        const float releaseCoeff = std::exp(-1.0f / (std::max(1.0e-5f, release * sr)));
-        if (ratioIndex == 4)
-        {
-            if (target < d.envelope)
+            // The installed unit charges most of its reduction in the FET cell,
+            // then adds a measured 2.2--3.4 dB programme-memory population with
+            // a roughly 0.9 s time constant. Keeping both populations in dB
+            // makes their settled sum equal the calibrated static law.
+            const float basePositiveReduction = std::max(0.0f, reduction);
+            const float allOverloadMemory = ratioIndex == 4
+                ? fetAllOverloadMemoryDb(basePositiveReduction) : 0.0f;
+            reduction = std::min(60.0f, reduction + allOverloadMemory);
+            const float positiveReduction = std::max(0.0f, reduction);
+            const float attackPosition = fetAttackPosition(
+                p.fetAttack.load(std::memory_order_relaxed));
+            const float attackPosition2 = attackPosition * attackPosition;
+            const float ratioSlowOffset = ratioIndex == 0 ? 0.80f
+                : ratioIndex == 1 ? 0.0f
+                : ratioIndex == 2 ? -0.65f
+                : ratioIndex == 3 ? -1.20f : 1.90f;
+            const float slowTarget = basePositiveReduction > 0.0f
+                ? std::min(basePositiveReduction,
+                    1.4f + 0.058f * basePositiveReduction
+                        + ratioSlowOffset
+                        + 0.8f * attackPosition2 * attackPosition2)
+                : 0.0f;
+            const float fastTarget
+                = reduction - slowTarget - allOverloadMemory;
+            // At the three deep 4:1 drive points, the installed unit's 40--60
+            // ms plateau exceeds ours by 0.567 / 0.545 / 0.684 dB while the
+            // settled reduction already matches. That nearly constant 0.599 dB
+            // is a third population, not more total reduction: split it out of
+            // the existing slow target and give it the measured intermediate
+            // charge time. All-buttons stays on its independently fitted arm.
+            constexpr float intermediateTargetCeilingDb = 0.5985f;
+            // The -42 dBFS row (4.2865 dB settled reduction) already has the
+            // reference shape without this population; the -36 dBFS row
+            // (9.1406 dB) benefits from the full split. Interpolate between the
+            // two measured anchors so the cell engages with reduction depth.
+            const float intermediateDepth = std::clamp(
+                (positiveReduction - 4.2865f) / (9.1406f - 4.2865f),
+                0.0f, 1.0f);
+            const float intermediateTarget = ratioIndex == 4
+                ? allOverloadMemory
+                : std::min(slowTarget,
+                    intermediateTargetCeilingDb * intermediateDepth);
+            const float longSlowTarget = ratioIndex == 4
+                ? slowTarget : slowTarget - intermediateTarget;
+            const float ratioAttackScale = ratioIndex == 0 ? 1.0f
+                : ratioIndex == 1 ? 0.65f
+                : ratioIndex == 2 ? 0.45f
+                : ratioIndex == 3 ? 0.25f : 0.90f;
+            const float baseFastAttackSeconds
+                = (0.000047f - 0.000026f * attackPosition
+                    - 0.000008f * attackPosition * attackPosition)
+                    * ratioAttackScale;
+            // The measured cell charges FASTER the harder it is driven -- the
+            // ordinary sense for a feedback detector, and the opposite of what
+            // this line used to say before the campaign measured it.
+            //
+            // `kFetDriveAttackScale` is a table, not a fit, and every entry is
+            // one rendered comparison against the installed unit: source levels
+            // -42 / -39 / -36 / -30 / -18 / -6 dBFS at input knob 0.8, which
+            // arrive here as settled reductions of 4.29 / 6.66 / 9.14 / 14.11 /
+            // 24.07 / 34.03 dB. Each entry was tuned to minimise the normalised
+            // curve RMS against the reference's own attack trajectory over
+            // 0.5-20 ms, which is the campaign's primary dynamics gate; the
+            // fitted time constant is a diagnostic only, because above ~30 dB of
+            // reduction it inverts sign against every other measure of speed.
+            //
+            // The abscissa is the SETTLED reduction, not the 40-60 ms plateau:
+            // the programme-memory population is only ~5 % charged at 50 ms, so
+            // the plateau reads 3-4 dB low and would put every anchor off axis.
+            //
+            // Both ends hold rather than extrapolate. The previous law was a
+            // parabola fitted only to the three deep anchors, and its 0-14 dB
+            // segment -- 2-10 dB of reduction, where most programme material
+            // sits -- was pure extrapolation that nothing gated. Below the
+            // first anchor the question is moot in any case: `slowTarget`
+            // saturates at `positiveReduction` under 2.39 dB, so the fast
+            // population is empty and this multiplier has no effect at all.
+            // Above the last anchor the deepest reduction any measured row
+            // reaches is All-buttons at 36.1 dB, 2 dB past it.
+            //
+            // Holding the ends is also the safety property. `reduction` is
+            // clamped to 60 dB, and `advance()` turns a non-positive time into
+            // std::max(1.0e-6f, time) -- a silent 1 us attack rather than a
+            // failure. The old parabola crossed zero at 47.7 dB, only 11.7 dB
+            // outside its clamp, so widening that clamp would have produced
+            // exactly that regime with no assertion firing. A table of positive
+            // values with held ends cannot, whatever argument it is given.
+            const float driveAttackScale
+                = fetDriveAttackScale(positiveReduction);
+            const float fastAttackSeconds
+                = baseFastAttackSeconds * driveAttackScale
+                    * (6.5f + 5.7f * attackPosition
+                        - 9.4f * attackPosition * attackPosition)
+                    * fetAttackKnobScale(attackPosition, positiveReduction);
+            const float allOverloadDepth = std::clamp(
+                (basePositiveReduction - 40.50f) / (41.75f - 40.50f),
+                0.0f, 1.0f);
+            const float slowAttackSeconds = ratioIndex == 4
+                ? 1.50f - 1.05f * allOverloadDepth
+                : 0.95f + 0.55f * attackPosition2 * attackPosition2;
+            const float intermediateAttackSeconds = ratioIndex == 4
+                ? 5.0f : 0.010f;
+            // Splitting a fixed target makes the practical 3--5 s "settled"
+            // windows charge slightly farther than the old single population.
+            // Keeping the remainder 8 % slower makes the two populations meet
+            // the old trajectory again in that measured window while leaving
+            // their asymptotic sum unchanged.
+            const float longSlowAttackSeconds
+                = ratioIndex != 4 && intermediateTarget > 0.0f
+                    ? slowAttackSeconds * 1.08f : slowAttackSeconds;
+            const float releasePosition = fetReleasePosition(
+                p.fetRelease.load(std::memory_order_relaxed));
+            const int programmeSilenceHoldSamples = std::max(
+                1, static_cast<int>(std::lround(0.002f * sr)));
+            if (vintageProgrammeActive)
+                d.programmeSilentSamples = 0;
+            else
+                d.programmeSilentSamples = std::min(
+                    d.programmeSilentSamples + 1,
+                    programmeSilenceHoldSamples + 1);
+            vintageProgrammeSupported = vintageProgrammeActive
+                || d.programmeSilentSamples <= programmeSilenceHoldSamples;
+            const float recoveryLevelDrop = std::max(
+                d.recoveryPreviousInstantLevel - vintageInstantLevel, 0.0f);
+            d.recoveryPreviousInstantLevel = vintageInstantLevel;
+            if (vintageProgrammeSupported)
             {
-                if (d.transient < 30) { const float delayedAttack = attackCoeff * 0.5f + 0.5f; d.envelope = delayedAttack * d.envelope + (1.0f - delayedAttack) * target; ++d.transient; }
-                else d.envelope = attackCoeff * d.envelope + (1.0f - attackCoeff) * target;
+                if (!d.recoveryWasSupported)
+                    d.recoveryMaximumLevelDrop = 0.0f;
+                d.recoveryMaximumLevelDrop = std::max(
+                    d.recoveryMaximumLevelDrop, recoveryLevelDrop);
+                d.recoveryWasSupported = true;
+                d.recoveryElapsedSeconds = 0.0f;
+                d.recoveryGain = 1.0f;
             }
             else
             {
-                d.transient = 0;
-                const float gr = -gainToDecibels(d.envelope + 0.001f);
-                const float fastBase = 0.05f, fastMin = 0.025f, scaleGr = std::clamp(gr / 20.0f, 0.0f, 1.0f);
-                const float fast = fastBase - scaleGr * (fastBase - fastMin);
-                const float fastCoeff = std::exp(-1.0f / (std::max(1.0e-5f, fast * sr)));
-                const float effective = fastCoeff * scaleGr + releaseCoeff * (1.0f - scaleGr);
-                d.envelope = effective * d.envelope + (1.0f - effective) * target;
+                if (d.recoveryWasSupported)
+                {
+                    d.recoveryWasSupported = false;
+                    d.recoveryMaximumGrDb = d.programmeMaximumGrDb;
+                    d.recoveryTerminalWeight = std::clamp(
+                        (d.recoveryMaximumLevelDrop - 12.0f) / 8.0f,
+                        0.0f, 1.0f);
+                    d.recoveryAttackPosition = attackPosition;
+                    d.recoveryReleasePosition = releasePosition;
+                    d.recoveryRatioIndex = ratioIndex;
+                    d.recoveryElapsedSeconds = 0.0f;
+                }
+                else
+                    d.recoveryElapsedSeconds += 1.0f / sr;
+                if (ratioIndex != d.recoveryRatioIndex
+                    || std::abs(attackPosition - d.recoveryAttackPosition)
+                        > 1.0e-4f
+                    || std::abs(releasePosition - d.recoveryReleasePosition)
+                        > 1.0e-4f)
+                    d.recoveryMaximumGrDb = 0.0f;
+                const float assistDb = fetPostBurstRecoveryAssistDb(
+                    d.recoveryElapsedSeconds, d.recoveryMaximumGrDb,
+                    d.recoveryRatioIndex, d.recoveryTerminalWeight,
+                    d.recoveryAttackPosition, d.recoveryReleasePosition,
+                    static_cast<float>(fs));
+                d.recoveryGain = decibelsToGain(assistDb);
+            }
+            if (vintageProgrammeSupported)
+            {
+                d.programmeExposureSeconds = std::min(
+                    5.0f, d.programmeExposureSeconds + 1.0f / sr);
+                d.programmeMaximumGrDb = std::max(
+                    d.programmeMaximumGrDb, positiveReduction);
+            }
+            const float exposureReleaseScale = fetReleaseExposureScale(
+                std::max(d.programmeExposureSeconds, 0.01f),
+                d.programmeMaximumGrDb);
+            const float ratioReleaseScale = ratioIndex == 0 ? 1.0f
+                : ratioIndex == 1 ? 0.875f
+                : ratioIndex == 2 ? 0.842f
+                : ratioIndex == 3 ? 0.762f : 1.0f;
+            const float fastReleaseSeconds = ratioIndex == 4
+                ? 0.020f
+                : (2.00f - 1.82f * releasePosition
+                    + 0.12f * releasePosition * releasePosition)
+                    * ratioReleaseScale * exposureReleaseScale;
+            const float slowReleaseSeconds = ratioIndex == 4
+                ? 0.020f
+                : (2.00f - 2.17f * releasePosition
+                    + 0.82f * releasePosition * releasePosition)
+                    * ratioReleaseScale * exposureReleaseScale;
+            const auto advance = [sr](float state, float target,
+                                      float attackSeconds,
+                                      float releaseTimeSeconds) noexcept {
+                float time = target > state ? attackSeconds : releaseTimeSeconds;
+                // Let a quiescent All-buttons cell acquire its measured
+                // small-signal expansion promptly; recovery from positive GR
+                // still uses the selected release above.
+                if (state <= 0.0f && target < 0.0f) time = 0.050f;
+                const float coefficient = std::exp(
+                    -1.0f / (std::max(1.0e-6f, time) * sr));
+                return target + (state - target) * coefficient;
+            };
+            d.fastGrDb = advance(
+                d.fastGrDb, fastTarget, fastAttackSeconds, fastReleaseSeconds);
+            d.intermediateGrDb = advance(
+                d.intermediateGrDb, intermediateTarget,
+                intermediateAttackSeconds, slowReleaseSeconds);
+            d.slowGrDb = advance(
+                d.slowGrDb, longSlowTarget,
+                longSlowAttackSeconds, slowReleaseSeconds);
+            d.envelope = decibelsToGain(
+                -(d.fastGrDb + d.intermediateGrDb + d.slowGrDb));
+            if (!vintageProgrammeActive
+                && d.programmeSilentSamples > programmeSilenceHoldSamples
+                && d.fastGrDb + d.intermediateGrDb + d.slowGrDb < 0.05f)
+            {
+                d.programmeExposureSeconds = 0.0f;
+                d.programmeMaximumGrDb = 0.0f;
             }
         }
-        else if (target < d.envelope) d.envelope = attackCoeff * d.envelope + (1.0f - attackCoeff) * target;
-        else d.envelope = releaseCoeff * d.envelope + (1.0f - releaseCoeff) * target;
-        d.envelope = std::clamp(d.envelope, 0.001f, ratioIndex == 4 ? 1.12f : 1.0f);
+        else
+        {
+            const float minRelease = 0.05f, maxRelease = 1.1f;
+            float attack = std::max(0.0001f,
+                p.fetAttack.load(std::memory_order_relaxed) * 0.001f);
+            const float releaseNorm = std::clamp(
+                p.fetRelease.load(std::memory_order_relaxed) / 1100.0f,
+                0.0f, 1.0f);
+            float release = minRelease * std::pow(
+                maxRelease / minRelease, releaseNorm);
+            if (ratioIndex == 4)
+            {
+                attack = std::max(0.0002f, attack * 2.0f);
+                release *= 1.0f + std::clamp(
+                    reduction / 20.0f, 0.0f, 1.0f) * 0.5f;
+                const float memoryDecay = std::exp(-1.0f / (0.5f * sr));
+                d.releaseMemory *= memoryDecay;
+                if (d.transient == 0 && reduction > 3.0f)
+                    d.releaseMemory = std::min(1.0f, d.releaseMemory + 0.15f);
+                release *= 1.0f + d.releaseMemory * 0.3f;
+            }
+            const float programFactor = std::clamp(
+                1.0f + reduction * 0.05f, 0.5f, 2.0f);
+            const float signalDelta = std::abs(detect - d.previousLevel);
+            d.previousLevel = detect;
+            if (signalDelta > 0.1f)
+            {
+                attack *= 0.8f;
+                release *= 1.2f;
+            }
+            else
+            {
+                attack *= programFactor;
+                release *= programFactor;
+            }
+            const float target = decibelsToGain(-reduction);
+            const float attackCoeff = std::exp(-1.0f / (
+                std::max(1.0e-5f, attack * sr)));
+            const float releaseCoeff = std::exp(-1.0f / (
+                std::max(1.0e-5f, release * sr)));
+            if (ratioIndex == 4)
+            {
+                if (target < d.envelope)
+                {
+                    if (d.transient < 30)
+                    {
+                        const float delayedAttack = attackCoeff * 0.5f + 0.5f;
+                        d.envelope = delayedAttack * d.envelope
+                            + (1.0f - delayedAttack) * target;
+                        ++d.transient;
+                    }
+                    else
+                        d.envelope = attackCoeff * d.envelope
+                            + (1.0f - attackCoeff) * target;
+                }
+                else
+                {
+                    d.transient = 0;
+                    const float gr = -gainToDecibels(d.envelope + 0.001f);
+                    const float fastBase = 0.05f, fastMin = 0.025f;
+                    const float scaleGr = std::clamp(gr / 20.0f, 0.0f, 1.0f);
+                    const float fast = fastBase
+                        - scaleGr * (fastBase - fastMin);
+                    const float fastCoeff = std::exp(-1.0f / (
+                        std::max(1.0e-5f, fast * sr)));
+                    const float effective = fastCoeff * scaleGr
+                        + releaseCoeff * (1.0f - scaleGr);
+                    d.envelope = effective * d.envelope
+                        + (1.0f - effective) * target;
+                }
+            }
+            else if (target < d.envelope)
+                d.envelope = attackCoeff * d.envelope
+                    + (1.0f - attackCoeff) * target;
+            else
+                d.envelope = releaseCoeff * d.envelope
+                    + (1.0f - releaseCoeff) * target;
+        }
+        const float maximumEnvelope = ratioIndex == 4
+            ? (studio ? 1.12f : 1.17f) : 1.0f;
+        d.envelope = std::clamp(d.envelope, 0.001f, maximumEnvelope);
         if (!std::isfinite(d.envelope)) d.envelope = 1.0f;
+        if (!studio && ratioIndex == 0)
+        {
+            const float currentBaseReduction = std::max(
+                0.0f, -gainToDecibels(d.envelope));
+            constexpr float kneeHoldSeconds = 0.030f;
+            if (currentBaseReduction >= d.kneeBaseReductionDb)
+            {
+                d.kneeBaseReductionDb = currentBaseReduction;
+                d.kneeBaseHoldSeconds = kneeHoldSeconds;
+            }
+            else if (d.kneeBaseHoldSeconds > 0.0f)
+                d.kneeBaseHoldSeconds = std::max(
+                    0.0f, d.kneeBaseHoldSeconds - 1.0f / sr);
+            else
+            {
+                const float release = std::exp(-1.0f / (0.250f * sr));
+                d.kneeBaseReductionDb = currentBaseReduction
+                    + (d.kneeBaseReductionDb - currentBaseReduction)
+                        * release;
+            }
+            if (kneeHandoff >= 1.0f)
+            {
+                // Once the raw detector reaches the accepted-law join this
+                // auxiliary cell is outside its measured domain. Clear it
+                // immediately: releasing its earlier onset correction into a
+                // deep attack would alter the established dynamics curve.
+                d.kneeCorrectionDb = 0.0f;
+                d.kneeGain = 1.0f;
+            }
+            else
+            {
+                // A retained deep envelope can pass back through the shallow
+                // range after the input has already fallen far below the
+                // knee. It is release memory, not a new onset error. Require
+                // the same live-programme support used by the envelope's
+                // exposure cell; its 2 ms hold spans carrier zero crossings
+                // but expires long before the 250 ms raw-peak release can
+                // manufacture a false +0.85 dB post-burst gain hump.
+                const float rawTargetCorrectionDb = vintageProgrammeSupported
+                    ? (d.kneeBaseReductionDb - kneeTargetReduction)
+                        * (1.0f - kneeHandoff)
+                    : 0.0f;
+                // The pre-change onset miss tops out at 0.724 dB. Keep this
+                // cell inside that shallow domain even while the main
+                // programme envelope is releasing from tens of dB of GR;
+                // otherwise it mistakes retained deep reduction for a knee
+                // error and cancels it on the auxiliary 100 ms time constant.
+                constexpr float maximumCorrectionDb = 0.85f;
+                const float targetCorrectionDb = std::clamp(
+                    rawTargetCorrectionDb,
+                    -maximumCorrectionDb, maximumCorrectionDb);
+                constexpr float timeSeconds = 0.100f;
+                const float coefficient = std::exp(
+                    -1.0f / (timeSeconds * sr));
+                d.kneeCorrectionDb = targetCorrectionDb
+                    + (d.kneeCorrectionDb - targetCorrectionDb) * coefficient;
+                d.kneeGain = decibelsToGain(d.kneeCorrectionDb);
+            }
+        }
+        else
+        {
+            d.kneeBaseReductionDb = 0.0f;
+            d.kneeCorrectionDb = 0.0f;
+            d.kneeGain = 1.0f;
+        }
         float sagGain = 1.0f;
-        if (ratioIndex == 4 && !studio)
+        if (ratioIndex == 4 && !studio
+            && p.fetCurve.load(std::memory_order_relaxed) != 0)
         {
             const float gr = -gainToDecibels(d.envelope + 0.001f);
             const int limit = static_cast<int>(sr * 0.1f);
@@ -1506,13 +3257,38 @@ private:
             out += k2 * hp + k3 * out * out * out;
         }
         out *= sagGain;
-        out = outT.processSample(out, ch);
+        if (!studio) out *= d.kneeGain * d.recoveryGain;
+        // Studio FET keeps the generic output-transformer model. The measured
+        // vintage spectrum is generated explicitly above; passing it through
+        // that transformer introduced a non-physical H2 cancellation notch.
+        if (studio) out = outT.processSample(out, ch);
         if (!studio) out = fetConvolution.processSample(out, ch) * fetHardwareGain;
         const float grHpf = -gainToDecibels(d.envelope + 0.001f);
-        const float hpfCutoff = 20.0f + std::clamp(grHpf / 20.0f, 0.0f, 1.0f) * 60.0f;
+        const float hpfCutoff = studio
+            ? 20.0f + std::clamp(grHpf / 20.0f, 0.0f, 1.0f) * 60.0f
+            : 5.0f;
         const float hpfAlpha = 1.0f - std::exp(-2.0f * kDuskPi * hpfCutoff / sr);
         if (!studio) { d.subBassHpState += hpfAlpha * (out - d.subBassHpState); out -= d.subBassHpState; }
-        return std::clamp(out * decibelsToGain(p.fetOutput.load(std::memory_order_relaxed)), -2.0f, 2.0f);
+        const float outputValue = p.fetOutput.load(std::memory_order_relaxed);
+        const float outputGain = decibelsToGain(
+            studio ? outputValue : fetOutputGainDb(outputValue));
+        // The installed model is linear throughout the measured steady range,
+        // then bends startup peaks toward a ~7.1 linear ceiling. The previous
+        // hard +/-2 guard flattened both the level sweep and its harmonics.
+        // The atan branch deliberately starts at slope span*(2/pi)/scale
+        // (~0.537), not 1.0: knee/span/scale are one joint fit to the measured
+        // reference startup-peak surface, and forcing C1 continuity at the
+        // knee reshapes that fitted curve. Do not smooth the derivative kink
+        // without re-fitting all three constants against fresh captures.
+        const float drivenOutput = out * outputGain;
+        constexpr float ceilingKnee = 1.97879118f;
+        constexpr float ceilingSpan = 5.16417142f;
+        constexpr float ceilingScale = 6.11998526f;
+        const float magnitude = std::abs(drivenOutput);
+        if (magnitude <= ceilingKnee) return drivenOutput;
+        const float limited = ceilingKnee + ceilingSpan * (2.0f / kDuskPi)
+            * std::atan((magnitude - ceilingKnee) / ceilingScale);
+        return std::copysign(limited, drivenOutput);
     }
 
     float processVCA(float input, int ch, float sidechain,

--- a/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
+++ b/plugins/multi-comp/core/tests/MultiCompCoreTests.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -23,6 +24,53 @@ struct MultiCompDSPTestAccess
     {
         return dsp.previousBusSidechainValid;
     }
+
+    // The vintage FET envelope gain, in dB, straight off the mode state --
+    // NOT the published meter, which is smoothed and clamped. `processFET`
+    // indexes `fetBroadbandK2` at `-gainToDecibels(envelope + 0.001f)`, so the
+    // raw envelope is the only way to read that lookup's own argument.
+    static float fetEnvelopeGainDb(const MultiCompDSP& dsp, int channel) noexcept
+    {
+        return dsp.modes.fetColourGainReduction(channel);
+    }
+
+    static float fetNetGainReductionDb(const MultiCompDSP& dsp,
+                                       int channel) noexcept
+    {
+        return dsp.modes.gainReduction(MultiCompMode::FET, channel);
+    }
+
+    static std::array<float, 2> fetRecoveryGains(
+        const MultiCompDSP& dsp) noexcept
+    {
+        return {{dsp.modes.fetPostBurstRecoveryGain(0),
+                 dsp.modes.fetPostBurstRecoveryGain(1)}};
+    }
+
+    static void setFetStartupState(
+        MultiCompDSP& dsp, std::array<float, 2> peaks,
+        std::array<int, 2> activeSamples,
+        std::array<int, 2> silentSamples) noexcept
+    {
+        dsp.fetStartupInputPeak = peaks;
+        dsp.fetStartupActiveSamples = activeSamples;
+        dsp.fetStartupSilentSamples = silentSamples;
+    }
+
+    static bool fetStartupStateIsClear(const MultiCompDSP& dsp) noexcept
+    {
+        return dsp.fetStartupInputPeak == std::array<float, 2>{{0.0f, 0.0f}}
+            && dsp.fetStartupActiveSamples == std::array<int, 2>{{0, 0}}
+            && dsp.fetStartupSilentSamples == std::array<int, 2>{{0, 0}};
+    }
+
+    static float advanceFetStartupBlend(
+        int& activeSamples, int fullCorrectionSamples,
+        int correctionEndSamples) noexcept
+    {
+        return MultiCompDSP::advanceFetStartupBlend(
+            activeSamples, fullCorrectionSamples, correctionEndSamples);
+    }
 };
 }
 
@@ -32,7 +80,9 @@ using duskaudio::MultiCompDSP;
 namespace
 {
 constexpr float kPi = duskaudio::kDuskPi;
+constexpr int kOversamplingOffSetting = 0;
 constexpr int kOversampling2xSetting = 1;
+constexpr int kOversampling4xSetting = 2;
 
 void require(bool condition, const char* message)
 {
@@ -2384,41 +2434,47 @@ void testOptoDenseProgrammeParity()
                 high.meanErrorDb, high.rmsErrorDb, high.correlation,
                 at85.meanErrorDb, at85.rmsErrorDb, at85.correlation,
                 at100.meanErrorDb, at100.rmsErrorDb, at100.correlation);
-    // For the PR 0.40/0.70 rows, the RMS ceilings reject the issue #210
-    // baseline (1.600 / 3.163 dB) with margin.  Correlation is gated separately
-    // so a uniform offset cannot conceal a time-inverted or shape-mismatched
-    // envelope.  (Pearson correlation is invariant to uniform offset AND
-    // uniform positive scaling, so flattening per se is owned by the RMS term,
-    // not this one.)
-    require(std::abs(low.meanErrorDb) < 0.60f && low.rmsErrorDb < 0.75f
-                && low.correlation > 0.75f,
-            "Opto low-PR dense-programme envelope stays inside the reference gate");
-    require(std::abs(high.meanErrorDb) < 1.75f && high.rmsErrorDb < 1.90f
-                && high.correlation > 0.72f,
-            "Opto high-PR dense-programme envelope stays inside the reference gate");
-    // The PR 0.85/1.00 rows are different in kind: their ceilings snapshot the
-    // CURRENT build (measured 2026-08-24: PR 0.85 +2.015929 / 2.130637 dB /
-    // 0.774589; PR 1.00 +2.445327 / 2.561165 dB / 0.726289) with 0.269-0.305 dB
-    // and ~0.075 correlation margin.  They document the open PR-dependent gap
-    // and reject regression beyond it; they do NOT certify parity, and they
-    // must be tightened when the event-boundary charge mechanism lands.
-    // Baselines were measured with the manual -O2 clang recipe and also pass
-    // under the ctest -O3 build; the margins cover the documented contraction
-    // baseline.  Hazard noted in review: the two reference envelopes sit only
-    // ~1.8 dB apart while these ceilings span ~2.3-2.9 dB, so a swapped
-    // PR/reference pairing could pass — convert the four rows to a paired
-    // table when these ceilings are next touched.  The mean gates are floored
-    // at -0.30 dB so a sign-flipped (under-compressing) regression cannot hide
-    // inside a two-sided ceiling.  Structural blind spots: these rows run mono
-    // (nCh = 1), so the linked-stereo Opto detector path is never exercised
-    // here (the stereo-link gates own it), and Linux arm64 has not yet run
-    // these rows (matrix: macOS clang, macOS no-contract, Linux gcc 12 x86-64).
-    require(at85.meanErrorDb > -0.30f && at85.meanErrorDb < 2.30f
-                && at85.rmsErrorDb < 2.40f && at85.correlation > 0.70f,
-            "Opto PR 0.85 dense-programme error stays within the documented gap ceiling (tripwire, not parity)");
-    require(at100.meanErrorDb > -0.30f && at100.meanErrorDb < 2.75f
-                && at100.rmsErrorDb < 2.85f && at100.correlation > 0.65f,
-            "Opto PR 1.00 dense-programme error stays within the documented gap ceiling (tripwire, not parity)");
+    // Issue #210's original PR 0.40/0.70 RMS errors were 1.600/3.163 dB.
+    // The continuous event-history law now keeps all four measured PR rows
+    // below 1.20 dB RMS. Keep the PR/reference pairings and their independently
+    // declared ceilings in one table: the old loose high-PR tripwires could let
+    // the 0.85/1.00 reference envelopes be exchanged without failing.
+    //
+    // Correlation is gated separately so a uniform offset cannot conceal a
+    // time-inverted or shape-mismatched envelope. Pearson correlation is
+    // invariant to uniform offset and uniform positive scaling, so flattening
+    // is owned by the RMS term. The rows are mono; the linked-stereo Opto path
+    // remains owned by the stereo-link gates. This revision was run with macOS
+    // clang and macOS no-contract. Linux GCC 12 x86-64 still needs re-running
+    // because the local Podman VM would not stay up; Linux arm64 remains unrun.
+    struct DenseProgrammeGate
+    {
+        const char* label;
+        OptoDenseProgrammeMetrics metrics;
+        float maximumAbsoluteMeanDb;
+        float maximumRmsDb;
+        float minimumCorrelation;
+    };
+    const std::array<DenseProgrammeGate, 4> gates{{
+        {"PR 0.40", low,   0.35f, 0.65f, 0.82f},
+        {"PR 0.70", high,  0.70f, 0.95f, 0.80f},
+        {"PR 0.85", at85,  0.85f, 1.15f, 0.75f},
+        {"PR 1.00", at100, 0.90f, 1.20f, 0.75f},
+    }};
+    for (const auto& gate : gates)
+    {
+        std::printf("opto dense parity gate: %s |mean| %.6f < %.2f, "
+                    "RMS %.6f < %.2f, correlation %.6f > %.2f\n",
+                    gate.label, std::abs(gate.metrics.meanErrorDb),
+                    gate.maximumAbsoluteMeanDb, gate.metrics.rmsErrorDb,
+                    gate.maximumRmsDb, gate.metrics.correlation,
+                    gate.minimumCorrelation);
+        require(std::abs(gate.metrics.meanErrorDb)
+                    < gate.maximumAbsoluteMeanDb
+                    && gate.metrics.rmsErrorDb < gate.maximumRmsDb
+                    && gate.metrics.correlation > gate.minimumCorrelation,
+                "Opto dense-programme row stays inside its paired parity gate");
+    }
 }
 
 struct OptoAttackCrossings
@@ -3791,9 +3847,72 @@ void testGoldenVectors()
         duskaudio::MultiCompMode::StudioVCA, duskaudio::MultiCompMode::Digital,
         duskaudio::MultiCompMode::Multiband};
     // Re-recorded 2026-08-19: affected hardware modes encoded stale oversampling-rate coefficients.
-    constexpr float expectedRms[] = {0.610338330f, 0.162082925f, 0.269918233f,
+    // FET was re-recorded 2026-08-25 after the measured reference calibration,
+    // again 2026-08-26 when the attack drive law was inverted to match the
+    // reference's measured direction (0.059634957/0.266311735), and again the
+    // same day when that law's unmeasured shallow-drive segment was replaced by
+    // the measured six-anchor table (0.042118039/0.242844120), and again the
+    // same day when the measured +0.149329 dB pre-detector gain excess was
+    // removed from fetInputGainDb (0.039900590/0.242788911 -> below; this
+    // vector runs at Input 18 dB, i.e. deep reduction, where a pre-detector
+    // change passes at the output slope, hence the small -0.030 dB move), and
+    // again the same day when fetBroadbandK2 was re-fitted against the measured
+    // H2 surface (0.039760567/0.242730290 -> below). That last move is larger
+    // than a colour term looks like it should be, and the reason is the vector
+    // itself: 512 of its 4096 samples are the step and the rest is the attack
+    // transient, so it integrates the whole 0-25 dB reduction sweep, including
+    // the band where the old table read 5.1 dB high. The settled-sine static
+    // grid, by contrast, moved 3.7e-05 dB across all 80 cells. Restoring the
+    // old table reproduces 0.039760567/0.242730290 exactly, which is what
+    // establishes this table as the sole cause. And again the same day when the
+    // low-frequency colour coefficient became the measured `fetLowFrequencyK2`
+    // table instead of `0.0400 * clamp(grDb / 12) * saturation`
+    // (0.039726499/0.241402537 -> below). Restoring the old expression
+    // reproduces that pair exactly, and the settled-sine static grid moved
+    // 1.6e-07 dB across all 80 cells, so this table is likewise the sole cause.
+    // The depth-gated intermediate FET population then moved only the vintage
+    // vector to 0.038088631/0.241441056; restoring the single slow population
+    // reproduces 0.039597437/0.241449714 and fails this assertion. Finally, the
+    // measured reduction-dependent broadband cubic moved it to
+    // 0.038748693/0.255038023. Restoring its constant -0.006 coefficient
+    // reproduces 0.038088631/0.241441056 and fails this assertion. The jointly
+    // closed low-frequency T3 and broadband K3 coordinate pair then moved it to
+    // 0.038780950/0.259218961; restoring the Wave 12 odd-order coefficients
+    // reproduces 0.038748693/0.255038023 and fails this assertion.
+    //
+    // Re-recorded 2026-08-26 (Wave 20) to the value below. This vector had gone
+    // stale: Waves 17-20A were accepted against their own targeted gates while
+    // the full suite was not re-run, so the pair above describes the pre-Wave-17
+    // core. The move is attributed, not assumed. Forcing `fetAttackKnobScale`
+    // to return 1.0f -- its pre-Wave-20A identity -- reproduces
+    // 0.038771123/0.259201407, so the Wave 20A drive-dependent Attack-knob
+    // correction accounts for essentially the whole move; the remaining
+    // 9.8e-06 of RMS is Waves 17-19 (stereo link, the ratio-specific detector
+    // caps, and the All-buttons overload memory), which touch this vector only
+    // where its transient grazes the deep-reduction caps.
+    //
+    // The Wave 20 startup peak ceiling itself moves this vector by EXACTLY
+    // zero: the stage-disabled diagnostic binary 28dd845b6adf reports the same
+    // 0.039380543/0.259151727 pair. This vector runs at Output 1.0, above the
+    // `outputControlBlend` fade-out at Output position 0.90, so the ceiling is
+    // switched off for it by construction -- which is the intended protection
+    // for the already-matched Output=1 ceiling sweep, here observed working.
+    //
+    // Re-recorded 2026-08-27 (Wave 21) after bounding only the source passed to
+    // the measured broadband K3 polynomial. The fitted coefficient is retained
+    // throughout its measured domain, while the first uncompressed cycle no
+    // longer extrapolates that cubic tens of times beyond the fitted source
+    // range. Removing the bound by setting kFetBroadbandK3SourceLimit to 1000
+    // reproduces the prior 0.039380543/0.259151727 pair exactly; restoring the
+    // bound moves only FET to 0.043111119/0.593543887. The six neighbouring
+    // modes print the same nine-decimal values in both control runs.
+    //
+    // The six neighbouring mode values remain the original regression oracles
+    // and must stay byte-identical across any vintage-FET change. They did:
+    // only mode=1 moved at any point in this wave.
+    constexpr float expectedRms[] = {0.043111119f, 0.162082925f, 0.269918233f,
                                      0.618480802f, 0.195874527f, 0.173109755f, 0.212109938f};
-    constexpr float expectedPeak[] = {1.912103295f, 0.350156724f, 0.797850311f,
+    constexpr float expectedPeak[] = {0.593543887f, 0.350156724f, 0.797850311f,
                                       1.836098075f, 0.657691538f, 0.349556237f, 0.815853894f};
     std::puts("golden vectors: seven non-Opto modes, deterministic step/sine-burst RMS peak");
     for (size_t vectorIndex = 0; vectorIndex < std::size(modes); ++vectorIndex)
@@ -5023,6 +5142,3635 @@ void testAllModesAreMonoSafe()
     std::puts("mono safety: all modes exercised with 4x, lookahead, external sidechain and stereo-link state");
 }
 
+float fetAttackPlain(float position)
+{
+    return 0.02f + (80.0f - 0.02f) * std::pow(
+        std::clamp(position, 0.0f, 1.0f), 1.0f / 0.3f);
+}
+
+float fetReleasePlain(float position)
+{
+    return 50.0f + (1100.0f - 50.0f)
+        * std::clamp(position, 0.0f, 1.0f);
+}
+
+void prepareReferenceFet(MultiCompDSP& dsp, double sampleRate, int blockSize,
+                         float inputPosition = 0.8f,
+                         float outputPosition = 0.625915527f,
+                         int ratio = 0, float curve = 0.0f)
+{
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::FET));
+    dsp.setMix(100.0f);
+    dsp.setStereoLink(100.0f);
+    dsp.setOversampling(kOversampling2xSetting);
+    dsp.setParameter(MultiCompDSP::Parameter::SidechainHP, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::TruePeakEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::AutoMakeup, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::Distortion, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::GlobalLookahead, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::NoiseEnable, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::FetInput,
+                     -20.0f + 60.0f * inputPosition);
+    dsp.setParameter(MultiCompDSP::Parameter::FetOutput,
+                     -20.0f + 40.0f * outputPosition);
+    dsp.setParameter(MultiCompDSP::Parameter::FetAttack, fetAttackPlain(0.5f));
+    dsp.setParameter(MultiCompDSP::Parameter::FetRelease, fetReleasePlain(0.5f));
+    dsp.setParameter(MultiCompDSP::Parameter::FetRatio, static_cast<float>(ratio));
+    dsp.setParameter(MultiCompDSP::Parameter::FetCurve, curve);
+    dsp.setParameter(MultiCompDSP::Parameter::FetTransient, 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::FetThreshold, -10.0f);
+    dsp.prepare(sampleRate, blockSize);
+}
+
+float renderReferenceFetRmsDb(float inputDbfs, float inputPosition,
+                              float outputPosition, int ratio,
+                              double sampleRate = 48000.0,
+                              int blockSize = 256,
+                              float curve = 0.0f)
+{
+    const int totalSamples = static_cast<int>(std::lround(5.0 * sampleRate));
+    const int measureStart = static_cast<int>(std::lround(3.0 * sampleRate));
+    const int measureStop = static_cast<int>(std::lround(4.5 * sampleRate));
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize,
+                        inputPosition, outputPosition, ratio, curve);
+    std::vector<float> input(static_cast<size_t>(blockSize));
+    std::vector<float> output(static_cast<size_t>(blockSize));
+    const float amplitude = duskaudio::decibelsToGain(inputDbfs);
+    double power = 0.0;
+    int measured = 0;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+            input[static_cast<size_t>(sample)] = amplitude * std::sin(
+                2.0f * kPi * 1000.0f * static_cast<float>(offset + sample)
+                / static_cast<float>(sampleRate));
+        const float* inputs[] = {input.data()};
+        float* outputs[] = {output.data()};
+        dsp.processBlock(inputs, outputs, 1, count);
+        for (int sample = 0; sample < count; ++sample)
+            if (offset + sample >= measureStart
+                && offset + sample < measureStop)
+            {
+                const float value = output[static_cast<size_t>(sample)];
+                power += static_cast<double>(value) * value;
+                ++measured;
+            }
+    }
+    require(measured == measureStop - measureStart,
+            "FET reference render measures exactly the reference 3.0-4.5 second window");
+    return duskaudio::gainToDecibels(static_cast<float>(
+        std::sqrt(power / static_cast<double>(measured))));
+}
+
+// ---------------------------------------------------------------------------
+// Vintage-FET flat gain against sample rate.
+//
+// `fetHardwareGain` is calibrated by `calibrateFetHardwareGain`, which measures
+// the RMS of `inputTransformerFet -> outputTransformerFet -> fetConvolution`
+// and inverts it. The vintage audio path applies that scalar to the
+// CONVOLUTION ALONE (`MultiCompModes.hpp`: `if (!studio) out =
+// fetConvolution.processSample(out, ch) * fetHardwareGain;`) -- the two
+// transformers are Studio-path stages and never run here. The normalisation
+// therefore inverts a three-stage response and is applied to a one-stage one,
+// and because each stage's response depends on the rate, the residual differs
+// per rate rather than cancelling as a constant.
+//
+// This measures the observable CONSEQUENCE rather than the coefficient: a
+// zero-reduction sine at a level far below the knee should come out at the same
+// level whatever the rate, since nothing else in the path is rate dependent at
+// 1 kHz. A constant part of the miscalibration is harmless -- it was absorbed
+// into `fetInputGainDb` when the static grid was fitted at 48 kHz -- so what
+// this guards is the part that cannot be absorbed, the RATE DEPENDENCE.
+//
+// Re-measured 2026-08-26 on plugin de386c39bdd9. A previous handoff recorded
+// this as "-0.010 dB at 96 k"; that number does not reproduce on the current
+// build, which reads -0.002266 dB there and worst 0.003448 dB at 88.2 kHz.
+//
+// The miscalibration is real but its consequence is NOT, and that was measured
+// rather than argued. Two deliberate breaks were run against this assertion:
+//
+//   `cacheHardwareGains` pinned to 48 kHz regardless of host rate,
+//   so 96 kHz uses a gain calibrated for the wrong rate   -> 0.004662 dB, PASSES
+//   `calibrateFetHardwareGain` probed at twice the rate   -> 0.003723 dB, PASSES
+//
+// Neither can breach the campaign's 0.02 dB tolerance, because the transformer
+// and convolution responses this coefficient normalises are all but flat around
+// the 1 kHz calibration tone. The constant part of the error is harmless in any
+// case -- it was absorbed into `fetInputGainDb` when the static grid was fitted
+// at 48 kHz -- so the item is closed as measured-and-immaterial rather than
+// fixed. What remains asserted here is the regression: a synthetic 1 %-per-rate
+// error in `fetHardwareGains` reads 0.083313 dB and fails, which is what proves
+// this assertion is wired to the quantity it names.
+void testFetSampleRateFlatGain()
+{
+    constexpr float probeDbfs = -60.0f;      // far below any knee: zero reduction
+    constexpr float inputPosition = 0.2f;
+    const float at48 = renderReferenceFetRmsDb(
+        probeDbfs, inputPosition, 0.625915527f, 0, 48000.0, 256);
+    std::printf("FET sample-rate flat gain: reference 48000 Hz -> %.6f dBFS\n",
+                at48);
+    double worst = 0.0;
+    for (const double rate : {44100.0, 48000.0, 88200.0, 96000.0})
+    {
+        const float measured = renderReferenceFetRmsDb(
+            probeDbfs, inputPosition, 0.625915527f, 0, rate, 256);
+        const double delta = static_cast<double>(measured) - at48;
+        worst = std::max(worst, std::abs(delta));
+        std::printf("FET sample-rate flat gain: %8.0f Hz -> %.6f dBFS "
+                    "delta %+.6f dB\n", rate, measured, delta);
+    }
+    std::printf("FET sample-rate flat gain: worst absolute delta %.6f dB\n",
+                worst);
+    require(worst < 0.02,
+            "vintage FET flat gain is sample-rate independent within the "
+            "campaign's 0.02 dB tolerance");
+}
+
+void testFetMeasuredControlTapers()
+{
+    struct Point { float position; float relativeDb; };
+    constexpr std::array<Point, 4> inputPoints{{
+        {0.2f, -33.678216f}, {0.5f, -13.389983f},
+        {0.8f, -1.246802f}, {1.0f, 0.0f}}};
+    constexpr std::array<Point, 4> outputPoints{{
+        {0.2f, -55.024575f}, {0.5f, -21.810000f},
+        {0.8f, -4.012500f}, {1.0f, 0.0f}}};
+    const float inputReference = renderReferenceFetRmsDb(
+        -72.0f, 1.0f, 1.0f, 0);
+    const float outputReference = inputReference;
+    float worstInputError = 0.0f;
+    float worstOutputError = 0.0f;
+    for (const auto& point : inputPoints)
+    {
+        const float measured = renderReferenceFetRmsDb(
+            -72.0f, point.position, 1.0f, 0) - inputReference;
+        std::printf("FET Input taper: position %.1f reference %+.6f measured %+.6f error %+.6f dB\n",
+                    point.position, point.relativeDb, measured,
+                    measured - point.relativeDb);
+        worstInputError = std::max(worstInputError,
+                                   std::abs(measured - point.relativeDb));
+    }
+    for (const auto& point : outputPoints)
+    {
+        const float measured = renderReferenceFetRmsDb(
+            -72.0f, 1.0f, point.position, 0) - outputReference;
+        std::printf("FET Output taper: position %.1f reference %+.6f measured %+.6f error %+.6f dB\n",
+                    point.position, point.relativeDb, measured,
+                    measured - point.relativeDb);
+        worstOutputError = std::max(worstOutputError,
+                                    std::abs(measured - point.relativeDb));
+    }
+    std::printf("FET measured tapers: input worst %.6f dB output worst %.6f dB\n",
+                worstInputError, worstOutputError);
+    require(worstInputError < 0.02f && worstOutputError < 0.02f,
+            "vintage FET Input and Output reproduce the measured pot tapers");
+}
+
+void testFetMeasuredStaticSurface()
+{
+    struct Point
+    {
+        float inputPosition;
+        float inputDbfs;
+        int ratio;
+        float referenceOutputDbfs;
+    };
+    constexpr std::array<Point, 5> points{{
+        {0.8f, -24.0f, 0, -15.926712f},
+        {0.8f, -6.0f, 0, -12.854822f},
+        {0.8f, -12.0f, 1, -14.280624f},
+        {0.6f, -12.0f, 3, -13.415414f},
+        {0.8f, -6.0f, 4, -14.918762f}
+    }};
+    float worstError = 0.0f;
+    for (const auto& point : points)
+    {
+        const float measured = renderReferenceFetRmsDb(
+            point.inputDbfs, point.inputPosition, 0.625915527f, point.ratio);
+        const float error = measured - point.referenceOutputDbfs;
+        worstError = std::max(worstError, std::abs(error));
+        std::printf("FET static reference: ratio %d input %.1f/%.1f reference %.6f measured %.6f error %+.6f dB\n",
+                    point.ratio, point.inputPosition, point.inputDbfs,
+                    point.referenceOutputDbfs, measured, error);
+    }
+    require(worstError < 0.20f,
+            "vintage FET representative static points stay within 0.20 dB of the live reference");
+}
+
+double renderFetKneeFundamentalDb(double frequencyHz, float inputDbfs,
+                                  float inputPosition)
+{
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 256;
+    constexpr int totalSamples = 12 * static_cast<int>(sampleRate);
+    constexpr int measureStart = 9 * static_cast<int>(sampleRate);
+    constexpr int measureStop = measureStart
+        + 3 * static_cast<int>(sampleRate) / 2;
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize,
+                        inputPosition, 0.625915527f, 0);
+    std::array<float, blockSize> input{};
+    std::array<float, blockSize> output{};
+    const double amplitude = duskaudio::decibelsToGain(inputDbfs);
+    double real = 0.0;
+    double imaginary = 0.0;
+    int measured = 0;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+            input[static_cast<size_t>(sample)] = static_cast<float>(
+                amplitude * std::sin(2.0 * duskaudio::kDuskPi * frequencyHz
+                    * static_cast<double>(offset + sample) / sampleRate));
+        const float* inputs[] = {input.data()};
+        float* outputs[] = {output.data()};
+        dsp.processBlock(inputs, outputs, 1, count);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            if (absolute < measureStart || absolute >= measureStop)
+                continue;
+            const double phase = 2.0 * duskaudio::kDuskPi * frequencyHz
+                * static_cast<double>(absolute) / sampleRate;
+            real += output[static_cast<size_t>(sample)] * std::cos(phase);
+            imaginary -= output[static_cast<size_t>(sample)] * std::sin(phase);
+            ++measured;
+        }
+    }
+    const double magnitude = 2.0 * std::hypot(real, imaginary)
+        / static_cast<double>(measured);
+    return 20.0 * std::log10(std::max(magnitude, 1.0e-30));
+}
+
+void testFetKneeOnsetMatchesReference()
+{
+    // Wave 27's independently repeated 100 Hz and 1 kHz captures agree within
+    // 0.00564 dB at every selected point: this is a common static-knee shape,
+    // not the deeper ratio/frequency detector surface that the joint LF shelf
+    // experiment rejected. The old representative static grid skipped this
+    // interval and therefore let the quadratic knee start up to 0.72 dB early.
+    struct Point
+    {
+        float driveDb;
+        double reference100HzDb;
+        double reference1kHzDb;
+    };
+    constexpr std::array<Point, 9> points{{
+        {-14.00f, 0.001054856, 0.001054679},
+        {-12.75f, 0.001418202, 0.001419694},
+        {-11.00f, 0.002144157, 0.002144161},
+        {-10.50f, 0.009454543, 0.010022404},
+        {-10.00f, 0.135284617, 0.129645572},
+        { -9.00f, 0.590613455, 0.589745640},
+        { -8.00f, 1.167230576, 1.167031554},
+        { -7.00f, 1.809697156, 1.808799028},
+        { -6.00f, 2.486826948, 2.483171013},
+    }};
+    constexpr float controlInputPosition = 0.2f;
+    constexpr float controlSourceDbfs = -36.0f;
+    constexpr double controlDriveDb = -29.827545;
+    constexpr float measuredInputPosition = 0.8f;
+    constexpr double measuredInputGainDb = 38.603869;
+    const auto outputOffset = [&](double frequencyHz) {
+        return renderFetKneeFundamentalDb(
+            frequencyHz, controlSourceDbfs, controlInputPosition)
+            - controlDriveDb;
+    };
+    const double offset100 = outputOffset(100.0);
+    const double offset1k = outputOffset(1000.0);
+    double worstError = 0.0;
+    double worstFrequencySplit = 0.0;
+    double measured1kAtMinusSix = 0.0;
+    for (const auto& point : points)
+    {
+        const double reduction100 = point.driveDb + offset100
+            - renderFetKneeFundamentalDb(
+                100.0, static_cast<float>(point.driveDb - measuredInputGainDb),
+                measuredInputPosition);
+        const double reduction1k = point.driveDb + offset1k
+            - renderFetKneeFundamentalDb(
+                1000.0, static_cast<float>(point.driveDb - measuredInputGainDb),
+                measuredInputPosition);
+        const double error100 = reduction100 - point.reference100HzDb;
+        const double error1k = reduction1k - point.reference1kHzDb;
+        worstError = std::max(
+            worstError, std::max(std::abs(error100), std::abs(error1k)));
+        worstFrequencySplit = std::max(
+            worstFrequencySplit, std::abs(reduction100 - reduction1k));
+        if (point.driveDb == -6.0f)
+            measured1kAtMinusSix = reduction1k;
+        std::printf("FET knee onset: drive %+.2f reference/measured/error "
+                    "100 Hz %.6f/%.6f/%+.6f dB, 1 kHz %.6f/%.6f/%+.6f dB\n",
+                    static_cast<double>(point.driveDb),
+                    point.reference100HzDb, reduction100, error100,
+                    point.reference1kHzDb, reduction1k, error1k);
+    }
+    // Wave 24 independently measured the same -6 dB endpoint at 40 and 60 Hz.
+    // Both are held out from the 1 kHz knee table, as is the 100 Hz curve above.
+    struct HeldOutFrequency
+    {
+        double frequencyHz;
+        double referenceReductionDb;
+    };
+    constexpr std::array<HeldOutFrequency, 2> heldOut{{
+        {40.0, 2.476338413},
+        {60.0, 2.487113619},
+    }};
+    for (const auto& point : heldOut)
+    {
+        const double offset = outputOffset(point.frequencyHz);
+        const double reduction = -6.0 + offset
+            - renderFetKneeFundamentalDb(
+                point.frequencyHz,
+                static_cast<float>(-6.0 - measuredInputGainDb),
+                measuredInputPosition);
+        const double error = reduction - point.referenceReductionDb;
+        worstError = std::max(worstError, std::abs(error));
+        worstFrequencySplit = std::max(
+            worstFrequencySplit,
+            std::abs(reduction - measured1kAtMinusSix));
+        std::printf("FET knee onset held-out: %.0f Hz drive -6.00 "
+                    "reference %.6f measured %.6f error %+.6f dB\n",
+                    point.frequencyHz, point.referenceReductionDb,
+                    reduction, error);
+    }
+    std::printf("FET knee onset: worst absolute error %.6f dB, "
+                "worst 100 Hz/1 kHz split %.6f dB\n",
+                worstError, worstFrequencySplit);
+    require(worstError < 0.04 && worstFrequencySplit < 0.03,
+            "vintage FET knee onset follows the measured UAD curve and frequency collapse");
+}
+
+void testFetKneeCellDoesNotCancelDeepReleaseMemory()
+{
+    // The auxiliary cell owns at most the shallow-knee difference (0.724 dB
+    // on the pre-change path). After a loud passage it must not mistake the
+    // main envelope's retained deep reduction for a new knee error and cancel
+    // that programme memory on its independent timing path.
+    constexpr double sampleRate = 48000.0;
+    constexpr int blockSize = 256;
+    constexpr int loudSamples = 3 * static_cast<int>(sampleRate);
+    constexpr int shallowSamples = 4 * static_cast<int>(sampleRate);
+    constexpr float measuredInputGainDb = 38.603869f;
+    constexpr float loudSourceDbfs = -6.0f;
+    constexpr float shallowSourceDbfs = -10.0f - measuredInputGainDb;
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize, 0.8f, 0.625915527f, 0);
+    std::array<float, blockSize> input{};
+    std::array<float, blockSize> output{};
+    float reductionAtTransition = 0.0f;
+    float maximumAuxiliaryCorrection = 0.0f;
+    float finalAuxiliaryCorrection = 0.0f;
+    const int totalSamples = loudSamples + shallowSamples;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            const float levelDb = absolute < loudSamples
+                ? loudSourceDbfs : shallowSourceDbfs;
+            input[static_cast<size_t>(sample)] = duskaudio::decibelsToGain(levelDb)
+                * std::sin(2.0f * kPi * 1000.0f
+                    * static_cast<float>(absolute) / static_cast<float>(sampleRate));
+        }
+        const float* inputs[] = {input.data()};
+        float* outputs[] = {output.data()};
+        dsp.processBlock(inputs, outputs, 1, count);
+        const float colourReduction = -duskaudio::MultiCompDSPTestAccess::
+            fetEnvelopeGainDb(dsp, 0);
+        const float netReduction = -duskaudio::MultiCompDSPTestAccess::
+            fetNetGainReductionDb(dsp, 0);
+        const float correction = colourReduction - netReduction;
+        if (offset < loudSamples && offset + count >= loudSamples)
+            reductionAtTransition = colourReduction;
+        if (offset >= loudSamples)
+        {
+            maximumAuxiliaryCorrection = std::max(
+                maximumAuxiliaryCorrection, correction);
+            finalAuxiliaryCorrection = correction;
+        }
+    }
+    std::printf("FET knee release neighbour: deep reduction %.6f dB, "
+                "maximum/final auxiliary correction %.6f/%.6f dB\n",
+                reductionAtTransition, maximumAuxiliaryCorrection,
+                finalAuxiliaryCorrection);
+    require(reductionAtTransition > 20.0f
+                && maximumAuxiliaryCorrection < 1.0f
+                && finalAuxiliaryCorrection > 0.3f,
+            "the exercised shallow FET knee cell never cancels deep release memory");
+}
+
+void testFetMaximumReductionSaturation()
+{
+    // The ordinary static surface stops at about +34 dB internal level. With
+    // Input and Output clockwise, the installed unit follows the same 4:1 law
+    // through a -3 dBFS source, then stops adding reduction over the last
+    // roughly 1.3 dB of detector level. Pin both directions: the 0 dBFS point
+    // proves that the saturation exists, while -3 dBFS proves that its onset
+    // does not narrow the already-fitted straight-law domain.
+    struct Point
+    {
+        int ratio;
+        float referenceMinusThreeDbfs;
+        float referenceZeroDbfs;
+    };
+    // Live-reference 3.0--4.5 second windows. The All-buttons -3 dBFS point is
+    // intentionally not replaced by its later asymptote: this helper and the
+    // campaign ceiling gate both measure this practical five-second window.
+    constexpr std::array<Point, 5> points{{
+        {0,  0.718774f,  2.253437f},
+        {1, -0.450040f,  0.856189f},
+        {2, -0.557974f,  0.505468f},
+        {3,  0.014880f,  0.857770f},
+        {4, -1.918019f, -0.552185f},
+    }};
+    float worstBelowError = 0.0f;
+    float worstSaturatedError = 0.0f;
+    for (const auto& point : points)
+    {
+        const float belowSaturation = renderReferenceFetRmsDb(
+            -3.0f, 1.0f, 1.0f, point.ratio);
+        const float saturated = renderReferenceFetRmsDb(
+            0.0f, 1.0f, 1.0f, point.ratio);
+        const float belowError = belowSaturation - point.referenceMinusThreeDbfs;
+        const float saturatedError = saturated - point.referenceZeroDbfs;
+        worstBelowError = std::max(worstBelowError, std::abs(belowError));
+        worstSaturatedError = std::max(
+            worstSaturatedError, std::abs(saturatedError));
+        std::printf("FET maximum reduction ratio %d: -3 dBFS reference %.6f "
+                    "measured %.6f error %+.6f; 0 dBFS reference %.6f "
+                    "measured %.6f error %+.6f dB\n",
+                    point.ratio, point.referenceMinusThreeDbfs,
+                    belowSaturation, belowError, point.referenceZeroDbfs,
+                    saturated, saturatedError);
+    }
+    require(worstBelowError < 0.15f,
+            "vintage FET maximum-reduction onset preserves the lower straight-law point");
+    require(worstSaturatedError < 0.15f,
+            "vintage FET maximum reduction reproduces every ratio's 0 dBFS reference point");
+}
+
+void testFetAllButtonsSettlingWindows()
+{
+    // A five-second ceiling row alone can hide a wrong asymptote: before this
+    // test, All-buttons crossed the reference around four seconds but kept
+    // charging to a level 0.466 dB too low by nine seconds. 4:1 already follows
+    // the reference's long population and is the opposite-path control.
+    constexpr int sampleRate = 48000;
+    constexpr int blockSize = 256;
+    constexpr int totalSamples = 12 * sampleRate;
+    struct Point
+    {
+        int ratio;
+        float inputDbfs;
+        float referenceEarlyDbfs;
+        float referenceLateDbfs;
+    };
+    constexpr std::array<Point, 3> points{{
+        {0,  0.0f,  2.253437f,  2.253322f},
+        {4, -3.0f, -1.918019f, -2.620076f},
+        {4,  0.0f, -0.552185f, -0.562661f},
+    }};
+    float worstEarlyError = 0.0f;
+    float worstLateError = 0.0f;
+    for (const auto& point : points)
+    {
+        MultiCompDSP dsp;
+        prepareReferenceFet(dsp, sampleRate, blockSize, 1.0f, 1.0f, point.ratio);
+        std::array<float, blockSize> input{}, output{};
+        const float amplitude = duskaudio::decibelsToGain(point.inputDbfs);
+        double earlyPower = 0.0;
+        double latePower = 0.0;
+        int earlySamples = 0;
+        int lateSamples = 0;
+        for (int offset = 0; offset < totalSamples; offset += blockSize)
+        {
+            const int count = std::min(blockSize, totalSamples - offset);
+            for (int sample = 0; sample < count; ++sample)
+                input[static_cast<size_t>(sample)] = amplitude * std::sin(
+                    2.0f * kPi * 1000.0f * static_cast<float>(offset + sample)
+                    / static_cast<float>(sampleRate));
+            const float* inputs[] = {input.data()};
+            float* outputs[] = {output.data()};
+            dsp.processBlock(inputs, outputs, 1, count);
+            for (int sample = 0; sample < count; ++sample)
+            {
+                const int absolute = offset + sample;
+                const double value = output[static_cast<size_t>(sample)];
+                if (absolute >= 3 * sampleRate
+                    && absolute < 9 * sampleRate / 2)
+                {
+                    earlyPower += value * value;
+                    ++earlySamples;
+                }
+                if (absolute >= 9 * sampleRate
+                    && absolute < 23 * sampleRate / 2)
+                {
+                    latePower += value * value;
+                    ++lateSamples;
+                }
+            }
+        }
+        require(earlySamples == 3 * sampleRate / 2
+                    && lateSamples == 5 * sampleRate / 2,
+                "FET settling windows contain every requested sample");
+        const float earlyDbfs = duskaudio::gainToDecibels(static_cast<float>(
+            std::sqrt(earlyPower / earlySamples)));
+        const float lateDbfs = duskaudio::gainToDecibels(static_cast<float>(
+            std::sqrt(latePower / lateSamples)));
+        const float earlyError = earlyDbfs - point.referenceEarlyDbfs;
+        const float lateError = lateDbfs - point.referenceLateDbfs;
+        worstEarlyError = std::max(worstEarlyError, std::abs(earlyError));
+        worstLateError = std::max(worstLateError, std::abs(lateError));
+        std::printf("FET settling ratio %d input %+.0f: early reference %.6f measured %.6f "
+                    "error %+.6f; late reference %.6f measured %.6f error %+.6f dB\n",
+                    point.ratio, static_cast<double>(point.inputDbfs),
+                    point.referenceEarlyDbfs, earlyDbfs, earlyError,
+                    point.referenceLateDbfs, lateDbfs, lateError);
+    }
+    require(worstEarlyError < 0.15f,
+            "vintage FET practical settling window remains reference-compatible");
+    require(worstLateError < 0.15f,
+            "vintage FET late settling window reaches the reference asymptote");
+}
+
+void testFetAbsoluteGainAnchors()
+{
+    // testFetMeasuredControlTapers above only ever compares knob positions with
+    // each other, so a uniform scalar in the vintage chain cancels out of every
+    // one of its assertions -- which is how a +0.149329 dB gain excess lived in
+    // this code through several waves of taper work. These two anchors are
+    // absolute and were measured on the reference unit itself.
+    //
+    // (a) Absolute output level at a proved zero-gain-reduction operating point:
+    //     1 kHz at -72 dBFS, Input knob 0.2, Output knob 1.0. Zero reduction is
+    //     not assumed -- the campaign's frequency sweep proves it by rendering a
+    //     6 dB source step at this setting and getting 6.0000 dB back from both
+    //     devices. With no reduction, no detector or ratio term can contribute,
+    //     so this pins the product of every gain constant in the chain.
+    constexpr float kReferenceZeroReductionDbfs = -64.488648f;
+    const float measured = renderReferenceFetRmsDb(-72.0f, 0.2f, 1.0f, 0);
+    const float error = measured - kReferenceZeroReductionDbfs;
+    std::printf("FET absolute gain: zero-reduction reference %.6f measured %.6f error %+.6f dB\n",
+                kReferenceZeroReductionDbfs, measured, error);
+
+    // (b) All-buttons small-signal gain, expressed as All-buttons minus 4:1 at
+    //     the same operating point (Input knob 0.4, 1 kHz at -36 dBFS, which is
+    //     below BOTH laws' knees). Taking the difference of two ratio buttons
+    //     cancels every gain constant common to them, so this reads the
+    //     All-buttons correction alone and no output trim can mask it. It was
+    //     1.046 dB here while the excess above was in place and the flat
+    //     +0.15 dB fit constant was being added to the correction plateau.
+    constexpr float kReferenceAllMinusFourToOneDb = 1.199919f;
+    const float allButtons = renderReferenceFetRmsDb(-36.0f, 0.4f, 0.625915527f, 4);
+    const float fourToOne = renderReferenceFetRmsDb(-36.0f, 0.4f, 0.625915527f, 0);
+    const float smallSignal = allButtons - fourToOne;
+    const float smallSignalError = smallSignal - kReferenceAllMinusFourToOneDb;
+    std::printf("FET All-buttons small signal: reference %+.6f measured %+.6f error %+.6f dB\n",
+                kReferenceAllMinusFourToOneDb, smallSignal, smallSignalError);
+
+    require(std::abs(error) < 0.01f,
+            "vintage FET absolute gain at zero reduction matches the measured reference");
+    require(std::abs(smallSignalError) < 0.02f,
+            "vintage FET All-buttons small-signal gain matches the measured reference");
+}
+
+void testFetMeasuredCurveAllButtons()
+{
+    // `processFET` reaches `fetAllProcessorCorrectionDb` only on the Modern
+    // curve. With Curve = Measured and ratio ALL it takes
+    // `lookupTables.getAllButtonsReduction()` instead, a different law, and the
+    // whole 1176 campaign is pinned to Modern -- so nothing else in this file
+    // or in the campaign exercises that arm. These are recorded regression
+    // vectors, not reference parity: the reference unit was never rendered on
+    // this arm.
+    //
+    // (a) Leak guard, and the open gap. Below the All-buttons detector
+    //     threshold the Measured arm generates NO reduction at all, so its
+    //     small-signal gain relative to 4:1 at the same operating point is
+    //     exactly 0 dB. The reference's is +1.199919 dB (see
+    //     testFetAbsoluteGainAnchors, where the Modern arm now reproduces it to
+    //     0.004 dB). That -1.20 dB shortfall is a real, separate defect and is
+    //     deliberately NOT fixed here; the assertion pins the current value so
+    //     that a change to it -- including anything leaking out of the Modern
+    //     correction table -- has to be deliberate.
+    constexpr float kMeasuredCurveSmallSignalDb = 0.0f;
+    const float measuredAll = renderReferenceFetRmsDb(
+        -36.0f, 0.4f, 0.625915527f, 4, 48000.0, 256, 1.0f);
+    const float fourToOne = renderReferenceFetRmsDb(
+        -36.0f, 0.4f, 0.625915527f, 0, 48000.0, 256, 0.0f);
+    const float smallSignal = measuredAll - fourToOne;
+    std::printf("FET Measured-curve All-buttons small signal: recorded %+.6f measured %+.6f "
+                "(reference wants +1.199919, i.e. a %+.6f dB gap this arm does not close)\n",
+                kMeasuredCurveSmallSignalDb, smallSignal, smallSignal - 1.199919f);
+
+    // (b) Four compressing points on the Measured arm, recorded from this
+    //     build. They were re-recorded when the shared vintage broadband cubic
+    //     became reduction-dependent: that colour path is deliberately common
+    //     to both curve arms, while the small-signal assertion above still
+    //     proves the Modern-only reduction correction does not leak here.
+    //     Restoring the old constant -0.006 cubic reproduces the previous
+    //     -27.010939/-26.974682/-27.533485/-14.744394 dBFS values and fails
+    //     this assertion. The All-buttons detector threshold is -16.03 dBFS and the
+    //     Input 0.4 law adds 19.209 dB, so these sources put the detector
+    //     7.2 / 15.2 / 23.2 dB over threshold -- three different segments of
+    //     `MultiCompHelpers::LookupTables`'s ten measured control points -- and
+    //     the Input 0.8 row lands at 42.8 dB over, past the table's 30 dB clamp.
+    //     Any change to that table moves at least one of them; the Modern-arm
+    //     correction fold moves none, which is the leak guard.
+    struct Point { float inputPosition; float inputDbfs; float recordedDbfs; };
+    constexpr std::array<Point, 4> points{{
+        {0.4f, -28.0f, -27.010859f}, {0.4f, -20.0f, -26.974270f},
+        {0.4f, -12.0f, -27.532766f}, {0.8f, -12.0f, -14.729914f}}};
+    float worstError = 0.0f;
+    for (const auto& point : points)
+    {
+        const float measured = renderReferenceFetRmsDb(
+            point.inputDbfs, point.inputPosition, 0.625915527f, 4, 48000.0, 256, 1.0f);
+        const float error = measured - point.recordedDbfs;
+        worstError = std::max(worstError, std::abs(error));
+        std::printf("FET Measured-curve All-buttons: input %.1f/%.1f recorded %.6f measured %.6f error %+.6f dB\n",
+                    point.inputPosition, point.inputDbfs, point.recordedDbfs, measured, error);
+    }
+
+    require(std::abs(smallSignal - kMeasuredCurveSmallSignalDb) < 0.002f,
+            "Measured-curve All-buttons small-signal gain is unchanged and the Modern correction does not leak into it");
+    require(worstError < 0.005f,
+            "Measured-curve All-buttons compressing points are unchanged");
+}
+
+void testFetAllButtonsKneeTransition()
+{
+    // The All-buttons knee, against the reference unit's own 0.5 dB sweep at
+    // Input 0.4 with Curve = Modern. `testFetAbsoluteGainAnchors` pins the
+    // plateau far below the knee and `testFetMeasuredStaticSurface` pins one
+    // point far above it; between them sat the whole transition, sampled by
+    // nothing. The campaign's own All-buttons sweep steps 2 dB, which is
+    // exactly the knot spacing `fetAllProcessorCorrectionDb` used there, so it
+    // read one knot per row and could not see the segment interiors either: it
+    // reported 0.167 dB of error where a 0.5 dB sweep of the same operating
+    // point found 0.334 dB.
+    //
+    // Levels are the internal level the Input 0.4 law produces under the
+    // pre-Wave-5 40.0 dB absolute input constant, which is the campaign's
+    // labelling convention; the sources are what that convention implies.
+    //
+    // The three `inNewSegment` rows are the only in-process guard on the
+    // [-8.145, -7.224] plateau extension. At Input 0.4 the detector sits
+    // 0.149329 dB below the label, so the campaign's 2 dB All-buttons sweep
+    // lands 0.0043 dB BELOW a knot on every row and samples no segment
+    // interior at all -- it cannot regress-detect a fault in the segment this
+    // table added. `probe_all_knee.py`'s 0.5 dB grid (and its --extra-levels,
+    // which measured the -7.7 and -7.3 reference points below) is the
+    // VST3-level guard for the same region; these are its in-process mirror,
+    // at detector fractions 0.32 / 0.54 / 0.76 of the segment.
+    constexpr float kInputGainDb = 40.0f - 20.790574f;
+    struct Point { float internalDb; float referenceOutputDbfs; bool inNewSegment; };
+    constexpr std::array<Point, 7> points{{
+        {-8.0f, -18.461636f, false}, {-7.7f, -18.161981f, true},
+        {-7.5f, -17.962224f, true}, {-7.3f, -17.766153f, true},
+        {-7.0f, -17.528762f, false}, {-6.5f, -17.312539f, false},
+        {-6.0f, -17.187491f, false}}};
+    std::array<float, 7> measured{};
+    float worstError = 0.0f;
+    float worstSegmentError = 0.0f;
+    for (size_t index = 0; index < points.size(); ++index)
+    {
+        measured[index] = renderReferenceFetRmsDb(
+            points[index].internalDb - kInputGainDb, 0.4f, 0.625915527f, 4);
+        const float error = measured[index] - points[index].referenceOutputDbfs;
+        worstError = std::max(worstError, std::abs(error));
+        if (points[index].inNewSegment)
+            worstSegmentError = std::max(worstSegmentError, std::abs(error));
+        std::printf("FET All-buttons knee: internal %+.1f reference %.6f measured %.6f error %+.6f dB%s\n",
+                    points[index].internalDb, points[index].referenceOutputDbfs,
+                    measured[index], error,
+                    points[index].inNewSegment ? "  [plateau-extension interior]" : "");
+    }
+
+    // The sub-knee step is the mechanism itself, and it is scalar-immune: the
+    // reference generates no reduction at all up to -7.5 dB internal, so a
+    // 0.5 dB source step must come back as 0.499412 dB. A correction table
+    // whose plateau ends at -8.145 instead of at the measured knee start
+    // returns 0.313541 here -- 0.186 dB of compression the reference does not
+    // produce -- while every absolute level in the row stays plausible, which
+    // is how it survived. Both bounds are set by that defect: 3.7x under it on
+    // the step and 4.2x under the 0.334 dB absolute error it caused.
+    constexpr float kReferenceSubKneeStepDb = 0.499412f;
+    const float subKneeStep = measured[2] - measured[0];
+    std::printf("FET All-buttons sub-knee 0.5 dB step: reference %+.6f measured %+.6f error %+.6f dB\n",
+                kReferenceSubKneeStepDb, subKneeStep,
+                subKneeStep - kReferenceSubKneeStepDb);
+    std::printf("FET All-buttons plateau-extension interior: worst %+.6f dB over 3 points\n",
+                worstSegmentError);
+
+    // Checked first, and on a tighter bound than the transition as a whole, so
+    // that a fault in the plateau extension fails on the rows that sample it
+    // rather than on the higher-leverage rows above the knot.
+    require(worstSegmentError < 0.05f,
+            "vintage FET All-buttons plateau extension holds inside the segment no campaign sweep samples");
+    require(worstError < 0.08f,
+            "vintage FET All-buttons knee transition matches the measured reference");
+    require(std::abs(subKneeStep - kReferenceSubKneeStepDb) < 0.05f,
+            "vintage FET All-buttons generates no reduction below the reference's knee start");
+}
+
+std::vector<float> renderReferenceFetProgramme(int blockSize)
+{
+    constexpr int totalSamples = 96000;
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, 48000.0, blockSize);
+    std::vector<float> result(totalSamples);
+    std::vector<float> input(static_cast<size_t>(blockSize));
+    std::vector<float> output(static_cast<size_t>(blockSize));
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            const float amplitude = absolute < 24000
+                ? duskaudio::decibelsToGain(-30.0f)
+                : absolute < 72000 ? duskaudio::decibelsToGain(-6.0f)
+                                   : duskaudio::decibelsToGain(-30.0f);
+            input[static_cast<size_t>(sample)] = amplitude * std::sin(
+                2.0f * kPi * 997.0f * static_cast<float>(absolute) / 48000.0f);
+        }
+        const float* inputs[] = {input.data()};
+        float* outputs[] = {output.data()};
+        dsp.processBlock(inputs, outputs, 1, count);
+        std::copy_n(output.data(), count, result.data() + offset);
+    }
+    return result;
+}
+
+void testFetBlockSizeInvariance()
+{
+    const auto small = renderReferenceFetProgramme(64);
+    const auto large = renderReferenceFetProgramme(512);
+    float signalPeak = 0.0f;
+    float maximumDelta = 0.0f;
+    for (size_t sample = 0; sample < small.size(); ++sample)
+    {
+        signalPeak = std::max(signalPeak, std::abs(small[sample]));
+        maximumDelta = std::max(maximumDelta,
+                                std::abs(small[sample] - large[sample]));
+    }
+    std::printf("FET block invariance: signal peak %.9g max delta %.9g\n",
+                signalPeak, maximumDelta);
+    require(signalPeak > 0.01f && maximumDelta < 1.0e-6f,
+            "vintage FET programme timing is invariant between 64- and 512-sample blocks");
+}
+
+void testFetResetClearsProgrammeAndColourState()
+{
+    constexpr int blockSize = 128;
+    MultiCompDSP reused;
+    MultiCompDSP fresh;
+    prepareReferenceFet(reused, 48000.0, blockSize);
+    prepareReferenceFet(fresh, 48000.0, blockSize);
+    std::array<float, blockSize> hot{}, scratch{}, reusedOut{}, freshOut{};
+    for (int block = 0; block < 500; ++block)
+    {
+        for (int sample = 0; sample < blockSize; ++sample)
+            hot[static_cast<size_t>(sample)] = 0.9f * std::sin(
+                2.0f * kPi * 100.0f * static_cast<float>(block * blockSize + sample)
+                / 48000.0f);
+        const float* inputs[] = {hot.data()};
+        float* outputs[] = {scratch.data()};
+        reused.processBlock(inputs, outputs, 1, blockSize);
+    }
+    reused.reset();
+    float maximumDelta = 0.0f;
+    float signalPeak = 0.0f;
+    for (int block = 0; block < 40; ++block)
+    {
+        for (int sample = 0; sample < blockSize; ++sample)
+            hot[static_cast<size_t>(sample)] = 0.2f * std::sin(
+                2.0f * kPi * 997.0f * static_cast<float>(block * blockSize + sample)
+                / 48000.0f);
+        const float* inputs[] = {hot.data()};
+        float* reusedOutputs[] = {reusedOut.data()};
+        float* freshOutputs[] = {freshOut.data()};
+        reused.processBlock(inputs, reusedOutputs, 1, blockSize);
+        fresh.processBlock(inputs, freshOutputs, 1, blockSize);
+        for (int sample = 0; sample < blockSize; ++sample)
+        {
+            signalPeak = std::max(signalPeak,
+                                  std::abs(freshOut[static_cast<size_t>(sample)]));
+            maximumDelta = std::max(maximumDelta, std::abs(
+                reusedOut[static_cast<size_t>(sample)]
+                - freshOut[static_cast<size_t>(sample)]));
+        }
+    }
+    std::printf("FET reset determinism: signal peak %.9g max delta %.9g\n",
+                signalPeak, maximumDelta);
+    require(signalPeak > 0.01f && maximumDelta < 1.0e-7f,
+            "vintage FET reset clears programme, detector, and coloration state");
+}
+
+void testFetInternalStereoLinkReference()
+{
+    constexpr int sampleRate = 48000;
+    constexpr int blockSize = 256;
+    constexpr int totalSamples = 5 * sampleRate;
+    constexpr int measureStart = 3 * sampleRate;
+    constexpr int measureStop = 9 * sampleRate / 2;
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize);
+    std::array<float, blockSize> left{}, right{}, outputLeft{}, outputRight{};
+    double leftPower = 0.0;
+    double rightPower = 0.0;
+    int measured = 0;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            left[static_cast<size_t>(sample)] = duskaudio::decibelsToGain(-12.0f)
+                * std::sin(2.0f * kPi * 997.0f * absolute / sampleRate);
+            right[static_cast<size_t>(sample)] = duskaudio::decibelsToGain(-30.0f)
+                * std::sin(2.0f * kPi * 1499.0f * absolute / sampleRate);
+        }
+        const float* inputs[] = {left.data(), right.data()};
+        float* outputs[] = {outputLeft.data(), outputRight.data()};
+        dsp.processBlock(inputs, outputs, 2, count);
+        for (int sample = 0; sample < count; ++sample)
+            if (offset + sample >= measureStart && offset + sample < measureStop)
+            {
+                const float l = outputLeft[static_cast<size_t>(sample)];
+                const float r = outputRight[static_cast<size_t>(sample)];
+                leftPower += static_cast<double>(l) * l;
+                rightPower += static_cast<double>(r) * r;
+                ++measured;
+            }
+    }
+    const float leftDb = duskaudio::gainToDecibels(static_cast<float>(
+        std::sqrt(leftPower / measured)));
+    const float rightDb = duskaudio::gainToDecibels(static_cast<float>(
+        std::sqrt(rightPower / measured)));
+    std::printf("FET internal stereo link: reference %.6f/%.6f measured %.6f/%.6f dBFS\n",
+                -13.877202f, -31.875823f, leftDb, rightDb);
+    require(std::abs(leftDb + 13.877202f) < 0.20f
+                && std::abs(rightDb + 31.875823f) < 0.20f,
+            "vintage FET internal link reproduces the asymmetric stereo reference");
+}
+
+void testFetStereoLinkPhaseLaw()
+{
+    // The installed unit is not power-sum linked. On converged 40 s renders,
+    // an equal in-phase right channel is bit-identical to left-only, while an
+    // equal antiphase channel makes the left output 0.179579 dB quieter. A
+    // signed sample-wise maximum followed by the unit's slow peak hold has
+    // exactly that shape: the antiphase copy refreshes the peak between the
+    // left channel's peaks, while a lower copy never overtakes the held peak.
+    constexpr int sampleRate = 48000;
+    constexpr int blockSize = 256;
+    constexpr int totalSamples = 15 * sampleRate;
+    constexpr int measureStart = 10 * sampleRate;
+    constexpr int measureStop = 14 * sampleRate;
+    const auto measure = [&](float rightScale, float& reductionDb) {
+        MultiCompDSP dsp;
+        prepareReferenceFet(dsp, sampleRate, blockSize);
+        std::array<float, blockSize> left{}, right{};
+        std::array<float, blockSize> outputLeft{}, outputRight{};
+        double leftPower = 0.0;
+        int measured = 0;
+        for (int offset = 0; offset < totalSamples; offset += blockSize)
+        {
+            const int count = std::min(blockSize, totalSamples - offset);
+            for (int sample = 0; sample < count; ++sample)
+            {
+                const int absolute = offset + sample;
+                const float value = duskaudio::decibelsToGain(-12.0f)
+                    * std::sin(2.0f * kPi * 997.0f * absolute / sampleRate);
+                left[static_cast<size_t>(sample)] = value;
+                right[static_cast<size_t>(sample)] = value * rightScale;
+            }
+            const float* inputs[] = {left.data(), right.data()};
+            float* outputs[] = {outputLeft.data(), outputRight.data()};
+            dsp.processBlock(inputs, outputs, 2, count);
+            for (int sample = 0; sample < count; ++sample)
+                if (offset + sample >= measureStart
+                    && offset + sample < measureStop)
+                {
+                    const float value = outputLeft[static_cast<size_t>(sample)];
+                    leftPower += static_cast<double>(value) * value;
+                    ++measured;
+                }
+        }
+        require(measured == measureStop - measureStart,
+                "FET stereo phase-law window is complete");
+        reductionDb = dsp.getGainReduction();
+        return duskaudio::gainToDecibels(static_cast<float>(
+            std::sqrt(leftPower / measured)));
+    };
+
+    float leftOnlyReductionDb = 0.0f;
+    float inPhaseReductionDb = 0.0f;
+    float antiphaseReductionDb = 0.0f;
+    const float leftOnlyDb = measure(0.0f, leftOnlyReductionDb);
+    const float inPhaseDb = measure(1.0f, inPhaseReductionDb);
+    const float antiphaseDb = measure(-1.0f, antiphaseReductionDb);
+    const float inPhaseResponseDb = inPhaseDb - leftOnlyDb;
+    const float antiphaseResponseDb = antiphaseDb - leftOnlyDb;
+    std::printf("FET stereo phase law: left-only %.9f in-phase %.9f "
+                "response %+.9f, antiphase %.9f response %+.9f "
+                "(reference -0.179579), GR %.9f/%.9f/%.9f\n",
+                leftOnlyDb, inPhaseDb, inPhaseResponseDb,
+                antiphaseDb, antiphaseResponseDb,
+                leftOnlyReductionDb, inPhaseReductionDb,
+                antiphaseReductionDb);
+    require(std::abs(inPhaseResponseDb) < 0.02f,
+            "vintage FET equal in-phase link remains identical to left-only");
+    require(std::abs(antiphaseResponseDb + 0.179579f) < 0.03f,
+            "vintage FET antiphase link reproduces the measured signed-maximum response");
+}
+
+float renderFetDenseStereoLevelDb(double sampleRate, float rightDbfs,
+                                  float phaseCycles)
+{
+    constexpr int blockSize = 512;
+    const int totalSamples = static_cast<int>(std::lround(15.0 * sampleRate));
+    const int measureStart = static_cast<int>(std::lround(10.0 * sampleRate));
+    const int measureStop = static_cast<int>(std::lround(14.0 * sampleRate));
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize);
+    // The dense Wave 27 capture used the installed unit's campaign default,
+    // not the 0.5 Release coordinate used by the older canonical phase test.
+    dsp.setParameter(MultiCompDSP::Parameter::FetRelease,
+                     fetReleasePlain(0.665954590f));
+    std::array<float, blockSize> left{}, right{};
+    std::array<float, blockSize> outputLeft{}, outputRight{};
+    const double leftAmplitude = duskaudio::decibelsToGain(-12.0f);
+    const double rightAmplitude = rightDbfs <= -150.0f
+        ? 0.0 : duskaudio::decibelsToGain(rightDbfs);
+    double power = 0.0;
+    int measured = 0;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const double cycles = 997.0 * (offset + sample) / sampleRate;
+            left[static_cast<size_t>(sample)] = static_cast<float>(
+                leftAmplitude * std::sin(2.0 * kPi * cycles));
+            right[static_cast<size_t>(sample)] = static_cast<float>(
+                rightAmplitude * std::sin(2.0 * kPi
+                    * (cycles + phaseCycles)));
+        }
+        const float* inputs[] = {left.data(), right.data()};
+        float* outputs[] = {outputLeft.data(), outputRight.data()};
+        dsp.processBlock(inputs, outputs, 2, count);
+        for (int sample = 0; sample < count; ++sample)
+            if (offset + sample >= measureStart
+                && offset + sample < measureStop)
+            {
+                const double value = outputLeft[static_cast<size_t>(sample)];
+                power += value * value;
+                ++measured;
+            }
+    }
+    return duskaudio::gainToDecibels(static_cast<float>(
+        std::sqrt(power / measured)));
+}
+
+void testFetDenseStereoPhaseParity()
+{
+    // Exact UAD Wave 27 same-stimulus link responses. The 96 kHz equal-level
+    // quarter-cycle row is the exposed defect; the adjacent phases, the same
+    // phase at 48 kHz, and the lower-level opposite arm reject a one-cell or
+    // phase-only correction.
+    struct Row
+    {
+        double sampleRate;
+        float rightDbfs;
+        float phaseCycles;
+        float referenceResponseDb;
+    };
+    constexpr std::array<Row, 5> rows{{
+        {48000.0, -12.0f, 0.250f, -0.179689254f},
+        {96000.0, -12.0f, 0.125f, -0.182474400f},
+        {96000.0, -12.0f, 0.250f, -0.180580158f},
+        {96000.0, -12.0f, 0.375f, -0.178920248f},
+        {96000.0, -18.0f, 0.250f,  0.000000000f},
+    }};
+    const float baseline48 = renderFetDenseStereoLevelDb(48000.0, -160.0f, 0.0f);
+    const float baseline96 = renderFetDenseStereoLevelDb(96000.0, -160.0f, 0.0f);
+    float worstError = 0.0f;
+    for (const auto& row : rows)
+    {
+        const float level = renderFetDenseStereoLevelDb(
+            row.sampleRate, row.rightDbfs, row.phaseCycles);
+        const float baseline = row.sampleRate == 48000.0
+            ? baseline48 : baseline96;
+        const float response = level - baseline;
+        const float error = response - row.referenceResponseDb;
+        worstError = std::max(worstError, std::abs(error));
+        std::printf("FET dense stereo: rate %.0f right %.1f phase %.3f "
+                    "response reference/measured %.9f/%.9f error %+.9f dB\n",
+                    row.sampleRate, row.rightDbfs, row.phaseCycles,
+                    row.referenceResponseDb, response, error);
+    }
+    std::printf("FET dense stereo: worst absolute response error %.9f dB\n",
+                worstError);
+    require(worstError < 0.020f,
+            "vintage FET dense stereo phase surface matches the UAD response");
+}
+
+std::array<float, 5> renderFetRecoveryH1Db(
+    double sampleRate, double frequencyHz, float loudDbfs,
+    float attackPosition, int ratio, float phaseDegrees, bool quietOnly)
+{
+    constexpr int blockSize = 512;
+    constexpr std::array<double, 5> windowStarts{{1.5, 3.0, 4.5, 6.0, 7.0}};
+    const int totalSamples = static_cast<int>(std::lround(8.0 * sampleRate));
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize,
+                        0.8f, 0.625915527f, ratio);
+    dsp.setParameter(MultiCompDSP::Parameter::FetAttack,
+                     fetAttackPlain(attackPosition));
+    std::array<float, blockSize> left{}, right{};
+    std::array<float, blockSize> outputLeft{}, outputRight{};
+    std::array<double, 5> real{}, imaginary{};
+    std::array<int, 5> counts{};
+    const double phaseRadians = phaseDegrees * kPi / 180.0;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            const bool loud = !quietOnly
+                && absolute >= static_cast<int>(std::lround(1.0 * sampleRate))
+                && absolute < static_cast<int>(std::lround(1.25 * sampleRate));
+            const double amplitude = duskaudio::decibelsToGain(
+                loud ? loudDbfs : -72.0f);
+            const float value = static_cast<float>(amplitude * std::sin(
+                2.0 * kPi * frequencyHz * absolute / sampleRate
+                    + phaseRadians));
+            left[static_cast<size_t>(sample)] = value;
+            right[static_cast<size_t>(sample)] = value;
+        }
+        const float* inputs[] = {left.data(), right.data()};
+        float* outputs[] = {outputLeft.data(), outputRight.data()};
+        dsp.processBlock(inputs, outputs, 2, count);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            for (size_t window = 0; window < windowStarts.size(); ++window)
+            {
+                const int start = static_cast<int>(std::lround(
+                    windowStarts[window] * sampleRate));
+                const int stop = start + static_cast<int>(std::lround(
+                    0.25 * sampleRate));
+                if (absolute < start || absolute >= stop) continue;
+                const double angle = 2.0 * kPi * frequencyHz
+                    * (absolute - start) / sampleRate;
+                const double value = outputLeft[static_cast<size_t>(sample)];
+                real[window] += value * std::cos(angle);
+                imaginary[window] -= value * std::sin(angle);
+                ++counts[window];
+            }
+        }
+    }
+    std::array<float, 5> result{};
+    for (size_t window = 0; window < result.size(); ++window)
+    {
+        const double amplitude = 2.0 * std::hypot(
+            real[window], imaginary[window]) / counts[window];
+        result[window] = duskaudio::gainToDecibels(
+            static_cast<float>(amplitude));
+    }
+    return result;
+}
+
+void testFetDenseStartupRecoveryParity()
+{
+    // Wave 27's equal 8 s sources, rescored against the current binary. These
+    // are absolute UAD H1 levels in the five declared 250 ms windows; the
+    // quiet render removes static device gain before the recovery residual is
+    // compared. Both phases are required because the reference recovery state
+    // is phase-sensitive, and both rates prevent a 96 kHz-only scalar patch.
+    struct Row
+    {
+        double sampleRate;
+        double frequencyHz;
+        float loudDbfs;
+        float attackPosition;
+        int ratio;
+        float phaseDegrees;
+        std::array<float, 5> referenceBurstH1Db;
+    };
+    constexpr std::array<float, 5> referenceQuiet48At1k{{
+        -41.893320337f, -41.893320368f, -41.893320383f,
+        -41.893320383f, -41.893320342f}};
+    constexpr std::array<float, 5> referenceQuiet48At4k{{
+        -41.893301721f, -41.893301999f, -41.893301863f,
+        -41.893301900f, -41.893301957f}};
+    constexpr std::array<float, 5> referenceQuiet96At1k{{
+        -41.893315285f, -41.893315284f, -41.893315295f,
+        -41.893315299f, -41.893315299f}};
+    constexpr std::array<float, 5> referenceQuiet96At4k{{
+        -41.893256638f, -41.893256649f, -41.893256616f,
+        -41.893256634f, -41.893256638f}};
+    constexpr std::array<Row, 16> rows{{
+        {48000.0, 1000.0, -30.0f, 1.0f, 0, 0.0f,
+         {{-47.419350088f, -42.650442047f, -42.068162291f,
+           -41.935354660f, -41.909370750f}}},
+        {48000.0, 1000.0, -18.0f, 1.0f, 0, 0.0f,
+         {{-54.036772679f, -43.774027215f, -42.343618938f,
+           -42.002990460f, -41.935819549f}}},
+        {48000.0, 1000.0, -6.0f, 0.0f, 0, 0.0f,
+         {{-62.220349821f, -45.875034457f, -42.890472921f,
+           -42.141661518f, -41.989978202f}}},
+        {48000.0, 1000.0, -6.0f, 0.5f, 0, 0.0f,
+         {{-62.348086472f, -45.918949483f, -42.902420025f,
+           -42.144733190f, -41.991205368f}}},
+        {48000.0, 1000.0, -6.0f, 1.0f, 0, 0.0f,
+         {{-61.713930703f, -45.721158272f, -42.849444759f,
+           -42.131120139f, -41.985762444f}}},
+        {48000.0, 4000.0, -6.0f, 1.0f, 0, 0.0f,
+         {{-61.749603648f, -45.733247595f, -42.852740715f,
+           -42.131954906f, -41.986083237f}}},
+        {48000.0, 1000.0, -6.0f, 0.5f, 1, 0.0f,
+         {{-61.945040336f, -45.202601731f, -42.657725180f,
+           -42.077761376f, -41.967769331f}}},
+        {48000.0, 1000.0, -6.0f, 1.0f, 0, 90.0f,
+         {{-61.705564454f, -45.718980353f, -42.848872874f,
+           -42.130973182f, -41.985703692f}}},
+        {96000.0, 1000.0, -30.0f, 1.0f, 0, 0.0f,
+         {{-47.415809867f, -42.644629538f, -42.067771570f,
+           -41.935679773f, -41.909903760f}}},
+        {96000.0, 1000.0, -18.0f, 1.0f, 0, 0.0f,
+         {{-54.027647794f, -43.769335252f, -42.343640894f,
+           -42.003419066f, -41.936346456f}}},
+        {96000.0, 1000.0, -6.0f, 0.0f, 0, 0.0f,
+         {{-62.201864830f, -45.886727593f, -42.895905602f,
+           -42.143223719f, -41.991170365f}}},
+        {96000.0, 1000.0, -6.0f, 0.5f, 0, 0.0f,
+         {{-62.322730153f, -45.915093954f, -42.902799746f,
+           -42.145043299f, -41.991851560f}}},
+        {96000.0, 1000.0, -6.0f, 1.0f, 0, 0.0f,
+         {{-61.703073934f, -45.718643957f, -42.849774945f,
+           -42.131019558f, -41.986576420f}}},
+        {96000.0, 4000.0, -6.0f, 1.0f, 0, 0.0f,
+         {{-61.715997425f, -45.722939034f, -42.850906413f,
+           -42.131273036f, -41.986637300f}}},
+        {96000.0, 1000.0, -6.0f, 0.5f, 1, 0.0f,
+         {{-61.916516268f, -45.222883277f, -42.669602672f,
+           -42.076591872f, -41.976011280f}}},
+        {96000.0, 1000.0, -6.0f, 1.0f, 0, 90.0f,
+         {{-61.697527700f, -45.716923653f, -42.849306859f,
+           -42.130897452f, -41.986529699f}}},
+    }};
+    const auto quiet48At1k = renderFetRecoveryH1Db(
+        48000.0, 1000.0, -72.0f, 0.5f, 0, 0.0f, true);
+    const auto quiet48At4k = renderFetRecoveryH1Db(
+        48000.0, 4000.0, -72.0f, 0.5f, 0, 0.0f, true);
+    const auto quiet96At1k = renderFetRecoveryH1Db(
+        96000.0, 1000.0, -72.0f, 0.5f, 0, 0.0f, true);
+    const auto quiet96At4k = renderFetRecoveryH1Db(
+        96000.0, 4000.0, -72.0f, 0.5f, 0, 0.0f, true);
+    float worstResidual = 0.0f;
+    for (const auto& row : rows)
+    {
+        const auto burst = renderFetRecoveryH1Db(
+            row.sampleRate, row.frequencyHz, row.loudDbfs,
+            row.attackPosition, row.ratio, row.phaseDegrees, false);
+        const auto& quiet = row.sampleRate == 48000.0
+            ? row.frequencyHz == 1000.0 ? quiet48At1k : quiet48At4k
+            : row.frequencyHz == 1000.0 ? quiet96At1k : quiet96At4k;
+        const auto& referenceQuiet = row.sampleRate == 48000.0
+            ? row.frequencyHz == 1000.0
+                ? referenceQuiet48At1k : referenceQuiet48At4k
+            : row.frequencyHz == 1000.0
+                ? referenceQuiet96At1k : referenceQuiet96At4k;
+        for (size_t window = 0; window < burst.size(); ++window)
+        {
+            const float residual = (burst[window] - row.referenceBurstH1Db[window])
+                - (quiet[window] - referenceQuiet[window]);
+            worstResidual = std::max(worstResidual, std::abs(residual));
+            std::printf("FET dense recovery: rate %.0f carrier %.0f level %.0f "
+                        "attack %.1f ratio %d phase %.0f window %zu "
+                        "candidate-minus-UAD residual %+.9f dB\n",
+                        row.sampleRate, row.frequencyHz, row.loudDbfs,
+                        row.attackPosition, row.ratio, row.phaseDegrees,
+                        window, residual);
+        }
+    }
+    std::printf("FET dense recovery: worst absolute residual %.9f dB\n",
+                worstResidual);
+    require(worstResidual < 0.150f,
+            "vintage FET post-burst recovery follows the UAD phase/rate surface");
+}
+
+void armFetPostBurstRecovery(MultiCompDSP& dsp, int channels)
+{
+    constexpr int blockSize = 256;
+    constexpr int loudSamples = 12000;
+    constexpr int quietSamples = 2400;
+    std::array<float, blockSize> left{}, right{}, outputLeft{}, outputRight{};
+    const int totalSamples = loudSamples + quietSamples;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            const float amplitude = duskaudio::decibelsToGain(
+                absolute < loudSamples ? -6.0f : -72.0f);
+            const float value = amplitude * std::sin(
+                2.0f * kPi * 1000.0f * absolute / 48000.0f);
+            left[static_cast<size_t>(sample)] = value;
+            right[static_cast<size_t>(sample)] = value;
+        }
+        const float* inputs[] = {left.data(), right.data()};
+        float* outputs[] = {outputLeft.data(), outputRight.data()};
+        dsp.processBlock(inputs, outputs, channels, count);
+    }
+}
+
+void testFetPostBurstRecoveryLifecycle()
+{
+    constexpr int blockSize = 256;
+    const auto isClear = [](const std::array<float, 2>& gains) noexcept {
+        return gains[0] == 1.0f && gains[1] == 1.0f;
+    };
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, 48000.0, blockSize);
+    armFetPostBurstRecovery(dsp, 2);
+    const auto armed = duskaudio::MultiCompDSPTestAccess::fetRecoveryGains(dsp);
+
+    dsp.prepare(48000.0, blockSize);
+    const auto afterPrepare = duskaudio::MultiCompDSPTestAccess::fetRecoveryGains(dsp);
+    armFetPostBurstRecovery(dsp, 2);
+    dsp.reset();
+    const auto afterReset = duskaudio::MultiCompDSPTestAccess::fetRecoveryGains(dsp);
+
+    prepareReferenceFet(dsp, 48000.0, blockSize);
+    armFetPostBurstRecovery(dsp, 2);
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::VCA));
+    std::array<float, blockSize> silence{}, outputLeft{}, outputRight{};
+    const float* inputs[] = {silence.data(), silence.data()};
+    float* outputs[] = {outputLeft.data(), outputRight.data()};
+    dsp.processBlock(inputs, outputs, 2, blockSize);
+    const auto afterModeExit = duskaudio::MultiCompDSPTestAccess::fetRecoveryGains(dsp);
+
+    prepareReferenceFet(dsp, 48000.0, blockSize);
+    armFetPostBurstRecovery(dsp, 2);
+    dsp.setBypass(true);
+    for (int block = 0; block < 8; ++block)
+        dsp.processBlock(inputs, outputs, 2, blockSize);
+    const auto afterBypass = duskaudio::MultiCompDSPTestAccess::fetRecoveryGains(dsp);
+
+    dsp.setBypass(false);
+    dsp.reset();
+    prepareReferenceFet(dsp, 48000.0, blockSize);
+    armFetPostBurstRecovery(dsp, 2);
+    dsp.processBlock(inputs, outputs, 1, blockSize);
+    const auto afterMono = duskaudio::MultiCompDSPTestAccess::fetRecoveryGains(dsp);
+
+    std::printf("FET recovery state: armed %.6f/%.6f; prepare %.6f/%.6f; "
+                "reset %.6f/%.6f; mode %.6f/%.6f; bypass %.6f/%.6f; "
+                "mono %.6f/%.6f\n",
+                armed[0], armed[1], afterPrepare[0], afterPrepare[1],
+                afterReset[0], afterReset[1], afterModeExit[0], afterModeExit[1],
+                afterBypass[0], afterBypass[1], afterMono[0], afterMono[1]);
+    require(armed[0] > 1.05f && armed[1] > 1.05f
+                && isClear(afterPrepare) && isClear(afterReset)
+                && isClear(afterModeExit) && isClear(afterBypass)
+                && afterMono[1] == 1.0f,
+            "FET post-burst recovery state arms and clears on every lifecycle path");
+}
+
+// --- vintage FET attack drive axis ---------------------------------------
+//
+// The 1176 comparison campaign's headline dynamics finding is that the
+// reference's attack time constant FALLS as it is driven harder
+// (1.73 -> 1.03 -> 0.72 ms for -30 / -18 / -6 dBFS at attack knob 0.5) while
+// this core's rose. The measurement below reproduces that campaign row
+// in process: same programme (1 s of a -72 dBFS 1 kHz carrier then a
+// phase-continuous burst), same estimator (exact 1 kHz quadrature
+// demodulation through a one-cycle boxcar, first-order log-linear fit over
+// 15-88 % of the 40-60 ms plateau starting half a carrier period in).
+//
+// Absolute milliseconds are NOT an oracle: the estimator carries a documented
+// x1.85 relaxation-domain ambiguity and a -4..-10 % bias below 1 ms
+// (report/opus_notes/wave3_validation.md). What is asserted is the direction of
+// the drive axis, and mine/reference through this same estimator.
+//
+// `MultiCompCoreTest --fet-attack-drive` prints the whole grid; setting
+// MC_FET_DUMP_GR=1 additionally dumps every `GRCURVE <drive> <knob> <ms> <dB>`
+// sample, which is how the reference and this core were compared curve for
+// curve rather than through a single fitted number.
+//
+// THE TAU AT -6 dBFS MOVES UNDER PURE COLOUR CHANGES, AND THAT IS THE
+// ESTIMATOR, NOT THE CELL. Measured twice, on two independent colour-only
+// changes to the vintage FET:
+//
+//   fetBroadbandK2 refit  tau -6 dBFS 3.238590 -> 3.626379 ms  (+12.0 %)
+//   fetLowFrequencyK2     tau -6 dBFS 3.626379 -> 4.099728 ms  (+13.1 %)
+//
+// while `--fet-envelope-trace` -- which reads `d.envelope` straight off the
+// mode state and never touches the demodulator -- returns a BIT-IDENTICAL
+// FNV-1a digest over the 60 ms after onset across all three builds, at -6,
+// -18 and -30 dBFS, with the plateau reduction unchanged to four decimals. The
+// same runs show the OUTPUT peak moving (4.4361 -> 4.4568 -> 4.4568), so the
+// control has a live positive arm: the audio really did change and the internal
+// trajectory really did not. It cannot change: for the vintage arm `detect`
+// comes from `|transformedInput * inputGain|`, never from `saturated`, so no
+// colour coefficient has a path into the envelope.
+//
+// The mechanism is the demodulator. `quadratureEnvelope`'s one-period boxcar
+// nulls harmonics exactly only for a STEADY amplitude; during the attack the 2f
+// product is amplitude modulated and its cancellation is incomplete. At -6 dBFS
+// the log-linear fit has 33 points inside a sub-millisecond band (against 104
+// at -30 dBFS), so a tiny envelope perturbation moves the slope a lot -- the
+// same rows move 0.05 % and 0.17 % at -30 and -18 dBFS.
+//
+// So: tau is a diagnostic (wave3b_validation.md section 3 already ratified
+// that), the gate is the normalised curve RMS, and a colour change that moves
+// tau at -6 dBFS while curve RMS moves 6e-06 is behaving correctly. Do not
+// re-tune the attack law against it.
+constexpr float kFetCampaignLatencySamples48k = 27.0f;
+
+struct FetAttackMeasurement
+{
+    float driveDbfs = 0.0f;
+    double plateauGrDb = 0.0;
+    double tauMs = 0.0;
+    // First crossing of 90 % of the plateau on the RUNNING MAXIMUM of the
+    // reduction curve, scanned from half a carrier period in. It is better
+    // conditioned than the log-linear tau -- the tau fit runs out of points
+    // above about 30 dB of reduction and inverts sign against this metric
+    // there, and the 63 % crossing saturates at the scan floor on every
+    // reference row because the centred one-cycle boxcar has smeared the step.
+    // The running maximum makes it immune to the first-cycle overshoot.
+    //
+    // It is NOT unconditionally trustworthy either, and the deep rows are where
+    // it degrades: at -6 dBFS the whole knob sweep reads 0.6439 / 0.6276 /
+    // 0.6041 ms, a 6 % spread across the entire control, all of it 0.10-0.14 ms
+    // above the 0.5 ms scan floor, against a 6.8x spread at -30 dBFS. Above
+    // ~30 dB of reduction neither estimator resolves this carrier; use the
+    // curve RMS against the reference trajectory instead.
+    double recovery90Ms = 0.0;
+    // Whole-programme output peak. The base-rate FET output ceiling in
+    // MultiCompDSP.cpp has its knee at 6.39712761; a first-cycle overshoot
+    // above it puts clipping harmonics into the captures, so any change to the
+    // attack must be checked against it.
+    double outputPeak = 0.0;
+    int fitPoints = 0;
+    bool fitted = false;
+};
+
+double medianOf(std::vector<double> values)
+{
+    if (values.empty()) return std::numeric_limits<double>::quiet_NaN();
+    std::sort(values.begin(), values.end());
+    const size_t middle = values.size() / 2;
+    return values.size() % 2 == 1
+        ? values[middle]
+        : 0.5 * (values[middle - 1] + values[middle]);
+}
+
+// One-carrier-period boxcar on the quadrature-demodulated signal. The boxcar
+// is exactly one period long, so every harmonic of the carrier lands on a
+// transfer-function null, and it is centred (the scorer's `mode="same"`), so
+// the envelope is zero phase.
+std::vector<double> quadratureEnvelope(const std::vector<double>& signal,
+                                       double sampleRate, double frequency)
+{
+    const int period = static_cast<int>(std::lround(sampleRate / frequency));
+    require(std::abs(sampleRate / frequency - period) < 1.0e-9,
+            "carrier period is an integer number of samples");
+    const int count = static_cast<int>(signal.size());
+    std::vector<double> real(signal.size()), imaginary(signal.size());
+    for (int n = 0; n < count; ++n)
+    {
+        const double phase = -2.0 * 3.14159265358979323846 * frequency * n / sampleRate;
+        real[static_cast<size_t>(n)] = signal[static_cast<size_t>(n)] * std::cos(phase);
+        imaginary[static_cast<size_t>(n)] = signal[static_cast<size_t>(n)] * std::sin(phase);
+    }
+    // numpy's convolve(..., mode="same") with an even-length kernel averages
+    // samples n-period/2 .. n+period/2-1; zero outside the signal.
+    const int back = period / 2;
+    std::vector<double> envelope(signal.size());
+    double sumReal = 0.0, sumImaginary = 0.0;
+    // Prime the window. At n = 0 the centred boxcar spans -back .. period-1-back,
+    // so indices 0 .. period-2-back are already inside it; the loop below only
+    // ever ADDS index n+period-1-back, and it later SUBTRACTS those primed
+    // indices as they leave. Without this the accumulator carries a constant
+    // complex offset -sum(x[0 .. period-2-back]) forever. It was benign here by
+    // accident -- the plugin's 27-sample latency keeps those samples 28.6 dB
+    // below the quiet carrier -- but on a programme that starts at level it is
+    // a multi-dB baseline error (measured: -78.008 dB read for a -72.000 dB
+    // carrier), and this helper is meant to be reusable.
+    for (int k = 0; k < period - 1 - back && k < count; ++k)
+    {
+        sumReal += real[static_cast<size_t>(k)];
+        sumImaginary += imaginary[static_cast<size_t>(k)];
+    }
+    for (int n = 0; n < count; ++n)
+    {
+        const int enter = n + period - 1 - back;
+        const int leave = n - 1 - back;
+        if (enter < count)
+        {
+            sumReal += real[static_cast<size_t>(enter)];
+            sumImaginary += imaginary[static_cast<size_t>(enter)];
+        }
+        if (leave >= 0)
+        {
+            sumReal -= real[static_cast<size_t>(leave)];
+            sumImaginary -= imaginary[static_cast<size_t>(leave)];
+        }
+        envelope[static_cast<size_t>(n)] = 2.0 * std::hypot(sumReal, sumImaginary)
+            / static_cast<double>(period);
+    }
+    return envelope;
+}
+
+FetAttackMeasurement measureFetAttack(float driveDbfs, float attackPosition = 0.5f,
+                                      int ratio = 0, double sampleRate = 48000.0,
+                                      std::vector<double>* reductionOut = nullptr,
+                                      double carrierHz = 1000.0)
+{
+    constexpr int blockSize = 256;
+    constexpr double quietSeconds = 1.0;
+    constexpr double burstSeconds = 0.25;
+    constexpr double quietPeakDbfs = -72.0;
+    const int totalSamples = static_cast<int>(
+        std::lround((quietSeconds + burstSeconds) * sampleRate));
+    const int loudFrom = static_cast<int>(std::lround(quietSeconds * sampleRate));
+
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize, 0.8f, 0.625915527f, ratio);
+    dsp.setParameter(MultiCompDSP::Parameter::FetAttack, fetAttackPlain(attackPosition));
+    const float quietAmplitude = duskaudio::decibelsToGain(
+        static_cast<float>(quietPeakDbfs));
+    const float loudAmplitude = duskaudio::decibelsToGain(driveDbfs);
+
+    std::vector<float> left(static_cast<size_t>(blockSize));
+    std::vector<float> right(static_cast<size_t>(blockSize));
+    std::vector<float> outLeft(static_cast<size_t>(blockSize));
+    std::vector<float> outRight(static_cast<size_t>(blockSize));
+    std::vector<double> mono(static_cast<size_t>(totalSamples));
+    double peak = 0.0;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            // Phase continuous across the step, exactly as gen_stimuli.py
+            // builds `amplitude_program`.
+            const float value = (absolute < loudFrom ? quietAmplitude : loudAmplitude)
+                * std::sin(2.0f * kPi * static_cast<float>(carrierHz)
+                    * static_cast<float>(absolute) / static_cast<float>(sampleRate));
+            left[static_cast<size_t>(sample)] = value;
+            right[static_cast<size_t>(sample)] = value;
+        }
+        const float* inputs[] = {left.data(), right.data()};
+        float* outputs[] = {outLeft.data(), outRight.data()};
+        dsp.processBlock(inputs, outputs, 2, count);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            mono[static_cast<size_t>(offset + sample)] = 0.5
+                * (static_cast<double>(outLeft[static_cast<size_t>(sample)])
+                    + static_cast<double>(outRight[static_cast<size_t>(sample)]));
+            peak = std::max(peak, std::max(
+                std::abs(static_cast<double>(outLeft[static_cast<size_t>(sample)])),
+                std::abs(static_cast<double>(outRight[static_cast<size_t>(sample)]))));
+        }
+    }
+
+    const auto envelope = quadratureEnvelope(mono, sampleRate, carrierHz);
+    const int latency = static_cast<int>(std::lround(
+        kFetCampaignLatencySamples48k * sampleRate / 48000.0));
+    const auto gainDb = [&envelope](int index, double referencePeakDbfs) {
+        return 20.0 * std::log10(std::max(envelope[static_cast<size_t>(index)], 1.0e-30))
+            - referencePeakDbfs;
+    };
+    std::vector<double> quiet;
+    for (int n = static_cast<int>(0.5 * sampleRate) + latency;
+         n < static_cast<int>(0.9 * sampleRate) + latency; ++n)
+        quiet.push_back(gainDb(n, quietPeakDbfs));
+    const double baseline = medianOf(quiet);
+
+    const int onset = static_cast<int>(std::lround(quietSeconds * sampleRate)) + latency;
+    const int stop = onset + static_cast<int>(std::lround(0.060 * sampleRate));
+    require(stop < totalSamples, "attack window fits inside the rendered burst");
+    std::vector<double> reductionDb, times;
+    for (int n = onset; n < stop; ++n)
+    {
+        reductionDb.push_back(baseline - gainDb(n, driveDbfs));
+        times.push_back(static_cast<double>(n - onset) / sampleRate);
+    }
+    if (std::getenv("MC_FET_DUMP_GR") != nullptr)
+        for (size_t i = 0; i < reductionDb.size(); ++i)
+            std::printf("GRCURVE %.1f %.4f %.6f %.6f\n",
+                        static_cast<double>(driveDbfs),
+                        static_cast<double>(attackPosition),
+                        1000.0 * times[i], reductionDb[i]);
+    std::vector<double> plateauSamples(
+        reductionDb.begin() + static_cast<long>(std::lround(0.040 * sampleRate)),
+        reductionDb.end());
+    FetAttackMeasurement result;
+    result.driveDbfs = driveDbfs;
+    result.plateauGrDb = medianOf(plateauSamples);
+    result.outputPeak = peak;
+
+    // The scan starts where the fit does, half a carrier period in. Before
+    // that the centred boxcar still straddles the pre-step carrier and the
+    // demodulated amplitude spikes above the plateau on every row of both
+    // devices -- scanning from zero reported the same 0.63 ms for laws a
+    // factor of 2.2 apart, which is the artefact and not the attack.
+    const size_t firstScannable = static_cast<size_t>(
+        std::lround(0.5 / carrierHz * sampleRate));
+    double runningMaximum = -1.0e30;
+    for (size_t i = firstScannable; i < reductionDb.size(); ++i)
+    {
+        const double previous = runningMaximum;
+        runningMaximum = std::max(runningMaximum, reductionDb[i]);
+        if (runningMaximum < 0.90 * result.plateauGrDb) continue;
+        // `previous` cannot already be above the threshold here: the guard
+        // above tests exactly that quantity, so the loop would have broken one
+        // iteration earlier. The only special case is the first scanned sample,
+        // where there is no earlier point to interpolate from.
+        result.recovery90Ms = i == firstScannable
+            ? 1000.0 * times[i]
+            : 1000.0 * (times[i - 1] + (times[i] - times[i - 1])
+                * (0.90 * result.plateauGrDb - previous)
+                / (runningMaximum - previous));
+        break;
+    }
+
+    double sumX = 0.0, sumY = 0.0, sumXX = 0.0, sumXY = 0.0;
+    int used = 0;
+    for (size_t i = 0; i < reductionDb.size(); ++i)
+    {
+        const double fraction = reductionDb[i] / result.plateauGrDb;
+        if (fraction < 0.15 || fraction > 0.88) continue;
+        if (times[i] < 0.5 / carrierHz) continue;
+        const double y = std::log(1.0 - fraction);
+        sumX += times[i]; sumY += y;
+        sumXX += times[i] * times[i]; sumXY += times[i] * y;
+        ++used;
+    }
+    result.fitPoints = used;
+    if (reductionOut != nullptr) *reductionOut = reductionDb;
+    if (used >= 4)
+    {
+        const double denominator = used * sumXX - sumX * sumX;
+        const double slope = (used * sumXY - sumX * sumY) / denominator;
+        if (slope < 0.0)
+        {
+            result.tauMs = -1000.0 / slope;
+            result.fitted = true;
+        }
+    }
+    return result;
+}
+
+void reportFetSettledReduction()
+{
+    // positiveReduction is the settled static-law output, which is what the
+    // drive law's clamp sees -- NOT the 40-60 ms plateau the attack estimator
+    // reads (the programme-memory population is only ~5 % charged there).
+    const float unity = renderReferenceFetRmsDb(-72.0f, 0.8f, 0.625915527f, 0)
+        - (-72.0f - 3.0102999566f);
+    for (int ratio : {0, 1, 2, 3, 4})
+        for (float drive : {-48.0f, -45.0f, -42.0f, -39.0f, -36.0f, -30.0f, -18.0f, -6.0f})
+        {
+            if (ratio != 0 && drive != -6.0f) continue;
+            const float through = renderReferenceFetRmsDb(
+                drive, 0.8f, 0.625915527f, ratio) - (drive - 3.0102999566f);
+            std::printf("  settled GR: ratio %d drive %+.0f dBFS -> %.4f dB\n",
+                        ratio, static_cast<double>(drive),
+                        static_cast<double>(unity - through));
+        }
+}
+
+void reportFetAttackDriveAxis()
+{
+    reportFetSettledReduction();
+    std::puts("FET attack drive axis (in-process, campaign estimator):");
+    for (float attackPosition : {0.0f, 0.5f, 1.0f})
+        for (float drive : {-48.0f, -45.0f, -42.0f, -39.0f, -36.0f, -30.0f, -18.0f, -6.0f})
+        {
+            const auto measured = measureFetAttack(drive, attackPosition);
+            std::printf("  knob %.2f drive %+.0f dBFS: plateau GR %.4f dB tau %s ms (%d pts) t90 %.4f ms peak %.4f\n",
+                        static_cast<double>(attackPosition), static_cast<double>(drive),
+                        measured.plateauGrDb,
+                        measured.fitted ? std::to_string(measured.tauMs).c_str() : "unfittable",
+                        measured.fitPoints, measured.recovery90Ms, measured.outputPeak);
+        }
+    for (int ratio : {1, 2, 3, 4})
+    {
+        const auto measured = measureFetAttack(-6.0f, 0.5f, ratio);
+        std::printf("  knob 0.50 drive -6 dBFS ratio index %d: plateau GR %.4f dB tau %s ms (%d pts) t90 %.4f ms peak %.4f\n",
+                    ratio, measured.plateauGrDb,
+                    measured.fitted ? std::to_string(measured.tauMs).c_str() : "unfittable",
+                    measured.fitPoints, measured.recovery90Ms, measured.outputPeak);
+    }
+}
+
+// The installed unit's own attack trajectory, measured through this same
+// estimator and normalised to its own 40-60 ms plateau. Rendered by
+// `probe_drive_axis.py` (dusk-audio-tools, reference_comparison_1176) from the
+// reference AU at attack knob 0.5, ratio 4:1, input knob 0.8; each row is one
+// source level. This is the campaign's PRIMARY dynamics gate: Wave 3b ratified
+// the demotion of the fitted time constant to a diagnostic, because above
+// ~30 dB of reduction the tau fit reports this core 1.6x SLOWER than the
+// reference on a row where it reaches 90 % of plateau 2.45x SOONER, and the row
+// ranking the two metrics produce is inverted.
+constexpr int kFetReferenceCurvePoints = 79;
+constexpr double kFetReferenceCurveFirstMs = 0.5;
+constexpr double kFetReferenceCurveStepMs = 0.25;
+constexpr float kFetCurveDrivesDbfs[5] = {-42.0f, -36.0f, -30.0f, -18.0f, -6.0f};
+constexpr double kFetReferencePlateauDb[5] = {
+    3.0336033509, 7.1708, 11.7581, 21.1670, 30.7397
+};
+constexpr double kFetReferenceCurve[5][kFetReferenceCurvePoints] = {
+    // -42 dBFS: reference plateau 3.0336 dB, candidate curve RMS 0.0218
+    {0.1265, 0.1933, 0.2695, 0.3330, 0.3960, 0.4438, 0.4904, 0.5290,
+     0.5659, 0.5940, 0.6216, 0.6455, 0.6684, 0.6860, 0.7036, 0.7196,
+     0.7351, 0.7467, 0.7585, 0.7697, 0.7806, 0.7887, 0.7972, 0.8056,
+     0.8139, 0.8199, 0.8263, 0.8330, 0.8397, 0.8443, 0.8495, 0.8551,
+     0.8607, 0.8644, 0.8686, 0.8734, 0.8781, 0.8811, 0.8845, 0.8885,
+     0.8926, 0.8950, 0.8978, 0.9013, 0.9048, 0.9069, 0.9092, 0.9122,
+     0.9154, 0.9171, 0.9191, 0.9218, 0.9246, 0.9261, 0.9278, 0.9302,
+     0.9327, 0.9340, 0.9354, 0.9375, 0.9398, 0.9408, 0.9421, 0.9440,
+     0.9460, 0.9469, 0.9479, 0.9496, 0.9515, 0.9522, 0.9530, 0.9546,
+     0.9563, 0.9569, 0.9576, 0.9590, 0.9605, 0.9610, 0.9616},
+    // -36 dBFS: reference plateau 7.1708 dB, candidate curve RMS 0.0322
+    {0.2588, 0.3704, 0.4740, 0.5473, 0.6095, 0.6534, 0.6933, 0.7245,
+     0.7522, 0.7730, 0.7926, 0.8090, 0.8241, 0.8356, 0.8468, 0.8567,
+     0.8660, 0.8730, 0.8800, 0.8866, 0.8929, 0.8974, 0.9022, 0.9069,
+     0.9114, 0.9146, 0.9180, 0.9216, 0.9252, 0.9275, 0.9302, 0.9332,
+     0.9361, 0.9379, 0.9400, 0.9425, 0.9449, 0.9464, 0.9480, 0.9500,
+     0.9521, 0.9532, 0.9546, 0.9563, 0.9581, 0.9590, 0.9601, 0.9616,
+     0.9631, 0.9639, 0.9647, 0.9661, 0.9675, 0.9681, 0.9688, 0.9700,
+     0.9712, 0.9717, 0.9723, 0.9734, 0.9745, 0.9749, 0.9754, 0.9763,
+     0.9773, 0.9776, 0.9780, 0.9789, 0.9798, 0.9800, 0.9803, 0.9811,
+     0.9819, 0.9821, 0.9824, 0.9830, 0.9838, 0.9839, 0.9841},
+    // -30 dBFS: reference plateau 11.7581 dB, candidate curve RMS 0.0315
+    {0.3716, 0.5086, 0.6133, 0.6793, 0.7306, 0.7656, 0.7961, 0.8194,
+     0.8393, 0.8540, 0.8676, 0.8789, 0.8891, 0.8968, 0.9042, 0.9109,
+     0.9170, 0.9215, 0.9260, 0.9303, 0.9344, 0.9372, 0.9402, 0.9432,
+     0.9462, 0.9481, 0.9502, 0.9525, 0.9548, 0.9562, 0.9578, 0.9597,
+     0.9616, 0.9626, 0.9639, 0.9655, 0.9670, 0.9678, 0.9688, 0.9701,
+     0.9714, 0.9720, 0.9727, 0.9739, 0.9750, 0.9755, 0.9760, 0.9770,
+     0.9780, 0.9784, 0.9788, 0.9797, 0.9806, 0.9809, 0.9812, 0.9820,
+     0.9828, 0.9830, 0.9833, 0.9840, 0.9847, 0.9849, 0.9851, 0.9857,
+     0.9863, 0.9865, 0.9866, 0.9872, 0.9878, 0.9878, 0.9879, 0.9885,
+     0.9890, 0.9890, 0.9891, 0.9896, 0.9901, 0.9901, 0.9901},
+    // -18 dBFS: reference plateau 21.1670 dB, candidate curve RMS 0.0273
+    {0.5484, 0.6976, 0.7761, 0.8193, 0.8504, 0.8714, 0.8892, 0.9026,
+     0.9137, 0.9220, 0.9296, 0.9359, 0.9415, 0.9456, 0.9496, 0.9532,
+     0.9565, 0.9588, 0.9611, 0.9634, 0.9655, 0.9669, 0.9684, 0.9700,
+     0.9716, 0.9725, 0.9735, 0.9748, 0.9761, 0.9768, 0.9776, 0.9787,
+     0.9797, 0.9802, 0.9808, 0.9817, 0.9826, 0.9829, 0.9833, 0.9840,
+     0.9848, 0.9850, 0.9853, 0.9859, 0.9866, 0.9868, 0.9870, 0.9875,
+     0.9881, 0.9882, 0.9884, 0.9889, 0.9894, 0.9895, 0.9896, 0.9901,
+     0.9906, 0.9906, 0.9906, 0.9911, 0.9915, 0.9915, 0.9916, 0.9920,
+     0.9924, 0.9924, 0.9923, 0.9927, 0.9931, 0.9931, 0.9930, 0.9934,
+     0.9937, 0.9937, 0.9936, 0.9939, 0.9943, 0.9942, 0.9942},
+    // -6 dBFS: reference plateau 30.7397 dB, candidate curve RMS 0.0249
+    {0.6611, 0.7898, 0.8484, 0.8785, 0.8995, 0.9142, 0.9266, 0.9354,
+     0.9426, 0.9484, 0.9536, 0.9577, 0.9613, 0.9641, 0.9669, 0.9692,
+     0.9713, 0.9729, 0.9745, 0.9760, 0.9774, 0.9784, 0.9794, 0.9805,
+     0.9815, 0.9821, 0.9828, 0.9837, 0.9846, 0.9850, 0.9855, 0.9862,
+     0.9869, 0.9872, 0.9876, 0.9882, 0.9888, 0.9890, 0.9892, 0.9897,
+     0.9902, 0.9904, 0.9905, 0.9910, 0.9914, 0.9915, 0.9916, 0.9920,
+     0.9924, 0.9925, 0.9925, 0.9929, 0.9932, 0.9933, 0.9933, 0.9936,
+     0.9939, 0.9939, 0.9939, 0.9942, 0.9945, 0.9945, 0.9945, 0.9948,
+     0.9951, 0.9950, 0.9950, 0.9952, 0.9955, 0.9955, 0.9954, 0.9956,
+     0.9959, 0.9958, 0.9958, 0.9960, 0.9962, 0.9962, 0.9961},
+};
+
+// Independent fast-Attack row that exposed the first-cycle cubic
+// extrapolation. Same reference AU, estimator, normalization and 0.5-20 ms
+// sampling grid as kFetReferenceCurve, but Attack at 0.0 and source -6 dBFS.
+// The ordinary attack-drive grid above deliberately fixes Attack at 0.5, so it
+// passed unchanged while this row regressed from 0.0372 to 0.0495 under the
+// old output-only startup correction. Keeping the complete 79-point curve
+// prevents a single hand-picked early sample from standing in for its shape.
+constexpr double kFetFastAttackReferenceCurve[kFetReferenceCurvePoints] = {
+    0.5706071, 0.6871019, 0.7607918, 0.8010365, 0.8320398, 0.8535559,
+    0.8728547, 0.8864650, 0.8985135, 0.9078389, 0.9167143, 0.9235340,
+    0.9299250, 0.9350079, 0.9400243, 0.9441639, 0.9481543, 0.9512554,
+    0.9543590, 0.9571029, 0.9597972, 0.9617954, 0.9638285, 0.9657916,
+    0.9677510, 0.9690963, 0.9704762, 0.9719545, 0.9734467, 0.9743731,
+    0.9753383, 0.9765010, 0.9776848, 0.9783268, 0.9789944, 0.9799258,
+    0.9808852, 0.9813297, 0.9818037, 0.9825868, 0.9833999, 0.9837119,
+    0.9840465, 0.9847241, 0.9854343, 0.9856527, 0.9858864, 0.9864811,
+    0.9871073, 0.9872519, 0.9874151, 0.9879509, 0.9885175, 0.9886107,
+    0.9887202, 0.9892094, 0.9897284, 0.9897819, 0.9898507, 0.9903024,
+    0.9907831, 0.9908067, 0.9908413, 0.9912601, 0.9917069, 0.9917052,
+    0.9917111, 0.9921007, 0.9925176, 0.9924949, 0.9924767, 0.9928406,
+    0.9932309, 0.9931909, 0.9931529, 0.9934937, 0.9938602, 0.9938058,
+    0.9937513,
+};
+
+// Worst normalised curve RMS accepted on any drive. Measured on this build:
+// 0.0218 / 0.0321 / 0.0315 / 0.0273 / 0.0249, shallow to deep, so the worst row
+// has 18 % of headroom. The bound is set by what it has to catch, not by taste:
+// restoring only the three SHALLOW table entries to the values the previous,
+// deep-anchored-only parabola extrapolated there reads 0.0436 at -42 dBFS, and
+// restoring the whole pre-campaign law reads 0.1578. A bound of 0.045 would
+// have let the first of those through, which is the exact defect this table
+// exists to fix. The measurement is deterministic -- same binary, same numbers
+// -- so the headroom does not have to cover run-to-run noise.
+//
+// It gates the SHAPE of the attack, so it fails for a law that is too fast as
+// readily as for one that is too slow.
+constexpr double kFetCurveRmsBound = 0.038;
+
+double fetCurveRmsAgainstValues(const FetAttackMeasurement& measured,
+                                const std::vector<double>& reductionDb,
+                                double sampleRate, const double* reference)
+{
+    double sum = 0.0;
+    int used = 0;
+    for (int point = 0; point < kFetReferenceCurvePoints; ++point)
+    {
+        const double milliseconds = kFetReferenceCurveFirstMs
+            + kFetReferenceCurveStepMs * point;
+        const size_t index = static_cast<size_t>(
+            std::lround(milliseconds * sampleRate / 1000.0));
+        if (index >= reductionDb.size()) break;
+        const double difference = reductionDb[index] / measured.plateauGrDb
+            - reference[point];
+        sum += difference * difference;
+        ++used;
+    }
+    require(used == kFetReferenceCurvePoints,
+            "the whole reference curve window is inside the rendered attack");
+    return std::sqrt(sum / used);
+}
+
+double fetCurveRmsAgainstReference(const FetAttackMeasurement& measured,
+                                   const std::vector<double>& reductionDb,
+                                   double sampleRate, int driveIndex)
+{
+    return fetCurveRmsAgainstValues(
+        measured, reductionDb, sampleRate, kFetReferenceCurve[driveIndex]);
+}
+
+void testFetAttackMatchesReferenceCurve()
+{
+    // Diagnostics only -- see kFetReferenceCurve. Kept because the DIRECTION of
+    // the drive axis is the mechanism this law exists to fix, and the direction
+    // is legible in tau on the rows where the fit is well conditioned.
+    constexpr double referenceTauMs[5] = {4.918, 2.540, 1.729, 1.030, 0.724};
+    double worst = 0.0;
+    int worstDrive = -1;
+    double worstDeepPlateauError = 0.0;
+    double previousPlateau = -1.0e30;
+    for (int driveIndex = 0; driveIndex < 5; ++driveIndex)
+    {
+        std::vector<double> curve;
+        const auto measured = measureFetAttack(
+            kFetCurveDrivesDbfs[driveIndex], 0.5f, 0, 48000.0, &curve);
+        require(measured.plateauGrDb > previousPlateau,
+                "the drive axis really is a monotonically increasing reduction");
+        previousPlateau = measured.plateauGrDb;
+        const double rms = fetCurveRmsAgainstReference(measured, curve, 48000.0, driveIndex);
+        std::printf("FET attack curve: %+.0f dBFS plateau %.4f dB  curve RMS %.4f"
+                    "  (tau %s ms, x%.3f reference)\n",
+                    static_cast<double>(kFetCurveDrivesDbfs[driveIndex]),
+                    measured.plateauGrDb, rms,
+                    measured.fitted ? std::to_string(measured.tauMs).c_str() : "unfittable",
+                    measured.fitted ? measured.tauMs / referenceTauMs[driveIndex] : 0.0);
+        if (rms > worst) { worst = rms; worstDrive = driveIndex; }
+        if (driveIndex >= 2)
+            worstDeepPlateauError = std::max(
+                worstDeepPlateauError,
+                std::abs(measured.plateauGrDb - kFetReferencePlateauDb[driveIndex]));
+    }
+    std::printf("FET attack curve: worst %.4f at %+.0f dBFS, bound %.4f\n",
+                worst, static_cast<double>(kFetCurveDrivesDbfs[worstDrive]),
+                kFetCurveRmsBound);
+    require(worst <= kFetCurveRmsBound,
+            "every vintage FET drive point tracks the reference attack trajectory");
+
+    std::vector<double> fastCurve;
+    const auto fastMeasured = measureFetAttack(
+        -6.0f, 0.0f, 0, 48000.0, &fastCurve);
+    const double fastRms = fetCurveRmsAgainstValues(
+        fastMeasured, fastCurve, 48000.0, kFetFastAttackReferenceCurve);
+    std::printf("FET fast-Attack curve: -6 dBFS plateau %.4f dB  "
+                "curve RMS %.4f, bound %.4f\n",
+                fastMeasured.plateauGrDb, fastRms, kFetCurveRmsBound);
+    require(fastRms <= kFetCurveRmsBound,
+            "the vintage FET first-cycle colour tracks the complete fast-Attack reference curve");
+
+    std::printf("FET attack deep plateau: worst absolute error %.4f dB, bound 0.2000 dB\n",
+                worstDeepPlateauError);
+    require(worstDeepPlateauError <= 0.20,
+            "the vintage FET intermediate attack population reaches the measured deep plateau");
+}
+
+void testFetAttackAcceleratesWithDrive()
+{
+    // Direction, on the two shallowest and the two deepest measured drives.
+    // Before this law was corrected the same points read 1.777 / 2.804 /
+    // 4.885 ms at -30 / -18 / -6 dBFS -- monotonically SLOWER with drive, the
+    // exact inverse of the reference's 1.729 / 1.030 / 0.724 ms.
+    const auto shallow = measureFetAttack(-42.0f);
+    const auto light = measureFetAttack(-36.0f);
+    const auto middle = measureFetAttack(-18.0f);
+    require(shallow.fitted && light.fitted && middle.fitted,
+            "every well-conditioned vintage FET drive point yields an attack fit");
+    std::printf("FET attack vs drive: %.4f dB -> %.4f ms, %.4f dB -> %.4f ms, "
+                "%.4f dB -> %.4f ms\n",
+                shallow.plateauGrDb, shallow.tauMs, light.plateauGrDb, light.tauMs,
+                middle.plateauGrDb, middle.tauMs);
+    require(light.tauMs < shallow.tauMs && middle.tauMs < light.tauMs,
+            "vintage FET attack gets FASTER as drive deepens, as the reference does");
+    // Spacing, not absolute milliseconds. The reference spans 4.918 -> 1.030 ms
+    // over these three drives, a factor of 4.8; a law that merely tilted the
+    // sign by a percent would satisfy the ordering above.
+    const double span = shallow.tauMs / middle.tauMs;
+    std::printf("FET attack drive span: %.4f (reference 4.775)\n", span);
+    require(span > 3.0 && span < 8.0,
+            "the vintage FET attack drive axis spans the reference's factor of ~4.8");
+    // No bound is asserted at -6 dBFS and none should be: there the estimator's
+    // fit band collapses to a fraction of a millisecond and the fitted tau
+    // stops tracking the cell entirely. testFetAttackMatchesReferenceCurve
+    // gates that row, on the curve.
+}
+
+void testFetHighCarrierAttackKnobAxis()
+{
+    // The 1 kHz estimator has a 0.5 ms floor and cannot resolve the reference's
+    // fast half of the Attack knob. At 4 kHz the period is exactly 12 samples;
+    // the campaign estimator's synthetic self-check recovers 0.2--2.0 ms
+    // exponentials within 3.1 %. These live-reference taus therefore pin the
+    // low-knob region without retuning against the known 1 kHz dead zone.
+    struct Point
+    {
+        float driveDbfs;
+        float attackPosition;
+        double referenceTauMs;
+    };
+    constexpr std::array<Point, 7> points{{
+        {-30.0f, 0.00f, 2.873214},
+        {-18.0f, 0.00f, 1.665809},
+        { -6.0f, 0.00f, 1.320637},
+        {-30.0f, 0.25f, 2.364919},
+        {-18.0f, 0.25f, 1.457143},
+        {-30.0f, 0.50f, 1.737511},
+        {-30.0f, 1.00f, 0.188000},
+    }};
+    double worstRelativeError = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetAttack(
+            point.driveDbfs, point.attackPosition, 0, 48000.0,
+            nullptr, 4000.0);
+        require(measured.fitted,
+                "every selected 4 kHz FET attack-knob row yields a fit");
+        const double relativeError
+            = measured.tauMs / point.referenceTauMs - 1.0;
+        worstRelativeError = std::max(
+            worstRelativeError, std::abs(relativeError));
+        std::printf("FET 4 kHz attack knob: drive %+.0f position %.2f "
+                    "reference %.6f measured %.6f error %+.3f%%\n",
+                    static_cast<double>(point.driveDbfs),
+                    static_cast<double>(point.attackPosition),
+                    point.referenceTauMs, measured.tauMs,
+                    100.0 * relativeError);
+    }
+    std::printf("FET 4 kHz attack knob: worst relative tau error %.3f%%\n",
+                100.0 * worstRelativeError);
+    require(worstRelativeError < 0.25,
+            "vintage FET Attack knob follows the resolved 4 kHz reference axis");
+}
+
+void testFetStartupPeakSurface()
+{
+    // Whole-capture peaks from the installed-unit 1 kHz dynamics campaign.
+    // Every row uses the same -6 dBFS step, Input 0.8 and Output 0.625915527;
+    // only Attack or Ratio changes. The old harness printed this quantity but
+    // never asserted it, allowing 3.0--7.0 dB first-cycle errors to stay green.
+    struct Point
+    {
+        float attackPosition;
+        int ratioIndex;
+        double referencePeak;
+    };
+    constexpr std::array<Point, 7> points{{
+        {0.00f, 0, 3.040199757},
+        {0.50f, 0, 2.489228725},
+        {1.00f, 0, 0.911336124},
+        {0.50f, 1, 2.128107786},
+        {0.50f, 2, 1.832375646},
+        {0.50f, 3, 1.477138281},
+        {0.50f, 4, 2.583157301},
+    }};
+    double worstErrorDb = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetAttack(
+            -6.0f, point.attackPosition, point.ratioIndex);
+        const double errorDb = 20.0 * std::log10(
+            measured.outputPeak / point.referencePeak);
+        worstErrorDb = std::max(worstErrorDb, std::abs(errorDb));
+        std::printf("FET startup peak: attack %.2f ratio %d reference %.6f "
+                    "measured %.6f error %+.3f dB\n",
+                    static_cast<double>(point.attackPosition), point.ratioIndex,
+                    point.referencePeak, measured.outputPeak, errorDb);
+    }
+    std::printf("FET startup peak: worst absolute error %.3f dB\n",
+                worstErrorDb);
+    require(worstErrorDb < 0.75,
+            "vintage FET first-cycle peaks match the installed-unit surface");
+}
+
+void testFetStartupStateLifecycleAndCounterSaturation()
+{
+    constexpr std::array<float, 2> peaks{{0.25f, 0.75f}};
+    constexpr std::array<int, 2> poisonedActiveSamples{{7, 11}};
+    constexpr std::array<int, 2> poisonedSilentSamples{{13, 17}};
+    const auto poisonState = [&](MultiCompDSP& dsp) {
+        duskaudio::MultiCompDSPTestAccess::setFetStartupState(
+            dsp, peaks, poisonedActiveSamples, poisonedSilentSamples);
+    };
+    const auto requireCleared = [&](const MultiCompDSP& dsp,
+                                    const char* message) {
+        require(duskaudio::MultiCompDSPTestAccess::fetStartupStateIsClear(dsp),
+                message);
+    };
+
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, 48000.0, 64, 0.8f, 0.625915527f, 0);
+    dsp.prepare(48000.0, 64);
+
+    poisonState(dsp);
+    dsp.prepare(48000.0, 64);
+    requireCleared(dsp,
+        "repeated prepare clears both channels of FET startup peak/counter state");
+
+    poisonState(dsp);
+    dsp.reset();
+    requireCleared(dsp,
+        "reset clears both channels of FET startup peak/counter state");
+
+    poisonState(dsp);
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::VCA));
+    std::array<float, 64> input{};
+    std::array<float, 64> output{};
+    const float* inputs[] = {input.data()};
+    float* outputs[] = {output.data()};
+    dsp.processBlock(inputs, outputs, 1, 1);
+    requireCleared(dsp,
+        "leaving FET clears both channels of FET startup peak/counter state");
+
+    dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::FET));
+    dsp.reset();
+    poisonState(dsp);
+    dsp.setBypass(true);
+    input.fill(0.5f); // keep the startup state armed until bypass has settled
+    for (int block = 0; block < 32; ++block)
+        dsp.processBlock(inputs, outputs, 1, static_cast<int>(input.size()));
+    requireCleared(dsp,
+        "settled bypass clears both channels of FET startup peak/counter state");
+
+    constexpr int fullCorrectionSamples = 12;
+    constexpr int correctionEndSamples = 24;
+    int activeSamples = correctionEndSamples;
+    float worstPastWindowBlend = 0.0f;
+    for (int sample = 0; sample < 1000000; ++sample)
+        worstPastWindowBlend = std::max(
+            worstPastWindowBlend,
+            duskaudio::MultiCompDSPTestAccess::advanceFetStartupBlend(
+                activeSamples, fullCorrectionSamples,
+                correctionEndSamples));
+    std::printf("FET startup state: peak/counters clear prepare/reset/mode/bypass yes, "
+                "counter after 1000000 post-window samples %d, blend %.9g\n",
+                activeSamples, static_cast<double>(worstPastWindowBlend));
+    require(activeSamples == correctionEndSamples,
+        "FET startup active counter saturates at the correction-window end");
+    require(worstPastWindowBlend == 0.0f,
+        "FET startup blend stays exactly zero after the correction window");
+}
+
+// ---------------------------------------------------------------------------
+// Wave 20 neighbours for the base-rate startup peak ceiling.
+//
+// The ceiling adds the first per-channel state the vintage path has ever
+// carried in `MultiCompDSP` itself rather than in `MultiCompModes`: a
+// preallocated input-scratch buffer plus a running source peak, an active
+// counter and a silence counter. Every path that shares that state is
+// enumerated here. The stage is deliberately gated on Output position, runs
+// after the mid/side decode and follows the AUDIO input rather than the
+// sidechain, so each of those is asserted rather than assumed.
+struct FetStartupProbeConfig
+{
+    double sampleRate = 48000.0;
+    int blockSize = 256;
+    float outputPosition = 0.625915527f;
+    int oversampling = kOversampling2xSetting;
+    int ratio = 0;
+    float attackPosition = 0.0f;
+    float driveDbfs = -6.0f;
+    float sidechainDbfs = 0.0f;       // 0 == follow driveDbfs
+    int channels = 1;
+    bool inPlace = false;
+    float stereoLink = 100.0f;
+    bool externalSidechain = false;
+    double leadSilenceSeconds = 0.050;
+    double burstSeconds = 0.120;
+    double gapSeconds = 0.0;          // optional silent gap, then a second burst
+    double secondBurstSeconds = 0.0;
+};
+
+struct FetStartupProbeResult
+{
+    std::vector<float> left;
+    double firstBurstPeak = 0.0;      // |out| over the first 3 ms of burst one
+    double secondBurstPeak = 0.0;     // |out| over the first 3 ms of burst two
+    double settledPeak = 0.0;         // |out| over the last 20 ms of burst one
+};
+
+FetStartupProbeResult renderFetStartupProbe(const FetStartupProbeConfig& cfg)
+{
+    const double sr = cfg.sampleRate;
+    const int lead = static_cast<int>(std::lround(cfg.leadSilenceSeconds * sr));
+    const int burst = static_cast<int>(std::lround(cfg.burstSeconds * sr));
+    const int gap = static_cast<int>(std::lround(cfg.gapSeconds * sr));
+    const int burst2 = static_cast<int>(std::lround(cfg.secondBurstSeconds * sr));
+    const int total = lead + burst + gap + burst2;
+
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sr, cfg.blockSize, 0.8f, cfg.outputPosition,
+                        cfg.ratio);
+    dsp.setOversampling(cfg.oversampling);
+    dsp.setStereoLink(cfg.stereoLink);
+    dsp.setExternalSidechain(cfg.externalSidechain);
+    dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain,
+                     cfg.externalSidechain ? 1.0f : 0.0f);
+    dsp.setParameter(MultiCompDSP::Parameter::FetAttack,
+                     fetAttackPlain(cfg.attackPosition));
+    dsp.prepare(sr, cfg.blockSize);
+
+    const float amplitude = duskaudio::decibelsToGain(cfg.driveDbfs);
+    const float sidechainAmplitude = cfg.sidechainDbfs < 0.0f
+        ? duskaudio::decibelsToGain(cfg.sidechainDbfs) : amplitude;
+    const auto sourceAt = [&](int n) {
+        const bool active = (n >= lead && n < lead + burst)
+            || (burst2 > 0 && n >= lead + burst + gap);
+        if (! active) return 0.0f;
+        return amplitude * std::sin(2.0f * kPi * 1000.0f
+            * static_cast<float>(n) / static_cast<float>(sr));
+    };
+
+    const int nCh = cfg.channels;
+    std::vector<std::vector<float>> in(static_cast<size_t>(nCh),
+        std::vector<float>(static_cast<size_t>(cfg.blockSize)));
+    std::vector<std::vector<float>> out(static_cast<size_t>(nCh),
+        std::vector<float>(static_cast<size_t>(cfg.blockSize)));
+    std::vector<std::vector<float>> sc(static_cast<size_t>(nCh),
+        std::vector<float>(static_cast<size_t>(cfg.blockSize)));
+
+    FetStartupProbeResult result;
+    result.left.resize(static_cast<size_t>(total));
+    for (int offset = 0; offset < total; offset += cfg.blockSize)
+    {
+        const int count = std::min(cfg.blockSize, total - offset);
+        for (int ch = 0; ch < nCh; ++ch)
+            for (int s = 0; s < count; ++s)
+            {
+                in[static_cast<size_t>(ch)][static_cast<size_t>(s)]
+                    = sourceAt(offset + s);
+                sc[static_cast<size_t>(ch)][static_cast<size_t>(s)]
+                    = sourceAt(offset + s) * (sidechainAmplitude / amplitude);
+            }
+        std::vector<const float*> inputs(static_cast<size_t>(nCh));
+        std::vector<const float*> sidechains(static_cast<size_t>(nCh));
+        std::vector<float*> outputs(static_cast<size_t>(nCh));
+        for (int ch = 0; ch < nCh; ++ch)
+        {
+            inputs[static_cast<size_t>(ch)] = in[static_cast<size_t>(ch)].data();
+            sidechains[static_cast<size_t>(ch)]
+                = sc[static_cast<size_t>(ch)].data();
+            outputs[static_cast<size_t>(ch)] = cfg.inPlace
+                ? in[static_cast<size_t>(ch)].data()
+                : out[static_cast<size_t>(ch)].data();
+        }
+        if (cfg.externalSidechain)
+            dsp.processBlockExternal(inputs.data(), sidechains.data(),
+                                     outputs.data(), nCh, count);
+        else
+            dsp.processBlock(inputs.data(), outputs.data(), nCh, count);
+        std::copy_n(outputs[0], count,
+                    result.left.data() + offset);
+    }
+
+    const int latency = static_cast<int>(std::lround(
+        kFetCampaignLatencySamples48k * sr / 48000.0));
+    const auto peakOver = [&result, total](int from, int to) {
+        double peak = 0.0;
+        for (int n = std::max(0, from); n < std::min(total, to); ++n)
+            peak = std::max(peak, std::abs(
+                static_cast<double>(result.left[static_cast<size_t>(n)])));
+        return peak;
+    };
+    const int firstOnset = lead + latency;
+    // Measured over the correction window itself (0.5 ms), not a few
+    // milliseconds of it: outside that window the stage is inert by
+    // construction, and a wider window would let an uncorrected later sample
+    // mask a correction that never happened.
+    const int window = static_cast<int>(std::lround(0.0005 * sr));
+    result.firstBurstPeak = peakOver(firstOnset, firstOnset + window);
+    result.settledPeak = peakOver(lead + burst + latency
+                                      - static_cast<int>(std::lround(0.020 * sr)),
+                                  lead + burst + latency);
+    if (burst2 > 0)
+    {
+        const int secondOnset = lead + burst + gap + latency;
+        result.secondBurstPeak = peakOver(secondOnset, secondOnset + window);
+    }
+    return result;
+}
+
+double maximumDeltaOf(const std::vector<float>& a, const std::vector<float>& b)
+{
+    require(a.size() == b.size(), "startup neighbour renders are the same length");
+    double worst = 0.0;
+    for (size_t n = 0; n < a.size(); ++n)
+        worst = std::max(worst, std::abs(static_cast<double>(a[n])
+                                         - static_cast<double>(b[n])));
+    return worst;
+}
+
+void testFetStartupCeilingNeighbours()
+{
+    // 1. REACHABILITY, and the Output-position fade that protects the already
+    //    matched Output = 1.0 ceiling sweep. The stage changes the first-cycle
+    //    peak but never the settled level, so the peak-to-settled ratio isolates
+    //    it from the makeup gain the Output knob also moves. `outputControlBlend`
+    //    is 1.0 at or below position 0.625915527 and exactly 0 at or above 0.90.
+    // The stage's contract is an ABSOLUTE ceiling, so assert it as one. At
+    // -6 dBFS / Attack 0.00 / 4:1 the table target is 2.7164 and our
+    // uncorrected first-cycle peak is 5.954755 (measured on the stage-disabled
+    // diagnostic binary 28dd845b6adf), i.e. 2.19x the target -- so a stage that
+    // does not run, indexes the wrong cell, or ignores `startupBlend` cannot
+    // squeeze under the bound below. The soft knee passes
+    // `startupCeilingSlope` of the excess, which is why the bound is 1.20x and
+    // not 1.00x; the observed value is 1.119x.
+    //
+    // Deliberately NOT asserted by a peak/settled ratio across Output
+    // positions. That construction looks gain invariant and is not: above
+    // about -36 dBFS the vintage output stage compresses the first-cycle peak
+    // relative to the settled level as Output rises, even with this stage
+    // switched off, so the ratio moves for reasons that have nothing to do
+    // with the ceiling (measured: peak/settled 5.89 at Output 0.6259 against
+    // 3.38 at 0.90 for a -18 dBFS row whose peak never approaches the main
+    // 6.39712761 output ceiling).
+    constexpr double kCeilingTargetAtMinusSix = 2.7164;
+    constexpr double kCeilingTargetAtMinusThirty = 0.9677;
+    FetStartupProbeConfig base;
+    FetStartupProbeConfig atTarget = base;
+    atTarget.driveDbfs = -6.0f;
+    atTarget.attackPosition = 0.0f;
+    FetStartupProbeConfig faded = atTarget;
+    faded.outputPosition = 0.90f;
+    const auto atDefault = renderFetStartupProbe(atTarget);
+    const auto atHigh = renderFetStartupProbe(faded);
+    std::printf("FET startup neighbours: ceiling target %.4f  peak at Output "
+                "0.6259 %.6f (%.3fx)  peak at Output 0.90 %.6f (%.3fx)\n",
+                kCeilingTargetAtMinusSix, atDefault.firstBurstPeak,
+                atDefault.firstBurstPeak / kCeilingTargetAtMinusSix,
+                atHigh.firstBurstPeak,
+                atHigh.firstBurstPeak / kCeilingTargetAtMinusSix);
+    require(atDefault.settledPeak > 1.0e-3 && atHigh.settledPeak > 1.0e-3,
+            "startup neighbour programme actually produces signal");
+    require(atDefault.firstBurstPeak
+                < 1.20 * kCeilingTargetAtMinusSix,
+            "the startup ceiling is REACHED at the default Output position and "
+            "holds the first cycle at its measured target");
+    require(atHigh.firstBurstPeak > 1.50 * kCeilingTargetAtMinusSix,
+            "the startup ceiling is switched off at Output position 0.90, so "
+            "the already-matched Output = 1.0 ceiling sweep is untouched by "
+            "this stage");
+
+    // 2. Determinism neighbours. Each must be EXACTLY zero: the stage adds no
+    //    rate-dependent smoothing, so any block-boundary or state-carry defect
+    //    shows up as a non-zero delta rather than a small one.
+    FetStartupProbeConfig small = base;  small.blockSize = 64;
+    FetStartupProbeConfig large = base;  large.blockSize = 512;
+    const double blockDelta = maximumDeltaOf(
+        renderFetStartupProbe(small).left, renderFetStartupProbe(large).left);
+
+    FetStartupProbeConfig stereo = base; stereo.channels = 2;
+    const double monoStereoDelta = maximumDeltaOf(
+        atDefault.left, renderFetStartupProbe(stereo).left);
+
+    FetStartupProbeConfig inPlace = base; inPlace.inPlace = true;
+    const double inPlaceDelta = maximumDeltaOf(
+        atDefault.left, renderFetStartupProbe(inPlace).left);
+
+    FetStartupProbeConfig unlinked = base;
+    unlinked.channels = 2; unlinked.stereoLink = 0.0f;
+    FetStartupProbeConfig linked = base;
+    linked.channels = 2; linked.stereoLink = 100.0f;
+    const double linkDelta = maximumDeltaOf(
+        renderFetStartupProbe(unlinked).left, renderFetStartupProbe(linked).left);
+
+    // The external sidechain path is NOT bit-identical to the internal one even
+    // with the same programme on both -- that is a pre-existing property of the
+    // vintage gain staging, quantified below at Output 0.90 where this stage is
+    // switched off entirely (10.7 there against 4.9 with it on, so the stage
+    // narrows the difference rather than causing it).
+    //
+    // What must hold is WHICH input the ceiling reads. It runs after the audio
+    // reconstruction and takes its source peak from `fetStartupInput`, so with
+    // -6 dBFS audio it must keep the -6 dBFS target (2.7164) even when the
+    // sidechain is 24 dB quieter. Had it read the sidechain it would have
+    // selected the -30 dBFS row instead and clamped near 0.9677 -- a 9 dB
+    // difference, which is what makes this assertion able to fail.
+    FetStartupProbeConfig external = atTarget; external.externalSidechain = true;
+    FetStartupProbeConfig externalFaded = external;
+    externalFaded.outputPosition = 0.90f;
+    FetStartupProbeConfig quietSidechain = external;
+    quietSidechain.sidechainDbfs = -30.0f;
+    const auto externalRender = renderFetStartupProbe(external);
+    const auto quietScRender = renderFetStartupProbe(quietSidechain);
+    const double sidechainDelta = maximumDeltaOf(
+        atDefault.left, externalRender.left);
+    const double sidechainDeltaStageOff = maximumDeltaOf(
+        atHigh.left, renderFetStartupProbe(externalFaded).left);
+
+    std::printf("FET startup neighbours: block %.9g  mono/stereo %.9g  "
+                "in-place %.9g  link %.9g | external-SC delta %.6g "
+                "(stage off %.6g) first-cycle peak %.6f (%.3fx target)\n",
+                blockDelta, monoStereoDelta, inPlaceDelta, linkDelta,
+                sidechainDelta, sidechainDeltaStageOff,
+                quietScRender.firstBurstPeak,
+                quietScRender.firstBurstPeak / kCeilingTargetAtMinusSix);
+    require(blockDelta == 0.0,
+            "startup ceiling is identical for 64- and 512-sample blocks");
+    require(monoStereoDelta == 0.0,
+            "startup ceiling treats a mono render and the left channel of an "
+            "identical stereo render alike");
+    require(inPlaceDelta == 0.0,
+            "startup ceiling reads the preserved input scratch, not the "
+            "overwritten in-place output");
+    require(linkDelta == 0.0,
+            "startup ceiling is unchanged by the stereo link law for identical "
+            "channels");
+    // A quiet sidechain leaves the compressor barely working, so the raw first
+    // cycle arrives around 19.1 and the 10 % knee passes a large excess: the
+    // clamped result is target + 0.1 * (19.1 - target), not the target itself.
+    // That makes this a three-way discriminator, and all three outcomes are
+    // separated by the bounds below:
+    //   no ceiling at all        -> about 19.1   (7.03x)
+    //   target read from the SC  -> about  2.78  (1.02x)  [-30 dBFS row, 0.9677]
+    //   target read from audio   -> about  4.36  (1.60x)  [ -6 dBFS row, 2.7164]
+    require(quietScRender.firstBurstPeak > 1.25 * kCeilingTargetAtMinusSix
+                && quietScRender.firstBurstPeak
+                    < 2.00 * kCeilingTargetAtMinusSix,
+            "startup ceiling selects its target from the AUDIO input, not from "
+            "a 24 dB quieter external sidechain");
+
+    // 3. Lifecycle neighbours: prepare twice, reset, and a fresh instance must
+    //    all agree, and leaving and re-entering FET must clear the state.
+    {
+        MultiCompDSP twice;
+        prepareReferenceFet(twice, 48000.0, base.blockSize, 0.8f,
+                            base.outputPosition, 0);
+        twice.prepare(48000.0, base.blockSize);
+        twice.prepare(48000.0, base.blockSize);   // must be safe to repeat
+        std::array<float, 64> silence{};
+        const float* inputs[] = {silence.data()};
+        std::array<float, 64> scratch{};
+        float* outputs[] = {scratch.data()};
+        twice.processBlock(inputs, outputs, 1, 0);          // zero-sample block
+        twice.processBlock(inputs, outputs, 1, 64);
+        std::puts("FET startup neighbours: prepare-twice and zero-sample block "
+                  "survived");
+    }
+
+    // 4. Silence rearm. The stage zeroes its source peak and its active
+    //    counter after 2 ms of input below -60 dBFS, and without that a second
+    //    burst would arrive with `fetStartupActiveSamples` long past the end of
+    //    the correction window and get no correction at all. Half a second of
+    //    silence both rearms the stage and lets the detector release, so the
+    //    second burst presents the same uncorrected 5.95 first cycle as the
+    //    first one did -- if it is still held at the target, the stage rearmed.
+    FetStartupProbeConfig rearm = atTarget;
+    rearm.burstSeconds = 0.060; rearm.gapSeconds = 0.500;
+    rearm.secondBurstSeconds = 0.060;
+    const auto rearmed = renderFetStartupProbe(rearm);
+    std::printf("FET startup neighbours: rearm after 500 ms silence, first "
+                "%.6f (%.3fx target) second %.6f (%.3fx target)\n",
+                rearmed.firstBurstPeak,
+                rearmed.firstBurstPeak / kCeilingTargetAtMinusSix,
+                rearmed.secondBurstPeak,
+                rearmed.secondBurstPeak / kCeilingTargetAtMinusSix);
+    // The upper bound is the one that bites: a stage that failed to rearm would
+    // leave the second burst uncorrected at about 5.95 (2.19x). The lower bound
+    // only guards against a silent render -- half a second is not long enough
+    // for the detector to release fully, so the second burst legitimately
+    // presents a smaller raw first cycle than the first (observed 0.554x).
+    require(rearmed.secondBurstPeak > 0.25 * kCeilingTargetAtMinusSix
+                && rearmed.secondBurstPeak
+                    < 1.20 * kCeilingTargetAtMinusSix,
+            "the startup ceiling rearms after a silence longer than its 2 ms "
+            "threshold and holds the next burst's first cycle at the target");
+
+    // 5. Oversampling and sample rate. The stage runs at the base rate and its
+    //    window is expressed in seconds, so every combination must both run and
+    //    still hold the same absolute target; state sized for one rate and
+    //    reused at another, or a window that collapsed to nothing at 96 kHz,
+    //    would show up here as a lost correction.
+    for (const int oversampling : {kOversamplingOffSetting, kOversampling2xSetting,
+                                   kOversampling4xSetting})
+        for (const double rate : {44100.0, 48000.0, 96000.0})
+        {
+            FetStartupProbeConfig cell = atTarget;
+            cell.oversampling = oversampling; cell.sampleRate = rate;
+            const auto rendered = renderFetStartupProbe(cell);
+            std::printf("FET startup neighbours: oversampling %d rate %.0f "
+                        "first-cycle peak %.6f (%.3fx target)\n",
+                        oversampling, rate, rendered.firstBurstPeak,
+                        rendered.firstBurstPeak / kCeilingTargetAtMinusSix);
+            require(rendered.firstBurstPeak < 1.20 * kCeilingTargetAtMinusSix,
+                    "the startup ceiling holds its target at every "
+                    "oversampling setting and sample rate");
+        }
+
+    // 6. Mode exit/re-entry and settled bypass. Both clear the stage's state;
+    //    a leaked source peak would suppress the next burst's first cycle.
+    const auto renderThroughDetour = [&](bool useBypass) {
+        MultiCompDSP dsp;
+        prepareReferenceFet(dsp, 48000.0, base.blockSize, 0.8f,
+                            base.outputPosition, 0);
+        dsp.setParameter(MultiCompDSP::Parameter::FetAttack,
+                         fetAttackPlain(base.attackPosition));
+        dsp.prepare(48000.0, base.blockSize);
+        std::vector<float> in(static_cast<size_t>(base.blockSize));
+        std::vector<float> out(static_cast<size_t>(base.blockSize));
+        const float amplitude = duskaudio::decibelsToGain(base.driveDbfs);
+        // Drive it hot so the stage is armed and charged, then detour.
+        for (int block = 0; block < 40; ++block)
+        {
+            for (int s = 0; s < base.blockSize; ++s)
+                in[static_cast<size_t>(s)] = amplitude * std::sin(
+                    2.0f * kPi * 1000.0f
+                    * static_cast<float>(block * base.blockSize + s) / 48000.0f);
+            const float* inputs[] = {in.data()};
+            float* outputs[] = {out.data()};
+            dsp.processBlock(inputs, outputs, 1, base.blockSize);
+        }
+        if (useBypass)
+        {
+            dsp.setBypass(true);
+            for (int block = 0; block < 400; ++block)
+            {
+                std::fill(in.begin(), in.end(), 0.0f);
+                const float* inputs[] = {in.data()};
+                float* outputs[] = {out.data()};
+                dsp.processBlock(inputs, outputs, 1, base.blockSize);
+            }
+            dsp.setBypass(false);
+        }
+        else
+        {
+            dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::VCA));
+            for (int block = 0; block < 400; ++block)
+            {
+                std::fill(in.begin(), in.end(), 0.0f);
+                const float* inputs[] = {in.data()};
+                float* outputs[] = {out.data()};
+                dsp.processBlock(inputs, outputs, 1, base.blockSize);
+            }
+            dsp.setMode(static_cast<int>(duskaudio::MultiCompMode::FET));
+        }
+        dsp.reset();
+        // Now the same programme a fresh instance would see.
+        const int lead = static_cast<int>(std::lround(0.050 * 48000.0));
+        const int burstSamples = static_cast<int>(std::lround(0.120 * 48000.0));
+        std::vector<float> rendered(static_cast<size_t>(lead + burstSamples));
+        for (int offset = 0; offset < lead + burstSamples;
+             offset += base.blockSize)
+        {
+            const int count = std::min(base.blockSize,
+                                       lead + burstSamples - offset);
+            for (int s = 0; s < count; ++s)
+            {
+                const int n = offset + s;
+                in[static_cast<size_t>(s)] = n < lead ? 0.0f
+                    : amplitude * std::sin(2.0f * kPi * 1000.0f
+                        * static_cast<float>(n) / 48000.0f);
+            }
+            const float* inputs[] = {in.data()};
+            float* outputs[] = {out.data()};
+            dsp.processBlock(inputs, outputs, 1, count);
+            std::copy_n(out.data(), count, rendered.data() + offset);
+        }
+        return rendered;
+    };
+    FetStartupProbeConfig freshCfg = base;
+    freshCfg.leadSilenceSeconds = 0.050; freshCfg.burstSeconds = 0.120;
+    const auto freshRender = renderFetStartupProbe(freshCfg).left;
+    const double modeDelta = maximumDeltaOf(freshRender, renderThroughDetour(false));
+    const double bypassDelta = maximumDeltaOf(freshRender, renderThroughDetour(true));
+    std::printf("FET startup neighbours: FET->VCA->FET+reset %.9g  "
+                "settled-bypass+reset %.9g\n", modeDelta, bypassDelta);
+    require(modeDelta == 0.0,
+            "leaving and re-entering FET leaves no startup ceiling state behind");
+    require(bypassDelta == 0.0,
+            "a settled bypass leaves no startup ceiling state behind");
+}
+
+// ---------------------------------------------------------------------------
+// Vintage-FET broadband H2 surface (`fetBroadbandK2`).
+//
+// The table is indexed by the value `processFET` computes per sample as
+// `-gainToDecibels(envelope + 0.001f)` -- NOT by the settled output-referred
+// reduction the campaign's render probes report, and not by the published
+// meter. The +0.001 offset alone costs 0.087 dB at 20 dB of reduction, and the
+// envelope ripples with the programme, so a fit performed in any other
+// coordinate lands its anchors in the wrong segment. Wave 7b's coordinate
+// artifact was exactly this class of error in a different table; this harness
+// exists so the H2 fit is done in the coordinate the code consumes.
+struct FetHarmonicMeasurement
+{
+    double reductionDbMean = 0.0;   // the fetBroadbandK2 argument, window mean
+    double reductionDbMin = 0.0;
+    double reductionDbMax = 0.0;
+    double h1Dbfs = 0.0;
+    double h2Dbfs = 0.0;
+    double h3Dbfs = 0.0;
+    double h5Dbfs = 0.0;
+    double h2RelativeDb = 0.0;
+    // The COMPLEX second-harmonic amplitude, same DFT and normalisation as
+    // h2Dbfs. Wave 9 needs it because the vintage FET's 2f output is the sum of
+    // two contributions -- `k2 * h2` (broadband) and `lowFrequencyK2 *
+    // colourLowH2` (the 250 Hz two-pole path) -- which at 100 Hz arrive nearly
+    // in QUADRATURE: the two-pole low pass shifts by -21.8 deg per pole there,
+    // and squaring doubles that to -87 deg. A magnitude-only reading cannot
+    // separate them, and inverting for the coefficient one of them needs is a
+    // complex problem, not a scalar one. h1 is carried for the same reason: the
+    // relative measure the campaign scores is h2 referred to it.
+    double h1Real = 0.0, h1Imag = 0.0;
+    double h2Real = 0.0, h2Imag = 0.0;
+    double h3Real = 0.0, h3Imag = 0.0;
+    double h5Real = 0.0, h5Imag = 0.0;
+};
+
+// Renders one settled sine through the vintage FET in process. The default
+// 3.0-4.5 s coherent-DFT window matches `harmonic_levels`; callers can select
+// the campaign's longer 9.0-10.5 s convergence window. The block size is
+// deliberately coprime with the 1 kHz period at 48 kHz (48 samples) so the
+// envelope samples walk every phase of the detector ripple instead of aliasing
+// onto three of them.
+FetHarmonicMeasurement measureFetHarmonics(double frequencyHz, float inputDbfs,
+                                           float inputPosition, int ratio = 0,
+                                           double sampleRate = 48000.0,
+                                           int blockSize = 13,
+                                           double totalSeconds = 5.0,
+                                           double measureStartSeconds = 3.0,
+                                           double measureStopSeconds = 4.5,
+                                           float releasePosition = 0.5f)
+{
+    const int totalSamples = static_cast<int>(
+        std::lround(totalSeconds * sampleRate));
+    const int measureStart = static_cast<int>(
+        std::lround(measureStartSeconds * sampleRate));
+    const int measureStop = static_cast<int>(
+        std::lround(measureStopSeconds * sampleRate));
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize,
+                        inputPosition, 0.625915527f, ratio);
+    dsp.setParameter(MultiCompDSP::Parameter::FetRelease,
+                     fetReleasePlain(releasePosition));
+    std::vector<float> input(static_cast<size_t>(blockSize));
+    std::vector<float> output(static_cast<size_t>(blockSize));
+    const double amplitude = duskaudio::decibelsToGain(inputDbfs);
+    double realPart[5] = {0.0, 0.0, 0.0, 0.0, 0.0};
+    double imagPart[5] = {0.0, 0.0, 0.0, 0.0, 0.0};
+    double reductionSum = 0.0;
+    double reductionMin = std::numeric_limits<double>::max();
+    double reductionMax = -std::numeric_limits<double>::max();
+    int reductionCount = 0;
+    int measured = 0;
+    for (int offset = 0; offset < totalSamples; offset += blockSize)
+    {
+        const int count = std::min(blockSize, totalSamples - offset);
+        for (int sample = 0; sample < count; ++sample)
+            input[static_cast<size_t>(sample)] = static_cast<float>(
+                amplitude * std::sin(2.0 * duskaudio::kDuskPi * frequencyHz
+                    * static_cast<double>(offset + sample) / sampleRate));
+        const float* inputs[] = {input.data()};
+        float* outputs[] = {output.data()};
+        dsp.processBlock(inputs, outputs, 1, count);
+        for (int sample = 0; sample < count; ++sample)
+        {
+            const int absolute = offset + sample;
+            if (absolute < measureStart || absolute >= measureStop)
+                continue;
+            const double value = output[static_cast<size_t>(sample)];
+            for (int harmonic = 0; harmonic < 5; ++harmonic)
+            {
+                const double phase = 2.0 * duskaudio::kDuskPi * frequencyHz
+                    * static_cast<double>(harmonic + 1)
+                    * static_cast<double>(absolute) / sampleRate;
+                realPart[harmonic] += value * std::cos(phase);
+                imagPart[harmonic] -= value * std::sin(phase);
+            }
+            ++measured;
+        }
+        if (offset + count > measureStart && offset < measureStop)
+        {
+            const float envelope = duskaudio::decibelsToGain(
+                duskaudio::MultiCompDSPTestAccess::fetEnvelopeGainDb(dsp, 0));
+            const double reduction = -static_cast<double>(
+                duskaudio::gainToDecibels(envelope + 0.001f));
+            reductionSum += reduction;
+            reductionMin = std::min(reductionMin, reduction);
+            reductionMax = std::max(reductionMax, reduction);
+            ++reductionCount;
+        }
+    }
+    require(measured == measureStop - measureStart && reductionCount > 0,
+            "FET harmonic render measures exactly the requested coherent window");
+    FetHarmonicMeasurement result;
+    result.reductionDbMean = reductionSum / static_cast<double>(reductionCount);
+    result.reductionDbMin = reductionMin;
+    result.reductionDbMax = reductionMax;
+    const auto levelDb = [measured](double re, double im) {
+        const double magnitude = 2.0 * std::hypot(re, im)
+            / static_cast<double>(measured);
+        return 20.0 * std::log10(std::max(magnitude, 1.0e-30));
+    };
+    result.h1Dbfs = levelDb(realPart[0], imagPart[0]);
+    result.h2Dbfs = levelDb(realPart[1], imagPart[1]);
+    result.h3Dbfs = levelDb(realPart[2], imagPart[2]);
+    result.h5Dbfs = levelDb(realPart[4], imagPart[4]);
+    result.h2RelativeDb = result.h2Dbfs - result.h1Dbfs;
+    const double scale = 2.0 / static_cast<double>(measured);
+    result.h1Real = realPart[0] * scale;
+    result.h1Imag = imagPart[0] * scale;
+    result.h2Real = realPart[1] * scale;
+    result.h2Imag = imagPart[1] * scale;
+    result.h3Real = realPart[2] * scale;
+    result.h3Imag = imagPart[2] * scale;
+    result.h5Real = realPart[4] * scale;
+    result.h5Imag = imagPart[4] * scale;
+    return result;
+}
+
+struct FetDetectorMeasurement
+{
+    double reductionDbMean = 0.0;
+    double reductionDbMinimum = 0.0;
+    double reductionDbMaximum = 0.0;
+};
+
+// Null-method diagnostic for the vintage detector's private transformer path.
+// The ordinary render and the external-sidechain render receive the same sine
+// as audio and detector input. Their audio path is therefore identical. The
+// only intended difference is at processFET's detector selection: internal
+// reads inputTransformerFet, external reads the raw prepared sidechain. Reading
+// the mode envelope directly avoids attributing GR-dependent audio coloration
+// or harmonic energy to the detector.
+FetDetectorMeasurement measureFetDetectorTransformer(
+    double frequencyHz, float inputDbfs, float inputPosition,
+    bool external, double sampleRate)
+{
+    constexpr int blockSize = 1;
+    const int totalSamples = static_cast<int>(std::lround(12.0 * sampleRate));
+    const int measureStart = static_cast<int>(std::lround(9.0 * sampleRate));
+    const int measureStop = static_cast<int>(std::lround(10.5 * sampleRate));
+    MultiCompDSP dsp;
+    prepareReferenceFet(dsp, sampleRate, blockSize,
+                        inputPosition, 0.625915527f, 0);
+    dsp.setParameter(MultiCompDSP::Parameter::ExternalSidechain,
+                     external ? 1.0f : 0.0f);
+    const double amplitude = duskaudio::decibelsToGain(inputDbfs);
+    double reductionSum = 0.0;
+    double reductionMinimum = std::numeric_limits<double>::max();
+    double reductionMaximum = -std::numeric_limits<double>::max();
+    int measured = 0;
+    float input = 0.0f;
+    float output = 0.0f;
+    for (int sample = 0; sample < totalSamples; ++sample)
+    {
+        input = static_cast<float>(amplitude * std::sin(
+            2.0 * duskaudio::kDuskPi * frequencyHz
+            * static_cast<double>(sample) / sampleRate));
+        const float* inputs[] = {&input};
+        float* outputs[] = {&output};
+        if (external)
+        {
+            const float* sidechains[] = {&input};
+            dsp.processBlockExternal(inputs, sidechains, outputs, 1, 1);
+        }
+        else
+            dsp.processBlock(inputs, outputs, 1, 1);
+        if (sample < measureStart || sample >= measureStop)
+            continue;
+        const double reduction = -static_cast<double>(
+            duskaudio::MultiCompDSPTestAccess::fetEnvelopeGainDb(dsp, 0));
+        reductionSum += reduction;
+        reductionMinimum = std::min(reductionMinimum, reduction);
+        reductionMaximum = std::max(reductionMaximum, reduction);
+        ++measured;
+    }
+    require(measured == measureStop - measureStart,
+            "FET detector null measures exactly the campaign 9.0-10.5 second window");
+    return {reductionSum / static_cast<double>(measured),
+            reductionMinimum, reductionMaximum};
+}
+
+void reportFetDetectorFrequencyNull()
+{
+    std::puts("FET detector transformer null (external raw minus internal transformed GR):");
+    for (double sampleRate : {48000.0, 96000.0})
+        for (double frequencyHz : {40.0, 60.0, 100.0, 1000.0,
+                                   15900.0, 16000.0, 16100.0})
+            for (const auto point : {std::array<float, 2>{{0.6f, -30.0f}},
+                                     std::array<float, 2>{{0.8f, -18.0f}}})
+            {
+                const auto internal = measureFetDetectorTransformer(
+                    frequencyHz, point[1], point[0], false, sampleRate);
+                const auto external = measureFetDetectorTransformer(
+                    frequencyHz, point[1], point[0], true, sampleRate);
+                std::printf("  rate %.0f f %7.1f i%.1f src %+.0f: "
+                            "internal %.7f [%.7f %.7f] external %.7f "
+                            "[%.7f %.7f] delta %+.7f dB\n",
+                            sampleRate, frequencyHz,
+                            static_cast<double>(point[0]),
+                            static_cast<double>(point[1]),
+                            internal.reductionDbMean,
+                            internal.reductionDbMinimum,
+                            internal.reductionDbMaximum,
+                            external.reductionDbMean,
+                            external.reductionDbMinimum,
+                            external.reductionDbMaximum,
+                            external.reductionDbMean - internal.reductionDbMean);
+            }
+}
+
+// Diagnostic grid: places every campaign harmonic row on the `fetBroadbandK2`
+// axis and reports what the in-process DSP produces there. Not gated -- the
+// gate is testFetBroadbandHarmonicSurface below.
+void reportFetBroadbandK2Surface()
+{
+    std::puts("FET broadband H2 surface (in-process, fetBroadbandK2 coordinate):");
+    for (double frequency : {1000.0, 100.0})
+        for (float inputPosition : {0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f,
+                                    0.9f, 1.0f})
+            // -45 and -15 dBFS are Wave 9 additions, and only the reduction
+            // axis motivates them: at 100 Hz the knob/level product jumps from
+            // 1.39 to 2.58 dB of reduction with nothing between, and from 4.97
+            // to 6.92, which are the two steepest stretches of the
+            // low-frequency colour law. Leaving a segment sampled only at its
+            // edges is the exact hole Wave 8 found in `fetBroadbandK2`.
+            for (float level : {-48.0f, -46.0f, -45.0f, -42.0f, -36.0f,
+                                -30.0f, -24.0f, -18.0f, -15.0f, -12.0f, -9.0f,
+                                -7.5f, -6.0f})
+            {
+                const auto measured = measureFetHarmonics(
+                    frequency, level, inputPosition);
+                // The complex H1/H2 tail is appended, never inserted: the
+                // campaign probe parses this line with a prefix-anchored
+                // regular expression, so growing the right-hand end is safe and
+                // reordering the left-hand end is not.
+                std::printf("  %6.0f Hz i%.2f src %+6.1f dBFS: gr %8.4f dB "
+                            "[%8.4f %8.4f] H1 %+10.5f H2 %+10.5f H2rel %+10.5f "
+                            "H3rel %+10.5f H2re %+.9e H2im %+.9e "
+                            "H1re %+.9e H1im %+.9e H3re %+.9e H3im %+.9e "
+                            "H5re %+.9e H5im %+.9e H5rel %+10.5f\n",
+                            frequency, static_cast<double>(inputPosition),
+                            static_cast<double>(level),
+                            measured.reductionDbMean, measured.reductionDbMin,
+                            measured.reductionDbMax, measured.h1Dbfs,
+                            measured.h2Dbfs, measured.h2RelativeDb,
+                            measured.h3Dbfs - measured.h1Dbfs,
+                            measured.h2Real, measured.h2Imag,
+                            measured.h1Real, measured.h1Imag,
+                            measured.h3Real, measured.h3Imag,
+                            measured.h5Real, measured.h5Imag,
+                            measured.h5Dbfs - measured.h1Dbfs);
+            }
+}
+
+// Wave 9 doubt #4 (wave3f_validation.md section 8.4). The drive-axis fitted
+// attack tau at -6 dBFS moved 3.2314 -> 3.6174 ms under Wave 8's colour-only
+// change while the gated curve RMS moved 3e-04. Either the added 2f content
+// perturbs the DEMODULATED envelope the estimator reads -- a measurement-side
+// artefact of a diagnostic -- or the internal gain-reduction trajectory really
+// moved, which would break Wave 8's isolation claim.
+//
+// This dumps the internal trajectory itself: `d.envelope` in dB, read straight
+// off the mode state, one sample per block with blockSize 1, over the same
+// window the estimator fits. Run it on two builds and diff. The whole point is
+// that it does NOT go through the demodulator, so it cannot share its artefact.
+void reportFetEnvelopeTrace()
+{
+    constexpr double sampleRate = 48000.0;
+    constexpr double quietSeconds = 1.0;
+    constexpr double traceSeconds = 0.060;
+    constexpr double carrierHz = 1000.0;
+    // The drive-axis row in question, with the campaign's controls: input knob
+    // 0.8, attack 0.5, 4:1, a phase-continuous burst after a -72 dBFS carrier.
+    for (float driveDbfs : {-6.0f, -18.0f, -30.0f})
+    {
+        MultiCompDSP dsp;
+        prepareReferenceFet(dsp, sampleRate, 1, 0.8f, 0.625915527f, 0);
+        dsp.setParameter(MultiCompDSP::Parameter::FetAttack, fetAttackPlain(0.5f));
+        const float quietAmplitude = duskaudio::decibelsToGain(-72.0f);
+        const float loudAmplitude = duskaudio::decibelsToGain(driveDbfs);
+        const int loudFrom = static_cast<int>(std::lround(quietSeconds * sampleRate));
+        const int totalSamples = loudFrom
+            + static_cast<int>(std::lround(traceSeconds * sampleRate));
+        float left = 0.0f, right = 0.0f, outLeft = 0.0f, outRight = 0.0f;
+        // FNV-1a over the raw bit patterns, so a one-ULP move is a different
+        // digest. Sampled values are printed alongside for human reading.
+        std::uint64_t digest = 1469598103934665603ull;
+        double outputPeak = 0.0;
+        for (int n = 0; n < totalSamples; ++n)
+        {
+            const float value = (n < loudFrom ? quietAmplitude : loudAmplitude)
+                * std::sin(2.0f * kPi * static_cast<float>(carrierHz)
+                    * static_cast<float>(n) / static_cast<float>(sampleRate));
+            left = right = value;
+            const float* inputs[] = {&left, &right};
+            float* outputs[] = {&outLeft, &outRight};
+            dsp.processBlock(inputs, outputs, 2, 1);
+            outputPeak = std::max(outputPeak,
+                std::max(std::abs(static_cast<double>(outLeft)),
+                         std::abs(static_cast<double>(outRight))));
+            if (n < loudFrom) continue;
+            const float envelopeDb
+                = duskaudio::MultiCompDSPTestAccess::fetEnvelopeGainDb(dsp, 0);
+            std::uint32_t bits;
+            std::memcpy(&bits, &envelopeDb, sizeof(bits));
+            for (int byte = 0; byte < 4; ++byte)
+            {
+                digest ^= (bits >> (byte * 8)) & 0xffu;
+                digest *= 1099511628211ull;
+            }
+            const int elapsed = n - loudFrom;
+            for (double milliseconds : {0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 40.0})
+                if (elapsed == static_cast<int>(std::lround(
+                        milliseconds * sampleRate / 1000.0)))
+                    std::printf("  ENVTRACE drive %+.0f dBFS t %6.2f ms "
+                                "envelope %+.9f dB\n",
+                                static_cast<double>(driveDbfs), milliseconds,
+                                static_cast<double>(envelopeDb));
+        }
+        std::printf("  ENVTRACE drive %+.0f dBFS digest %016llx samples %d "
+                    "output peak %.9f\n",
+                    static_cast<double>(driveDbfs),
+                    static_cast<unsigned long long>(digest),
+                    static_cast<int>(std::lround(traceSeconds * sampleRate)),
+                    outputPeak);
+    }
+}
+
+void testFetBroadbandHarmonicSurface()
+{
+    // Six absolute anchors on the reference unit's own 1 kHz second harmonic,
+    // one per region of `fetBroadbandK2`, rendered from the installed AU by
+    // `probe_h2_surface.py` (campaign reference_comparison_1176) and quoted
+    // here as H2 relative to the fundamental, which is scalar-immune: a gain
+    // error anywhere in the chain cancels out of the ratio, so this measures
+    // the colour law and nothing else.
+    //
+    // Two of the six sit where NOTHING previously looked. The campaign's
+    // sixteen-row harmonic grid reaches only eight distinct reduction depths,
+    // four of them zero, so three of the old table's seven segments held no
+    // measured point at all -- and the interior of the widest of them read
+    // 5.14 dB high. `probe_h2_surface.py` is the VST3-level guard on the dense
+    // axis; these are its in-process mirror at the depths that matter.
+    struct Point
+    {
+        float inputPosition;
+        float inputDbfs;
+        double reductionDb;              // the fetBroadbandK2 argument
+        double referenceH2RelativeDb;
+        double previousErrorDb;          // what the pre-Wave-8 table read here
+    };
+    constexpr std::array<Point, 6> points{{
+        {0.2f, -36.0f,  -0.009, -83.991595, -0.2590},
+        {0.4f, -30.0f,   0.557, -65.114341, -1.3251},
+        {0.8f, -36.0f,   8.984, -65.319662, +3.1241},
+        {0.6f, -24.0f,  12.800, -61.448271, +5.1379},
+        {0.8f, -24.0f,  18.864, -54.794383, +3.7694},
+        {0.8f, -12.0f,  28.663, -43.927124, -0.4908}}};
+
+    // Set by what it has to catch, not by taste. The table this replaced read
+    // 5.14 dB high at the fourth point and 3.77 at the fifth; the campaign's
+    // own harmonic gate is 1.0 dB. 0.35 dB is 14x under the worst defect, 2.9x
+    // under the campaign gate, and 3.5x over the worst error this build
+    // actually produces anywhere on the 39-row 1 kHz surface (0.262 dB).
+    constexpr double kBoundDb = 0.35;
+    double worstError = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetHarmonics(
+            1000.0, point.inputDbfs, point.inputPosition);
+        const double error = measured.h2RelativeDb - point.referenceH2RelativeDb;
+        worstError = std::max(worstError, std::abs(error));
+        // The reduction is checked too: these anchors are only meaningful at
+        // the depth they were measured at, so a change that moved the detector
+        // must fail here rather than silently re-point the assertion.
+        std::printf("FET H2 surface: i%.1f %+.0f dBFS gr %.4f (expected %.3f) "
+                    "reference %.6f measured %.6f error %+.6f dB "
+                    "(previous table %+.4f)\n",
+                    static_cast<double>(point.inputPosition),
+                    static_cast<double>(point.inputDbfs),
+                    measured.reductionDbMean, point.reductionDb,
+                    point.referenceH2RelativeDb, measured.h2RelativeDb, error,
+                    point.previousErrorDb);
+        require(std::abs(measured.reductionDbMean - point.reductionDb) < 0.02,
+                "vintage FET H2 anchors are evaluated at the reduction they were measured at");
+    }
+    std::printf("FET H2 surface: worst %+.6f dB over %zu anchors (bound %.2f)\n",
+                worstError, points.size(), kBoundDb);
+    require(worstError < kBoundDb,
+            "vintage FET broadband H2 matches the measured reference across the reduction axis");
+}
+
+void testFetBroadbandOddHarmonicSurface()
+{
+    // Absolute anchors on the installed reference unit's 1 kHz third
+    // harmonic, rendered by `probe_h2_surface.py` and quoted relative to each
+    // row's own fundamental.  The ten rows span every region of the measured
+    // reduction-dependent cubic law; all sit above the campaign's -92 dBc
+    // harmonic floor.
+    struct Point
+    {
+        float inputPosition;
+        float inputDbfs;
+        double reductionDb;              // the broadband cubic argument
+        double referenceH3RelativeDb;
+        double previousErrorDb;          // the constant -0.006 law
+    };
+    constexpr std::array<Point, 10> points{{
+        {0.2f, -18.0f,  0.3543, -83.185967, +2.4514},
+        {0.8f, -48.0f,  1.0175, -78.547980, +1.5210},
+        {0.4f, -24.0f,  3.1457, -72.965816, +0.9981},
+        {0.4f, -18.0f,  7.7089, -68.541805, +0.3595},
+        {1.0f, -36.0f, 10.0089, -67.305299, +0.4806},
+        {0.8f, -30.0f, 13.9253, -66.683950, +1.9392},
+        {0.8f, -24.0f, 18.8564, -67.067362, +3.7122},
+        {0.8f, -18.0f, 23.7855, -67.007091, +5.1897},
+        {0.8f, -12.0f, 28.6512, -66.239258, +6.1158},
+        {0.8f,  -6.0f, 33.4397, -65.841835, +7.5232}}};
+
+    // The fitted table predicts 0.090 dB worst over all 36 scoreable dense
+    // rows. 0.25 dB leaves 0.16 dB for render/fit error, is 4x tighter than the
+    // campaign harmonic gate, and is 30x below the defect this test guards.
+    constexpr double kBoundDb = 0.25;
+    double worstError = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetHarmonics(
+            1000.0, point.inputDbfs, point.inputPosition,
+            0, 48000.0, 13, 5.0, 3.0, 4.5, 0.66595459f);
+        const double relativeDb = measured.h3Dbfs - measured.h1Dbfs;
+        const double error = relativeDb - point.referenceH3RelativeDb;
+        worstError = std::max(worstError, std::abs(error));
+        std::printf("FET H3 surface: i%.1f %+.0f dBFS gr %.4f (expected %.4f) "
+                    "reference %.6f measured %.6f error %+.6f dB "
+                    "(constant cubic %+.4f)\n",
+                    static_cast<double>(point.inputPosition),
+                    static_cast<double>(point.inputDbfs),
+                    measured.reductionDbMean, point.reductionDb,
+                    point.referenceH3RelativeDb, relativeDb, error,
+                    point.previousErrorDb);
+        require(std::abs(measured.reductionDbMean - point.reductionDb) < 0.02,
+                "vintage FET H3 anchors are evaluated at the reduction they were measured at");
+    }
+    std::printf("FET H3 surface: worst %+.6f dB over %zu anchors (bound %.2f)\n",
+                worstError, points.size(), kBoundDb);
+    require(worstError < kBoundDb,
+            "vintage FET broadband H3 matches the measured reference across the reduction axis");
+}
+
+void testFetDenseShallowLowFrequencyH3()
+{
+    // Wave 25's long-window quarter-dB sweep resolved a shallow 100 Hz H3
+    // discontinuity that the sparse anchor grid cannot see. Wave 31 corrected
+    // the net transfer knee after the colour stage, so H3/H1 is deliberately
+    // unchanged and this is the red gate for re-keying only the shallow T3
+    // lookup coordinate. All 33 reference rows are above the -92 dBc floor;
+    // phase is H3 normalised to the measured H1 phase in the retained UAD WAVs.
+    constexpr std::array<double, 33> referenceH3RelativeDb{{
+        -87.5355661498, -87.0345848794, -86.5351668744,
+        -86.0312293496, -85.5273531539, -85.0280479681,
+        -84.5333143309, -84.0341295974, -83.5338373029,
+        -83.0330680840, -82.5339559301, -82.0337489982,
+        -81.5355197908, -81.0348656644, -80.5314591569,
+        -79.8022302194, -78.4827434384, -76.7603074239,
+        -74.9308655682, -73.1561258963, -71.5103369991,
+        -70.0956033502, -68.8039456730, -67.6385917602,
+        -66.5862012345, -65.6257125540, -64.7530959602,
+        -63.9492703885, -63.2050707290, -62.4919866483,
+        -61.8479698190, -61.2448072109, -60.6779950280,
+    }};
+    constexpr std::array<double, 33> referenceH3PhaseDegrees{{
+        164.574386210, 164.568754298, 164.587209264,
+        164.583462881, 164.555582900, 164.581018951,
+        164.559148355, 164.563333155, 164.565172531,
+        164.564831551, 164.567394428, 164.581083527,
+        164.567890256, 164.565486682, 162.609175403,
+        151.692183566, 137.444247340, 125.704337058,
+        116.545006349, 109.996295484, 105.443832946,
+        101.992914880, 99.447364997, 97.455138422,
+        95.971594935, 94.726141534, 93.789663654,
+        93.000992621, 92.347180306, 91.808287130,
+        91.337563273, 90.975973893, 90.682247744,
+    }};
+    // Wave 31 disabled-cell controls. The complex H3 correction must not move
+    // the detector coordinate, fundamental, H2, or H5 while closing H3.
+    constexpr std::array<double, 33> baselineRawReductionDb{{
+        0.029716000, 0.048177000, 0.070274000, 0.096058000,
+        0.125481000, 0.158561000, 0.195368000, 0.235742000,
+        0.279877000, 0.327532000, 0.378935000, 0.434012000,
+        0.492733000, 0.555186000, 0.621030000, 0.691084000,
+        0.764184000, 0.841293000, 0.922006000, 1.006012000,
+        1.094495000, 1.186523000, 1.280972000, 1.380174000,
+        1.483288000, 1.589177000, 1.698991000, 1.812978000,
+        1.930353000, 2.050711000, 2.175596000, 2.330144000,
+        2.523558000,
+    }};
+    constexpr std::array<double, 33> baselineH1Dbfs{{
+        -22.517646519, -22.267776115, -22.017924806, -21.768063099,
+        -21.518243558, -21.268396665, -21.018562962, -20.768732336,
+        -20.518977564, -20.269160613, -20.019358791, -19.769581424,
+        -19.519810191, -19.270195905, -19.028065592, -18.823623932,
+        -18.647961145, -18.492946606, -18.353784838, -18.225785490,
+        -18.108660738, -17.993383887, -17.886011202, -17.784177402,
+        -17.686316849, -17.593147310, -17.501647061, -17.413560609,
+        -17.328535586, -17.238455408, -17.158407652, -17.079629548,
+        -17.003295320,
+    }};
+    constexpr std::array<double, 33> baselineH2RelativeDb{{
+        -68.176862518, -67.919736609, -67.661408400, -67.401899067,
+        -67.141503189, -66.880034702, -66.617654179, -66.354426405,
+        -66.090456669, -65.825923755, -65.560601330, -65.294723278,
+        -65.028456835, -64.761711657, -64.558376597, -64.503492683,
+        -64.458505667, -64.426396787, -64.344126736, -63.974874818,
+        -63.415142104, -62.693191572, -61.858654057, -60.940430082,
+        -60.256219303, -59.583329668, -58.898983716, -58.215039428,
+        -57.538036035, -56.944940939, -56.456114109, -55.923925238,
+        -55.340584815,
+    }};
+    constexpr std::array<double, 33> baselineH5RelativeDb{{
+        -107.650059235, -103.475767425, -100.217278878, -97.499889181,
+        -95.181745995, -93.143545054, -91.321140508, -89.677320044,
+        -88.198104175, -86.844162414, -85.590532914, -84.423507653,
+        -83.334528742, -82.307836261, -81.335691130, -80.407565785,
+        -80.570779415, -82.113527529, -82.035633823, -79.712111086,
+        -77.708341240, -76.065702145, -74.667480346, -73.365161890,
+        -72.349628632, -71.367801275, -70.406562232, -69.659530361,
+        -68.943540125, -68.245675954, -67.556478621, -67.038444608,
+        -66.426639305,
+    }};
+    constexpr float inputPosition = 0.8f;
+    constexpr float inputGainDb = 38.603869f;
+    constexpr double worstErrorBoundDb = 0.75;
+    constexpr double adjacentErrorStepBoundDb = 0.20;
+    constexpr double phaseErrorBoundDegrees = 3.0;
+    constexpr double neighbourMovementBoundDb = 0.02;
+    double worstError = 0.0;
+    double worstAdjacentErrorStep = 0.0;
+    double worstPhaseErrorDegrees = 0.0;
+    double worstReductionMovementDb = 0.0;
+    double worstH1MovementDb = 0.0;
+    double worstH2MovementDb = 0.0;
+    double worstH5MovementDb = 0.0;
+    double previousError = 0.0;
+    for (size_t index = 0; index < referenceH3RelativeDb.size(); ++index)
+    {
+        const double driveDb = -14.0 + 0.25 * static_cast<double>(index);
+        const auto measured = measureFetHarmonics(
+            100.0, static_cast<float>(driveDb - inputGainDb),
+            inputPosition, 0, 48000.0, 13, 12.0, 9.0, 10.5);
+        const double relativeDb = measured.h3Dbfs - measured.h1Dbfs;
+        const double error = relativeDb - referenceH3RelativeDb[index];
+        const double relativePhaseDegrees = std::remainder(
+            (std::atan2(measured.h3Imag, measured.h3Real)
+                - 3.0 * std::atan2(measured.h1Imag, measured.h1Real))
+                * 180.0 / static_cast<double>(kPi),
+            360.0);
+        const double phaseErrorDegrees = std::remainder(
+            relativePhaseDegrees - referenceH3PhaseDegrees[index], 360.0);
+        worstError = std::max(worstError, std::abs(error));
+        worstPhaseErrorDegrees = std::max(
+            worstPhaseErrorDegrees, std::abs(phaseErrorDegrees));
+        worstReductionMovementDb = std::max(worstReductionMovementDb,
+            std::abs(measured.reductionDbMean
+                - baselineRawReductionDb[index]));
+        worstH1MovementDb = std::max(worstH1MovementDb,
+            std::abs(measured.h1Dbfs - baselineH1Dbfs[index]));
+        worstH2MovementDb = std::max(worstH2MovementDb,
+            std::abs(measured.h2RelativeDb
+                - baselineH2RelativeDb[index]));
+        worstH5MovementDb = std::max(worstH5MovementDb,
+            std::abs(measured.h5Dbfs - measured.h1Dbfs
+                - baselineH5RelativeDb[index]));
+        if (index > 0)
+            worstAdjacentErrorStep = std::max(
+                worstAdjacentErrorStep, std::abs(error - previousError));
+        previousError = error;
+        std::printf("FET dense shallow H3: drive %+.2f raw GR %.6f "
+                    "reference %.6f measured %.6f error %+.6f dB "
+                    "phase ref %.3f measured %.3f error %+.3f deg "
+                    "H1dB %.9f H2rel %.9f H5rel %.9f\n",
+                    driveDb, measured.reductionDbMean,
+                    referenceH3RelativeDb[index], relativeDb, error,
+                    referenceH3PhaseDegrees[index], relativePhaseDegrees,
+                    phaseErrorDegrees,
+                    measured.h1Dbfs, measured.h2RelativeDb,
+                    measured.h5Dbfs - measured.h1Dbfs);
+    }
+    std::printf("FET dense shallow H3: worst error %.6f dB (bound %.2f), "
+                "worst adjacent error step %.6f dB (bound %.2f)\n",
+                worstError, worstErrorBoundDb,
+                worstAdjacentErrorStep, adjacentErrorStepBoundDb);
+    std::printf("FET dense shallow H3: worst phase error %.6f degrees "
+                "(bound %.1f)\n",
+                worstPhaseErrorDegrees, phaseErrorBoundDegrees);
+    std::printf("FET dense shallow H3 neighbours: GR %.9f H1 %.9f H2 %.9f "
+                "H5 %.9f dB movement (bound %.2f)\n",
+                worstReductionMovementDb, worstH1MovementDb,
+                worstH2MovementDb, worstH5MovementDb,
+                neighbourMovementBoundDb);
+    require(worstError < worstErrorBoundDb
+                && worstAdjacentErrorStep < adjacentErrorStepBoundDb
+                && worstPhaseErrorDegrees < phaseErrorBoundDegrees
+                && worstReductionMovementDb < neighbourMovementBoundDb
+                && worstH1MovementDb < neighbourMovementBoundDb
+                && worstH2MovementDb < neighbourMovementBoundDb
+                && worstH5MovementDb < neighbourMovementBoundDb,
+            "vintage FET dense shallow H3 follows the continuous UAD knee surface");
+}
+
+void testFetDenseBroadbandComplexH3()
+{
+    // Wave 27's matched-reduction experiment exposed a hole between the sparse
+    // broadband-K3 anchors: at the campaign's standard Input 0.8 setting the
+    // reference H3 vector rotates by more than 120 degrees as drive increases,
+    // while the reduction-only cubic remains near 135 degrees. These are
+    // same-stimulus UAD rows, so unlike the diagnostic matched-GR pairs they
+    // are an absolute parity surface. Nine 6 dB-spaced calibration rows are the
+    // fit candidates. The interleaved original campaign rows are held out.
+    struct Point
+    {
+        double driveDb;
+        double referenceH3RelativeDb;
+        double referenceH3PhaseDegrees;
+        bool longWindow;
+    };
+    constexpr std::array<Point, 17> points48{{
+        {-10.000000, -80.093341978695, 177.687066107719, true},
+        { -9.396131, -78.547979854381, 171.226193686187, false},
+        { -6.000000, -75.275138780963, 161.662663170743, true},
+        {  0.000000, -71.341723628416, 148.874140373035, true},
+        {  2.603869, -67.758380420931, 134.327004564712, false},
+        {  6.000000, -69.398865553427, 143.746264604366, true},
+        {  8.603869, -66.683950146981, 129.606510806320, false},
+        { 12.000000, -69.994428200374, 133.836171775278, true},
+        { 14.603869, -67.067362001200, 114.802823644219, false},
+        { 18.000000, -71.693122390628, 105.360058420843, true},
+        { 20.603869, -67.007091083965,  97.413860751674, false},
+        { 24.000000, -71.022650547630, 104.135549319130, true},
+        { 26.603869, -66.239258321331, 103.756598802683, false},
+        { 29.603869, -66.280253217482,  90.457415082858, false},
+        { 30.000000, -70.799346975874,  82.234725653060, true},
+        { 32.603869, -65.841834939054,  78.825484571464, false},
+        { 34.000000, -68.728361536357,  52.833790119970, true},
+    }};
+    constexpr std::array<Point, 13> points96{{
+        {-10.000000, -80.097042453048, 177.696342306673, true},
+        { -6.000000, -75.455011881557, 161.038265236934, true},
+        {  0.000000, -71.628434186257, 147.756265096633, true},
+        {  2.603869, -68.081229874941, 131.316680755374, false},
+        {  6.000000, -69.742686119066, 141.522779246719, true},
+        { 12.000000, -70.306788585484, 130.972063972273, true},
+        { 14.603869, -67.231070894836, 111.064005040855, false},
+        { 18.000000, -71.753961126338, 100.247994488755, true},
+        { 24.000000, -71.046582933575,  98.881462478703, true},
+        { 26.603869, -66.344200218942,  99.526868957747, false},
+        { 30.000000, -70.507458664241,  77.826050538591, true},
+        { 32.603869, -65.687203176704,  74.615490903841, false},
+        { 34.000000, -68.244547763047,  50.193464717676, true},
+    }};
+    struct Neighbour
+    {
+        double reductionDb;
+        double h1Dbfs;
+        double h2RelativeDb;
+        double h5RelativeDb;
+    };
+    // GR/H1/H2 are the Wave 32 disabled-cell controls. H5 is the accepted
+    // Wave 34 complex-H5 surface; keeping it here preserves the isolation
+    // check on the H3 cell after that independently intended H5 movement.
+    constexpr std::array<Neighbour, 17> neighbours48{{
+        {0.841649000, -18.629714537, -64.887909553, -99.581655271},
+        {1.017519000, -18.285063626, -64.846393526, -100.879597828},
+        {2.575931000, -16.984825081, -65.586058982, -91.534458011},
+        {6.890009000, -15.413734199, -66.844373894, -83.085557935},
+        {8.982944000, -14.909029296, -65.422977733, -77.202491691},
+        {11.845395000, -14.385453508, -62.441230449, -80.058262355},
+        {13.924587000, -13.870014377, -60.081638318, -75.647198253},
+        {16.792435000, -13.358179157, -56.969671451, -79.034972720},
+        {18.855112000, -12.832771605, -54.763665988, -74.626986666},
+        {21.740536000, -12.351838120, -51.626013367, -78.192254130},
+        {23.772755000, -11.808827369, -48.961281052, -73.785922015},
+        {26.637381000, -11.331278484, -45.593773604, -77.563605756},
+        {28.638845000, -10.778717817, -43.962033952, -73.267264548},
+        {31.046316000, -10.263438194, -43.210607233, -73.005297776},
+        {31.472347000, -10.309492422, -43.213892135, -77.110961415},
+        {33.429245000,  -9.749078832, -42.466283929, -72.684391483},
+        {34.640800000,  -9.629165393, -42.230297759, -76.742451740},
+    }};
+    constexpr std::array<Neighbour, 13> neighbours96{{
+        {0.840455000, -18.632275228, -64.886996710, -99.473814047},
+        {2.563588000, -16.987101913, -65.552781857, -91.448550478},
+        {6.876930000, -15.402907847, -66.812403986, -83.352131442},
+        {8.979934000, -14.908283965, -65.396640992, -77.186430657},
+        {11.842650000, -14.384965875, -62.429217230, -80.220393326},
+        {16.794703000, -13.362716404, -56.963142668, -79.133477181},
+        {18.860217000, -12.840183893, -54.756840865, -74.650385893},
+        {21.742937000, -12.356526314, -51.622620658, -78.215637876},
+        {26.637899000, -11.334068943, -45.592883592, -77.527998525},
+        {28.656762000, -10.799360916, -43.977103985, -73.448082011},
+        {31.468414000, -10.307674402, -43.209729376, -77.004771575},
+        {33.443372000,  -9.766143549, -42.478466744, -72.935668328},
+        {34.636967000,  -9.627382846, -42.226193831, -76.676009167},
+    }};
+    constexpr float inputPosition = 0.8f;
+    constexpr double inputGainDb = 38.603869;
+    constexpr double magnitudeBoundDb = 0.25;
+    constexpr double phaseBoundDegrees = 3.0;
+    constexpr double adjacentErrorStepBoundDb = 0.20;
+    double worstMagnitudeErrorDb = 0.0;
+    double worstPhaseErrorDegrees = 0.0;
+    double worstAdjacentErrorStepDb = 0.0;
+    double worstReductionMovementDb = 0.0;
+    double worstH1MovementDb = 0.0;
+    double worstH2MovementDb = 0.0;
+    double worstH5MovementDb = 0.0;
+
+    const auto measureRate = [&](double sampleRate, const auto& points,
+                                 const auto& neighbours) {
+        double previousError = 0.0;
+        for (size_t index = 0; index < points.size(); ++index)
+        {
+            const auto& point = points[index];
+            const auto measured = measureFetHarmonics(
+                1000.0, static_cast<float>(point.driveDb - inputGainDb),
+                inputPosition, 0, sampleRate, 13,
+                point.longWindow ? 12.0 : 5.0,
+                point.longWindow ? 9.0 : 3.0,
+                point.longWindow ? 10.5 : 4.5,
+                point.longWindow ? 0.5f : 0.66595459f);
+            const double relativeDb = measured.h3Dbfs - measured.h1Dbfs;
+            const double magnitudeErrorDb
+                = relativeDb - point.referenceH3RelativeDb;
+            const double relativePhaseDegrees = std::remainder(
+                (std::atan2(measured.h3Imag, measured.h3Real)
+                    - 3.0 * std::atan2(measured.h1Imag, measured.h1Real))
+                    * 180.0 / static_cast<double>(kPi),
+                360.0);
+            const double phaseErrorDegrees = std::remainder(
+                relativePhaseDegrees - point.referenceH3PhaseDegrees, 360.0);
+            worstMagnitudeErrorDb = std::max(
+                worstMagnitudeErrorDb, std::abs(magnitudeErrorDb));
+            worstPhaseErrorDegrees = std::max(
+                worstPhaseErrorDegrees, std::abs(phaseErrorDegrees));
+            worstReductionMovementDb = std::max(worstReductionMovementDb,
+                std::abs(measured.reductionDbMean
+                    - neighbours[index].reductionDb));
+            worstH1MovementDb = std::max(worstH1MovementDb,
+                std::abs(measured.h1Dbfs - neighbours[index].h1Dbfs));
+            worstH2MovementDb = std::max(worstH2MovementDb,
+                std::abs(measured.h2RelativeDb
+                    - neighbours[index].h2RelativeDb));
+            worstH5MovementDb = std::max(worstH5MovementDb,
+                std::abs(measured.h5Dbfs - measured.h1Dbfs
+                    - neighbours[index].h5RelativeDb));
+            if (index > 0)
+                worstAdjacentErrorStepDb = std::max(
+                    worstAdjacentErrorStepDb,
+                    std::abs(magnitudeErrorDb - previousError));
+            previousError = magnitudeErrorDb;
+            std::printf("FET dense broadband complex H3: %.0f kHz drive "
+                        "%+.6f raw GR %.6f reference %.6f measured %.6f "
+                        "error %+.6f dB phase ref %.3f measured %.3f "
+                        "error %+.3f deg H1 %.9f H2rel %.9f H5rel %.9f %s\n",
+                        sampleRate / 1000.0, point.driveDb,
+                        measured.reductionDbMean,
+                        point.referenceH3RelativeDb, relativeDb,
+                        magnitudeErrorDb, point.referenceH3PhaseDegrees,
+                        relativePhaseDegrees, phaseErrorDegrees,
+                        measured.h1Dbfs, measured.h2RelativeDb,
+                        measured.h5Dbfs - measured.h1Dbfs,
+                        point.longWindow ? "fit" : "heldout");
+        }
+    };
+    measureRate(48000.0, points48, neighbours48);
+    measureRate(96000.0, points96, neighbours96);
+    std::printf("FET dense broadband complex H3 summary: magnitude %.6f dB "
+                "(bound %.2f), phase %.6f degrees (bound %.1f), adjacent "
+                "error step %.6f dB (bound %.2f)\n",
+                worstMagnitudeErrorDb, magnitudeBoundDb,
+                worstPhaseErrorDegrees, phaseBoundDegrees,
+                worstAdjacentErrorStepDb, adjacentErrorStepBoundDb);
+    std::printf("FET dense broadband complex H3 neighbours: GR %.9f H1 "
+                "%.9f H2 %.9f H5 %.9f dB movement (bound 0.02)\n",
+                worstReductionMovementDb, worstH1MovementDb,
+                worstH2MovementDb, worstH5MovementDb);
+    require(worstReductionMovementDb < 0.02
+                && worstH1MovementDb < 0.02
+                && worstH2MovementDb < 0.02
+                && worstH5MovementDb < 0.02,
+            "vintage FET broadband complex H3 preserves GR, H1, H2, and H5");
+    require(worstMagnitudeErrorDb < magnitudeBoundDb
+                && worstPhaseErrorDegrees < phaseBoundDegrees
+                && worstAdjacentErrorStepDb < adjacentErrorStepBoundDb,
+            "vintage FET dense broadband complex H3 follows the UAD drive and rate surface");
+}
+
+void testFetDenseBroadbandComplexH5()
+{
+    // Wave 27 proved that the high-passed T5 source is complex-linear, but its
+    // proposed reduction-only scale compared two different Release controls:
+    // the matched-reduction probe used 0.5 while the original campaign used
+    // 0.66595459. The apparent contradiction was therefore a missing control
+    // coordinate. These rows close that measurement hole with same-stimulus
+    // UAD vectors. The Release-0.5 rows are the retained 6 dB-spaced rate
+    // calibration captures; the Release-0.66595459 rows are the independently
+    // captured original 96 kHz campaign grid.
+    struct Point
+    {
+        double sampleRate;
+        float inputPosition;
+        float inputDbfs;
+        float releasePosition;
+        double referenceH5RelativeDb;
+        double referenceH5PhaseDegrees;
+        bool calibration;
+    };
+    constexpr std::array<Point, 31> points{{
+        {48000.0, 0.8f, -44.603869f, 0.5f, -91.533179234405, 105.900970272912, true},
+        {48000.0, 0.8f, -38.603869f, 0.5f, -83.083794562062, 105.048867429580, true},
+        {48000.0, 0.8f, -32.603869f, 0.5f, -80.057145956160, 107.618090045645, true},
+        {48000.0, 0.8f, -26.603869f, 0.5f, -79.035871730328, 107.440746891236, true},
+        {48000.0, 0.8f, -20.603869f, 0.5f, -78.192600105118, 107.268602058487, true},
+        {48000.0, 0.8f, -14.603869f, 0.5f, -77.563532531602, 107.098390087017, true},
+        {48000.0, 0.8f,  -8.603869f, 0.5f, -77.110371461677, 107.129903567437, true},
+        {48000.0, 0.8f,  -4.603869f, 0.5f, -76.743252387396, 108.593988909372, true},
+        {96000.0, 0.8f, -44.603869f, 0.5f, -91.449657516767,  96.097304738500, true},
+        {96000.0, 0.8f, -38.603869f, 0.5f, -83.351695647491,  96.931650857938, true},
+        {96000.0, 0.8f, -32.603869f, 0.5f, -80.220609495544,  97.853510967479, true},
+        {96000.0, 0.8f, -26.603869f, 0.5f, -79.133402786188,  97.952804569443, true},
+        {96000.0, 0.8f, -20.603869f, 0.5f, -78.215989155770,  97.758513230822, true},
+        {96000.0, 0.8f, -14.603869f, 0.5f, -77.528149737899,  97.624203875896, true},
+        {96000.0, 0.8f,  -8.603869f, 0.5f, -77.004561671439,  98.289469095491, true},
+        {96000.0, 0.8f,  -4.603869f, 0.5f, -76.675624919709,  99.072196558121, true},
+        {48000.0, 0.8f, -36.000000f, 0.66595459f, -77.202512804068, 106.812037993755, false},
+        {48000.0, 0.8f, -30.000000f, 0.66595459f, -75.647217239294, 106.560727086506, false},
+        {48000.0, 0.8f, -24.000000f, 0.66595459f, -74.626974737862, 106.477570022950, false},
+        {48000.0, 0.2f, -12.000000f, 0.66595459f, -86.169521078737, 104.904138993336, false},
+        {48000.0, 0.8f, -18.000000f, 0.66595459f, -73.785900563641, 106.480020496798, false},
+        {48000.0, 0.8f, -12.000000f, 0.66595459f, -73.267311371359, 106.277905357769, false},
+        {48000.0, 0.2f,  -6.000000f, 0.66595459f, -78.820903125102, 107.020699420289, false},
+        {48000.0, 0.8f,  -9.000000f, 0.66595459f, -73.005278739567, 106.479510610175, false},
+        {48000.0, 0.8f,  -6.000000f, 0.66595459f, -72.684399572396, 106.768369965984, false},
+        {96000.0, 0.8f, -36.000000f, 0.66595459f, -77.186414195630, 97.604616779722, false},
+        {96000.0, 0.8f, -24.000000f, 0.66595459f, -74.650335303332, 98.651857220974, false},
+        {96000.0, 0.2f, -12.000000f, 0.66595459f, -86.410298909599, 97.167861054148, false},
+        {96000.0, 0.8f, -12.000000f, 0.66595459f, -73.447941957507, 98.436663459609, false},
+        {96000.0, 0.2f,  -6.000000f, 0.66595459f, -78.886313234298, 97.779477772866, false},
+        {96000.0, 0.8f,  -6.000000f, 0.66595459f, -72.935442093146, 98.986422851229, false},
+    }};
+    constexpr double magnitudeBoundDb = 0.25;
+    constexpr double phaseBoundDegrees = 3.0;
+    double worstMagnitudeErrorDb = 0.0;
+    double worstPhaseErrorDegrees = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetHarmonics(
+            1000.0, point.inputDbfs, point.inputPosition, 0,
+            point.sampleRate, 13,
+            point.calibration ? 12.0 : 5.0,
+            point.calibration ? 9.0 : 3.0,
+            point.calibration ? 10.5 : 4.5,
+            point.releasePosition);
+        const double relativeDb = measured.h5Dbfs - measured.h1Dbfs;
+        const double magnitudeErrorDb
+            = relativeDb - point.referenceH5RelativeDb;
+        const double relativePhaseDegrees = std::remainder(
+            (std::atan2(measured.h5Imag, measured.h5Real)
+                - 5.0 * std::atan2(measured.h1Imag, measured.h1Real))
+                * 180.0 / static_cast<double>(kPi),
+            360.0);
+        const double relativeMagnitude = std::hypot(
+            measured.h5Real, measured.h5Imag)
+            / std::max(std::hypot(measured.h1Real, measured.h1Imag), 1.0e-30);
+        const double relativeReal = relativeMagnitude * std::cos(
+            relativePhaseDegrees * static_cast<double>(kPi) / 180.0);
+        const double relativeImag = relativeMagnitude * std::sin(
+            relativePhaseDegrees * static_cast<double>(kPi) / 180.0);
+        const double phaseErrorDegrees = std::remainder(
+            relativePhaseDegrees - point.referenceH5PhaseDegrees, 360.0);
+        worstMagnitudeErrorDb = std::max(
+            worstMagnitudeErrorDb, std::abs(magnitudeErrorDb));
+        worstPhaseErrorDegrees = std::max(
+            worstPhaseErrorDegrees, std::abs(phaseErrorDegrees));
+        std::printf("FET dense broadband complex H5: %.0f kHz i%.1f src "
+                    "%+.6f Release %.9f raw GR %.6f reference %.6f "
+                    "measured %.6f error %+.6f dB phase ref %.3f "
+                    "measured %.6f error %+.6f deg H5re %+.12e "
+                    "H5im %+.12e %s\n",
+                    point.sampleRate / 1000.0,
+                    static_cast<double>(point.inputPosition),
+                    static_cast<double>(point.inputDbfs),
+                    static_cast<double>(point.releasePosition),
+                    measured.reductionDbMean,
+                    point.referenceH5RelativeDb, relativeDb,
+                    magnitudeErrorDb, point.referenceH5PhaseDegrees,
+                    relativePhaseDegrees, phaseErrorDegrees,
+                    relativeReal, relativeImag,
+                    point.calibration ? "calibration" : "campaign");
+    }
+    std::printf("FET dense broadband complex H5 summary: magnitude %.6f dB "
+                "(bound %.2f), phase %.6f degrees (bound %.1f)\n",
+                worstMagnitudeErrorDb, magnitudeBoundDb,
+                worstPhaseErrorDegrees, phaseBoundDegrees);
+    require(worstMagnitudeErrorDb < magnitudeBoundDb
+                && worstPhaseErrorDegrees < phaseBoundDegrees,
+            "vintage FET dense broadband complex H5 follows the UAD drive, Release, and rate surface");
+}
+
+void testFetLowFrequencyOddHarmonicSurface()
+{
+    // Absolute H3 anchors from the installed reference unit. The 100 Hz set
+    // spans the complete low-frequency T3 law; the 1 kHz set is the opposite
+    // failure-mode guard, because this nominally low-frequency path remains
+    // large enough there that an unconstrained 100 Hz fit would undo Wave 12.
+    struct Point
+    {
+        double frequencyHz;
+        float inputPosition;
+        float inputDbfs;
+        double reductionDb;
+        double referenceH3RelativeDb;
+        double previousErrorDb;          // the constant -0.0058 T3 term
+    };
+    constexpr std::array<Point, 18> points{{
+        {100.0, 0.3f, -30.0f, -0.0087, -91.700375, +0.5559},
+        {100.0, 0.7f, -46.0f,  0.2378, -83.943235, +0.7112},
+        {100.0, 0.6f, -42.0f,  0.5373, -81.075196, +4.9007},
+        {100.0, 0.3f, -24.0f,  0.7234, -78.962196, +5.5109},
+        {100.0, 0.9f, -48.0f,  1.3622, -67.407430, -0.2529},
+        {100.0, 0.2f, -12.0f,  2.5753, -60.225389, -1.4289},
+        {100.0, 0.8f, -36.0f,  8.9210, -50.600997, +0.0783},
+        {100.0, 0.8f, -30.0f, 13.8515, -48.872046, +2.3465},
+        {100.0, 0.8f, -18.0f, 23.6915, -47.030741, +0.6235},
+        {100.0, 0.9f,  -7.5f, 33.1003, -46.020733, -0.4754},
+        {100.0, 1.0f,  -6.0f, 34.3368, -46.009239, -0.5075},
+        {1000.0, 0.4f, -30.0f,  0.5570, -81.411229, -0.0501},
+        {1000.0, 0.6f, -36.0f,  3.2496, -72.802041, -0.0073},
+        {1000.0, 0.8f, -36.0f,  8.9830, -67.758380, -0.0895},
+        {1000.0, 0.8f, -30.0f, 13.9253, -66.683950, +0.0055},
+        {1000.0, 0.4f,  -9.0f, 15.1374, -66.685792, -0.0476},
+        {1000.0, 0.8f, -24.0f, 18.8564, -67.067362, +0.0040},
+        {1000.0, 0.8f, -12.0f, 28.6512, -66.239258, -0.0394}}};
+
+    constexpr double kLowFrequencyBoundDb = 0.75;
+    constexpr double kBroadbandGuardDb = 0.98;
+    double lowFrequencyWorst = 0.0;
+    double broadbandWorst = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetHarmonics(
+            point.frequencyHz, point.inputDbfs, point.inputPosition,
+            0, 48000.0, 13, 5.0, 3.0, 4.5,
+            point.frequencyHz == 1000.0 ? 0.66595459f : 0.5f);
+        const double relativeDb = measured.h3Dbfs - measured.h1Dbfs;
+        const double error = relativeDb - point.referenceH3RelativeDb;
+        if (point.frequencyHz == 100.0)
+            lowFrequencyWorst = std::max(lowFrequencyWorst, std::abs(error));
+        else
+            broadbandWorst = std::max(broadbandWorst, std::abs(error));
+        std::printf("FET low T3: %.0f Hz i%.1f %+.1f dBFS gr %.4f "
+                    "(expected %.4f) reference %.6f measured %.6f "
+                    "error %+.6f dB (constant T3 %+.4f)\n",
+                    point.frequencyHz,
+                    static_cast<double>(point.inputPosition),
+                    static_cast<double>(point.inputDbfs),
+                    measured.reductionDbMean, point.reductionDb,
+                    point.referenceH3RelativeDb, relativeDb, error,
+                    point.previousErrorDb);
+        require(std::abs(measured.reductionDbMean - point.reductionDb) < 0.02,
+                "vintage FET low-T3 anchors are evaluated at the reduction they were measured at");
+    }
+    std::printf("FET low T3: 100 Hz worst %.6f dB (bound %.2f), "
+                "1 kHz guard worst %.6f dB (bound %.2f)\n",
+                lowFrequencyWorst, kLowFrequencyBoundDb,
+                broadbandWorst, kBroadbandGuardDb);
+    require(lowFrequencyWorst < kLowFrequencyBoundDb,
+            "vintage FET low-frequency H3 matches the measured reference across the reduction axis");
+    require(broadbandWorst < kBroadbandGuardDb,
+            "vintage FET low-frequency T3 fit does not undo the broadband H3 surface");
+}
+
+void testFetLowFrequencyFifthHarmonicSurface()
+{
+    // Absolute 100 Hz H5 anchors from the installed reference unit. All sit
+    // above the campaign's -92 dBc floor and span the complete measured
+    // low-frequency T5 law. H3 is guarded independently by
+    // testFetLowFrequencyOddHarmonicSurface, which is necessary because this
+    // fifth-order term also feeds the compressor loop.
+    struct Point
+    {
+        float inputPosition;
+        float inputDbfs;
+        double reductionDb;
+        double referenceH5RelativeDb;
+        double previousErrorDb;          // the constant +0.00255 T5 term
+    };
+    constexpr std::array<Point, 11> points{{
+        {0.5f, -36.0f,  0.8882, -83.281606, +6.3542},
+        {0.8f, -48.0f,  0.9345, -81.697045, +5.2159},
+        {0.2f, -15.0f,  1.1328, -77.026211, +2.2414},
+        {0.8f, -46.0f,  1.7057, -70.430321, -0.7602},
+        {0.8f, -45.0f,  2.1781, -67.616563, -1.4404},
+        {0.6f, -36.0f,  3.1896, -64.403196, -1.1304},
+        {0.2f,  -6.0f,  6.9247, -58.897481, +0.0256},
+        {0.9f, -36.0f,  9.8790, -56.672763, +0.8281},
+        {0.8f, -30.0f, 13.8515, -55.670300, +2.7093},
+        {0.9f, -18.0f, 24.6525, -53.815062, +0.9463},
+        {1.0f,  -6.0f, 34.3368, -52.992012, +0.1356}}};
+
+    constexpr double kBoundDb = 0.20;
+    double worstError = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetHarmonics(
+            100.0, point.inputDbfs, point.inputPosition);
+        const double relativeDb = measured.h5Dbfs - measured.h1Dbfs;
+        const double error = relativeDb - point.referenceH5RelativeDb;
+        worstError = std::max(worstError, std::abs(error));
+        std::printf("FET low T5: i%.1f %+.1f dBFS gr %.9f (expected %.4f) "
+                    "reference %.6f measured %.6f error %+.6f dB "
+                    "(constant T5 %+.4f)\n",
+                    static_cast<double>(point.inputPosition),
+                    static_cast<double>(point.inputDbfs),
+                    measured.reductionDbMean, point.reductionDb,
+                    point.referenceH5RelativeDb, relativeDb, error,
+                    point.previousErrorDb);
+        require(std::abs(measured.reductionDbMean - point.reductionDb) < 0.02,
+                "vintage FET low-T5 anchors are evaluated at the reduction they were measured at");
+    }
+    std::printf("FET low T5: worst %.6f dB over %zu anchors (bound %.2f)\n",
+                worstError, points.size(), kBoundDb);
+    require(worstError < kBoundDb,
+            "vintage FET low-frequency H5 matches the measured reference across the reduction axis");
+}
+
+void testFetBroadbandFifthHarmonicSurface()
+{
+    // Absolute 1 kHz H5 anchors from the installed reference unit. They span
+    // every scoreable reduction region of the dense campaign and are kept
+    // separate from the low-frequency T5 gate because that path's finite
+    // leakage cannot reproduce the nearly uniform broadband residual without
+    // undoing its 100 Hz fit.
+    struct Point
+    {
+        float inputPosition;
+        float inputDbfs;
+        double reductionDb;
+        double referenceH5RelativeDb;
+        double previousErrorDb;          // after the fitted low-T5 path
+    };
+    constexpr std::array<Point, 10> points{{
+        {0.2f, -12.0f,  2.6305, -86.169521, -3.5774},
+        {0.6f, -36.0f,  3.2496, -84.117415, -3.7298},
+        {0.7f, -36.0f,  5.0243, -80.818005, -3.7525},
+        {0.8f, -36.0f,  8.9830, -77.202513, -3.6191},
+        {0.4f, -12.0f, 12.6634, -75.951320, -3.5684},
+        {0.6f, -18.0f, 17.7317, -74.841900, -3.6337},
+        {0.6f, -12.0f, 22.6659, -73.960898, -3.7055},
+        {0.6f,  -6.0f, 27.5467, -73.353275, -3.7455},
+        {0.8f,  -9.0f, 31.0579, -73.005279, -3.7882},
+        {0.8f,  -6.0f, 33.4397, -72.684400, -3.9067}}};
+
+    constexpr double kBoundDb = 0.25;
+    double worstError = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetHarmonics(
+            1000.0, point.inputDbfs, point.inputPosition,
+            0, 48000.0, 13, 5.0, 3.0, 4.5, 0.66595459f);
+        const double relativeDb = measured.h5Dbfs - measured.h1Dbfs;
+        const double error = relativeDb - point.referenceH5RelativeDb;
+        worstError = std::max(worstError, std::abs(error));
+        std::printf("FET broadband T5: i%.1f %+.1f dBFS gr %.9f "
+                    "(expected %.4f) reference %.6f measured %.6f "
+                    "error %+.6f dB (low T5 %+.4f)\n",
+                    static_cast<double>(point.inputPosition),
+                    static_cast<double>(point.inputDbfs),
+                    measured.reductionDbMean, point.reductionDb,
+                    point.referenceH5RelativeDb, relativeDb, error,
+                    point.previousErrorDb);
+        require(std::abs(measured.reductionDbMean - point.reductionDb) < 0.02,
+                "vintage FET broadband-T5 anchors are evaluated at the reduction they were measured at");
+    }
+    std::printf("FET broadband T5: worst %.6f dB over %zu anchors "
+                "(bound %.2f)\n", worstError, points.size(), kBoundDb);
+    require(worstError < kBoundDb,
+            "vintage FET broadband H5 matches the measured reference across the reduction axis");
+}
+
+void testFetLowFrequencyColourSurface()
+{
+    // The 100 Hz twin of testFetBroadbandHarmonicSurface, gating
+    // `fetLowFrequencyK2`. Seven absolute anchors on the reference unit's own
+    // 100 Hz second harmonic, rendered from the installed AU by
+    // `probe_h2_surface.py` (campaign reference_comparison_1176) and quoted as
+    // H2 relative to the fundamental, which is scalar-immune.
+    //
+    // Why 100 Hz needs its own gate at all: at 1 kHz this table contributes
+    // 49 dB down and the broadband table owns the spectrum, so
+    // testFetBroadbandHarmonicSurface cannot see a low-frequency fault. It was
+    // run with the pre-Wave-9 law installed and passes -- at that point the
+    // 100 Hz surface was 2.07 dB out on 45 of its 91 compressing rows.
+    struct Point
+    {
+        float inputPosition;
+        float inputDbfs;
+        double reductionDb;              // the fetLowFrequencyK2 argument
+        double referenceH2RelativeDb;
+        double previousErrorDb;          // what the pre-Wave-9 law read here
+    };
+    // One per region of the table, and deliberately not a flattering set: the
+    // 0.9345 dB anchor is in the band this table CANNOT fix (see
+    // fetLowFrequencyK2 -- the broadband table alone reads high there), so the
+    // test carries the honest residual rather than sampling around it. The
+    // 18.7912 and 33.3699 anchors are the two rows the sixteen-row campaign
+    // grid failed on, at +1.5999 and -0.4610.
+    constexpr std::array<Point, 7> points{{
+        {0.2f, -36.0f,  -0.009, -83.993408, -0.0168},
+        {0.8f, -48.0f,   0.934, -64.008370, +1.1667},
+        {0.8f, -45.0f,   2.178, -56.347350, -1.9758},
+        {0.2f,  -6.0f,   6.918, -47.274840, -0.6102},
+        {0.6f, -24.0f,  12.726, -43.761082, +1.9464},
+        {0.8f, -24.0f,  18.791, -41.975760, +1.5999},
+        {0.8f,  -6.0f,  33.370, -37.552714, -0.4610}}};
+
+    // Set by what it has to catch. The law this replaced read 2.07 dB out at
+    // 100 Hz and 1.97 at the third anchor; the campaign's harmonic gate is
+    // 1.0 dB. 0.35 dB is 5.9x under the worst defect, 2.9x under the campaign
+    // gate, and 1.8x over the worst error this build produces anywhere on the
+    // 91-row 100 Hz surface (0.196 dB, rendered).
+    constexpr double kBoundDb = 0.35;
+    double worstError = 0.0;
+    for (const auto& point : points)
+    {
+        const auto measured = measureFetHarmonics(
+            100.0, point.inputDbfs, point.inputPosition);
+        const double error = measured.h2RelativeDb - point.referenceH2RelativeDb;
+        worstError = std::max(worstError, std::abs(error));
+        std::printf("FET LF colour: i%.1f %+.0f dBFS gr %.4f (expected %.3f) "
+                    "reference %.6f measured %.6f error %+.6f dB "
+                    "(previous law %+.4f)\n",
+                    static_cast<double>(point.inputPosition),
+                    static_cast<double>(point.inputDbfs),
+                    measured.reductionDbMean, point.reductionDb,
+                    point.referenceH2RelativeDb, measured.h2RelativeDb, error,
+                    point.previousErrorDb);
+        // Same guard as the broadband test: an anchor is only meaningful at the
+        // depth it was measured at, so a detector change must fail here rather
+        // than silently re-point the assertion.
+        require(std::abs(measured.reductionDbMean - point.reductionDb) < 0.02,
+                "vintage FET low-frequency anchors are evaluated at the reduction they were measured at");
+    }
+    std::printf("FET LF colour: worst %+.6f dB over %zu anchors (bound %.2f)\n",
+                worstError, points.size(), kBoundDb);
+    require(worstError < kBoundDb,
+            "vintage FET low-frequency colour matches the measured reference across the reduction axis");
+}
+
 void testPublishedGainReductionRange()
 {
     MultiCompDSP dsp;
@@ -5111,8 +8859,233 @@ void testAtomicControlSnapshotsAreSingleLoad()
     std::puts("atomic snapshots: oversampling/global lookahead/Digital lookahead loaded once per block");
 }
 
-int main()
+int main(int argc, char** argv)
 {
+    if (argc == 2 && std::strcmp(argv[1], "--opto-dense") == 0)
+    {
+        testOptoDenseProgrammeParity();
+        std::puts("Multi-Comp Opto dense-programme parity test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--golden") == 0)
+    {
+        testGoldenVectors();
+        std::puts("Multi-Comp golden-vector test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-tapers") == 0)
+    {
+        testFetMeasuredControlTapers();
+        std::puts("Multi-Comp FET taper test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-static") == 0)
+    {
+        testFetMeasuredStaticSurface();
+        std::puts("Multi-Comp FET static test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-knee-onset") == 0)
+    {
+        testFetKneeOnsetMatchesReference();
+        std::puts("Multi-Comp FET knee-onset test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-knee-release") == 0)
+    {
+        testFetKneeCellDoesNotCancelDeepReleaseMemory();
+        std::puts("Multi-Comp FET knee release-neighbour test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-max-gr") == 0)
+    {
+        testFetMaximumReductionSaturation();
+        std::puts("Multi-Comp FET maximum-reduction test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-all-settling") == 0)
+    {
+        testFetAllButtonsSettlingWindows();
+        std::puts("Multi-Comp FET All-buttons settling test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-absolute-gain") == 0)
+    {
+        testFetAbsoluteGainAnchors();
+        testFetMeasuredCurveAllButtons();
+        std::puts("Multi-Comp FET absolute-gain anchor test: PASS");
+        return 0;
+    }
+    // Separately reachable so the Measured arm can be shown to hold while the
+    // Modern-arm anchor above is deliberately broken -- `require` aborts on the
+    // first failure, so a leak test needs the two runnable independently.
+    if (argc == 2 && std::strcmp(argv[1], "--fet-measured-curve-all") == 0)
+    {
+        testFetMeasuredCurveAllButtons();
+        std::puts("Multi-Comp FET Measured-curve All-buttons test: PASS");
+        return 0;
+    }
+    // Likewise separate: the knee assertions and the plateau anchor guard
+    // different entries of the same table, so each has to be runnable while the
+    // other is deliberately broken.
+    if (argc == 2 && std::strcmp(argv[1], "--fet-all-knee") == 0)
+    {
+        testFetAllButtonsKneeTransition();
+        std::puts("Multi-Comp FET All-buttons knee test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-block") == 0)
+    {
+        testFetBlockSizeInvariance();
+        std::puts("Multi-Comp FET block-size test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-reset") == 0)
+    {
+        testFetResetClearsProgrammeAndColourState();
+        std::puts("Multi-Comp FET reset test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-stereo") == 0)
+    {
+        testFetInternalStereoLinkReference();
+        std::puts("Multi-Comp FET stereo-link test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-stereo-phase") == 0)
+    {
+        testFetStereoLinkPhaseLaw();
+        std::puts("Multi-Comp FET stereo phase-law test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-stereo-dense") == 0)
+    {
+        testFetDenseStereoPhaseParity();
+        std::puts("Multi-Comp FET dense stereo-phase test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-recovery-dense") == 0)
+    {
+        testFetDenseStartupRecoveryParity();
+        std::puts("Multi-Comp FET dense recovery test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-recovery-state") == 0)
+    {
+        testFetPostBurstRecoveryLifecycle();
+        std::puts("Multi-Comp FET recovery-state test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-h2-surface") == 0)
+    {
+        reportFetBroadbandK2Surface();
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-envelope-trace") == 0)
+    {
+        reportFetEnvelopeTrace();
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-detector-fr") == 0)
+    {
+        reportFetDetectorFrequencyNull();
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-h2") == 0)
+    {
+        testFetBroadbandHarmonicSurface();
+        std::puts("Multi-Comp FET broadband H2 surface test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-h3") == 0)
+    {
+        testFetBroadbandOddHarmonicSurface();
+        std::puts("Multi-Comp FET broadband H3 surface test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-low-h3-dense") == 0)
+    {
+        testFetDenseShallowLowFrequencyH3();
+        std::puts("Multi-Comp FET dense shallow low-frequency H3 test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-broadband-h3-dense") == 0)
+    {
+        testFetDenseBroadbandComplexH3();
+        std::puts("Multi-Comp FET dense broadband complex H3 test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-broadband-h5-dense") == 0)
+    {
+        testFetDenseBroadbandComplexH5();
+        std::puts("Multi-Comp FET dense broadband complex H5 test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-low-h3") == 0)
+    {
+        testFetLowFrequencyOddHarmonicSurface();
+        std::puts("Multi-Comp FET low-frequency H3 surface test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-low-h5") == 0)
+    {
+        testFetLowFrequencyFifthHarmonicSurface();
+        std::puts("Multi-Comp FET low-frequency H5 surface test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-h5") == 0)
+    {
+        testFetBroadbandFifthHarmonicSurface();
+        std::puts("Multi-Comp FET broadband H5 surface test: PASS");
+        return 0;
+    }
+    // Separate from --fet-h2 on purpose: the two tables are independently
+    // breakable and each has to be runnable while the other is deliberately
+    // faulted, which is how the coverage-hole justification is demonstrated.
+    if (argc == 2 && std::strcmp(argv[1], "--fet-lf") == 0)
+    {
+        testFetLowFrequencyColourSurface();
+        std::puts("Multi-Comp FET low-frequency colour test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-attack-drive") == 0)
+    {
+        reportFetAttackDriveAxis();
+        testFetAttackMatchesReferenceCurve();
+        testFetAttackAcceleratesWithDrive();
+        std::puts("Multi-Comp FET attack drive test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-attack-knob") == 0)
+    {
+        testFetHighCarrierAttackKnobAxis();
+        std::puts("Multi-Comp FET high-carrier attack-knob test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-startup-peak") == 0)
+    {
+        testFetStartupPeakSurface();
+        std::puts("Multi-Comp FET startup-peak test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-rate-gain") == 0)
+    {
+        testFetSampleRateFlatGain();
+        std::puts("Multi-Comp FET sample-rate flat-gain test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-startup-neighbours") == 0)
+    {
+        testFetStartupCeilingNeighbours();
+        std::puts("Multi-Comp FET startup-neighbour test: PASS");
+        return 0;
+    }
+    if (argc == 2 && std::strcmp(argv[1], "--fet-startup-state") == 0)
+    {
+        testFetStartupStateLifecycleAndCounterSaturation();
+        std::puts("Multi-Comp FET startup-state test: PASS");
+        return 0;
+    }
     testOptoMeasuredGainTaper();
     testOptoMeasuredOutputCeiling();
     testOptoDriveApplicability();
@@ -5148,6 +9121,38 @@ int main()
     testOptoOverloadOrderingAndMonotonicity();
     testOptoSampleRateParity();
     testAtomicControlSnapshotsAreSingleLoad();
+    testFetMeasuredControlTapers();
+    testFetMeasuredStaticSurface();
+    testFetKneeOnsetMatchesReference();
+    testFetKneeCellDoesNotCancelDeepReleaseMemory();
+    testFetMaximumReductionSaturation();
+    testFetAllButtonsSettlingWindows();
+    testFetAbsoluteGainAnchors();
+    testFetMeasuredCurveAllButtons();
+    testFetAllButtonsKneeTransition();
+    testFetBlockSizeInvariance();
+    testFetResetClearsProgrammeAndColourState();
+    testFetInternalStereoLinkReference();
+    testFetStereoLinkPhaseLaw();
+    testFetDenseStereoPhaseParity();
+    testFetDenseStartupRecoveryParity();
+    testFetPostBurstRecoveryLifecycle();
+    testFetAttackMatchesReferenceCurve();
+    testFetAttackAcceleratesWithDrive();
+    testFetHighCarrierAttackKnobAxis();
+    testFetStartupPeakSurface();
+    testFetStartupStateLifecycleAndCounterSaturation();
+    testFetStartupCeilingNeighbours();
+    testFetSampleRateFlatGain();
+    testFetBroadbandHarmonicSurface();
+    testFetBroadbandOddHarmonicSurface();
+    testFetDenseShallowLowFrequencyH3();
+    testFetDenseBroadbandComplexH3();
+    testFetDenseBroadbandComplexH5();
+    testFetLowFrequencyOddHarmonicSurface();
+    testFetLowFrequencyFifthHarmonicSurface();
+    testFetBroadbandFifthHarmonicSurface();
+    testFetLowFrequencyColourSurface();
     testPublishedGainReductionRange();
     testAllModesAreMonoSafe();
     testOversamplingBlockSizeInvariance();

--- a/plugins/multi-comp/daf-plugin/CMakeLists.txt
+++ b/plugins/multi-comp/daf-plugin/CMakeLists.txt
@@ -16,6 +16,11 @@ daf_add_plugin(multi_comp_2
   FILES_UI MultiCompUI.cpp ${DUSK_DAF_UI_SOURCES})
 target_include_directories(multi_comp_2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/../core" ${DUSK_DAF_INCLUDE_DIRS})
 target_compile_definitions(multi_comp_2 PUBLIC MULTICOMP2_VERSION_MAJOR=${PROJECT_VERSION_MAJOR} MULTICOMP2_VERSION_MINOR=${PROJECT_VERSION_MINOR} MULTICOMP2_VERSION_PATCH=${PROJECT_VERSION_PATCH})
+if(APPLE)
+  # DAF's generic AU path lookup can resolve the remote host executable in
+  # AUHostingService. Resolve from code linked into this component instead.
+  target_sources(multi_comp_2-au PRIVATE MultiCompAUComponentBundlePath.mm)
+endif()
 dusk_daf_install_local(multi_comp_2 LV2_PROGRAMS)
 
 if(NOT CMAKE_CROSSCOMPILING)

--- a/plugins/multi-comp/daf-plugin/MultiCompAUComponentBundlePath.mm
+++ b/plugins/multi-comp/daf-plugin/MultiCompAUComponentBundlePath.mm
@@ -1,0 +1,47 @@
+#include <src/DafDefines.h>
+
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdlib.h>
+
+#include <cstdio>
+#include <cstring>
+
+START_NAMESPACE_DAF
+extern const char* d_nextBundlePath;
+END_NAMESPACE_DAF
+
+namespace
+{
+char componentBundlePath[PATH_MAX]{};
+
+__attribute__((constructor))
+void setMultiCompAUComponentBundlePath()
+{
+    Dl_info imageInfo{};
+    if (dladdr(reinterpret_cast<const void*>(&setMultiCompAUComponentBundlePath),
+               &imageInfo) == 0
+        || imageInfo.dli_fname == nullptr)
+        return;
+
+    if (realpath(imageInfo.dli_fname, componentBundlePath) == nullptr)
+        std::snprintf(componentBundlePath, sizeof(componentBundlePath), "%s",
+                      imageInfo.dli_fname);
+
+    constexpr const char* contentsMarker = "/Contents/MacOS/";
+    char* const contents = std::strstr(componentBundlePath, contentsMarker);
+    if (contents == nullptr)
+        return;
+    *contents = '\0';
+
+    constexpr const char* componentSuffix = ".component";
+    const size_t pathLength = std::strlen(componentBundlePath);
+    const size_t suffixLength = std::strlen(componentSuffix);
+    if (pathLength < suffixLength
+        || std::strcmp(componentBundlePath + pathLength - suffixLength,
+                       componentSuffix) != 0)
+        return;
+
+    DAF_NAMESPACE::d_nextBundlePath = componentBundlePath;
+}
+} // namespace

--- a/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
@@ -442,6 +442,26 @@ void testFractionalEnumUiAndDspAgreement()
     std::puts("fractional enum automation: UI and DSP select the same rounded index");
 }
 
+void testEditorMirrorSeedsFromCurrentPluginState()
+{
+    multicompp::StateValues mirror{};
+    for (int i = 0; i < multicompp::kMeterMaster; ++i)
+        mirror[static_cast<size_t>(i)] = multicompp::resolveParameter(i,
+            [](const multicompp::Param& d) { return multicompp::hostDefault(d); },
+            [](const multicompp::BandParam& d, int) { return multicompp::hostDefault(d); });
+    auto pluginValues = mirror;
+    const auto mode = static_cast<uint32_t>(multicompp::ParamId::Mode);
+    const auto fetInput = static_cast<uint32_t>(multicompp::ParamId::FetInput);
+    pluginValues[mode] = 1.0f;
+    pluginValues[fetInput] = 17.25f;
+    multicompp::ui_detail::refreshParameterMirror(mirror,
+        [&pluginValues](uint32_t index) { return pluginValues[index]; },
+        static_cast<uint32_t>(multicompp::kMeterMaster));
+    require(mirror[mode] == 1.0f && mirror[fetInput] == 17.25f,
+            "a newly opened editor seeds its mirror from the live plugin state");
+    std::puts("editor mirror seed: pre-open FET host state adopted on the first frame");
+}
+
 void testCrossoverMirrorRefreshesEveryPluginChangedValue()
 {
     multicompp::StateValues values{};
@@ -666,6 +686,82 @@ void testShippingUiUsesConformingHeaderWithoutUtilityBands()
                 "all eight compressor modes are exposed as top-row buttons");
 }
 
+void testFetFaceplateContract()
+{
+    const std::string source = readSiblingSource("MultiCompUI.cpp");
+    const bool hasBlackFaceIdentity = source.find("\"FET 76\"") != std::string::npos
+        && source.find("\"LIMITING AMPLIFIER\"") != std::string::npos;
+    const bool reusesOptoMeter =
+        source.find("drawOptoMeter(dl, 675") != std::string::npos
+        && source.find("void drawFetMeter(") == std::string::npos
+        && source.find("mode == 0 || mode == 1") != std::string::npos;
+    const bool hasFiveRatioButtons = source.find("drawFetRatioButtons(dl") != std::string::npos
+        && source.find("visualOrder") != std::string::npos
+        && source.find("row < 5") != std::string::npos;
+    const bool exposesOnlyMixExtension =
+        source.find("fetTrimKnob(dl, \"fet_mix\"") != std::string::npos
+        && source.find("fetTrimKnob(dl, \"fet_threshold\"") == std::string::npos
+        && source.find("fetTrimKnob(dl, \"fet_trans\"") == std::string::npos
+        && source.find("drawFetCurveSwitch") == std::string::npos;
+    const bool hasConcentricKnobSkirts =
+        source.find("AddCircleFilled(center, r * 0.96f") != std::string::npos
+        && source.find("center.x - r * 0.13f") == std::string::npos;
+    const size_t studioBranch = source.find("if (studio)");
+    const size_t vintageFace = source.find("constexpr float left = 0.0f",
+                                           studioBranch);
+    const bool keepsStudioDistinct = studioBranch != std::string::npos
+        && vintageFace != std::string::npos && studioBranch < vintageFace
+        && source.find("\"sf_in\"", studioBranch) < vintageFace;
+    const auto attack = static_cast<uint32_t>(multicompp::ParamId::FetAttack);
+    const auto release = static_cast<uint32_t>(multicompp::ParamId::FetRelease);
+    const auto input = static_cast<uint32_t>(multicompp::ParamId::FetInput);
+    const bool timingReadoutUsesDialPosition =
+        multicompp::ui_detail::fetTimingDialValue(multicompp::hostMin(
+            multicompp::kParams[attack]), attack) == 1.0f
+        && multicompp::ui_detail::fetTimingDialValue(multicompp::hostMax(
+            multicompp::kParams[attack]), attack) == 7.0f
+        && multicompp::ui_detail::fetTimingDialValue(multicompp::hostMin(
+            multicompp::kParams[release]), release) == 1.0f
+        && multicompp::ui_detail::fetTimingDialValue(multicompp::hostMax(
+            multicompp::kParams[release]), release) == 7.0f
+        && multicompp::ui_detail::fetTimingHostValue(4.0f, attack) == 0.5f
+        && multicompp::ui_detail::fetTimingHostValue(4.0f, release) == 575.0f
+        && !multicompp::ui_detail::fetTimingUsesDialReadout(input);
+    std::printf("FET faceplate: identity=%s opto-meter=%s ratios=%s mix-only=%s "
+                "concentric-knobs=%s studio-distinct=%s timing-readout=%s\n",
+                hasBlackFaceIdentity ? "yes" : "no",
+                reusesOptoMeter ? "yes" : "no",
+                hasFiveRatioButtons ? "yes" : "no",
+                exposesOnlyMixExtension ? "yes" : "no",
+                hasConcentricKnobSkirts ? "yes" : "no",
+                keepsStudioDistinct ? "yes" : "no",
+                timingReadoutUsesDialPosition ? "1-7" : "legacy-ms");
+    require(hasBlackFaceIdentity && reusesOptoMeter && hasFiveRatioButtons
+                && exposesOnlyMixExtension && hasConcentricKnobSkirts
+                && keepsStudioDistinct && timingReadoutUsesDialPosition,
+            "vintage FET uses 1-7 timing readouts while preserving its hardware faceplate");
+}
+
+void testAuCustomViewUsesComponentBundle()
+{
+#if defined(__APPLE__)
+    const std::string cmake = readSiblingSource("CMakeLists.txt");
+    const std::string resolver = readSiblingSource("MultiCompAUComponentBundlePath.mm");
+    const bool resolverIsLinkedIntoAu =
+        cmake.find("target_sources(multi_comp_2-au PRIVATE "
+                   "MultiCompAUComponentBundlePath.mm)") != std::string::npos;
+    const bool resolverUsesItsOwnImage =
+        resolver.find("&setMultiCompAUComponentBundlePath") != std::string::npos
+        && resolver.find("DAF_NAMESPACE::d_nextBundlePath = componentBundlePath")
+            != std::string::npos;
+    require(resolverIsLinkedIntoAu && resolverUsesItsOwnImage,
+            "AU custom view bundle is resolved from code inside the component image");
+    std::printf("AU Cocoa editor path: component-local resolver linked=%s source=%s\n",
+                resolverIsLinkedIntoAu ? "yes" : "no",
+                resolverUsesItsOwnImage ? "yes" : "no");
+#endif
+}
+
 void testHostProgramChangeUpdatesUiMirror()
 {
     for (size_t presetIndex = 0; presetIndex < multicompp::kFactoryPresets.size(); ++presetIndex)
@@ -732,9 +828,11 @@ void testOptoFaceplateContract()
             "Opto faceplate fills the complete mode canvas below the toolbar");
     require(multicompp::ui_detail::designHeightForMode(0.0f) == 380.0f
                 && multicompp::ui_detail::designHeightForMode(0.4f) == 380.0f
-                && multicompp::ui_detail::designHeightForMode(0.6f) == 486.0f
+                && multicompp::ui_detail::designHeightForMode(0.6f) == 380.0f
+                && multicompp::ui_detail::designHeightForMode(1.4f) == 380.0f
+                && multicompp::ui_detail::designHeightForMode(1.6f) == 486.0f
                 && multicompp::ui_detail::designHeightForMode(7.0f) == 486.0f,
-            "Opto uses the compact rack canvas while every other mode keeps the full canvas");
+            "Opto and vintage FET use rack-height canvases while the other modes keep the full canvas");
 
     const float zero = multicompp::ui_detail::optoMeterNeedleAngle(0.0f);
     const float ten = multicompp::ui_detail::optoMeterNeedleAngle(-10.0f);
@@ -747,10 +845,30 @@ void testOptoFaceplateContract()
             "Opto mode control exposes the Comp and Limit panel labels");
     require(std::strcmp(multicompp::ui_detail::optoMeterLabel(), "GR") == 0,
             "Opto analogue meter is fixed to the GR panel readout");
-    const float afterOneTimeConstant =
-        multicompp::ui_detail::optoMeterBallisticStep(0.0f, -20.0f, 0.300f);
-    reviewCheck(std::abs(afterOneTimeConstant + 12.64241f) < 0.001f,
-                "Opto needle applies a 300 ms RC response instead of raw block GR");
+    const float attackDisplay = multicompp::ui_detail::optoMeterDisplayValue(-20.0f);
+    const float releaseDisplay = multicompp::ui_detail::optoMeterDisplayValue(0.0f);
+    const std::string source = readSiblingSource("MultiCompUI.cpp");
+    const size_t meterStart = source.find("void drawOptoMeter(");
+    const size_t meterEnd = source.find("void drawFet(", meterStart);
+    require(meterStart != std::string::npos && meterEnd != std::string::npos,
+            "shared Opto/FET meter renderer is present");
+    const std::string meterSource = source.substr(meterStart, meterEnd - meterStart);
+    const bool hasOneDbTickScale =
+        meterSource.find("for (int tick = 0; tick <= 20; ++tick)") != std::string::npos
+        && meterSource.find("static_cast<float>(tick) / 20.0f") != std::string::npos
+        && meterSource.find("const bool major = tick % 5 == 0") != std::string::npos;
+    const bool omitsVuLevelLegend =
+        meterSource.find("VU LEVEL INDICATOR") == std::string::npos;
+    require(hasOneDbTickScale && omitsVuLevelLegend,
+            "shared Opto/FET meter has one tick per dB and no VU level legend");
+    const bool drawsRawGainReduction = source.find(
+        "optoMeterDisplayValue(meter(kMeterMaster))") != std::string::npos;
+    const bool keepsDisplayEnvelope = source.find("optoMeterBallisticStep")
+            != std::string::npos
+        || source.find("optoMeterGainReductionDb") != std::string::npos;
+    reviewCheck(attackDisplay == -20.0f && releaseDisplay == 0.0f
+                    && drawsRawGainReduction && !keepsDisplayEnvelope,
+                "Opto needle follows raw DSP gain reduction without added display lag or state");
     reviewCheck(std::strcmp(multicompp::ui_detail::optoKnobValueSuffix(), "") == 0,
                 "Opto knob value bubbles show unitless 0-100 values");
     const float idleReadout = multicompp::ui_detail::optoMeterReadoutAmount(0.0f);
@@ -759,7 +877,8 @@ void testOptoFaceplateContract()
                 && multicompp::ui_detail::optoMeterReadoutAmount(1.0f) == 0.0f
                 && multicompp::ui_detail::optoMeterReadoutAmount(-150.0f) == 99.9f,
             "Opto GR readout is positive, bounded, and never displays negative zero");
-    std::printf("opto faceplate: aspect %.6f reference %.6f; meter angles "
+    std::printf("opto faceplate: aspect %.6f reference %.6f; meter ticks=21 "
+                "(1 dB each), legend=removed; meter angles "
                 "0/10/20 dB %.6f/%.6f/%.6f rad; modes %s/%s\n",
                 aspect, referenceAspect, zero, ten, twenty,
                 multicompp::ui_detail::optoModeLabel(0.0f),
@@ -823,14 +942,22 @@ void testFractionalIntegerAutomationStaysLoadable()
     std::puts("fractional integer automation: snapped on store, state stays loadable");
 }
 
-int main()
+int main(int argc, char** argv)
 {
+    if (argc == 2 && std::strcmp(argv[1], "--fet-ui") == 0)
+    {
+        testFetFaceplateContract();
+        std::puts("Multi-Comp FET faceplate test: PASS");
+        return 0;
+    }
     testRunGuardsSidechainPortsPerLayout();
     testCrossoverOrderingDoesNotRatchet();
     testQuantisedFineStepFallsBackToRestingPrecision();
     testOptoSidechainHpUsesPhysicalDragDomain();
     testShippingUiHasNoDeadCrossoverDescriptor();
     testShippingUiUsesConformingHeaderWithoutUtilityBands();
+    testFetFaceplateContract();
+    testAuCustomViewUsesComponentBundle();
     testOptoFaceplateContract();
     testCrossoverMirrorRefreshesEveryPluginChangedValue();
     require(reviewFailureCount == 0, "review regressions are fixed");
@@ -842,6 +969,7 @@ int main()
     testHostProgramChangeUpdatesUiMirror();
     testPresetIdentityFollowsPresetOwnership();
     testFractionalEnumUiAndDspAgreement();
+    testEditorMirrorSeedsFromCurrentPluginState();
     testFractionalIntegerAutomationStaysLoadable();
     std::puts("Multi-Comp plugin-layer tests: PASS");
     return 0;

--- a/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
@@ -35,11 +35,11 @@ inline constexpr float optoFaceplateAspect() noexcept
 
 inline float designHeightForMode(float hostValue) noexcept
 {
-    // Opto is a single rack face and should have the same shallow proportion as
-    // the hardware it evokes. Multiband still needs the original tall canvas;
-    // keeping the decision here also gives fractional host automation the same
-    // rounding rule as the DSP and the mode picker.
-    return choiceIndex(hostValue, 8) == 0 ? 380.0f : 486.0f;
+    // Opto and vintage FET are single rack faces and use the same compact
+    // canvas. The modern modes still need the original tall control surface;
+    // keeping the decision here gives fractional host automation the same
+    // rounding rule as the DSP and mode picker.
+    return choiceIndex(hostValue, 8) <= 1 ? 380.0f : 486.0f;
 }
 
 inline float optoMeterNeedleAngle(float gainReductionDb) noexcept
@@ -49,23 +49,43 @@ inline float optoMeterNeedleAngle(float gainReductionDb) noexcept
     return (55.0f - 110.0f * amount) * pi / 180.0f;
 }
 
-inline float optoMeterBallisticStep(float currentGainReductionDb,
-                                    float targetGainReductionDb,
-                                    float elapsedSeconds) noexcept
+inline float optoMeterDisplayValue(float gainReductionDb) noexcept
 {
-    // Display-only VU inertia. Use elapsed time rather than a per-frame blend
-    // so the response remains the same at different host repaint rates.
-    if (!std::isfinite(currentGainReductionDb)) currentGainReductionDb = 0.0f;
-    if (!std::isfinite(targetGainReductionDb) || !(elapsedSeconds > 0.0f))
-        return currentGainReductionDb;
-    constexpr float timeConstantSeconds = 0.300f;
-    const float boundedElapsed = std::min(elapsedSeconds, 3.0f);
-    const float response = 1.0f - std::exp(-boundedElapsed / timeConstantSeconds);
-    return currentGainReductionDb
-        + (targetGainReductionDb - currentGainReductionDb) * response;
+    // The Opto gain cell already carries the measured LA-2A attack and release.
+    // The separate display decay was not measured from the reference and made
+    // the needle return materially later than the audio. Keep only a finite guard.
+    return std::isfinite(gainReductionDb) ? gainReductionDb : 0.0f;
 }
 
 inline constexpr const char* optoKnobValueSuffix() noexcept { return ""; }
+
+inline bool fetTimingUsesDialReadout(uint32_t parameter) noexcept
+{
+    return parameter == static_cast<uint32_t>(ParamId::FetAttack)
+        || parameter == static_cast<uint32_t>(ParamId::FetRelease);
+}
+
+// Vintage FET timing follows the reference unit's numbered 1-7 controls. Keep
+// the legacy host ranges intact for automation/state compatibility and convert
+// only the faceplate readout, gesture domain, and pointer position.
+inline float fetTimingDialValue(float hostValue, uint32_t parameter) noexcept
+{
+    if (!fetTimingUsesDialReadout(parameter)) return hostValue;
+    const auto& descriptor = kParams[parameter];
+    const float minimum = hostMin(descriptor);
+    const float range = hostMax(descriptor) - minimum;
+    const float position = std::clamp((hostValue - minimum) / range, 0.0f, 1.0f);
+    return 1.0f + 6.0f * position;
+}
+
+inline float fetTimingHostValue(float dialValue, uint32_t parameter) noexcept
+{
+    if (!fetTimingUsesDialReadout(parameter)) return dialValue;
+    const auto& descriptor = kParams[parameter];
+    const float position = std::clamp((dialValue - 1.0f) / 6.0f, 0.0f, 1.0f);
+    return hostMin(descriptor)
+        + position * (hostMax(descriptor) - hostMin(descriptor));
+}
 
 inline bool optoKnobUsesPlainDomainDrag(uint32_t parameter) noexcept
 {
@@ -124,6 +144,20 @@ inline void refreshCrossoverMirror(std::array<float, N>& values, ReadParameter r
         if (index != skipIndex)
             values[index] = readParameter(index);
 }
+
+// A host may set parameters before it creates the editor, and DPF does not
+// replay those earlier parameterChanged() calls to a newly constructed UI.
+// Seed the mirror once from the live plugin so the first frame represents the
+// state the host actually opened rather than the compile-time defaults.
+template <size_t N, typename ReadParameter>
+inline void refreshParameterMirror(std::array<float, N>& values,
+                                   ReadParameter readParameter,
+                                   uint32_t parameterCount)
+{
+    const uint32_t count = std::min(parameterCount, static_cast<uint32_t>(N));
+    for (uint32_t index = 0; index < count; ++index)
+        values[index] = readParameter(index);
+}
 } // namespace multicompp::ui_detail
 
 #ifndef MULTICOMP_UI_LOGIC_TEST
@@ -136,7 +170,6 @@ inline void refreshCrossoverMirror(std::array<float, N>& values, ReadParameter r
 #include "DuskSupportersOverlay.hpp"
 #include "DuskUserPresetStore.hpp"
 
-#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -229,8 +262,8 @@ public:
                 values[multicompp::kBandBase + b * 8 + f] =
                     multicompp::hostDefault(multicompp::bandParam(f, b));
 
-        // Opto opens as a shallow rack face. Other modes request their taller
-        // authored canvas when selected, preserving the user's current scale.
+        // Hardware modes open as shallow rack faces. Modern modes request their
+        // taller authored canvas when selected, preserving the user's scale.
         constrainedDesignH = multicompp::ui_detail::designHeightForMode(values[P_MODE]);
         pendingDesignH = constrainedDesignH;
         setGeometryConstraints(static_cast<uint32_t>(kDesignW),
@@ -288,13 +321,14 @@ protected:
 
     void uiIdle() override
     {
+        seedParameterMirror();
         refreshCrossoverMirror();
-        updateOptoMeter();
         repaint();
     }
 
     void onImGuiDisplay() override
     {
+        seedParameterMirror();
         // The crossovers are only submitted in Multiband mode. If the host
         // switches Mode away mid-drag the widget stops being drawn, so ImGui
         // never reports IsItemDeactivated for it: the gesture would stay open on
@@ -380,6 +414,7 @@ private:
     std::array<float, multicompp::kTotalParamCount> values{};
     duskdaf::DuskPanel panel;
     ImDrawListSplitter optoKnobSplitter;
+    ImDrawListSplitter fetKnobSplitter;
     duskdaf::CrispFontSet fontSet;
     ImFont* labelFont = nullptr;
     duskdaf::SupportersOverlay supporters;
@@ -388,9 +423,7 @@ private:
     float constrainedDesignH = 380.0f;
     float pendingDesignH = 380.0f;
     bool modeGeometryPending = false;
-    float optoMeterGainReductionDb = 0.0f;
-    std::chrono::steady_clock::time_point optoMeterLastUpdate{};
-    bool optoMeterInitialized = false;
+    bool parameterMirrorSeeded = false;
     static constexpr uint32_t kNoCrossover = ~uint32_t(0);
     // The crossover handle under an active drag. Owns both the open automation
     // gesture and the mirror's skip, so the two cannot disagree.
@@ -413,25 +446,6 @@ private:
     bool saveFailed = false;
 
     float value(uint32_t p) const { return values[p]; }
-
-    void updateOptoMeter()
-    {
-        const auto now = std::chrono::steady_clock::now();
-        const float target = meter(kMeterMaster);
-        if (!optoMeterInitialized)
-        {
-            optoMeterGainReductionDb = target;
-            optoMeterInitialized = true;
-        }
-        else
-        {
-            const float elapsed = std::chrono::duration<float>(
-                now - optoMeterLastUpdate).count();
-            optoMeterGainReductionDb = multicompp::ui_detail::optoMeterBallisticStep(
-                optoMeterGainReductionDb, target, elapsed);
-        }
-        optoMeterLastUpdate = now;
-    }
 
     void scheduleModeGeometry(float hostMode)
     {
@@ -570,6 +584,19 @@ private:
         multicompp::ui_detail::refreshCrossoverMirror(values,
             [instance](uint32_t index) { return multiCompGetParameterValue(instance, index); },
             draggedCrossover);
+    }
+
+    void seedParameterMirror()
+    {
+        if (parameterMirrorSeeded || multiCompGetParameterValue == nullptr) return;
+        void* const instance = getPluginInstancePointer();
+        if (instance == nullptr) return;
+        multicompp::ui_detail::refreshParameterMirror(values,
+            [instance](uint32_t index) { return multiCompGetParameterValue(instance, index); },
+            static_cast<uint32_t>(multicompp::kMeterMaster));
+        parameterMirrorSeeded = true;
+        scheduleModeGeometry(values[P_MODE]);
+        syncPresetSelection();
     }
 
     void setValue(uint32_t p, float v)
@@ -1063,14 +1090,24 @@ private:
         return static_cast<MultiCompUI*>(context)->hostValueForPlain(p, plain);
     }
 
+    static float fetTimingHostToDial(float host, uint32_t p, void*)
+    {
+        return multicompp::ui_detail::fetTimingDialValue(host, p);
+    }
+
+    static float fetTimingDialToHost(float dial, uint32_t p, void*)
+    {
+        return multicompp::ui_detail::fetTimingHostValue(dial, p);
+    }
+
     void drawModePanel(ImDrawList* dl)
     {
         const int mode = multicompp::ui_detail::choiceIndex(value(P_MODE), 8);
         drawSection(dl, kModeCanvasTop, kModeCanvasBottom - 8, "");
         drawModeToolbar(dl);
-        if (mode == 0)
+        if (mode == 0 || mode == 1)
         {
-            // Opto owns a panel-integrated analogue GR meter.
+            // Opto and vintage FET own panel-integrated analogue GR meters.
         }
         else if (mode == 7)
             drawMeter(dl, 1062, kModeCanvasTop + 42, 42, 92, meter(kMeterMaster), kAccent, "MASTER GR");
@@ -1180,7 +1217,7 @@ private:
         optoModeSwitch(dl, 139, top + 170.0f);
         optoKnob(dl, "opto_gain", P_OPTO_GAIN, 287, top + 170.0f, 53.0f, "GAIN");
         drawOptoMeter(dl, 390, top + 54.0f, 348, 196,
-                      optoMeterGainReductionDb);
+                      multicompp::ui_detail::optoMeterDisplayValue(meter(kMeterMaster)));
         optoKnob(dl, "opto_peak", P_OPTO_PEAK, 838, top + 170.0f, 53.0f,
                  "PEAK REDUCTION");
         optoKnob(dl, "opto_sc_hp", P_SC_HP, 996, top + 108.0f, 18.0f,
@@ -1479,32 +1516,29 @@ private:
                       -35.0f * kUiPi / 180.0f, 40);
         dl->PathStroke(IM_COL32(92, 70, 38, 185), 0, scale);
         constexpr std::array<const char*, 5> labels{{"20", "15", "10", "5", "0"}};
-        for (int tick = 0; tick <= 40; ++tick)
+        for (int tick = 0; tick <= 20; ++tick)
         {
-            const float amount = static_cast<float>(tick) / 40.0f;
+            const float amount = static_cast<float>(tick) / 20.0f;
             const float angle = (-55.0f + 110.0f * amount)
                 * kUiPi / 180.0f;
             const ImVec2 direction(std::sin(angle), -std::cos(angle));
-            const bool major = tick % 10 == 0;
-            const bool medium = tick % 5 == 0;
+            const bool major = tick % 5 == 0;
             dl->AddLine(ImVec2(pivot.x + direction.x * radius
-                                   * (major ? 0.70f : medium ? 0.74f : 0.78f),
+                                   * (major ? 0.70f : 0.78f),
                                pivot.y + direction.y * radius
-                                   * (major ? 0.70f : medium ? 0.74f : 0.78f)),
+                                   * (major ? 0.70f : 0.78f)),
                         ImVec2(pivot.x + direction.x * radius * 0.88f,
                                pivot.y + direction.y * radius * 0.88f),
                         kOptoInk, (major ? 1.45f : 0.70f) * scale);
             if (major)
             {
-                const size_t label = static_cast<size_t>(tick / 10);
+                const size_t label = static_cast<size_t>(tick / 5);
                 const float labelRadius = radiusDesign * 0.61f;
                 panel.text(dl, pivotX + direction.x * labelRadius,
                            pivotY + direction.y * labelRadius - 4.0f,
                            8.5f, kOptoInk, labels[label], 0, true);
             }
         }
-        panel.text(dl, x + w * 0.5f, y + 17.0f, 8.0f,
-                   IM_COL32(89, 67, 35, 255), "VU LEVEL INDICATOR", 0, true);
         panel.text(dl, x + 31.0f, y + 54.0f, 12.0f, kOptoInk, "VU", 0, true);
         panel.text(dl, x + w - 32.0f, y + 54.0f, 12.0f, kOptoRed,
                    multicompp::ui_detail::optoMeterLabel(), 0, true);
@@ -1536,16 +1570,358 @@ private:
 
     void drawFet(ImDrawList* dl, bool studio)
     {
-        knob(dl, studio ? "sf_in" : "fet_in", P_FET_IN, 120, 380, "INPUT", "%.1f", " dB");
-        knob(dl, studio ? "sf_out" : "fet_out", P_FET_OUT, 250, 380, "OUTPUT", "%.1f", " dB");
-        knob(dl, studio ? "sf_att" : "fet_att", P_FET_ATTACK, 380, 380, "ATTACK", "%.2f", " ms");
-        knob(dl, studio ? "sf_rel" : "fet_rel", P_FET_RELEASE, 510, 380, "RELEASE", "%.0f", " ms");
-        knob(dl, studio ? "sf_mix" : "fet_mix", P_MIX, 640, 380, "MIX", "%.0f", "%");
-        combo(studio ? "sf_ratio" : "fet_ratio", P_FET_RATIO, multicompp::kRatios, 5, 775, 352, 118, "RATIO");
-        combo(studio ? "sf_curve" : "fet_curve", P_FET_CURVE, multicompp::kFetCurve, 2, 905, 352, 142, "CURVE");
-        knob(dl, studio ? "sf_trans" : "fet_trans", P_FET_TRANSIENT, 1020, 380, "TRANSIENT", "%.0f", "%");
-        panel.text(dl, 560, 500, 12, studio ? IM_COL32(80, 215, 205, 255) : IM_COL32(235, 175, 80, 255),
-                   studio ? "Clean FET response with controlled harmonics" : "Fast FET response with program-dependent release", 0);
+        if (studio)
+        {
+            knob(dl, "sf_in", P_FET_IN, 120, 380, "INPUT", "%.1f", " dB");
+            knob(dl, "sf_out", P_FET_OUT, 250, 380, "OUTPUT", "%.1f", " dB");
+            knob(dl, "sf_att", P_FET_ATTACK, 380, 380, "ATTACK", "%.2f", " ms");
+            knob(dl, "sf_rel", P_FET_RELEASE, 510, 380, "RELEASE", "%.0f", " ms");
+            knob(dl, "sf_mix", P_MIX, 640, 380, "MIX", "%.0f", "%");
+            combo("sf_ratio", P_FET_RATIO, multicompp::kRatios, 5, 775, 352, 118, "RATIO");
+            combo("sf_curve", P_FET_CURVE, multicompp::kFetCurve, 2, 905, 352, 142, "CURVE");
+            knob(dl, "sf_trans", P_FET_TRANSIENT, 1020, 380, "TRANSIENT", "%.0f", "%");
+            panel.text(dl, 560, 500, 12, IM_COL32(80, 215, 205, 255),
+                       "Clean FET response with controlled harmonics", 0);
+            return;
+        }
+
+        constexpr float left = 0.0f, right = 1120.0f;
+        constexpr float top = 344.0f, bottom = 654.0f;
+        dl->AddRectFilled(panel.P(left + 5, top + 7), panel.P(right + 5, bottom + 7),
+                          IM_COL32(0, 0, 0, 150), 4.0f * panel.scale());
+        dl->AddRectFilledMultiColor(panel.P(left, top), panel.P(right, bottom),
+                                    IM_COL32(27, 28, 27, 255),
+                                    IM_COL32(17, 18, 18, 255),
+                                    IM_COL32(7, 8, 8, 255),
+                                    IM_COL32(13, 14, 14, 255));
+        dl->AddRect(panel.P(left, top), panel.P(right, bottom),
+                    IM_COL32(114, 116, 111, 255), 4.0f * panel.scale(), 0,
+                    1.3f * panel.scale());
+        for (int row = static_cast<int>(top + 4); row < static_cast<int>(bottom); row += 4)
+            dl->AddLine(panel.P(left + 3, static_cast<float>(row)),
+                        panel.P(right - 3, static_cast<float>(row)),
+                        row % 8 == 0 ? IM_COL32(255, 255, 255, 9)
+                                     : IM_COL32(0, 0, 0, 17), panel.scale());
+        // Rack ears and mounting slots use the same full-face construction as
+        // Opto mode so switching hardware models feels like swapping rack units.
+        dl->AddRectFilled(panel.P(left, top), panel.P(left + 38.0f, bottom),
+                          IM_COL32(35, 36, 35, 255));
+        dl->AddRectFilled(panel.P(right - 38.0f, top), panel.P(right, bottom),
+                          IM_COL32(35, 36, 35, 255));
+        dl->AddLine(panel.P(left + 38.0f, top), panel.P(left + 38.0f, bottom),
+                    IM_COL32(104, 106, 101, 180), panel.scale());
+        dl->AddLine(panel.P(right - 38.0f, top), panel.P(right - 38.0f, bottom),
+                    IM_COL32(104, 106, 101, 180), panel.scale());
+        for (const float slotY : {top + 62.0f, bottom - 62.0f})
+        {
+            dl->AddRectFilled(panel.P(-9.0f, slotY - 9.0f),
+                              panel.P(23.0f, slotY + 9.0f),
+                              IM_COL32(2, 3, 3, 255), 8.0f * panel.scale());
+            dl->AddRectFilled(panel.P(right - 23.0f, slotY - 9.0f),
+                              panel.P(right + 9.0f, slotY + 9.0f),
+                              IM_COL32(2, 3, 3, 255), 8.0f * panel.scale());
+        }
+        for (const ImVec2 screw : {ImVec2(left + 73, top + 18),
+                                   ImVec2(right - 73, top + 18),
+                                   ImVec2(left + 73, bottom - 18),
+                                   ImVec2(right - 73, bottom - 18)})
+        {
+            dl->AddCircleFilled(panel.P(screw.x, screw.y), 5.5f * panel.scale(),
+                                IM_COL32(130, 132, 127, 255), 24);
+            dl->AddLine(panel.P(screw.x - 3.0f, screw.y),
+                        panel.P(screw.x + 3.0f, screw.y),
+                        IM_COL32(38, 39, 38, 255), panel.scale());
+        }
+
+        // Match the reference unit's left-to-right reading order: two large gain
+        // controls, vertically paired timing controls, ratio buttons, the same
+        // VU assembly proven in Opto mode, then the fixed GR meter bank.
+        fetKnob(dl, "fet_in", P_FET_IN, 194, 496, 45.0f,
+                "INPUT", true, "%.1f", " dB");
+        fetKnob(dl, "fet_out", P_FET_OUT, 390, 496, 45.0f,
+                "OUTPUT", true, "%.1f", " dB");
+        fetKnob(dl, "fet_att", P_FET_ATTACK, 548, 422, 22.0f,
+                "ATTACK", false, "%.2f", "");
+        fetKnob(dl, "fet_rel", P_FET_RELEASE, 548, 526, 22.0f,
+                "RELEASE", false, "%.2f", "");
+        drawFetRatioButtons(dl, 635, 392);
+        drawOptoMeter(dl, 675, 384, 300, 178,
+                      multicompp::ui_detail::optoMeterDisplayValue(meter(kMeterMaster)));
+        panel.text(dl, 825, top + 14, 13.0f, IM_COL32(234, 234, 221, 255),
+                   "FET 76", 0, true);
+        panel.text(dl, 825, top + 32, 7.2f, IM_COL32(177, 179, 170, 255),
+                   "REFERENCE SERIES", 0, true);
+        panel.text(dl, 825, top + 226, 9.2f, IM_COL32(234, 234, 221, 255),
+                   "MC-2", 0, true);
+        panel.text(dl, 825, top + 243, 8.0f, IM_COL32(202, 204, 194, 255),
+                   "LIMITING AMPLIFIER", 0, true);
+        drawFetMeterSwitch(dl, 997, 393);
+        fetTrimKnob(dl, "fet_mix", P_MIX, 1048, 594, 13.0f,
+                    "MIX", "%.0f", "%");
+    }
+
+    void fetKnob(ImDrawList* dl, const char* id, uint32_t p,
+                 float x, float y, float radius, const char* label,
+                 bool gainScale, const char* format, const char* suffix)
+    {
+        // Reuse the shared gesture and type-entry contract, but draw the body
+        // here so FET mode gets the reference unit's silver skirt and knurling.
+        fetKnobSplitter.Split(dl, 2);
+        fetKnobSplitter.SetCurrentChannel(dl, 1);
+        const bool timingDial = multicompp::ui_detail::fetTimingUsesDialReadout(p);
+        panel.knob(id, p, hostMinimum(p), hostMaximum(p), x, y, radius,
+                   values[p], hostDefaultValue(p), false, false, format, suffix,
+                   0, true, false, nullptr, false, 1.0f, 0.0f, label, true,
+                   nullptr, false, 0.0f, 0.0f, false, true, 9.5f, true, false,
+                   timingDial ? &fetTimingHostToDial : &knobHostToPlain,
+                   timingDial ? &fetTimingDialToHost : &knobPlainToHost,
+                   this, true);
+        fetKnobSplitter.SetCurrentChannel(dl, 0);
+
+        const float plain = plainValueForHost(p, values[p]);
+        const float minimum = plainValueForHost(p, hostMinimum(p));
+        const float maximum = plainValueForHost(p, hostMaximum(p));
+        const float t = timingDial
+            ? std::clamp((multicompp::ui_detail::fetTimingDialValue(values[p], p) - 1.0f)
+                             / 6.0f,
+                         0.0f, 1.0f)
+            : std::clamp((plain - minimum)
+                             / std::max(maximum - minimum, 1.0e-6f),
+                         0.0f, 1.0f);
+        const float scale = panel.scale();
+        const ImVec2 center = panel.P(x, y);
+        const float r = radius * scale;
+
+        if (gainScale)
+        {
+            constexpr std::array<const char*, 9> labels{{
+                "INF", "48", "36", "30", "24", "18", "12", "6", "0"}};
+            for (int tick = 0; tick <= 16; ++tick)
+            {
+                const float tickT = static_cast<float>(tick) / 16.0f;
+                const float angle = duskdaf::DuskPanel::knobAngle(tickT);
+                const ImVec2 direction(std::sin(angle), -std::cos(angle));
+                const bool major = tick % 2 == 0;
+                const float inner = r + (major ? 4.0f : 7.0f) * scale;
+                const float outer = r + 10.0f * scale;
+                dl->AddLine(ImVec2(center.x + direction.x * inner,
+                                   center.y + direction.y * inner),
+                            ImVec2(center.x + direction.x * outer,
+                                   center.y + direction.y * outer),
+                            IM_COL32(229, 230, 219, 240),
+                            (major ? 1.25f : 0.75f) * scale);
+                if (major)
+                    panel.text(dl, x + direction.x * (radius + 19.0f),
+                               y + direction.y * (radius + 19.0f) - 3.0f,
+                               7.3f, IM_COL32(232, 232, 220, 255),
+                               labels[static_cast<size_t>(tick / 2)], 0, true);
+            }
+        }
+        else
+        {
+            constexpr std::array<const char*, 4> labels{{"1", "3", "5", "7"}};
+            for (int tick = 0; tick <= 6; ++tick)
+            {
+                const float tickT = static_cast<float>(tick) / 6.0f;
+                const float angle = duskdaf::DuskPanel::knobAngle(tickT);
+                const ImVec2 direction(std::sin(angle), -std::cos(angle));
+                const bool major = tick % 2 == 0;
+                dl->AddCircleFilled(ImVec2(center.x + direction.x * (r + 7.0f * scale),
+                                           center.y + direction.y * (r + 7.0f * scale)),
+                                    (major ? 1.45f : 0.85f) * scale,
+                                    IM_COL32(230, 230, 218, 255), 10);
+                if (major)
+                    panel.text(dl, x + direction.x * (radius + 15.0f),
+                               y + direction.y * (radius + 15.0f) - 3.0f,
+                               7.0f, IM_COL32(232, 232, 220, 255),
+                               labels[static_cast<size_t>(tick / 2)], 0, true);
+            }
+        }
+
+        // Soft shadow, concentric spun-metal skirt, knurled black collar and
+        // machined cap. Keep every structural circle on the exact center; the
+        // previous offset 91% disk read as a second gray knob at upper left.
+        dl->AddCircleFilled(ImVec2(center.x + 3.0f * scale, center.y + 4.0f * scale),
+                            r * 1.01f, IM_COL32(0, 0, 0, 150), 56);
+        dl->AddCircleFilled(center, r, IM_COL32(66, 67, 66, 255), 56);
+        dl->AddCircleFilled(center, r * 0.96f, IM_COL32(139, 140, 137, 255), 56);
+        dl->AddCircleFilled(center, r * 0.83f, IM_COL32(176, 177, 173, 255), 56);
+        dl->AddCircleFilled(center, r * 0.75f, IM_COL32(91, 92, 90, 255), 56);
+        dl->PathArcTo(center, r * 0.90f, -2.55f, -0.55f, 30);
+        dl->PathStroke(IM_COL32(238, 239, 234, 75), 0, 1.5f * scale);
+        dl->PathArcTo(center, r * 0.91f, 0.55f, 2.55f, 30);
+        dl->PathStroke(IM_COL32(24, 25, 24, 110), 0, 1.8f * scale);
+        dl->AddCircle(center, r, IM_COL32(31, 32, 31, 255), 56, 1.3f * scale);
+        const float collarR = r * 0.69f;
+        dl->AddCircleFilled(center, collarR, IM_COL32(20, 20, 20, 255), 52);
+        for (int notch = 0; notch < 28; ++notch)
+        {
+            const float angle = 2.0f * kUiPi * static_cast<float>(notch) / 28.0f;
+            const ImVec2 direction(std::sin(angle), -std::cos(angle));
+            dl->AddLine(ImVec2(center.x + direction.x * collarR * 0.78f,
+                               center.y + direction.y * collarR * 0.78f),
+                        ImVec2(center.x + direction.x * collarR,
+                               center.y + direction.y * collarR),
+                        IM_COL32(92, 93, 90, 235), 1.0f * scale);
+        }
+        const float capR = r * 0.49f;
+        dl->AddCircleFilled(center, capR, IM_COL32(111, 112, 110, 255), 48);
+        dl->AddCircleFilled(center, capR * 0.92f,
+                            IM_COL32(198, 199, 196, 255), 48);
+        dl->PathArcTo(center, capR * 0.78f, -2.50f, -0.65f, 22);
+        dl->PathStroke(IM_COL32(255, 255, 251, 95), 0, 1.2f * scale);
+        dl->AddCircle(center, capR, IM_COL32(44, 45, 44, 255), 48, 1.1f * scale);
+        const float pointerAngle = duskdaf::DuskPanel::knobAngle(t);
+        const ImVec2 pointer(std::sin(pointerAngle), -std::cos(pointerAngle));
+        dl->AddLine(ImVec2(center.x + pointer.x * capR * 0.12f,
+                           center.y + pointer.y * capR * 0.12f),
+                    ImVec2(center.x + pointer.x * capR * 0.88f,
+                           center.y + pointer.y * capR * 0.88f),
+                    IM_COL32(36, 37, 36, 255), 2.2f * scale);
+        dl->AddCircleFilled(ImVec2(center.x + pointer.x * collarR * 0.88f,
+                                   center.y + pointer.y * collarR * 0.88f),
+                            1.8f * scale, IM_COL32(221, 197, 145, 255), 12);
+
+        panel.text(dl, x, gainScale ? y + radius + 27.0f
+                                    : y + (label[0] == 'A' ? -50.0f : 39.0f),
+                   gainScale ? 8.8f : 8.0f,
+                   IM_COL32(235, 235, 222, 255), label, 0, true);
+        fetKnobSplitter.Merge(dl);
+    }
+
+    void fetTrimKnob(ImDrawList* dl, const char* id, uint32_t p,
+                     float x, float y, float radius, const char* label,
+                     const char* format, const char* suffix)
+    {
+        // The Opto face established the fleet contract for non-reference
+        // controls: keep the full parameter available as a small set-screw trim
+        // without letting it compete with the hardware's primary controls.
+        fetKnobSplitter.Split(dl, 2);
+        fetKnobSplitter.SetCurrentChannel(dl, 1);
+        panel.knob(id, p, hostMinimum(p), hostMaximum(p), x, y, radius,
+                   values[p], hostDefaultValue(p), false, false, format, suffix,
+                   0, true, false, nullptr, false, 1.0f, 0.0f, label, true,
+                   nullptr, false, 0.0f, 0.0f, false, true, 8.0f, true, false,
+                   &knobHostToPlain, &knobPlainToHost, this, true);
+        fetKnobSplitter.SetCurrentChannel(dl, 0);
+
+        const float plain = plainValueForHost(p, values[p]);
+        const float minimum = plainValueForHost(p, hostMinimum(p));
+        const float maximum = plainValueForHost(p, hostMaximum(p));
+        const float t = std::clamp((plain - minimum)
+            / std::max(maximum - minimum, 1.0e-6f), 0.0f, 1.0f);
+        const float scale = panel.scale();
+        const ImVec2 center = panel.P(x, y);
+        const float r = radius * scale;
+
+        std::array<ImVec2, 6> nut{};
+        for (int point = 0; point < 6; ++point)
+        {
+            const float angle = kUiPi / 6.0f + static_cast<float>(point)
+                * kUiPi / 3.0f;
+            nut[static_cast<size_t>(point)] = ImVec2(
+                center.x + std::cos(angle) * r * 1.18f,
+                center.y + std::sin(angle) * r * 1.18f);
+        }
+        std::array<ImVec2, 6> shadow = nut;
+        for (auto& point : shadow)
+        {
+            point.x += 2.0f * scale;
+            point.y += 3.0f * scale;
+        }
+        dl->AddConvexPolyFilled(shadow.data(), 6, IM_COL32(0, 0, 0, 120));
+        dl->AddConvexPolyFilled(nut.data(), 6, IM_COL32(94, 96, 93, 255));
+        dl->AddCircleFilled(center, r, IM_COL32(116, 118, 115, 255), 32);
+        dl->AddCircleFilled(center, r * 0.84f,
+                            IM_COL32(190, 192, 188, 255), 32);
+        dl->PathArcTo(center, r * 0.70f, -2.45f, -0.75f, 18);
+        dl->PathStroke(IM_COL32(247, 248, 242, 80), 0, panel.scale());
+        dl->AddCircle(center, r, IM_COL32(43, 44, 43, 255), 32, 1.1f * scale);
+        const float angle = duskdaf::DuskPanel::knobAngle(t);
+        const ImVec2 pointer(std::sin(angle), -std::cos(angle));
+        dl->AddLine(ImVec2(center.x - pointer.x * r * 0.58f,
+                           center.y - pointer.y * r * 0.58f),
+                    ImVec2(center.x + pointer.x * r * 0.58f,
+                           center.y + pointer.y * r * 0.58f),
+                    IM_COL32(42, 43, 42, 255), 2.0f * scale);
+        panel.text(dl, x, y - 38.0f, 7.5f,
+                   IM_COL32(225, 226, 215, 255), label, 0, true);
+        panel.text(dl, x - 27.0f, y - 5.0f, 10.0f,
+                   IM_COL32(157, 160, 152, 255), "-", 0, true);
+        panel.text(dl, x + 27.0f, y - 5.0f, 10.0f,
+                   IM_COL32(210, 212, 201, 255), "+", 0, true);
+        fetKnobSplitter.Merge(dl);
+    }
+
+    void drawFetRatioButtons(ImDrawList* dl, float x, float y)
+    {
+        const int selected = multicompp::ui_detail::choiceIndex(value(P_FET_RATIO), 5);
+        panel.text(dl, x + 14, y - 23, 8.5f, IM_COL32(230, 231, 219, 255),
+                   "RATIO", 0, true);
+        constexpr std::array<int, 5> visualOrder{{3, 2, 1, 0, 4}};
+        constexpr std::array<const char*, 5> visualLabels{{
+            "20", "12", "8", "4", "ALL"}};
+        for (int row = 0; row < 5; ++row)
+        {
+            const int index = visualOrder[static_cast<size_t>(row)];
+            const float y0 = y + static_cast<float>(row) * 31.0f;
+            const ImVec2 p0 = panel.P(x, y0);
+            const ImVec2 p1 = panel.P(x + 28.0f, y0 + 27.0f);
+            char id[32];
+            std::snprintf(id, sizeof(id), "##fet_ratio_button_%d", index);
+            ImGui::SetCursorScreenPos(p0);
+            const bool clicked = ImGui::InvisibleButton(
+                id, ImVec2(p1.x - p0.x, p1.y - p0.y));
+            const bool active = index == selected;
+            dl->AddRectFilled(panel.P(x + 2.0f, y0 + 3.0f),
+                              panel.P(x + 31.0f, y0 + 30.0f),
+                              IM_COL32(0, 0, 0, 130), 1.5f * panel.scale());
+            dl->AddRectFilled(p0, p1,
+                              active ? IM_COL32(24, 24, 23, 255)
+                                     : ImGui::IsItemHovered()
+                                         ? IM_COL32(52, 52, 49, 255)
+                                         : IM_COL32(31, 31, 29, 255),
+                              1.5f * panel.scale());
+            dl->AddRect(p0, p1, IM_COL32(91, 92, 87, 255),
+                        1.5f * panel.scale(), 0, panel.scale());
+            if (active)
+                dl->AddRectFilled(panel.P(x + 1.0f, y0 + 2.0f),
+                                  panel.P(x + 3.0f, y0 + 25.0f),
+                                  index == 4 ? IM_COL32(160, 48, 34, 255)
+                                             : IM_COL32(226, 151, 61, 255));
+            panel.text(dl, x - 10.0f, y0 + 7.0f, 8.0f,
+                       active ? IM_COL32(246, 224, 177, 255)
+                              : IM_COL32(228, 228, 216, 255),
+                       visualLabels[static_cast<size_t>(row)], 1, true);
+            if (clicked && !active) setValue(P_FET_RATIO, static_cast<float>(index));
+        }
+    }
+
+    void drawFetMeterSwitch(ImDrawList* dl, float x, float y)
+    {
+        panel.text(dl, x + 10.0f, y - 24.0f, 8.5f,
+                   IM_COL32(230, 231, 219, 255), "METER", 0, true);
+        constexpr std::array<const char*, 4> labels{{"GR", "+8", "+4", "OFF"}};
+        for (int row = 0; row < 4; ++row)
+        {
+            const float y0 = y + static_cast<float>(row) * 38.0f;
+            dl->AddRectFilled(panel.P(x + 2.0f, y0 + 3.0f),
+                              panel.P(x + 23.0f, y0 + 35.0f),
+                              IM_COL32(0, 0, 0, 145), 1.5f * panel.scale());
+            dl->AddRectFilled(panel.P(x, y0), panel.P(x + 20.0f, y0 + 32.0f),
+                              IM_COL32(29, 29, 28, 255), 1.5f * panel.scale());
+            dl->AddRect(panel.P(x, y0), panel.P(x + 20.0f, y0 + 32.0f),
+                        IM_COL32(87, 88, 84, 255), 1.5f * panel.scale(), 0,
+                        panel.scale());
+            if (row == 0)
+                dl->AddRectFilled(panel.P(x + 1.0f, y0 + 2.0f),
+                                  panel.P(x + 3.0f, y0 + 30.0f),
+                                  IM_COL32(226, 151, 61, 255));
+            panel.text(dl, x + 31.0f, y0 + 9.0f, 8.0f,
+                       row == 0 ? IM_COL32(246, 224, 177, 255)
+                                : IM_COL32(227, 227, 215, 255),
+                       labels[static_cast<size_t>(row)], -1, true);
+        }
     }
 
     void drawVca(ImDrawList* dl)

--- a/plugins/shared-daf/tests/DafAUViewProbe.mm
+++ b/plugins/shared-daf/tests/DafAUViewProbe.mm
@@ -1,0 +1,538 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// Headless AU Cocoa-view probe for any installed DAF plugin. It instantiates the
+// view the way a host does, which is the step auval never performs: auval only
+// enumerates the view class, so a plugin whose view fails to build still passes.
+//
+// It reports the view tree at each stage and, for in-process hosting, reads the
+// plugin's own GL front buffer back and writes it to a PNG. A drawn ImGui panel
+// yields hundreds of distinct colours; a blank surface yields one or two, which
+// is the "black box in the host" symptom expressed as a number.
+//
+//   clang++ -std=c++17 -ObjC++ -Wno-deprecated-declarations \
+//     plugins/shared-daf/tests/DafAUViewProbe.mm \
+//     -framework AudioToolbox -framework AudioUnit -framework AppKit \
+//     -framework Foundation -framework CoreGraphics -framework ImageIO \
+//     -framework OpenGL -o /tmp/daf_au_view_probe
+//
+// Arguments, all optional:
+//   [1] [2] [3]  AU type, subtype, manufacturer codes   (default aufx DsMc Dusk)
+//   [4]          "oop" to load out of process as a sandboxing host does, any
+//                other value for in-process. Out of process the host receives
+//                Apple's _RemoteAUv2ViewFactory and an NSRemoteView, so the GL
+//                readback is unavailable and an external screencapture of the
+//                window id printed as "WINDOWID:" is the only way to see pixels.
+//   [5]          seconds to hold the window open, for that screencapture
+//   [6]          "WxH" to replay the resize a host performs immediately after
+//                creating the view, which is how Logic restores a saved size
+//   [7]          directory for shot_<subtype>.png (default DAF_PROBE_CAPTURE_DIR,
+//                then the system temporary directory)
+
+#import <AppKit/AppKit.h>
+#import <CoreServices/CoreServices.h>
+#import <OpenGL/gl.h>
+#import <ImageIO/ImageIO.h>
+#import <AudioToolbox/AudioToolbox.h>
+#import <AudioUnit/AUCocoaUIView.h>
+#import <AudioUnit/AudioUnit.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+
+namespace
+{
+OSType fourcc(const char* s)
+{
+    if (s == nullptr || std::strlen(s) < 4)
+        return 0;
+    return (static_cast<OSType>(s[0]) << 24) | (static_cast<OSType>(s[1]) << 16)
+         | (static_cast<OSType>(s[2]) << 8) | static_cast<OSType>(s[3]);
+}
+
+// Feeds every connected input bus, so the plugin runs its real signal path while
+// the editor is open. Set DAF_PROBE_RENDER=1 to exercise it.
+OSStatus feedInput(void* refCon,
+                   AudioUnitRenderActionFlags*,
+                   const AudioTimeStamp*,
+                   UInt32,
+                   UInt32 frames,
+                   AudioBufferList* data)
+{
+    const float level = *static_cast<const float*>(refCon);
+    for (UInt32 buffer = 0; buffer < data->mNumberBuffers; ++buffer)
+    {
+        float* const samples = static_cast<float*>(data->mBuffers[buffer].mData);
+        if (samples == nullptr)
+            continue;
+        for (UInt32 frame = 0; frame < frames; ++frame)
+            samples[frame] = level * std::sin(6.2831853f * 220.0f
+                                              * (float) frame / 48000.0f);
+    }
+    return noErr;
+}
+
+void describeView(NSView* view, int depth)
+{
+    if (view == nil)
+        return;
+    const NSRect f = [view frame];
+    std::printf("%*s%-28s frame=(%.1f,%.1f %.1fx%.1f) hidden=%d layer=%p wantsLayer=%d\n",
+                depth * 2, "", [NSStringFromClass([view class]) UTF8String],
+                f.origin.x, f.origin.y, f.size.width, f.size.height,
+                (int) [view isHidden], (void*) [view layer], (int) [view wantsLayer]);
+    for (NSView* sub in [view subviews])
+        describeView(sub, depth + 1);
+}
+
+NSView* findGLView(NSView* view)
+{
+    if (view == nil)
+        return nil;
+    if ([view respondsToSelector:@selector(openGLContext)])
+        return view;
+    for (NSView* sub in [view subviews])
+        if (NSView* const found = findGLView(sub))
+            return found;
+    return nil;
+}
+}
+
+int main(int argc, const char* argv[])
+{
+    @autoreleasepool
+    {
+        const char* typeCode = argc > 1 ? argv[1] : "aufx";
+        const char* subCode  = argc > 2 ? argv[2] : "DsMc";
+        const char* manuCode = argc > 3 ? argv[3] : "Dusk";
+
+        // AppKit has to be up before any NSView is created, even with no UI session.
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+
+        AudioComponentDescription description{};
+        description.componentType         = fourcc(typeCode);
+        description.componentSubType      = fourcc(subCode);
+        description.componentManufacturer = fourcc(manuCode);
+        if (description.componentType == 0 || description.componentSubType == 0
+            || description.componentManufacturer == 0)
+        {
+            std::fprintf(stderr,
+                         "FAIL: AU type, subtype, and manufacturer codes must each contain at least four characters\n");
+            return 1;
+        }
+
+        AudioComponent component = AudioComponentFindNext(nullptr, &description);
+        if (component == nullptr)
+        {
+            std::fprintf(stderr, "FAIL: no registered AU for %s %s %s\n",
+                         typeCode, subCode, manuCode);
+            return 1;
+        }
+
+        CFStringRef nameRef = nullptr;
+        AudioComponentCopyName(component, &nameRef);
+        std::printf("component: %s\n",
+                    nameRef ? [(__bridge NSString*) nameRef UTF8String] : "(unnamed)");
+        if (nameRef) CFRelease(nameRef);
+
+        const bool outOfProcess = (argc > 4 && std::strcmp(argv[4], "oop") == 0);
+        AudioUnit unit = nullptr;
+        OSStatus status = noErr;
+
+        if (outOfProcess)
+        {
+            // What Logic does when it sandboxes a plugin: the DSP lives in
+            // AUHostingServiceXPC and the host talks to a proxy AudioUnit.
+            __block AudioUnit produced = nullptr;
+            __block OSStatus produceStatus = noErr;
+            __block bool done = false;
+            AudioComponentInstantiate(
+                component, kAudioComponentInstantiation_LoadOutOfProcess,
+                ^(AudioComponentInstance instance, OSStatus err) {
+                    produced = instance; produceStatus = err; done = true;
+                });
+            for (int spin = 0; spin < 2000 && !done; ++spin)
+                [[NSRunLoop currentRunLoop]
+                    runMode:NSDefaultRunLoopMode
+                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+            unit = produced;
+            status = produceStatus;
+            std::printf("instantiation: OUT OF PROCESS (done=%d status=%d)\n",
+                        (int) done, (int) status);
+        }
+        else
+        {
+            status = AudioComponentInstanceNew(component, &unit);
+            std::printf("instantiation: in-process\n");
+        }
+
+        if (status != noErr || unit == nullptr)
+        {
+            std::fprintf(stderr, "FAIL: instantiation -> %d\n", (int) status);
+            return 1;
+        }
+        std::printf("instantiated: unit=%p\n", (void*) unit);
+
+        // Connect every input bus before initialising, so the plugin can be driven
+        // with real audio while its editor is open.
+        const bool doRender = std::getenv("DAF_PROBE_RENDER") != nullptr;
+        static float mainLevel = 0.5f, sideLevel = 0.9f;
+        UInt32 inputBuses = 0;
+        if (doRender && !outOfProcess)
+        {
+            UInt32 busSize = sizeof(inputBuses);
+            AudioUnitGetProperty(unit, kAudioUnitProperty_ElementCount,
+                                 kAudioUnitScope_Input, 0, &inputBuses, &busSize);
+            for (UInt32 bus = 0; bus < inputBuses; ++bus)
+            {
+                const AURenderCallbackStruct callback = {
+                    feedInput, bus == 0 ? &mainLevel : &sideLevel
+                };
+                const OSStatus connected =
+                    AudioUnitSetProperty(unit, kAudioUnitProperty_SetRenderCallback,
+                                         kAudioUnitScope_Input, bus,
+                                         &callback, sizeof(callback));
+                std::printf("input bus %u callback -> %d\n",
+                            (unsigned) bus, (int) connected);
+            }
+        }
+
+        status = AudioUnitInitialize(unit);
+        std::printf("AudioUnitInitialize -> %d\n", (int) status);
+
+        // --- the property a host reads to find the view -------------------------
+        UInt32 dataSize = 0;
+        Boolean writable = false;
+        status = AudioUnitGetPropertyInfo(unit, kAudioUnitProperty_CocoaUI,
+                                          kAudioUnitScope_Global, 0, &dataSize, &writable);
+        if (status != noErr || dataSize < sizeof(AudioUnitCocoaViewInfo))
+        {
+            std::fprintf(stderr, "FAIL: CocoaUI property info -> %d size=%u\n",
+                         (int) status, (unsigned) dataSize);
+            return 1;
+        }
+
+        AudioUnitCocoaViewInfo* info =
+            static_cast<AudioUnitCocoaViewInfo*>(std::calloc(1, dataSize));
+        status = AudioUnitGetProperty(unit, kAudioUnitProperty_CocoaUI,
+                                      kAudioUnitScope_Global, 0, info, &dataSize);
+        if (status != noErr || dataSize < sizeof(AudioUnitCocoaViewInfo))
+        {
+            std::fprintf(stderr, "FAIL: CocoaUI property -> %d size=%u\n",
+                         (int) status, (unsigned) dataSize);
+            return 1;
+        }
+
+        const UInt32 classCount =
+            1 + (dataSize - sizeof(AudioUnitCocoaViewInfo)) / sizeof(CFStringRef);
+        NSURL* const bundleURL = (__bridge NSURL*) info->mCocoaAUViewBundleLocation;
+        std::printf("view bundle: %s\n",
+                    bundleURL ? [[bundleURL path] UTF8String] : "(null)");
+        std::printf("view classes: %u\n", (unsigned) classCount);
+        CFStringRef firstViewClass = nullptr;
+        for (UInt32 i = 0; i < classCount; ++i)
+        {
+            if (info->mCocoaAUViewClass[i] == nullptr)
+                continue;
+            if (firstViewClass == nullptr)
+                firstViewClass = info->mCocoaAUViewClass[i];
+            std::printf("  [%u] %s\n", (unsigned) i,
+                        [(__bridge NSString*) info->mCocoaAUViewClass[i] UTF8String]);
+        }
+
+        // --- load the bundle and build the view, exactly as a host does ---------
+        if (bundleURL == nil)
+        {
+            std::fprintf(stderr, "FAIL: CocoaUI property returned a null view bundle URL\n");
+            return 1;
+        }
+        NSBundle* const viewBundle = [NSBundle bundleWithURL:bundleURL];
+        if (viewBundle == nil)
+        {
+            std::fprintf(stderr, "FAIL: NSBundle bundleWithURL returned nil\n");
+            return 1;
+        }
+        if (![viewBundle load] && ![viewBundle isLoaded])
+        {
+            std::fprintf(stderr, "FAIL: view bundle would not load\n");
+            return 1;
+        }
+        std::printf("view bundle loaded: %s\n", [[viewBundle bundlePath] UTF8String]);
+
+        if (firstViewClass == nullptr)
+        {
+            std::fprintf(stderr, "FAIL: CocoaUI property returned no view classes\n");
+            return 1;
+        }
+        NSString* const className = (__bridge NSString*) firstViewClass;
+        Class factoryClass = [viewBundle classNamed:className];
+        if (factoryClass == nil)
+            factoryClass = NSClassFromString(className);
+        if (factoryClass == nil)
+        {
+            std::fprintf(stderr, "FAIL: class %s not found in the loaded bundle\n",
+                         [className UTF8String]);
+            return 1;
+        }
+        std::printf("factory class resolved: %s\n", [className UTF8String]);
+
+        id<AUCocoaUIBase> factory = [[factoryClass alloc] init];
+        std::printf("factory instance: %p interfaceVersion=%u\n",
+                    (void*) factory, (unsigned) [factory interfaceVersion]);
+
+        std::printf("--- calling uiViewForAudioUnit ---\n");
+        std::fflush(stdout);
+        NSView* const view = [factory uiViewForAudioUnit:unit
+                                                withSize:NSMakeSize(1120, 380)];
+        std::fflush(stdout);
+        std::printf("--- returned view=%p ---\n", (void*) view);
+        if (view == nil)
+        {
+            std::fprintf(stderr, "FAIL: uiViewForAudioUnit returned nil\n");
+            return 1;
+        }
+
+        std::printf("view tree immediately after creation:\n");
+        describeView(view, 1);
+
+        // Logic resizes the view it was handed straight after creating it, to the
+        // plugin window size saved with the session. argv[6] = "WxH" replays that.
+        NSSize hostSize = NSMakeSize(1120, 380);
+        if (argc > 6)
+        {
+            int hw = 0, hh = 0;
+            if (std::sscanf(argv[6], "%dx%d", &hw, &hh) == 2 && hw > 0 && hh > 0)
+            {
+                hostSize = NSMakeSize(hw, hh);
+                std::printf("host resize: setFrameSize %dx%d right after creation\n", hw, hh);
+                [view setFrameSize:hostSize];
+                std::printf("view tree after host resize:\n");
+                describeView(view, 1);
+            }
+        }
+
+        // --- put it in a window and let the run loop turn, as a host would ------
+        NSWindow* const window =
+            [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, hostSize.width, hostSize.height)
+                                        styleMask:NSWindowStyleMaskTitled
+                                          backing:NSBackingStoreBuffered
+                                            defer:NO];
+        [window setContentView:view];
+        [window orderFront:nil];
+        std::printf("WINDOWID: %ld\n", (long) [window windowNumber]);
+        std::fflush(stdout);
+
+        for (int tick = 0; tick < 120; ++tick)
+        {
+            NSEvent* event = nil;
+            while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                               untilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]
+                                                  inMode:NSDefaultRunLoopMode
+                                                 dequeue:YES]) != nil)
+                [NSApp sendEvent:event];
+            [[NSRunLoop currentRunLoop]
+                runMode:NSDefaultRunLoopMode
+             beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+        }
+
+        // Drive audio through the plugin with the editor open, interleaved with the
+        // run loop, which is the state a DAW actually keeps it in.
+        if (doRender && !outOfProcess)
+        {
+            constexpr UInt32 frames = 64;
+            float left[frames]{}, right[frames]{};
+            struct { UInt32 count; AudioBuffer buffers[2]; } output = {
+                2, {{1, sizeof(left), left}, {1, sizeof(right), right}}
+            };
+            AudioTimeStamp timestamp{};
+            timestamp.mFlags = kAudioTimeStampSampleTimeValid;
+            AudioUnitRenderActionFlags renderFlags = 0;
+            OSStatus worst = noErr;
+            unsigned blocks = 0;
+
+            for (int round = 0; round < 40; ++round)
+            {
+                for (int block = 0; block < 25; ++block)
+                {
+                    const OSStatus rendered = AudioUnitRender(
+                        unit, &renderFlags, &timestamp, 0, frames,
+                        reinterpret_cast<AudioBufferList*>(&output));
+                    if (rendered != noErr && worst == noErr)
+                        worst = rendered;
+                    timestamp.mSampleTime += frames;
+                    ++blocks;
+                }
+                [[NSRunLoop currentRunLoop]
+                    runMode:NSDefaultRunLoopMode
+                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+            }
+            std::printf("RENDER: %u blocks over %u input buses, worstStatus=%d, "
+                        "lastSample=%.6f\n",
+                        blocks, (unsigned) inputBuses, (int) worst,
+                        (double) left[frames - 1]);
+        }
+
+        std::printf("view tree after ~2.4s of run loop:\n");
+        describeView(view, 1);
+
+        const NSRect finalFrame = [view frame];
+        std::printf("RESULT: view=%.0fx%.0f subviews=%lu\n",
+                    finalFrame.size.width, finalFrame.size.height,
+                    (unsigned long) [[view subviews] count]);
+
+        // --- does the GL surface actually paint anything? -----------------------
+        // Captured through the window server, so this sees exactly what a host
+        // would composite. A capture that is uniformly one colour is the "black
+        // box" symptom; a capture with many distinct colours is a drawn UI.
+        NSView* const glView = findGLView(view);
+        bool captureFailed = false;
+
+        if (glView == nil)
+        {
+            std::printf("CAPTURE: no NSOpenGLView in the tree\n");
+        }
+        else
+        {
+            NSOpenGLContext* const glContext = [(NSOpenGLView*) glView openGLContext];
+            std::printf("CAPTURE: gl view=%s context=%p\n",
+                        [NSStringFromClass([glView class]) UTF8String], (void*) glContext);
+            [glContext makeCurrentContext];
+
+            const NSRect backing = [glView convertRectToBacking:[glView bounds]];
+            const GLsizei w = (GLsizei) backing.size.width;
+            const GLsizei h = (GLsizei) backing.size.height;
+            const size_t total = (size_t) w * (size_t) h;
+            unsigned char* pixels = static_cast<unsigned char*>(std::calloc(total, 4));
+            if (pixels == nullptr)
+            {
+                std::fprintf(stderr, "FAIL: could not allocate %zu capture pixels\n", total);
+                captureFailed = true;
+            }
+            else
+            {
+                glReadBuffer(GL_FRONT);
+                glPixelStorei(GL_PACK_ALIGNMENT, 1);
+                glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+                const GLenum err = glGetError();
+
+                // Distinct colours, quantised to 5 bits per channel, plus mean luma.
+                // A drawn ImGui panel has hundreds; a blank surface has one or two.
+                static unsigned char seen[32 * 32 * 32];
+                std::memset(seen, 0, sizeof(seen));
+                unsigned distinct = 0;
+                double lumaSum = 0.0;
+                for (size_t i = 0; i < total; ++i)
+                {
+                    const unsigned char* p = pixels + i * 4;
+                    const unsigned key = ((p[0] >> 3) << 10)
+                        | ((p[1] >> 3) << 5) | (p[2] >> 3);
+                    if (!seen[key]) { seen[key] = 1; ++distinct; }
+                    lumaSum += 0.2126 * p[0] + 0.7152 * p[1] + 0.0722 * p[2];
+                }
+                std::printf("CAPTURE: %dx%d glError=0x%04x distinctColours=%u meanLuma=%.2f\n",
+                            (int) w, (int) h, (unsigned) err, distinct,
+                            total ? lumaSum / (double) total : 0.0);
+
+                // glReadPixels hands back rows bottom-to-top, while CGBitmapContext
+                // reads them top-to-bottom, so the PNG came out vertically mirrored.
+                // Flip here, after the order-independent colour statistics above.
+                const size_t rowBytes = (size_t) w * 4;
+                unsigned char* const rowSwap =
+                    static_cast<unsigned char*>(std::malloc(rowBytes));
+                if (rowSwap != nullptr)
+                {
+                    for (GLsizei row = 0; row < h / 2; ++row)
+                    {
+                        unsigned char* const top = pixels + (size_t) row * rowBytes;
+                        unsigned char* const bottom =
+                            pixels + (size_t) (h - 1 - row) * rowBytes;
+                        std::memcpy(rowSwap, top, rowBytes);
+                        std::memcpy(top, bottom, rowBytes);
+                        std::memcpy(bottom, rowSwap, rowBytes);
+                    }
+                    std::free(rowSwap);
+                }
+
+                const char* captureDirectory = argc > 7 ? argv[7]
+                    : std::getenv("DAF_PROBE_CAPTURE_DIR");
+                NSString* const outputDirectory =
+                    captureDirectory != nullptr && captureDirectory[0] != '\0'
+                        ? [NSString stringWithUTF8String:captureDirectory]
+                        : NSTemporaryDirectory();
+                NSString* const out = [outputDirectory stringByAppendingPathComponent:
+                    [NSString stringWithFormat:@"shot_%s.png", subCode]];
+                [[NSFileManager defaultManager] removeItemAtPath:out error:nil];
+
+                CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
+                CGContextRef bmp = space != nullptr ? CGBitmapContextCreate(
+                    pixels, (size_t) w, (size_t) h, 8, rowBytes, space,
+                    kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big) : nullptr;
+                CGImageRef image = bmp != nullptr ? CGBitmapContextCreateImage(bmp) : nullptr;
+                CGImageDestinationRef dest = CGImageDestinationCreateWithURL(
+                    (__bridge CFURLRef) [NSURL fileURLWithPath:out],
+                    CFSTR("public.png"), 1, nullptr);
+                if (image == nullptr)
+                    std::fprintf(stderr, "FAIL: CGBitmapContextCreateImage failed\n");
+                if (dest == nullptr)
+                    std::fprintf(stderr,
+                                 "FAIL: CGImageDestinationCreateWithURL failed for %s\n",
+                                 [out UTF8String]);
+
+                bool pngWritten = false;
+                if (dest != nullptr && image != nullptr)
+                {
+                    CGImageDestinationAddImage(dest, image, nullptr);
+                    if (!CGImageDestinationFinalize(dest))
+                        std::fprintf(stderr,
+                                     "FAIL: CGImageDestinationFinalize failed for %s\n",
+                                     [out UTF8String]);
+                    else if (![[NSFileManager defaultManager] fileExistsAtPath:out])
+                        std::fprintf(stderr, "FAIL: no PNG was produced at %s\n",
+                                     [out UTF8String]);
+                    else
+                    {
+                        pngWritten = true;
+                        std::printf("CAPTURE written: %s\n", [out UTF8String]);
+                    }
+                }
+                if (!pngWritten)
+                    captureFailed = true;
+                if (dest) CFRelease(dest);
+                if (image) CGImageRelease(image);
+                if (bmp) CGContextRelease(bmp);
+                if (space) CGColorSpaceRelease(space);
+                std::free(pixels);
+            }
+            [NSOpenGLContext clearCurrentContext];
+        }
+
+        // Optional hold so an external screencapture can photograph the window,
+        // which is the only way to see what a remote (out-of-process) view paints.
+        const int holdSeconds = argc > 5 ? std::atoi(argv[5]) : 0;
+        if (holdSeconds > 0)
+        {
+            std::printf("HOLDING %d s\n", holdSeconds);
+            std::fflush(stdout);
+            for (int tick = 0; tick < holdSeconds * 50; ++tick)
+            {
+                NSEvent* event = nil;
+                while ((event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                                   untilDate:[NSDate dateWithTimeIntervalSinceNow:0.005]
+                                                      inMode:NSDefaultRunLoopMode
+                                                     dequeue:YES]) != nil)
+                    [NSApp sendEvent:event];
+                [[NSRunLoop currentRunLoop]
+                    runMode:NSDefaultRunLoopMode
+                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.015]];
+            }
+        }
+
+        [window orderOut:nil];
+        AudioUnitUninitialize(unit);
+        AudioComponentInstanceDispose(unit);
+        std::printf("disposed cleanly\n");
+        return captureFailed ? 1 : 0;
+    }
+}

--- a/tests/duskverb_render/render.cpp
+++ b/tests/duskverb_render/render.cpp
@@ -54,7 +54,8 @@ namespace
     // from plugin-internal FPU/SSE handling crashed at 4096). 256 is
     // historical default but hits yabridge IPC overhead. 2048 is the
     // measured sweet spot: 8× fewer round-trips than 256, no stack issue.
-    constexpr int    kBlockSize    = 2048;
+    int              kBlockSize    = 2048;
+    int              kChannelCount = 2;
     constexpr int    kRenderSec    = 6;
     int              kTotalSamples = static_cast<int> (kSampleRate * kRenderSec);
     // Silence tail appended after the opt-in long sine tone (Render 4). Shared so
@@ -98,12 +99,16 @@ namespace
             << "  --program NAME                Select a factory program\n"
             << "  --output-dir DIR              Render destination\n"
             << "  --sample-rate HZ              Render rate (default 48000)\n"
+            << "  --block-size FRAMES           Host block size (default 2048)\n"
+            << "  --channels 1|2                Main input/output channels (default 2)\n"
             << "  --self-test-resampler         Check rate conversion is band-limited, then exit\n"
             << "  --list-params|--list-programs Inspect the hosted plugin\n"
             << "  --dump-nparams               Dump normalized parameter values\n"
             << "  --param NAME=VALUE            Set a displayed parameter value\n"
             << "  --nparam NAME=VALUE           Set a normalized parameter value\n"
             << "  --nparam-event NAME=VALUE@SEC Automate at an exact sample\n"
+            << "  --meter-film STEM,START,STOP,STEP[,A:B:D[;A:B:D...]] Capture editor frames at rendered-sample times\n"
+            << "  --print-params IDX|NAME,...   Log post-apply values of those parameters\n"
             << "  --help                        Show this help\n";
     }
 
@@ -1083,6 +1088,7 @@ int main (int argc, char** argv)
     juce::String saveStatePath;         // dump getStateInformation bytes here after preset
     juce::String loadStatePath;         // setStateInformation from these bytes (one round-trip)
     juce::String screenshotPath;        // --screenshot: open the plugin editor + grab its window to PNG, then exit
+    juce::String meterFilmArg;          // --meter-film: persistent editor capture driven by one --input-wav
     int          waitAfterLoadMs = 0;   // for yabridge handshake races
     int          perParamDelayMs = 0;   // throttle preset apply for slow plugin bridges
     // SixAPTank-specific engine-state property overrides. Useful for tuner
@@ -1094,6 +1100,17 @@ int main (int argc, char** argv)
     float        sixAPEarlyMixOverride = -1.0f;  // -1 = no override
     bool         listParamsOnly   = false;
     bool         listProgramsOnly = false;
+    // --print-params LIST: after the authoritative preset/state apply, print the
+    // host-side value and display text of the named parameters. LIST is comma
+    // separated; a token that is a plain non-negative integer addresses a
+    // parameter by INDEX (the only unambiguous address when a plugin exposes
+    // duplicate display names), anything else is matched as a display name.
+    // Purely diagnostic setup-time logging on the message thread: it proves a
+    // --load-state blob actually took effect, which the per-parameter --nparam
+    // path already proves via its own read_back line. Bounded by
+    // kMaxPrintParams so a stray argument cannot flood a render log.
+    juce::StringArray printParamSpecs;
+    constexpr int kMaxPrintParams = 64;
     bool         selfTestResampler = false;  // --self-test-resampler: see below
     bool         dumpParams       = false;   // --dump-params: emit baked program
     bool         dumpNParams      = false;   // --dump-nparams: normalized host values
@@ -1170,6 +1187,23 @@ int main (int argc, char** argv)
             kTotalSamples        = static_cast<int> (kSampleRate * kRenderSec);
             kLongSineTailSamples = static_cast<int> (kSampleRate * 12.0);
         }
+        else if (a == "--block-size" && i + 1 < argc)
+        {
+            if (! parseInt (argv[++i], kBlockSize) || kBlockSize < 1 || kBlockSize > 16384)
+            {
+                std::cerr << "Invalid --block-size (expected 1-16384 frames)\n";
+                return 2;
+            }
+        }
+        else if (a == "--channels" && i + 1 < argc)
+        {
+            if (! parseInt (argv[++i], kChannelCount)
+                || (kChannelCount != 1 && kChannelCount != 2))
+            {
+                std::cerr << "Invalid --channels (expected 1 or 2)\n";
+                return 2;
+            }
+        }
         else if (a == "--input-wav"  && i + 1 < argc) inputWavPaths.emplace_back (argv[++i]);
         else if (a == "--legacy-stem-name")          legacyStemName = true;
         else if (a == "--program"   && i + 1 < argc) programArg   = argv[++i];
@@ -1199,6 +1233,7 @@ int main (int argc, char** argv)
         }
         else if (a == "--save-state" && i + 1 < argc) saveStatePath = argv[++i];
         else if (a == "--screenshot" && i + 1 < argc) screenshotPath = argv[++i];
+        else if (a == "--meter-film" && i + 1 < argc) meterFilmArg = argv[++i];
         else if (a == "--sixap-early-hpf" && i + 1 < argc)
         {
             double parsed = 0.0;
@@ -1224,6 +1259,26 @@ int main (int argc, char** argv)
             sixAPEarlyMixOverride = static_cast<float> (parsed);
         }
         else if (a == "--load-state" && i + 1 < argc) loadStatePath = argv[++i];
+        else if (a == "--print-params" && i + 1 < argc)
+        {
+            juce::StringArray tokens;
+            tokens.addTokens (juce::String (argv[++i]), ",", "");
+            tokens.trim();
+            tokens.removeEmptyStrings();
+            if (tokens.isEmpty())
+            {
+                std::cerr << "Invalid --print-params (expected a comma separated list of"
+                             " parameter indices or display names)\n";
+                return 2;
+            }
+            if (tokens.size() > kMaxPrintParams)
+            {
+                std::cerr << "Invalid --print-params (" << tokens.size() << " entries exceeds the "
+                          << kMaxPrintParams << "-entry cap)\n";
+                return 2;
+            }
+            printParamSpecs = tokens;
+        }
         else if (a == "--list-params")              listParamsOnly   = true;
         else if (a == "--list-programs")            listProgramsOnly = true;
         else if (a == "--self-test-resampler")      selfTestResampler = true;
@@ -1419,6 +1474,21 @@ int main (int argc, char** argv)
 
     // ---- Resolve everything rate-dependent, now that kSampleRate is final ----
     // Runs regardless of the order the options were written in.
+    struct MeterFilmDenseRange
+    {
+        double startSeconds = 0.0;
+        double stopSeconds = 0.0;
+        double stepSeconds = 0.0;
+    };
+    struct MeterFilmSpec
+    {
+        juce::String stem;
+        double startSeconds = 0.0;
+        double stopSeconds = 0.0;
+        double stepSeconds = 0.0;
+        std::vector<MeterFilmDenseRange> denseRanges;
+    } meterFilm;
+
     {
         const double maxPrerun =
             static_cast<double> (std::numeric_limits<int>::max()) / kSampleRate;
@@ -1464,6 +1534,85 @@ int main (int argc, char** argv)
                 pending.normalized,
                 static_cast<int> (std::llround (pending.seconds * kSampleRate))
             });
+        }
+
+        if (meterFilmArg.isNotEmpty())
+        {
+            juce::StringArray fields;
+            fields.addTokens (meterFilmArg, ",", "");
+            fields.trim();
+            if (fields.size() != 4 && fields.size() != 5)
+            {
+                std::cerr << "Invalid --meter-film (expected STEM,START,STOP,STEP[,A:B:D[;A:B:D...]])\n";
+                return 2;
+            }
+            meterFilm.stem = fields[0];
+            if (meterFilm.stem.isEmpty() || meterFilm.stem.containsAnyOf ("/\\"))
+            {
+                std::cerr << "Invalid --meter-film STEM (use a filename stem without path separators)\n";
+                return 2;
+            }
+            if (! parseFiniteDouble (fields[1], meterFilm.startSeconds)
+                || ! parseFiniteDouble (fields[2], meterFilm.stopSeconds)
+                || ! parseFiniteDouble (fields[3], meterFilm.stepSeconds)
+                || meterFilm.startSeconds < 0.0
+                || meterFilm.stopSeconds <= meterFilm.startSeconds
+                || meterFilm.stepSeconds <= 0.0)
+            {
+                std::cerr << "Invalid --meter-film time range\n";
+                return 2;
+            }
+            if (fields.size() == 5)
+            {
+                juce::StringArray denseSpecs;
+                denseSpecs.addTokens (fields[4], ";", "");
+                denseSpecs.trim();
+                if (denseSpecs.isEmpty())
+                {
+                    std::cerr << "Invalid --meter-film dense range "
+                                 "(expected A:B:D[;A:B:D...] inside START..STOP)\n";
+                    return 2;
+                }
+                for (const auto& denseSpec : denseSpecs)
+                {
+                    juce::StringArray dense;
+                    dense.addTokens (denseSpec, ":", "");
+                    dense.trim();
+                    MeterFilmDenseRange range;
+                    if (dense.size() != 3
+                        || ! parseFiniteDouble (dense[0], range.startSeconds)
+                        || ! parseFiniteDouble (dense[1], range.stopSeconds)
+                        || ! parseFiniteDouble (dense[2], range.stepSeconds)
+                        || range.startSeconds < meterFilm.startSeconds
+                        || range.stopSeconds <= range.startSeconds
+                        || range.stopSeconds > meterFilm.stopSeconds
+                        || range.stepSeconds <= 0.0)
+                    {
+                        std::cerr << "Invalid --meter-film dense range "
+                                     "(expected A:B:D[;A:B:D...] inside START..STOP)\n";
+                        return 2;
+                    }
+                    meterFilm.denseRanges.push_back (range);
+                }
+            }
+            const double maxFilmSeconds =
+                static_cast<double> (std::numeric_limits<int>::max()) / kSampleRate;
+            if (meterFilm.stopSeconds > maxFilmSeconds)
+            {
+                std::cerr << "Invalid --meter-film STOP (max " << maxFilmSeconds
+                          << " at " << kSampleRate << " Hz)\n";
+                return 2;
+            }
+            if (inputWavPaths.size() != 1)
+            {
+                std::cerr << "--meter-film requires exactly one --input-wav\n";
+                return 2;
+            }
+            if (dryPassthroughTest || screenshotPath.isNotEmpty())
+            {
+                std::cerr << "--meter-film cannot be combined with --dry-passthrough-test or --screenshot\n";
+                return 2;
+            }
         }
     }
 
@@ -1524,20 +1673,31 @@ int main (int argc, char** argv)
         }
     }
 
-    // Build a stereo bus layout that matches the plugin's bus topology.
+    // Build a mono or stereo bus layout that matches the plugin's bus topology.
     // Most reverbs are 1-in/1-out, but some (Arturia Rev LX-24) expose a
     // sidechain or auxiliary input bus. If we configure too few buses
     // here the plugin's processBlock segfaults trying to read from an
     // unprepared channel.
     juce::AudioProcessor::BusesLayout layout;
+    const auto channelSet = kChannelCount == 1
+                          ? juce::AudioChannelSet::mono()
+                          : juce::AudioChannelSet::stereo();
     for (int i = 0; i < plugin->getBusCount (true);  ++i)
-        layout.inputBuses.add  (juce::AudioChannelSet::stereo());
+        layout.inputBuses.add  (channelSet);
     for (int i = 0; i < plugin->getBusCount (false); ++i)
-        layout.outputBuses.add (juce::AudioChannelSet::stereo());
+        layout.outputBuses.add (channelSet);
     if (! plugin->setBusesLayout (layout))
-        std::cerr << "Warning: could not force stereo bus layout (in="
+    {
+        std::cerr << "Warning: could not force " << kChannelCount
+                  << "-channel bus layout (in="
                   << plugin->getBusCount (true) << ", out=" << plugin->getBusCount (false)
                   << ")" << std::endl;
+        // A plugin running with an unintended channel topology renders garbage
+        // that downstream analysis can accept silently — fail hard instead.
+        std::cerr << "Error: refusing to render with an unconfirmed bus layout"
+                  << std::endl;
+        return 1;
+    }
 
     plugin->prepareToPlay (kSampleRate, kBlockSize);
 
@@ -1803,6 +1963,63 @@ int main (int argc, char** argv)
     applyAnyPreset();
     applyParamOverrides();
 
+    // --print-params: readback of the post-apply host parameter values. This is
+    // the --load-state counterpart of the "read_back=" line every --nparam write
+    // already emits: a state blob is applied in one opaque dispatch, so without
+    // this there is no evidence in the log that the requested values took. It only
+    // reads the host-side parameter proxies, and it is invoked on the message
+    // thread AFTER the last parameter override (--gate-off, --dry-passthrough-test)
+    // and before any audio is rendered, so the values printed are the ones the
+    // renderer actually hears. Returns false if a requested spec did not resolve.
+    auto printParamReadback = [&plugin, &printParamSpecs]() -> bool
+    {
+        if (printParamSpecs.isEmpty())
+            return true;
+
+        const auto& hosted = plugin->getParameters();
+        const std::streamsize previousPrecision = std::cout.precision();
+        bool printParamsResolved = true;
+        for (const auto& spec : printParamSpecs)
+        {
+            juce::AudioProcessorParameter* p = nullptr;
+            int index = -1;
+            if (spec.containsOnly ("0123456789") && spec.isNotEmpty())
+            {
+                // parseInt, not getIntValue: JUCE's integer parse accumulates in
+                // int with no overflow check, so "99999999999999" comes back as
+                // 276447231. A wrapped value that lands INSIDE 0..numParams-1
+                // silently addresses the wrong parameter and prints a
+                // well-formed readback line for it.
+                if (! parseInt (spec, index) || index < 0 || index >= hosted.size())
+                {
+                    std::cerr << "  ! --print-params: index '" << spec << "' is not a parameter index in 0.."
+                              << (hosted.size() - 1) << std::endl;
+                    printParamsResolved = false;
+                    continue;
+                }
+                p = hosted[index];
+            }
+            else
+            {
+                p = findParam (*plugin, spec);
+                if (p == nullptr)
+                {
+                    std::cerr << "  ! --print-params: parameter '" << spec << "' not found" << std::endl;
+                    printParamsResolved = false;
+                    continue;
+                }
+                index = hosted.indexOf (p);
+            }
+            std::cout << "  --print-params [" << index << "] '" << p->getName (128)
+                      << "' norm=" << std::setprecision (9) << p->getValue()
+                      << " read_back='" << p->getText (p->getValue(), 50) << "'" << std::endl;
+        }
+        // std::setprecision is sticky on the stream; restore it so this
+        // diagnostic cannot change the formatting of any later output.
+        std::cout << std::setprecision (previousPrecision);
+        return printParamsResolved;
+    };
+
     // --screenshot PATH: open the plugin's editor (with --param/--nparam preset
     // applied so the GUI shows that state), let it paint, then grab the desktop
     // to a PNG and exit. A reusable way to read a closed-source plugin's GUI
@@ -1823,6 +2040,24 @@ int main (int argc, char** argv)
     // Crop the full-desktop PNG to the window (at the printed screen bounds) to read.
     if (screenshotPath.isNotEmpty())
     {
+        // This path exits without rendering and no override runs past it, so
+        // the values are already final here.
+        if (! printParamReadback())
+        {
+            plugin->releaseResources();
+            return 1;
+        }
+
+        // VST3 parameter changes are delivered from the controller to the
+        // processor at a process boundary. Without one silent block here, a
+        // newly created editor can receive the processor's old/default state
+        // even though the host-side parameter proxy already reads back the
+        // requested value. A DAW naturally supplies this boundary before or
+        // while showing an editor; make the screenshot harness do the same.
+        juce::AudioBuffer<float> screenshotWarmup (
+            std::max (1, plugin->getTotalNumInputChannels()), kBlockSize);
+        screenshotWarmup.clear();
+        (void) renderThroughPlugin (*plugin, screenshotWarmup);
         if (! plugin->hasEditor())
         {
             std::cerr << "  ! --screenshot: plugin reports no editor" << std::endl;
@@ -1872,15 +2107,45 @@ int main (int argc, char** argv)
         shotFile.deleteFile();
         juce::ChildProcess cap;
         bool capExitOk = false;
-        if (cap.start (juce::StringArray { "gnome-screenshot", "-f", screenshotPath }))
+#if JUCE_MAC
+        const juce::String captureBounds = juce::String (b.getX()) + ","
+                                         + juce::String (b.getY()) + ","
+                                         + juce::String (b.getWidth()) + ","
+                                         + juce::String (b.getHeight());
+        const juce::StringArray captureCommand {
+            "screencapture", "-x", "-R" + captureBounds, screenshotPath
+        };
+#elif JUCE_LINUX
+        const juce::StringArray captureCommand {
+            "gnome-screenshot", "-f", screenshotPath
+        };
+#else
+        // No stock CLI capture tool on this platform (e.g. Windows). Fail
+        // clearly instead of falling through to the Linux-only command.
+        const juce::StringArray captureCommand;
+#endif
+        if (captureCommand.isEmpty())
         {
+            std::cerr << "  ! --screenshot: unsupported platform for capture" << std::endl;
+        }
+        else if (cap.start (captureCommand))
+        {
+            // Wait (bounded) for the capture tool to exit before draining its
+            // output: readAllProcessOutput() blocks until the child closes its
+            // pipes, which made the 25 s timeout below unreachable and hung the
+            // harness whenever the capture tool stalled.
+            const bool capFinished = cap.waitForProcessToFinish (25000);
+            if (! capFinished)
+            {
+                std::cerr << "  ! --screenshot: capture tool timed out, killing it" << std::endl;
+                cap.kill();
+            }
             cap.readAllProcessOutput();
-            cap.waitForProcessToFinish (25000);
-            capExitOk = (cap.getExitCode() == 0);
+            capExitOk = capFinished && (cap.getExitCode() == 0);
         }
         else
         {
-            std::cerr << "  ! --screenshot: could not launch gnome-screenshot" << std::endl;
+            std::cerr << "  ! --screenshot: could not launch platform capture tool" << std::endl;
         }
         // Success requires BOTH a clean process exit AND a freshly written file.
         const bool shotOk = capExitOk && shotFile.existsAsFile();
@@ -2105,6 +2370,333 @@ int main (int argc, char** argv)
         runPreroll (prerunSeconds);
     }
 
+    // --meter-film: keep one editor alive while an input WAV is processed up to
+    // exact rendered-sample capture boundaries. This is intentionally a separate
+    // early-exit mode: when the flag is absent the standard render path below is
+    // byte-for-byte unchanged. Frame names contain both a sequence number and the
+    // authoritative rendered sample position; screenshot wall time is never used
+    // as the measurement clock.
+    if (meterFilmArg.isNotEmpty())
+    {
+        if (! printParamReadback())
+        {
+            plugin->releaseResources();
+            return 1;
+        }
+        if (! plugin->hasEditor())
+        {
+            std::cerr << "  ! --meter-film: plugin reports no editor" << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+
+        juce::File sourceFile (inputWavPaths.front());
+        juce::AudioFormatManager filmFormats;
+        filmFormats.registerBasicFormats();
+        std::unique_ptr<juce::AudioFormatReader> filmReader (
+            filmFormats.createReaderFor (sourceFile));
+        if (filmReader == nullptr)
+        {
+            std::cerr << "  ! --meter-film: could not read input WAV: "
+                      << sourceFile.getFullPathName() << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+        if (std::abs (filmReader->sampleRate - kSampleRate) > 1.0e-6)
+        {
+            std::cerr << "  ! --meter-film: input sample rate " << filmReader->sampleRate
+                      << " != renderer rate " << kSampleRate << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+        if (filmReader->lengthInSamples <= 0
+            || filmReader->lengthInSamples > std::numeric_limits<int>::max())
+        {
+            std::cerr << "  ! --meter-film: input length is unsupported" << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+        const int filmSamples = static_cast<int> (filmReader->lengthInSamples);
+        const int filmStopSample = static_cast<int> (
+            std::llround (meterFilm.stopSeconds * kSampleRate));
+        if (filmStopSample > filmSamples)
+        {
+            std::cerr << "  ! --meter-film: STOP reaches sample " << filmStopSample
+                      << " but input has only " << filmSamples << " samples" << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+
+        juce::AudioBuffer<float> filmInput (2, filmSamples);
+        filmInput.clear();
+        if (! filmReader->read (&filmInput, 0, filmSamples, 0, true, true))
+        {
+            std::cerr << "  ! --meter-film: failed to read input samples" << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+        if (filmReader->numChannels == 1)
+            filmInput.copyFrom (1, 0, filmInput, 0, 0, filmSamples);
+
+        constexpr size_t maxMeterFilmFrames = 10000;
+        std::vector<int> captureSamples;
+        auto appendGrid = [&captureSamples] (double start, double stop, double step)
+        {
+            // Integer loop counter avoids accumulated floating-point drift over
+            // long films. STOP is exclusive, matching duration/step frame counts.
+            int previousSample = -1;
+            for (int64_t i = 0; ; ++i)
+            {
+                const double seconds = start + static_cast<double> (i) * step;
+                if (seconds >= stop)
+                    break;
+                const int sample = static_cast<int> (
+                    std::llround (seconds * kSampleRate));
+                if (sample <= previousSample)
+                {
+                    std::cerr << "  ! --meter-film: STEP does not advance to a "
+                                 "distinct sample position" << std::endl;
+                    return false;
+                }
+                if (captureSamples.size() >= maxMeterFilmFrames)
+                {
+                    std::cerr << "  ! --meter-film: capture schedule exceeds "
+                              << maxMeterFilmFrames << " frames" << std::endl;
+                    return false;
+                }
+                captureSamples.push_back (sample);
+                previousSample = sample;
+            }
+            return true;
+        };
+        bool captureScheduleValid = appendGrid (
+            meterFilm.startSeconds, meterFilm.stopSeconds, meterFilm.stepSeconds);
+        for (const auto& dense : meterFilm.denseRanges)
+        {
+            if (! captureScheduleValid)
+                break;
+            captureScheduleValid = appendGrid (
+                dense.startSeconds, dense.stopSeconds, dense.stepSeconds);
+        }
+        if (! captureScheduleValid)
+        {
+            plugin->releaseResources();
+            return 1;
+        }
+        std::sort (captureSamples.begin(), captureSamples.end());
+        captureSamples.erase (std::unique (captureSamples.begin(), captureSamples.end()),
+                              captureSamples.end());
+        if (captureSamples.empty())
+        {
+            std::cerr << "  ! --meter-film: capture schedule is empty" << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+
+        auto* filmEditor = plugin->createEditorIfNeeded();
+        if (filmEditor == nullptr)
+        {
+            std::cerr << "  ! --meter-film: createEditor returned null" << std::endl;
+            plugin->releaseResources();
+            return 1;
+        }
+        auto filmWindow = std::make_unique<juce::DocumentWindow> (
+            "DuskVerb-meter-film", juce::Colours::black,
+            juce::DocumentWindow::allButtons);
+        filmWindow->setUsingNativeTitleBar (true);
+        filmWindow->setAlwaysOnTop (true);
+        filmWindow->setContentNonOwned (filmEditor, true);
+        filmWindow->setTopLeftPosition (60, 60);
+        filmWindow->setVisible (true);
+        filmWindow->toFront (true);
+
+        // JUCE_MODAL_LOOPS_PERMITTED is disabled for this host, so the film uses
+        // one persistent dispatch loop rather than trying to nest a loop at every
+        // frame. The timer alternates process/repaint and capture phases; this
+        // gives the editor one event-loop turn to paint the newly published meter
+        // state, while audio still advances only to the declared sample boundary.
+        struct MeterFilmRunner final : juce::Timer
+        {
+            MeterFilmRunner (juce::AudioPluginInstance& pluginIn,
+                             juce::Component& editorIn,
+                             juce::Component& captureWindowIn,
+                             const juce::AudioBuffer<float>& inputIn,
+                             const std::vector<int>& captureSamplesIn,
+                             const std::vector<NormalizedParameterEvent>& eventsIn,
+                             const juce::File& outputDirectoryIn,
+                             const juce::String& stemIn,
+                             int settleMs)
+                : plugin (pluginIn), editor (editorIn), captureWindow (captureWindowIn),
+                  input (inputIn),
+                  captureSamples (captureSamplesIn), events (eventsIn),
+                  outputDirectory (outputDirectoryIn), stem (stemIn),
+                  block (std::max (plugin.getTotalNumInputChannels(),
+                                   plugin.getTotalNumOutputChannels()), kBlockSize),
+                  copyChans (std::min (input.getNumChannels(),
+                                      plugin.getTotalNumInputChannels()))
+            {
+                startTimer (settleMs);
+            }
+
+            void timerCallback() override
+            {
+                stopTimer();
+                if (capturePhase)
+                {
+                    captureCurrentFrame();
+                    if (failures > 0 || ++frameIndex >= captureSamples.size())
+                    {
+                        juce::MessageManager::getInstance()->stopDispatchLoop();
+                        return;
+                    }
+                    capturePhase = false;
+                    startTimer (1);
+                    return;
+                }
+
+                const int processed = processNextBlock (captureSamples[frameIndex]);
+                editor.repaint();
+                if (position >= captureSamples[frameIndex])
+                {
+                    capturePhase = true;
+                    startTimer (20);
+                    return;
+                }
+                // Pace offline processBlock calls at their rendered duration so
+                // editor timers receive the same inter-block message turns they
+                // get in a DAW. Processing several seconds inside one callback
+                // leaves both DPF and PACE needles visually frozen even though
+                // their DSP meter states advance.
+                const int blockDurationMs = std::max (1, static_cast<int> (
+                    std::llround (1000.0 * processed / kSampleRate)));
+                startTimer (blockDurationMs);
+            }
+
+            int processNextBlock (int captureSample)
+            {
+                while (eventIndex < events.size()
+                       && events[eventIndex].sampleOffset <= position)
+                {
+                    const auto& event = events[eventIndex++];
+                    if (auto* parameter = findParam (plugin, event.parameter))
+                        parameter->setValueNotifyingHost (event.normalized);
+                }
+
+                int next = std::min (position + kBlockSize, captureSample);
+                if (eventIndex < events.size())
+                    next = std::min (next, events[eventIndex].sampleOffset);
+                if (next <= position)
+                    return 0;
+                const int n = next - position;
+                juce::AudioBuffer<float> activeBlock (
+                    block.getArrayOfWritePointers(), block.getNumChannels(), n);
+                activeBlock.clear();
+                for (int ch = 0; ch < copyChans; ++ch)
+                    activeBlock.copyFrom (ch, 0, input, ch, position, n);
+                plugin.processBlock (activeBlock, midi);
+                position = next;
+                return n;
+            }
+
+            void captureCurrentFrame()
+            {
+                const int captureSample = captureSamples[frameIndex];
+                if (bounds.isEmpty())
+                {
+                    // The native peer is not guaranteed to be mapped or at its
+                    // requested position until the dispatch loop has turned.
+                    bounds = captureWindow.getScreenBounds();
+                    std::cout << "Meter film window: " << bounds.getWidth() << "x"
+                              << bounds.getHeight() << " @ (" << bounds.getX() << ","
+                              << bounds.getY() << "), " << captureSamples.size()
+                              << " unique frames" << std::endl;
+                    if (bounds.isEmpty())
+                    {
+                        std::cerr << "  ! --meter-film: mapped window has empty bounds"
+                                  << std::endl;
+                        ++failures;
+                        return;
+                    }
+                }
+                const auto frameName = stem + "_"
+                                     + juce::String (static_cast<int> (frameIndex)).paddedLeft ('0', 4)
+                                     + "_" + juce::String (captureSample) + ".png";
+                const auto frameFile = outputDirectory.getChildFile (frameName);
+                frameFile.deleteFile();
+                juce::ChildProcess capture;
+                bool frameOk = false;
+#if JUCE_MAC
+                const juce::String captureBounds = juce::String (bounds.getX()) + ","
+                                                 + juce::String (bounds.getY()) + ","
+                                                 + juce::String (bounds.getWidth()) + ","
+                                                 + juce::String (bounds.getHeight());
+                const juce::StringArray captureCommand {
+                    "screencapture", "-x", "-R" + captureBounds,
+                    frameFile.getFullPathName()
+                };
+#elif JUCE_LINUX
+                const juce::StringArray captureCommand {
+                    "gnome-screenshot", "-f", frameFile.getFullPathName()
+                };
+#else
+                const juce::StringArray captureCommand;
+#endif
+                if (captureCommand.isEmpty())
+                {
+                    std::cerr << "  ! --meter-film: unsupported platform for capture" << std::endl;
+                }
+                else if (capture.start (captureCommand))
+                {
+                    const bool finished = capture.waitForProcessToFinish (25000);
+                    if (! finished)
+                        capture.kill();
+                    frameOk = finished && capture.getExitCode() == 0
+                           && frameFile.existsAsFile();
+                }
+                if (! frameOk)
+                {
+                    std::cerr << "  ! --meter-film: capture failed at frame " << frameIndex
+                              << " sample " << captureSample << std::endl;
+                    ++failures;
+                }
+            }
+
+            juce::AudioPluginInstance& plugin;
+            juce::Component& editor;
+            juce::Component& captureWindow;
+            const juce::AudioBuffer<float>& input;
+            const std::vector<int>& captureSamples;
+            const std::vector<NormalizedParameterEvent>& events;
+            juce::File outputDirectory;
+            juce::String stem;
+            juce::Rectangle<int> bounds;
+            juce::AudioBuffer<float> block;
+            juce::MidiBuffer midi;
+            const int copyChans;
+            size_t eventIndex = 0;
+            size_t frameIndex = 0;
+            int position = 0;
+            int failures = 0;
+            bool capturePhase = false;
+        } filmRunner (*plugin, *filmEditor, *filmWindow, filmInput,
+                      captureSamples, nparamEvents, outDir, meterFilm.stem,
+                      waitAfterLoadMs > 0 ? waitAfterLoadMs : 12000);
+
+        juce::MessageManager::getInstance()->runDispatchLoop();
+
+        filmWindow->clearContentComponent();
+        plugin->editorBeingDeleted (filmEditor);
+        delete filmEditor;
+        plugin->releaseResources();
+        if (filmRunner.failures > 0)
+            return 1;
+        std::cout << "Wrote meter film " << meterFilm.stem << " ("
+                  << captureSamples.size() << " frames, samples "
+                  << captureSamples.front() << ".." << captureSamples.back() << ")"
+                  << std::endl;
+        return 0;
+    }
+
     // Dry-passthrough test: forcibly override Bus Mode = false and Dry/Wet = 0
     // so the engine outputs only the dry passthrough (the wet path is silent).
     // Used to verify that the gain_trim parameter does not bleed into the dry
@@ -2114,6 +2706,12 @@ int main (int argc, char** argv)
         if (auto* p = findParam (*plugin, "Bus Mode"))   p->setValue (0.0f);
         if (auto* p = findParam (*plugin, "Dry/Wet"))    p->setValue (0.0f);
         std::cout << "DRY PASSTHROUGH TEST: Bus Mode=0, Dry/Wet=0 (gain_trim retained)" << std::endl;
+        if (! printParamReadback())
+        {
+            plugin->releaseResources();
+            return 1;
+        }
+
         // Re-settle AFTER the override so the dry-path measurement isn't contaminated
         // by the Bus Mode / Dry-Wet smoothers ramping out of the pre-override (wet)
         // state the initial preroll left them in.
@@ -2141,6 +2739,14 @@ int main (int argc, char** argv)
     // writes. Captures are NOT byte-identical to the pre-rewrite renderer:
     // partial final blocks now process exactly n samples (host-accurate), and
     // all cross-renderer-version render comparisons are invalid.
+    // Every parameter override (--param/--nparam, --load-state, --gate-off) has
+    // been written by now, so this readback reports what the renders hear.
+    if (! printParamReadback())
+    {
+        plugin->releaseResources();
+        return 1;
+    }
+
     std::vector<float> configuredParamValues;
     configuredParamValues.reserve (static_cast<size_t> (plugin->getParameters().size()));
     for (auto* p : plugin->getParameters())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned vintage FET interface with dedicated controls, timing dials, ratio selection, meter switching, and trim.
  * Improved FET stereo linking and startup response for smoother, more consistent output.
  * Added enhanced Audio Unit view handling on macOS.
  * Added rendering tools for configurable block sizes, channel counts, parameter readback, and editor capture.

* **Bug Fixes**
  * Improved initial plugin state and preset synchronization.
  * Corrected Opto and FET meter display behavior and compact layout sizing.

* **Documentation**
  * Updated design QA, handoff notes, and DAF rename guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->