### PR TITLE
cmake: name the DAF-Widgets console widget set as an opt-in source

### DIFF
--- a/plugins/shared-daf/cmake/DuskDafPlugin.cmake
+++ b/plugins/shared-daf/cmake/DuskDafPlugin.cmake
@@ -7,9 +7,10 @@
 # include() this from a plugin's CMakeLists after project(). It locates the
 # DAF and DAF-Widgets checkouts (siblings of the repo by default, overridable
 # with -DDAF_PATH=... / -DDAFWIDGETS_PATH=...), adds DAF as a subdirectory, and
-# exposes DUSK_DAF_UI_SOURCES (the DearImGui wrapper) and DUSK_DAF_INCLUDE_DIRS
-# (shared-daf dsp/ui + DAF-Widgets opengl) for the caller to attach. Plugins
-# still call daf_add_plugin themselves so per-plugin TARGETS/FILES stay local.
+# exposes DUSK_DAF_UI_SOURCES (the DearImGui wrapper), DUSK_DAF_WIDGET_SOURCES
+# (the Dusk console widget set, opt-in) and DUSK_DAF_INCLUDE_DIRS (shared-daf
+# dsp/ui + DAF-Widgets opengl) for the caller to attach. Plugins still call
+# daf_add_plugin themselves so per-plugin TARGETS/FILES stay local.
 
 if(NOT DEFINED DUSK_SHARED_DAF_DIR)
     set(DUSK_SHARED_DAF_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
@@ -33,6 +34,20 @@ if(NOT TARGET daf)
 endif()
 
 set(DUSK_DAF_UI_SOURCES  "${DAFWIDGETS_PATH}/opengl/DearImGui.cpp")
+
+# The Dusk console widget set (DAF-Widgets opengl/DuskWidgets.hpp): the knob with
+# its baked dome, the fader, the meters, the needle meter, the button bank and the
+# rest. Its header is not header-only, so a plugin that includes it and does not
+# compile this fails to link -- which is what dusk-audio/DAF-Widgets#6 reports.
+#
+# Named rather than folded into DUSK_DAF_UI_SOURCES, because it is opt-in. The
+# plugins in this repository draw with the header-only toolkit in shared-daf/ui
+# instead, and none of them includes DuskWidgets.hpp today; adding a thousand
+# lines to all six for a kit they do not call would cost build time and binary
+# size for nothing. A plugin that does draw with the kit appends this to its
+# FILES_UI next to DUSK_DAF_UI_SOURCES.
+set(DUSK_DAF_WIDGET_SOURCES "${DAFWIDGETS_PATH}/opengl/DuskWidgets.cpp")
+
 set(DUSK_DAF_INCLUDE_DIRS
     "${DUSK_SHARED_DAF_DIR}"
     "${DUSK_SHARED_DAF_DIR}/dsp"


### PR DESCRIPTION
The wiring half of dusk-audio/DAF-Widgets#6.

`DAF-Widgets/opengl/DuskWidgets.hpp` is not header-only. A plugin that included it and did not also compile `opengl/DuskWidgets.cpp` failed to link, and nothing here said where that source lived. `DUSK_DAF_WIDGET_SOURCES` now names it.

### Why not just add it to `DUSK_DAF_UI_SOURCES`

That is what the issue proposes, and I think it is the wrong shape today. All six DAF plugins here draw with the header-only toolkit in `shared-daf/ui/DuskImGuiWidgets.hpp`, and `grep` finds no include of `DuskWidgets.hpp` anywhere in this repository. Folding it into the shared list would compile about a thousand lines into all six for a kit none of them calls — build time and binary size for nothing, and it would not make the kit adopted either.

Opt-in removes the footgun without paying that. A plugin that draws with the kit appends `${DUSK_DAF_WIDGET_SOURCES}` to its `FILES_UI` next to `${DUSK_DAF_UI_SOURCES}`.

### What is still open

Two toolkits now overlap and #6 asks which one the fleet keeps:

- `shared-daf/ui/DuskImGuiWidgets.hpp` — 880 lines, header-only, used by 4K EQ, TapeMachine, Multi-Comp, Multi-Q, Tape Echo and Sunset Circuits. Knob, LED, toggle, design-space mapper, response curves, FFT.
- `DAF-Widgets/opengl/DuskWidgets.{hpp,cpp}` — larger, compiled, themed, used by Dusk Studio. Knob with a baked dome, fader, meters, gain reduction, text field, and as of dusk-audio/DAF-Widgets#7 the needle meter and button bank.

Converging them means moving knob/LED/toggle out of the header-only toolkit and re-pointing six plugin UIs at the kit. That is a real piece of work with real regression risk on faceplates that are tuned to the pixel, not something to fold into a cmake change. **#6 should stay open for it** — this PR only stops the link failure being a surprise.

### Verified

`cmake -S plugins/multi-comp/daf-plugin -B …` configures clean, and the variable resolves to an existing file. No plugin's build changes: nothing references the new variable yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional source configuration for plugins that use the Dusk console widget set.

* **Documentation**
  * Documented the new widget source configuration and clarified how it differs from the existing UI sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->