### PR TITLE
TapeMachine: replace invalid enum sentinels with explicit cache-validity flags

### DIFF
--- a/plugins/TapeMachine/Source/ImprovedTapeEmulation.cpp
+++ b/plugins/TapeMachine/Source/ImprovedTapeEmulation.cpp
@@ -400,6 +400,7 @@ void ImprovedTapeEmulation::prepare(double sampleRate, int samplesPerBlock, int 
 
 void ImprovedTapeEmulation::reset()
 {
+    m_filterCacheValid = false;
     headBumpFilter.reset();
     hfLossFilter1.reset();
     hfLossFilter2.reset();
@@ -805,7 +806,7 @@ float ImprovedTapeEmulation::processSample(float input,
     // ========================================================================
     // 1. Parameter change detection → updateFilters()
     // ========================================================================
-    if (machine != m_lastMachine || speed != m_lastSpeed || type != m_lastType ||
+    if (!m_filterCacheValid || machine != m_lastMachine || speed != m_lastSpeed || type != m_lastType ||
         std::abs(biasAmount - m_lastBias) > 0.01f || eqStandard != m_lastEqStandard)
     {
         updateFilters(machine, speed, type, biasAmount, eqStandard);
@@ -814,6 +815,7 @@ float ImprovedTapeEmulation::processSample(float input,
         m_lastType = type;
         m_lastBias = biasAmount;
         m_lastEqStandard = eqStandard;
+        m_filterCacheValid = true;
 
         m_cachedMachineChars = getMachineCharacteristics(machine);
         m_cachedTapeChars = getTapeCharacteristics(type);

--- a/plugins/TapeMachine/Source/ImprovedTapeEmulation.h
+++ b/plugins/TapeMachine/Source/ImprovedTapeEmulation.h
@@ -1151,11 +1151,12 @@ private:
     std::atomic<float> gainReduction{0.0f};
 
     // Filter update tracking
-    TapeMachine m_lastMachine = static_cast<TapeMachine>(-1);
-    TapeSpeed m_lastSpeed = static_cast<TapeSpeed>(-1);
-    TapeType m_lastType = static_cast<TapeType>(-1);
-    EQStandard m_lastEqStandard = static_cast<EQStandard>(-1);
+    TapeMachine m_lastMachine = Swiss;
+    TapeSpeed m_lastSpeed = Speed_7_5_IPS;
+    TapeType m_lastType = FormulaClassic;
+    EQStandard m_lastEqStandard = NAB;
     float m_lastBias = -1.0f;
+    bool m_filterCacheValid = false;
 
     // Cached characteristics
     MachineCharacteristics m_cachedMachineChars;

--- a/plugins/TapeMachine/core/TapeMachineDSP.hpp
+++ b/plugins/TapeMachine/core/TapeMachineDSP.hpp
@@ -916,17 +916,15 @@ public:
         deEmphasisEQ.setDeEmphasis   (50.0f, 125.0f);
         phaseSmear.setMachineCharacter (true);
 
-        // Force a full updateFilters() next processSample so machine coeffs replace these neutral defaults.
-        m_lastMachine = static_cast<TapeMachine> (-1);
-        m_lastSpeed   = static_cast<TapeSpeed> (-1);
-        m_lastNoiseSpeed = static_cast<TapeSpeed> (-1);   // re-prepare the noise gen at the new rate on next updateFilters
-        m_lastType    = static_cast<TapeType> (-1);
-        m_lastEqStandard = static_cast<EQStandard> (-1);
-        m_lastBias    = -1.0f;
+        // Force a full updateFilters() next processSample so machine coefficients
+        // replace these neutral defaults and the noise generator sees the new rate.
+        m_filterCacheValid = false;
+        m_noiseCacheValid = false;
     }
 
     void reset()
     {
+        m_filterCacheValid = false;
         headBumpFilter.reset(); hfLossFilter1.reset(); hfLossFilter2.reset();
         gapLossFilter.reset(); biasFilter.reset(); dcBlocker.reset();
         headWidthFilter.reset(); driveHfShelf.reset(); levelHfShelf.reset(); levelLfShelf.reset();
@@ -1219,13 +1217,14 @@ public:
         if (std::abs (input) < denormalPrevention)
             input = 0.0f;
 
-        if (machine != m_lastMachine || speed != m_lastSpeed || type != m_lastType ||
+        if (! m_filterCacheValid || machine != m_lastMachine || speed != m_lastSpeed || type != m_lastType ||
             std::abs (biasAmount - m_lastBias) > 0.01f || eqStandard != m_lastEqStandard ||
             headWidth != m_lastHeadWidth)
         {
             updateFilters (machine, speed, type, biasAmount, eqStandard, headWidth);
             m_lastMachine = machine; m_lastSpeed = speed; m_lastType = type;
             m_lastBias = biasAmount; m_lastEqStandard = eqStandard; m_lastHeadWidth = headWidth;
+            m_filterCacheValid = true;
 
             m_cachedMachineChars = getMachineCharacteristics (machine);
             m_cachedSpeedChars = getSpeedCharacteristics (speed);
@@ -1549,13 +1548,15 @@ private:
 
     float crosstalkBuffer = 0.0f;
 
-    TapeMachine m_lastMachine = static_cast<TapeMachine> (-1);
-    TapeSpeed   m_lastSpeed = static_cast<TapeSpeed> (-1);
-    TapeSpeed   m_lastNoiseSpeed = static_cast<TapeSpeed> (-1);   // gates improvedNoiseGen.prepare (noise state reset only on real speed/rate change)
-    TapeType    m_lastType = static_cast<TapeType> (-1);
-    EQStandard  m_lastEqStandard = static_cast<EQStandard> (-1);
+    TapeMachine m_lastMachine = Swiss;
+    TapeSpeed   m_lastSpeed = Speed_7_5_IPS;
+    TapeSpeed   m_lastNoiseSpeed = Speed_7_5_IPS;
+    TapeType    m_lastType = FormulaClassic;
+    EQStandard  m_lastEqStandard = NAB;
     float m_lastBias = -1.0f;
     int   m_lastHeadWidth = -1;
+    bool m_filterCacheValid = false;
+    bool m_noiseCacheValid = false;
 
     MachineCharacteristics m_cachedMachineChars{};
     SpeedCharacteristics m_cachedSpeedChars{};
@@ -1980,10 +1981,11 @@ private:
         // scrape state. Calling it on every updateFilters (bias automation, head-width
         // changes, etc.) restarted the idle hiss mid-stream (an audible click); those
         // updates don't touch the noise spectrum, which depends only on speed + rate.
-        if (speed != m_lastNoiseSpeed)
+        if (! m_noiseCacheValid || speed != m_lastNoiseSpeed)
         {
             improvedNoiseGen.prepare (currentSampleRate, static_cast<int> (speed));
             m_lastNoiseSpeed = speed;
+            m_noiseCacheValid = true;
         }
 
         const HeadBump hb = getHeadBump (machine, speed);


### PR DESCRIPTION
`ImprovedTapeEmulation` (JUCE) and `TapeMachineDSP` (DAF core) both tracked
"have the filter coefficients been computed yet" by seeding their last-seen
parameter members with an out-of-range enum value:

```cpp
TapeMachine m_lastMachine = static_cast<TapeMachine>(-1);
```

These are unscoped enums with no fixed underlying type:

```cpp
enum TapeMachine { Swiss = 0, American };
enum EQStandard  { NAB = 0, CCIR };
```

Their value range is therefore the smallest bit-field that holds every
enumerator, and -1 is outside it, so the conversion is undefined. The
guard it feeds, `machine != m_lastMachine`, is the one thing standing
between a fresh instance and running audio through neutral placeholder
coefficients, and a compiler is entitled to assume the comparison is
always true, always false, or anything else.

## Fix

Seed the members with real enumerators and track "not computed yet" in an
explicit `bool m_filterCacheValid`, which is what the sentinel was
standing in for. The DAF core has a second one, `m_noiseCacheValid`, for
the noise generator's separate speed gate, which was seeded the same way.
`reset()` now clears the filter flag in both implementations, so a host
reset recomputes coefficients rather than trusting values that belong to
the state it just cleared.

No sentinel casts remain in either file.

## Verification

Built and run on this branch rebased onto `43052ad`:

- `tapemachine-2` DAF plugin (`TapeMachineDSP.hpp`): build clean, ctest
  4/4 on two consecutive full runs.
- TapeMachine JUCE VST3 (`ImprovedTapeEmulation.*`): build clean; the only
  warnings are pre-existing ones in `GUI/AnalogVUMeter.cpp`.

One caveat worth recording: the first ctest run failed `tapemachine-2UiDrag`,
then passed in isolation and in both later full runs. That gate drives a real
editor through XTest, so it is contending with the live desktop session; it is
not related to this change, but it is flaky here at roughly 1 in 3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tape emulation behavior after resetting, ensuring audio filters are correctly refreshed before processing resumes.
  - Improved reliability when changing tape machine settings, playback speed, tape type, bias, or EQ standard.
  - Ensured noise-processing updates are applied consistently when the emulation is reinitialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->