### PR TITLE
TapeMachine 2: draw its VU with the shared needle meter (#249)

### DIFF
--- a/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
@@ -17,6 +17,7 @@
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
 #include "DuskSupportersOverlay.hpp"   // shared DAF Patreon "Special Thanks" overlay (click title)
+#include "DuskVuMeter.hpp"             // shared analogue needle meter (this face is where it came from)
 #include "DuskUserPresetStore.hpp"
 #include "util/CrashLog.hpp"
 
@@ -780,107 +781,54 @@ private:
         ImGui::PopStyleColor(6);
     }
 
-    static constexpr float kVuA0 = -2.70f, kVuA1 = -0.44f;
-
+    // The face lives in the shared widget now (plugins/shared-daf/ui/DuskVuMeter.hpp);
+    // this is the TapeMachine scale and styling that the widget draws.
     void drawVU(ImDrawList* dl, float x0, float y0, float x1, float y1,
                 float level, float& needle, ImU32 accent, const char* label)
     {
         // 0 VU = -12 dBFS: the reference/Swiss/American spec ("plug-in operates at an internal
         // level of -12 dBFS ... a -12 dBFS input equates to 0 dB on the meters").
-        // The DSP now feeds a mean-abs (rectified) value, which reads 2/pi (-3.92 dB) below
+        // The DSP feeds a mean-abs (rectified) value, which reads 2/pi (-3.92 dB) below
         // peak for a sine. So a -12 dBFS sine arrives here as 0.15992 lin, and the offset is
         // 12 + 20*log10(pi/2) = 15.92 dB so that sine still lands exactly on 0 VU.
         const float dB = 20.0f * std::log10(level > 1e-4f ? level : 1e-4f) + 15.92f;
-        // deflection is linear in signal level (%), not dB: gives the classic
+
+        static constexpr duskdaf::VuTick kTicks[11] = {
+            {-20.0f, "20", true}, {-10.0f, "10", true}, {-7.0f, "7", true},
+            {-5.0f, "5", true},   {-3.0f, "3", true},   {-2.0f, "2", false},
+            {-1.0f, "1", true},   {0.0f, "0", true},    {1.0f, "1", true},
+            {2.0f, "2", false},   {3.0f, "3", true}};
+
+        duskdaf::VuScaleConfig cfg;
+        cfg.ticks = kTicks;
+        cfg.tickCount = 11;
+        cfg.minDb = -20.0f;
+        cfg.maxDb = 3.0f;
+        // Numerals go red above 0, but the overload arc starts on 0 itself.
+        cfg.redFromDb = 1.0f;
+        cfg.arcFromDb = 0.0f;
+        // deflection is linear in signal level (%), not dB: the classic
         // log-spread VU scale (marks bunch at the bottom, open up near 0..+3).
-        float target = std::pow(10.0f, (dB - 3.0f) / 20.0f);
-        target = target < 0.0f ? 0.0f : (target > 1.0f ? 1.0f : target);
-        // The 300 ms ANSI ballistic lives entirely in the DSP integrator now; this UI filter
-        // is only a fast cosmetic anti-jitter / frame-interpolation pole (tau ~= 25 ms, well
-        // under 30 ms) so it does not add a second, slower time constant to the needle.
-        needle += (target - needle) * (1.0f - std::exp(-ImGui::GetIO().DeltaTime * 40.0f));
+        cfg.deflection = duskdaf::vuBroadcastDeflection;
+        cfg.percentRow.enabled = true;      // 0..100 %, with 100 % on 0 VU
+        cfg.percentRow.fullScaleDb = 0.0f;
+        cfg.legend = "VU";
+        cfg.sublabel = label;
 
-        // warm tan bezel -> dark inner lip -> aged-cream face
-        dl->AddRectFilledMultiColor(P(x0, y0), P(x1, y1),
-            IM_COL32(170, 142, 100, 255), IM_COL32(158, 130, 88, 255),
-            IM_COL32(120, 96, 60, 255),  IM_COL32(110, 88, 54, 255));
-        dl->AddRect(P(x0, y0), P(x1, y1), IM_COL32(92, 72, 44, 255), 6.0f * s, 0, 1.4f * s);
-        dl->AddLine(P(x0 + 6, y0 + 3), P(x1 - 6, y0 + 3), accent, 1.6f * s); // machine accent stripe
-        dl->AddRectFilled(P(x0 + 4, y0 + 4), P(x1 - 4, y1 - 4), IM_COL32(56, 44, 30, 255), 4.0f * s);
-        const float fx0 = x0 + 7, fy0 = y0 + 7, fx1 = x1 - 7, fy1 = y1 - 7;
-        dl->AddRectFilled(P(fx0, fy0), P(fx1, fy1), IM_COL32(240, 231, 205, 255), 3.0f * s);
-        dl->AddRectFilledMultiColor(P(fx0, fy0), P(fx1, fy1),
-            IM_COL32(252, 246, 226, 130), IM_COL32(252, 246, 226, 130),
-            IM_COL32(210, 194, 158, 150), IM_COL32(210, 194, 158, 150));
+        duskdaf::VuStyle style;
+        style.bezelLightRight = IM_COL32(158, 130, 88, 255);
+        style.bezelDark = IM_COL32(120, 96, 60, 255);
+        style.bezelDarkLeft = IM_COL32(110, 88, 54, 255);
+        style.radiusWidthFrac = 0.48f;
+        style.radiusHeightFrac = 0.92f;
+        // The face was drawn against these endpoints, which are very slightly
+        // asymmetric; keeping them exact holds every numeral on its pixel.
+        style.sweepStartRad = -2.70f;
+        style.sweepEndRad = -0.44f;
+        style.tickLabelRadiusFrac = 0.80f;
+        style.sublabelGap = 2.0f;
 
-        const float cx = 0.5f * (fx0 + fx1);
-        const float pivotY = fy1 - 4.0f;
-        const float L = std::min((fx1 - fx0) * 0.48f, (fy1 - fy0) * 0.92f);
-        auto pt = [&](float r, float a) { return P(cx + r * std::cos(a), pivotY + r * std::sin(a)); };
-        ImFont* f = labelFont ? labelFont : ImGui::GetFont();
-        const ImU32 ink = IM_COL32(38, 32, 24, 255), red = IM_COL32(196, 42, 34, 255);
-        auto num = [&](float r, float a, const char* b, ImU32 c, float sz) {
-            ImFont* nf = panel.pickFont(sz * s); if (nf == nullptr) nf = f;   // nearest baked size -> crisp
-            ImVec2 ts = nf->CalcTextSizeA(sz * s, FLT_MAX, 0, b);
-            ImVec2 tp = pt(r, a);
-            dl->AddText(nf, sz * s, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f), c, b);
-        };
-        auto ang = [&](float db) { float n = std::pow(10.0f, (db - 3.0f) / 20.0f);
-                                   n = n < 0.0f ? 0.0f : (n > 1.0f ? 1.0f : n);
-                                   return kVuA0 + n * (kVuA1 - kVuA0); };
-
-        // bold red arc over the 0..+3 zone
-        dl->PathClear();
-        dl->PathArcTo(P(cx, pivotY), L * 0.90f * s, ang(0.0f), kVuA1, 26);
-        dl->PathStroke(red, 0, 3.4f * s);
-
-        // dB scale: ticks + numbers (black below 0, red above)
-        const float dbv[11] = { -20, -10, -7, -5, -3, -2, -1, 0, 1, 2, 3 };
-        for (int i = 0; i < 11; ++i)
-        {
-            const float db = dbv[i], a = ang(db);
-            const bool major = !(db == -2 || db == 2);
-            const bool rz = db > 0.0f;
-            const float rt = L * 0.90f;
-            dl->AddLine(pt(rt, a), pt(rt + (major ? 6.0f : 4.0f), a),
-                        rz ? red : ink, (major ? 1.6f : 1.0f) * s);
-            char b[6]; std::snprintf(b, sizeof(b), "%d", (int)std::abs(db));
-            num(L * 0.80f, a, b, rz ? red : ink, 10.0f);
-        }
-        // percentage row (0..100) across the black zone, closer to the pivot
-        const float pct0 = std::pow(10.0f, -3.0f / 20.0f); // 0 VU == 100%
-        for (int k = 0; k <= 5; ++k)
-        {
-            const float aP = kVuA0 + (k / 5.0f) * pct0 * (kVuA1 - kVuA0);
-            char b[6]; std::snprintf(b, sizeof(b), "%d", k * 20);
-            num(L * 0.60f, aP, b, IM_COL32(70, 60, 46, 255), 8.5f);
-        }
-        // - (left) and + (red, right) marks in the top corners
-        text(dl, fx0 + 10, fy0 + 3, 15.0f, ink, "-", -1, true);
-        text(dl, fx1 - 10, fy0 + 3, 15.0f, red, "+", 1, true);
-
-        // VU legend + channel tag
-        text(dl, cx, pivotY - L * 0.46f, 11, ink, "VU", 0, true);
-        text(dl, cx, pivotY - L * 0.46f + 13.0f, 9.0f, IM_COL32(90, 80, 64, 255), label, 0, true);
-
-        // black needle with soft shadow + mound pivot
-        const float na = kVuA0 + needle * (kVuA1 - kVuA0);
-        dl->AddLine(P(cx + 2, pivotY + 1), pt(L * 0.95f, na), IM_COL32(60, 50, 36, 70), 4.0f * s);
-        {
-            const float perp = na + 1.5707963f, bw = 3.4f;
-            dl->AddTriangleFilled(P(cx + bw * 0.5f * std::cos(perp), pivotY + bw * 0.5f * std::sin(perp)),
-                                  pt(L * 0.95f, na),
-                                  P(cx - bw * 0.5f * std::cos(perp), pivotY - bw * 0.5f * std::sin(perp)),
-                                  IM_COL32(28, 24, 18, 255));
-        }
-        dl->AddCircleFilled(P(cx, pivotY + 1), 8.0f * s, IM_COL32(40, 32, 22, 90), 20);
-        dl->AddCircleFilled(P(cx, pivotY), 4.6f * s, IM_COL32(24, 20, 14, 255), 18);
-        dl->AddCircleFilled(P(cx - 1.2f * s, pivotY - 1.4f * s), 1.5f * s, IM_COL32(150, 140, 120, 150), 10);
-
-        // glass top highlight
-        dl->AddRectFilledMultiColor(P(fx0 + 4, fy0 + 2), P(fx1 - 4, fy0 + (fy1 - fy0) * 0.22f),
-            IM_COL32(255, 255, 255, 30), IM_COL32(255, 255, 255, 30),
-            IM_COL32(255, 255, 255, 0), IM_COL32(255, 255, 255, 0));
+        duskdaf::drawVuMeter(panel, dl, x0, y0, x1, y1, dB, needle, cfg, accent, style);
     }
 
     //--- selectors (single row of six) -----------------------------------------

--- a/plugins/shared-daf/ui/DuskVuMeter.hpp
+++ b/plugins/shared-daf/ui/DuskVuMeter.hpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <limits>
 
 #include "DuskImGuiWidgets.hpp"
 #include "DuskVuMeterGeometry.hpp"
@@ -38,14 +39,34 @@ struct VuTick
     bool major;
 };
 
+// An optional second numeral row inside the tick ring, reading 0..100 % of a
+// reference level. The broadcast VU faces carry one: 100 % sits on 0 VU, not
+// on full deflection, so the row is laid out in deflection space against
+// `fullScaleDb` rather than against the ends of the scale.
+struct VuPercentRow
+{
+    bool enabled = false;
+    int divisions = 5;             // labels at k/divisions, k = 0..divisions
+    float fullScaleDb = 0.0f;      // the dB value the last label (100 %) sits on
+    float radiusFrac = 0.60f;      // as a fraction of the needle radius
+    float textSize = 8.5f;
+    ImU32 color = IM_COL32(70, 60, 46, 255);
+};
+
 struct VuScaleConfig
 {
     const VuTick* ticks = nullptr;
     int tickCount = 0;
     float minDb = -20.0f;         // deflection domain: full-left
     float maxDb = 3.0f;           // full-right
-    float redFromDb = 0.0f;       // red numerals + overload arc from here up;
-                                  // set above maxDb to disable the red zone
+    float redFromDb = 0.0f;       // red numerals from here up; set above maxDb
+                                  // to disable the red zone
+    // Where the bold overload arc starts, when it differs from the numerals.
+    // A face that inks its 0 numeral black but sweeps the arc from 0 upward
+    // wants redFromDb just above 0 and arcFromDb exactly on it. NaN = follow
+    // redFromDb.
+    float arcFromDb = std::numeric_limits<float>::quiet_NaN();
+    VuPercentRow percentRow;
     const char* legend = "VU";
     const char* sublabel = nullptr;
     // 0..1 deflection for a dB value. Default is linear in dB across
@@ -58,8 +79,13 @@ struct VuScaleConfig
 // lit reference window overrides only what differs.
 struct VuStyle
 {
-    ImU32 bezelLight = IM_COL32(170, 142, 100, 255);
-    ImU32 bezelDark = IM_COL32(110, 88, 54, 255);
+    // Bezel corners, in ImGui's multicolour order. The right/left variants
+    // default to their neighbour, so a two-tone bezel sets two colours and a
+    // moulded one (the TapeMachine face) sets all four.
+    ImU32 bezelLight = IM_COL32(170, 142, 100, 255);      // upper left
+    ImU32 bezelLightRight = 0;                            // 0 = bezelLight
+    ImU32 bezelDark = IM_COL32(110, 88, 54, 255);         // lower right
+    ImU32 bezelDarkLeft = 0;                              // 0 = bezelDark
     ImU32 bezelLine = IM_COL32(92, 72, 44, 255);
     ImU32 lip = IM_COL32(56, 44, 30, 255);
     ImU32 faceBase = IM_COL32(240, 231, 205, 255);
@@ -81,12 +107,25 @@ struct VuStyle
     // and a flatter arc; both are expressed here so the widget stays shared.
     float pivotBelowFace = -4.0f;     // design px below the face's bottom edge (negative = above)
     float sweepHalfAngleDeg = 64.7f;
+    // Sweep endpoints in radians, for a face whose arc is not symmetric about
+    // straight up. NaN = derive both from sweepHalfAngleDeg, which is what a
+    // face designed around a half-angle wants.
+    float sweepStartRad = std::numeric_limits<float>::quiet_NaN();
+    float sweepEndRad = std::numeric_limits<float>::quiet_NaN();
+    // Needle radius. By default the arc is sized to clear the top of the face
+    // and stay inside its sides, which is what a meter with a low pivot needs.
+    // A face whose radius was drawn as a fraction of the face box instead (the
+    // TapeMachine VU) sets both fractions and gets min(faceW * w, faceH * h).
+    float radiusWidthFrac = 0.0f;     // 0 = use the clearance rule
+    float radiusHeightFrac = 0.0f;
     float majorTickLength = 6.0f;
     float minorTickLength = 4.0f;
+    float tickLabelRadiusFrac = 0.76f;  // numeral centres, as a fraction of the radius
     ImU32 minorTickColor = 0;         // 0 = same as ink
     ImU32 bezelInnerLine = 0;         // 0 = none; a lighter bevel line inside the bezel
     ImU32 faceGlow = 0;               // 0 = none; a soft lit band across the top of the face
     float legendOffset = 0.46f;       // legend centre as a fraction of the radius above the pivot
+    float sublabelGap = 3.0f;         // sublabel baseline, below legend centre + legendSize
 };
 
 inline float vuLinearDeflection(float db, const VuScaleConfig& cfg) noexcept
@@ -139,8 +178,10 @@ inline void drawVuMeter(DuskPanel& panel, ImDrawList* dl,
     }
 
     // bezel -> dark inner lip -> face
+    const ImU32 bezelUR = style.bezelLightRight != 0 ? style.bezelLightRight : style.bezelLight;
+    const ImU32 bezelBL = style.bezelDarkLeft != 0 ? style.bezelDarkLeft : style.bezelDark;
     dl->AddRectFilledMultiColor(panel.P(x0, y0), panel.P(x1, y1),
-        style.bezelLight, style.bezelLight, style.bezelDark, style.bezelDark);
+        style.bezelLight, bezelUR, style.bezelDark, bezelBL);
     dl->AddRect(panel.P(x0, y0), panel.P(x1, y1), style.bezelLine, 6.0f * s, 0, 1.4f * s);
     dl->AddLine(panel.P(x0 + 6, y0 + 3), panel.P(x1 - 6, y0 + 3), accent, 1.6f * s);
     dl->AddRectFilled(panel.P(x0 + 4, y0 + 4), panel.P(x1 - 4, y1 - 4), style.lip, 4.0f * s);
@@ -163,10 +204,13 @@ inline void drawVuMeter(DuskPanel& panel, ImDrawList* dl,
     const float cx = 0.5f * (fx0 + fx1);
     const float pivotY = fy1 + style.pivotBelowFace;
     const float half = style.sweepHalfAngleDeg * 3.14159265f / 180.0f;
-    const float angle0 = -1.5707963f - half, angle1 = -1.5707963f + half;
+    const float angle0 = std::isnan(style.sweepStartRad) ? -1.5707963f - half : style.sweepStartRad;
+    const float angle1 = std::isnan(style.sweepEndRad) ? -1.5707963f + half : style.sweepEndRad;
     // Radius: the arc must clear the top of the face at its highest point
     // (directly above the pivot) and its ends must stay inside the sides.
-    const float radius = std::min((pivotY - fy0 - 12.0f), (fx1 - fx0) * 0.5f / std::max(std::sin(half), 0.2f) - 6.0f);
+    const float radius = (style.radiusWidthFrac > 0.0f && style.radiusHeightFrac > 0.0f)
+        ? std::min((fx1 - fx0) * style.radiusWidthFrac, (fy1 - fy0) * style.radiusHeightFrac)
+        : std::min((pivotY - fy0 - 12.0f), (fx1 - fx0) * 0.5f / std::max(std::sin(half), 0.2f) - 6.0f);
     const ImVec2 pivot = panel.P(cx, pivotY);
     const auto pt = [&](float r, float a) {
         const auto offset = vuScreenOffset(r, a, s);
@@ -179,11 +223,12 @@ inline void drawVuMeter(DuskPanel& panel, ImDrawList* dl,
     };
 
     // bold red arc across the overload zone
-    if (style.overloadArc && cfg.redFromDb <= cfg.maxDb)
+    const float arcFromDb = std::isnan(cfg.arcFromDb) ? cfg.redFromDb : cfg.arcFromDb;
+    if (style.overloadArc && arcFromDb <= cfg.maxDb)
     {
         dl->PathClear();
         dl->PathArcTo(panel.P(cx, pivotY), radius * 0.90f * s,
-                      angleFor(cfg.redFromDb), angle1, 26);
+                      angleFor(arcFromDb), angle1, 26);
         dl->PathStroke(red, 0, 3.4f * s);
     }
 
@@ -201,9 +246,29 @@ inline void drawVuMeter(DuskPanel& panel, ImDrawList* dl,
             const float px = style.tickLabelSize * s;
             ImFont* nf = panel.pickFont(px);
             const ImVec2 ts = nf->CalcTextSizeA(px, FLT_MAX, 0, tick.label);
-            const ImVec2 tp = pt(radius * 0.76f, a);
+            const ImVec2 tp = pt(radius * style.tickLabelRadiusFrac, a);
             dl->AddText(nf, px, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f),
                         rz ? red : ink, tick.label);
+        }
+    }
+
+    // Percentage row, laid out in deflection space so 100 % lands on its
+    // reference level rather than on the end of the scale.
+    if (cfg.percentRow.enabled && cfg.percentRow.divisions > 0)
+    {
+        const VuPercentRow& row = cfg.percentRow;
+        const float fullScale = vuDeflection(row.fullScaleDb, cfg);
+        for (int k = 0; k <= row.divisions; ++k)
+        {
+            const float t = (static_cast<float>(k) / static_cast<float>(row.divisions)) * fullScale;
+            const float a = angle0 + t * (angle1 - angle0);
+            char label[8];
+            std::snprintf(label, sizeof(label), "%d", k * 100 / row.divisions);
+            const float px = row.textSize * s;
+            ImFont* nf = panel.pickFont(px);
+            const ImVec2 ts = nf->CalcTextSizeA(px, FLT_MAX, 0, label);
+            const ImVec2 tp = pt(radius * row.radiusFrac, a);
+            dl->AddText(nf, px, ImVec2(tp.x - ts.x * 0.5f, tp.y - ts.y * 0.5f), row.color, label);
         }
     }
 
@@ -217,7 +282,7 @@ inline void drawVuMeter(DuskPanel& panel, ImDrawList* dl,
     if (cfg.legend != nullptr)
         panel.text(dl, cx, pivotY - radius * style.legendOffset, style.legendSize, ink, cfg.legend, 0, true);
     if (cfg.sublabel != nullptr)
-        panel.text(dl, cx, pivotY - radius * style.legendOffset + style.legendSize + 3.0f,
+        panel.text(dl, cx, pivotY - radius * style.legendOffset + style.legendSize + style.sublabelGap,
                    style.sublabelSize, style.sublabelColor, cfg.sublabel, 0, true);
 
     // black needle with soft shadow + mound pivot


### PR DESCRIPTION
`plugins/shared-daf/ui/DuskVuMeter.hpp` was extracted from this very face, so
TapeMachine 2 was left maintaining a second copy of the widget it seeded. This
is the first half of #249: TapeMachine's `drawVU` now configures the shared
widget instead of redrawing it. Multi-Comp's `drawOptoMeter` is deliberately
not in this PR (see below).

## What the shared widget gained

Five properties of this face had no expression in the shared config, and one
threshold was doing two jobs. Added rather than approximated, since a meter
face is judged by eye:

| addition | why |
|---|---|
| `bezelLightRight` / `bezelDarkLeft` | this bezel is moulded from four corner colours, not two |
| `radiusWidthFrac` / `radiusHeightFrac` | its needle radius was drawn as a fraction of the face box, not by the clearance rule |
| `sweepStartRad` / `sweepEndRad` | its arc endpoints (`-2.70`, `-0.44`) are slightly asymmetric about straight up |
| `tickLabelRadiusFrac`, `sublabelGap` | both differed from the defaults |
| `VuPercentRow` | the 0..100 % row, laid out in deflection space so 100 % sits on 0 VU rather than on full deflection |
| `arcFromDb` | this face inks its `0` numeral black but sweeps the overload arc from 0 upward |

Every addition defaults to previous behaviour, so Multi-Comp's VCA meter, the
other consumer, is untouched by construction.

## Verification

Pixel comparison, not eyeballing. Editor dumps captured before and after with
`DUSK_UI_DRAG_DEBUG=1 DUSK_UI_DRAG_DUMP=...`:

```
differing pixels: 120 of 376000 (0.0319%)  bbox=(220, 191, 580, 196)
max channel delta: 27
  within 8px of L pivot: 60
  within 8px of R pivot: 60
  outside both pivots: 0
```

That residue is intentional. The old code drew the pivot's glass highlight at
`P(cx - 1.2f * s, pivotY - 1.4f * s)` while `P()` already applies the panel
scale, so the highlight offset grew with the square of the scale — the same bug
class the recent `DuskVuMeterGeometry` fix corrected. The shared widget scales
it once. Both numeral rows, the red zone, the overload arc, the corner marks and
the needle land on the same pixels.

Gates, locally: `tapemachine-2` 4/4 twice, `multi-comp-2` 3/3 after rebuilding
against the changed header.

## Why Multi-Comp's Opto meter is not here

`drawOptoMeter` looks like the same kind of widget and is not one. It has a
machined housing built from four bevel quads over a drop shadow, an amber
gradient face, a fixed 165 px design radius rather than a derived one, an
inward-drawn tick ring with its own scale arc, three fixed-position legends, and
a line needle with an offset shadow instead of the triangle-and-mound pivot.
Its scale also runs backwards (20 dB of gain reduction at the left, 0 at the
right).

Pushing it through the shared widget means adding a housing mode, a needle
mode, a legend-placement mode and an inverted scale — at which point the widget
is a switchboard with two callers that share no branch, which is worse than two
honest implementations. Suggest re-scoping that half of #249 to sharing the
geometry helpers only, unless a third face turns up that actually wants the
machined housing. Happy to do it either way, but I would rather not force it
silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a refreshed VU meter display with improved visual consistency.
  - Added configurable percentage markings alongside the meter scale.
  - Added more flexible control over meter sweep, sizing, tick-label placement, sublabel spacing, and bezel colouring.
  - Improved overload indication with an independently configurable arc range.
  - Updated the TapeMachine meter to use the shared VU meter presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
