### PR TITLE
Multi-Comp 2: make the FET faceplate meter switch work (#248)

### DIFF
--- a/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompPluginLayerTests.cpp
@@ -1028,6 +1028,47 @@ void testOptoFaceplateContract()
             "Opto mode control exposes the Comp and Limit panel labels");
     require(std::strcmp(multicompp::ui_detail::optoMeterLabel(), "GR") == 0,
             "Opto analogue meter is fixed to the GR panel readout");
+
+    {
+        using namespace multicompp::ui_detail;
+        require(kFetMeterModeCount == 4
+                    && std::strcmp(fetMeterModeLabel(0), "GR") == 0
+                    && std::strcmp(fetMeterModeLabel(1), "+8") == 0
+                    && std::strcmp(fetMeterModeLabel(2), "+4") == 0
+                    && std::strcmp(fetMeterModeLabel(3), "OFF") == 0,
+                "FET meter switch exposes the reference unit's GR/+8/+4/OFF positions");
+
+        // GR position passes gain reduction through untouched, so the needle
+        // keeps the raw feed the Opto path is required to keep.
+        require(fetMeterNeedleValueDb(0, -7.5f, -30.0f) == -7.5f
+                    && fetMeterNeedleValueDb(0, 0.0f, -3.0f) == 0.0f,
+                "FET meter GR position reads gain reduction and ignores output level");
+
+        // On a level position the needle reads distance below the reference,
+        // so 0 VU parks on the same 0 mark the GR scale rests at.
+        require(fetMeterNeedleValueDb(2, -6.0f, kFetMeterPlus4ReferenceDbFs) == 0.0f
+                    && fetMeterNeedleValueDb(1, -6.0f, kFetMeterPlus8ReferenceDbFs) == 0.0f,
+                "FET meter level positions park 0 VU on the scale's 0 mark");
+        require(std::abs(fetMeterNeedleValueDb(2, 0.0f, -24.0f) + 6.0f) < 1.0e-5f
+                    && std::abs(fetMeterNeedleValueDb(1, 0.0f, -24.0f) + 10.0f) < 1.0e-5f,
+                "FET meter level positions deflect by the shortfall below their reference");
+        require(kFetMeterPlus8ReferenceDbFs - kFetMeterPlus4ReferenceDbFs == 4.0f,
+                "FET meter +4 and +8 references stay the panel's 4 dB apart");
+
+        // Louder than the reference pegs at 0 rather than running off the arc,
+        // and nothing exceeds the 20 dB the face is drawn for.
+        require(fetMeterNeedleValueDb(2, 0.0f, 0.0f) == 0.0f
+                    && fetMeterNeedleValueDb(2, 0.0f, -60.0f) == -20.0f,
+                "FET meter level positions clamp to the drawn 0..20 sweep");
+
+        require(fetMeterNeedleValueDb(3, -9.0f, -3.0f) == -20.0f,
+                "FET meter OFF position rests the needle at the mechanical stop");
+
+        const float nan = std::numeric_limits<float>::quiet_NaN();
+        require(fetMeterNeedleValueDb(0, nan, -18.0f) == 0.0f
+                    && fetMeterNeedleValueDb(2, 0.0f, nan) == 0.0f,
+                "FET meter survives a non-finite reading on either feed");
+    }
     const float attackDisplay = multicompp::ui_detail::optoMeterDisplayValue(-20.0f);
     const float releaseDisplay = multicompp::ui_detail::optoMeterDisplayValue(0.0f);
     const std::string source = readSiblingSource("MultiCompUI.cpp");

--- a/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
@@ -159,6 +159,59 @@ inline const char* optoModeLabel(float hostValue) noexcept
 
 inline constexpr const char* optoMeterLabel() noexcept { return "GR"; }
 
+// --- FET faceplate meter switch -------------------------------------------
+//
+// The reference unit's four-position selector: gain reduction, two output-level
+// settings, and off. Like the VCA face's source buttons this is hardware
+// display behaviour, so it is UI state rather than a host parameter.
+inline constexpr int kFetMeterModeCount = 4;
+
+inline const char* fetMeterModeLabel(int mode) noexcept
+{
+    switch (mode)
+    {
+        case 0: return "GR";
+        case 1: return "+8";
+        case 2: return "+4";
+        default: return "OFF";
+    }
+}
+
+// What "+4" and "+8" reference. The switch positions mean 0 VU = +4 dBu and
+// 0 VU = +8 dBu on the hardware, which says nothing on its own about digital
+// full scale, so the mapping is a decision recorded here rather than a number
+// read off the artwork: full scale is taken as +22 dBu, the convention that
+// puts +4 dBu at -18 dBFS. The two settings then sit 4 dB apart, as the front
+// panel implies. Changing the house reference means changing these two
+// constants and nothing else.
+inline constexpr float kFetMeterPlus4ReferenceDbFs = -18.0f;
+inline constexpr float kFetMeterPlus8ReferenceDbFs = -14.0f;
+
+// The face carries a single 0..20 sweep, 0 at the right. In GR it reads gain
+// reduction. On a level setting the same sweep reads how far the output sits
+// below the selected reference, so 0 VU parks on the same 0 mark and a quieter
+// signal swings left exactly as gain reduction does. OFF drops the needle to
+// the mechanical rest at full left, which is where an unpowered moving coil
+// goes.
+//
+// The level bridge publishes peak dBFS, and this deflection uses it as-is: no
+// VU averaging ballistic is invented here, matching the GR path, which the
+// plugin-layer tests require to stay free of a display envelope.
+inline float fetMeterNeedleValueDb(int mode, float gainReductionDb,
+                                   float outputDbFs) noexcept
+{
+    if (mode == 0)
+        return std::isfinite(gainReductionDb) ? gainReductionDb : 0.0f;
+    if (mode == 1 || mode == 2)
+    {
+        if (!std::isfinite(outputDbFs)) return 0.0f;
+        const float reference = mode == 1 ? kFetMeterPlus8ReferenceDbFs
+                                          : kFetMeterPlus4ReferenceDbFs;
+        return -std::clamp(reference - outputDbFs, 0.0f, 20.0f);
+    }
+    return -20.0f;   // OFF
+}
+
 inline float optoMeterReadoutAmount(float gainReductionDb) noexcept
 {
     return std::clamp(std::max(0.0f, -gainReductionDb), 0.0f, 99.9f);
@@ -482,6 +535,9 @@ private:
     // Display-only hardware behaviour (reference INPUT/OUTPUT/GAIN CHANGE
     // buttons): UI state, deliberately not a host parameter.
     int vcaMeterSource = 2;
+    // FET faceplate meter selector (GR / +8 / +4 / OFF), display-only like the
+    // VCA source buttons above.
+    int fetMeterMode = 0;
     float vcaVuNeedle = 0.0f;
     float vcaLastScHp = 1.0f;
     duskdaf::CrispFontSet fontSet;
@@ -1550,7 +1606,8 @@ private:
                       IM_COL32(48, 50, 49, 255), 28, 1.0f * panel.scale());
     }
 
-    void drawOptoMeter(ImDrawList* dl, float x, float y, float w, float h, float gr)
+    void drawOptoMeter(ImDrawList* dl, float x, float y, float w, float h, float gr,
+                       const char* legend = multicompp::ui_detail::optoMeterLabel())
     {
         const float scale = panel.scale();
         dl->AddRectFilled(panel.P(x + 5.0f, y + 7.0f),
@@ -1622,7 +1679,7 @@ private:
         }
         panel.text(dl, x + 31.0f, y + 54.0f, 12.0f, kOptoInk, "VU", 0, true);
         panel.text(dl, x + w - 32.0f, y + 54.0f, 12.0f, kOptoRed,
-                   multicompp::ui_detail::optoMeterLabel(), 0, true);
+                   legend, 0, true);
         panel.text(dl, x + w * 0.5f, y + h - 51.0f, 7.0f,
                    IM_COL32(94, 64, 34, 255), "GAIN REDUCTION", 0, true);
         const float needleAngle = multicompp::ui_detail::optoMeterNeedleAngle(gr);
@@ -1727,7 +1784,11 @@ private:
                 "RELEASE", false, "%.2f", "");
         drawFetRatioButtons(dl, 635, 392);
         drawOptoMeter(dl, 675, 384, 300, 178,
-                      multicompp::ui_detail::optoMeterDisplayValue(meter(kMeterMaster)));
+                      multicompp::ui_detail::fetMeterNeedleValueDb(
+                          fetMeterMode,
+                          multicompp::ui_detail::optoMeterDisplayValue(meter(kMeterMaster)),
+                          levelMeterDb(true)),
+                      multicompp::ui_detail::fetMeterModeLabel(fetMeterMode));
         panel.text(dl, 825, top + 14, 13.0f, IM_COL32(234, 234, 221, 255),
                    "FET 76", 0, true);
         panel.text(dl, 825, top + 32, 7.2f, IM_COL32(177, 179, 170, 255),
@@ -1982,26 +2043,40 @@ private:
     {
         panel.text(dl, x + 10.0f, y - 24.0f, 8.5f,
                    IM_COL32(230, 231, 219, 255), "METER", 0, true);
-        constexpr std::array<const char*, 4> labels{{"GR", "+8", "+4", "OFF"}};
-        for (int row = 0; row < 4; ++row)
+        for (int row = 0; row < multicompp::ui_detail::kFetMeterModeCount; ++row)
         {
             const float y0 = y + static_cast<float>(row) * 38.0f;
+            const bool active = row == fetMeterMode;
+
+            // The button covers the switch body and its label, so the whole
+            // row is clickable rather than just the 20 px cap.
+            char id[32];
+            std::snprintf(id, sizeof(id), "##fet_meter_mode_%d", row);
+            const ImVec2 b0 = panel.P(x, y0), b1 = panel.P(x + 52.0f, y0 + 32.0f);
+            ImGui::SetCursorScreenPos(b0);
+            if (ImGui::InvisibleButton(id, ImVec2(b1.x - b0.x, b1.y - b0.y)))
+                fetMeterMode = row;
+            const bool hovered = ImGui::IsItemHovered();
+
             dl->AddRectFilled(panel.P(x + 2.0f, y0 + 3.0f),
                               panel.P(x + 23.0f, y0 + 35.0f),
                               IM_COL32(0, 0, 0, 145), 1.5f * panel.scale());
             dl->AddRectFilled(panel.P(x, y0), panel.P(x + 20.0f, y0 + 32.0f),
-                              IM_COL32(29, 29, 28, 255), 1.5f * panel.scale());
+                              active ? IM_COL32(44, 43, 41, 255)
+                                     : IM_COL32(29, 29, 28, 255),
+                              1.5f * panel.scale());
             dl->AddRect(panel.P(x, y0), panel.P(x + 20.0f, y0 + 32.0f),
-                        IM_COL32(87, 88, 84, 255), 1.5f * panel.scale(), 0,
-                        panel.scale());
-            if (row == 0)
+                        hovered ? IM_COL32(132, 133, 128, 255)
+                                : IM_COL32(87, 88, 84, 255),
+                        1.5f * panel.scale(), 0, panel.scale());
+            if (active)
                 dl->AddRectFilled(panel.P(x + 1.0f, y0 + 2.0f),
                                   panel.P(x + 3.0f, y0 + 30.0f),
                                   IM_COL32(226, 151, 61, 255));
             panel.text(dl, x + 31.0f, y0 + 9.0f, 8.0f,
-                       row == 0 ? IM_COL32(246, 224, 177, 255)
-                                : IM_COL32(227, 227, 215, 255),
-                       labels[static_cast<size_t>(row)], -1, true);
+                       active ? IM_COL32(246, 224, 177, 255)
+                              : IM_COL32(227, 227, 215, 255),
+                       multicompp::ui_detail::fetMeterModeLabel(row), -1, true);
         }
     }
 


### PR DESCRIPTION
Closes #248. `drawFetMeterSwitch` drew four keycaps, hard-lit row 0 and
hit-tested nothing, so the reference unit's GR / +8 / +4 / OFF selector was
decoration. It now selects what the needle reads, and the meter's red legend
names the selected position instead of always saying `GR`.

Selection is UI state rather than a host parameter, matching the VCA face's
INPUT/OUTPUT/GAIN CHANGE bank: it is display behaviour of the hardware, and
exposing it would add an automatable control the reference does not have.

## The calibration decision, recorded rather than inferred

The panel positions mean 0 VU = +4 dBu and 0 VU = +8 dBu, which says nothing on
its own about digital full scale. `kFetMeterPlus4ReferenceDbFs` and
`kFetMeterPlus8ReferenceDbFs` write the choice down: full scale is taken as
+22 dBu, the convention that puts +4 dBu at -18 dBFS, which leaves the two
settings the panel's 4 dB apart. Changing the house reference is those two
constants and nothing else.

The face carries one 0..20 sweep with 0 at the right. On a level setting it
reads how far the output sits below the selected reference, so 0 VU parks on
the same 0 mark and a quieter signal swings left exactly as gain reduction
does, clamped to the arc that is actually drawn. OFF drops the needle to the
mechanical stop at full left, where an unpowered moving coil goes. The level
feed is the existing peak-dBFS bridge used as-is: no VU averaging ballistic is
invented on the display side, which keeps the needle raw the way the Opto path
is required to stay.

## Verification

Rendering was checked, not assumed. The editor was dumped with the mode default
temporarily pointed at the FET face, once per selection (both hacks reverted
before committing; `MultiCompParams.hpp` is untouched in this PR):

- GR selected: GR row lit, meter legend reads `GR`, needle at the 0 mark.
- +4 selected: +4 row lit, legend reads `+4`, needle at full left, which is
  correct for silence sitting more than 20 dB below a -18 dBFS reference.

The plugin-layer suite covers the labels, the GR passthrough, both references
and their 4 dB spacing, the clamps at both ends of the sweep, the OFF stop, and
a non-finite reading on either feed. Those assertions were confirmed to fail
when deliberately given a wrong expectation, then restored:

```
FAIL: FET meter OFF position rests the needle at the mechanical stop
```

`multi-comp-2` ctest 3/3 on the final tree.

## Known limitation

The face has one set of numerals, the GR scale, so on a level setting they read
dB below the reference rather than VU. The hardware prints both scales on the
dial; adding the second row is a faceplate change rather than a wiring one, so
it is not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a four-position FET meter selector: GR, +8, +4, and OFF.
  * The meter now displays gain reduction or output level relative to the selected reference.
  * Added clickable selector rows with labels and visual position feedback.
  * Added clamping, OFF positioning, and handling for non-finite meter inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
