### PR TITLE
DAF drag gate: tell a stolen pointer apart from a broken editor (#254)

### DIFF
--- a/plugins/shared-daf/tests/DafClapUiDragTest.cpp
+++ b/plugins/shared-daf/tests/DafClapUiDragTest.cpp
@@ -48,6 +48,19 @@
 // gate suite. XTest drives the server the way real hardware does rather than
 // pushing synthetic events at a window, so pugl sees ordinary input and nothing
 // here depends on a toolkit honouring SendEvent.
+//
+// RUN IT HEADLESS, even on a workstation that has a display:
+//
+//     Xvfb :99 -screen 0 1600x1200x24 &
+//     DISPLAY=:99 ctest --test-dir build -R UiDrag
+//
+// XTest delivers by screen position, and this harness's window is
+// override-redirect and therefore unmanaged, so anything a desktop session puts
+// on top of it takes the gesture instead. A GNOME Wayland session does exactly
+// that: synthetic input raises a Remote Desktop permission prompt, and until
+// someone approves it every run fails identically, blaming the plugin. The gate
+// now detects that case and says so, but a headless display avoids it, matches
+// CI, and does not fight the user for the pointer.
 
 #include <cmath>
 #include <cstdint>
@@ -204,6 +217,7 @@ struct EmptyInEvents {
 
 struct Fixture {
     const clap_plugin_t* plugin = nullptr;
+    Window parent = None;              // the editor's host window
     const clap_plugin_params_t* params = nullptr;
     const clap_plugin_timer_support_t* timer = nullptr;
     Display* display = nullptr;
@@ -231,6 +245,20 @@ struct Fixture {
         }
     }
 
+    // Pump frames until the editor has done something observable, rather than
+    // for a fixed number of frames. A warm editor on an idle machine answers on
+    // the first frame; a loaded one takes longer and is not wrong for it.
+    template <typename Ready>
+    bool pumpUntil(Ready ready, const int timeoutMs = 512)
+    {
+        for (int waited = 0; waited < timeoutMs; waited += 16)
+        {
+            pump(1);
+            if (ready()) return true;
+        }
+        return false;
+    }
+
     std::vector<double> snapshot() const
     {
         std::vector<double> values;
@@ -249,6 +277,7 @@ struct DragResult {
     size_t edits = 0;           // parameter edits the host would have received
     size_t midEdits = 0;        // how many had arrived halfway through the gesture
     uint32_t gestureBegins = 0; // begin-edit gestures seen
+    bool pointerBlocked = false;// another window sat above the editor
 
     // A knob follows the pointer, so edits arrive throughout the gesture. A
     // button, a preset step or an INIT produces one burst at the press. Requiring
@@ -259,6 +288,43 @@ struct DragResult {
         return midEdits > 0 && edits > midEdits;
     }
 };
+
+// Which top-level window the pointer is actually over. XTest events are
+// delivered by position, not by addressee, so this is the difference between
+// driving the editor and driving whatever happens to be stacked above it.
+Window topLevelUnderPointer(Display* const display)
+{
+    const Window root = DefaultRootWindow(display);
+    Window reportedRoot = None, child = None;
+    int rootX = 0, rootY = 0, winX = 0, winY = 0;
+    unsigned int mask = 0;
+    if (! XQueryPointer(display, root, &reportedRoot, &child, &rootX, &rootY, &winX, &winY, &mask))
+        return None;
+    return child;
+}
+
+// Put the editor under the pointer and keep it there. Under Xvfb, where this
+// gate runs in CI, nothing else is on screen and this is a no-op. On a desktop
+// the test window is override-redirect and unmanaged, so anything the user (or
+// the compositor) raises afterwards sits above it and silently swallows every
+// synthetic click -- which reads as "the editor ignores input" for the whole
+// process, retry included. Raising it back is cheap and turns an invisible
+// environment failure into either a pass or a specific diagnostic.
+bool raiseEditorUnderPointer(Fixture& fx, const Window parent, const int rootX, const int rootY)
+{
+    for (int attempt = 0; attempt < 4; ++attempt)
+    {
+        XTestFakeMotionEvent(fx.display, -1, rootX, rootY, CurrentTime);
+        XSync(fx.display, False);
+        if (topLevelUnderPointer(fx.display) == parent)
+            return true;
+
+        XRaiseWindow(fx.display, parent);
+        XSync(fx.display, False);
+        fx.pump(1);
+    }
+    return topLevelUnderPointer(fx.display) == parent;
+}
 
 DragResult dragAt(Fixture& fx, const int rootX, const int rootY, const int stepDy, const Window focusThief)
 {
@@ -277,11 +343,13 @@ DragResult dragAt(Fixture& fx, const int rootX, const int rootY, const int stepD
     fx.collected.paramValueIds.clear();
     fx.collected.gestureBegins = 0;
 
-    XTestFakeMotionEvent(fx.display, -1, rootX, rootY, CurrentTime);
+    const bool onTop = raiseEditorUnderPointer(fx, fx.parent, rootX, rootY);
     fx.pump();
 
     XTestFakeButtonEvent(fx.display, 1, True, CurrentTime);
-    fx.pump();
+    // The press is what the rest of the gesture hangs off, so wait for the
+    // editor to acknowledge it instead of assuming four frames is enough.
+    fx.pumpUntil([&] { return fx.collected.gestureBegins > 0 || countFor() > 0; });
 
     const int steps = 12;
     size_t midCount = 0;
@@ -304,6 +372,12 @@ DragResult dragAt(Fixture& fx, const int rootX, const int rootY, const int stepD
     fx.pump();
 
     DragResult result;
+    // Checked at both ends of the gesture. Before, because a window that was
+    // already above the editor takes the press; after, because one that raises
+    // itself mid-gesture (a permission prompt appearing, a compositor putting a
+    // dialog back on top) takes the rest of it, and a snapshot from before the
+    // drag would have said everything was fine.
+    result.pointerBlocked = ! onTop || topLevelUnderPointer(fx.display) != fx.parent;
     result.edits         = countFor();
     result.midEdits      = midCount;
     result.gestureBegins = fx.collected.gestureBegins;
@@ -449,6 +523,7 @@ int main(const int argc, const char* const* const argv)
                                         CopyFromParent, InputOutput, CopyFromParent,
                                         CWOverrideRedirect | CWEventMask, &attr);
     XMapRaised(fx.display, parent);
+    fx.parent = parent;
 
     // The thief only has to be focusable; it is never drawn over the editor.
     const Window thief = XCreateWindow(fx.display, root, (int) width + 32, 0, 32, 32, 0,
@@ -584,6 +659,26 @@ int main(const int argc, const char* const* const argv)
 
     if (phaseA.edits == 0)
     {
+        // Distinguish "the plugin is broken" from "this machine has something
+        // else on screen". XTest delivers by position, so a window stacked over
+        // the test window takes every click and the plugin never sees one --
+        // deterministically, retry included. Under Xvfb, where CI runs this,
+        // nothing else exists and this branch cannot trigger.
+        if (phaseA.pointerBlocked)
+        {
+            std::fprintf(stderr,
+                         "\nFAIL (environment): another window stayed above the editor at (%d,%d), so\n"
+                         "  the synthetic clicks went to it and not to the plugin. This says nothing\n"
+                         "  about the plugin.\n"
+                         "  On a GNOME Wayland session the usual culprit is the Remote Desktop\n"
+                         "  permission prompt that XTest raises: until it is approved it sits above\n"
+                         "  the editor and eats the gesture, and every run fails identically.\n"
+                         "  Run the gate on a headless display instead, which is also what CI does:\n"
+                         "    Xvfb :99 -screen 0 1600x1200x24 &  DISPLAY=:99 ctest -R UiDrag\n",
+                         knobX, knobY);
+            return 1;
+        }
+
         std::fprintf(stderr,
                      "\nFAIL (phase A): dragging at (%d,%d) produced no parameter edit, in either\n"
                      "  direction. Either the editor is ignoring pointer input, or there is no longer\n"

--- a/plugins/shared-daf/tests/DafClapUiDragTest.cpp
+++ b/plugins/shared-daf/tests/DafClapUiDragTest.cpp
@@ -251,11 +251,24 @@ struct Fixture {
     template <typename Ready>
     bool pumpUntil(Ready ready, const int timeoutMs = 512)
     {
-        for (int waited = 0; waited < timeoutMs; waited += 16)
+        // Measured against the clock, not counted in frames. A frame here is a
+        // timer tick, a flush, an XSync and a 16 ms sleep, so on a loaded
+        // machine it overruns its nominal 16 ms and a frame count would let the
+        // wait run several times longer than the bound it advertises.
+        struct timespec start;
+        clock_gettime(CLOCK_MONOTONIC, &start);
+        const auto elapsedMs = [&start]() {
+            struct timespec now;
+            clock_gettime(CLOCK_MONOTONIC, &now);
+            return (now.tv_sec - start.tv_sec) * 1000L
+                 + (now.tv_nsec - start.tv_nsec) / 1000000L;
+        };
+
+        do
         {
             pump(1);
             if (ready()) return true;
-        }
+        } while (elapsedMs() < timeoutMs);
         return false;
     }
 
@@ -382,6 +395,30 @@ DragResult dragAt(Fixture& fx, const int rootX, const int rootY, const int stepD
     result.midEdits      = midCount;
     result.gestureBegins = fx.collected.gestureBegins;
     return result;
+}
+
+// Every failure below this point accuses the plugin of something specific: a
+// dead input path, a coordinate aimed at a button, or the DAF-Widgets focus
+// regression. None of those conclusions survive the pointer having been
+// somewhere else, so each phase asks this first. Under Xvfb, where CI runs,
+// nothing else is on screen and this never fires.
+bool reportInterception(const DragResult& result, const char* const phase,
+                        const int knobX, const int knobY)
+{
+    if (! result.pointerBlocked)
+        return false;
+
+    std::fprintf(stderr,
+                 "\nFAIL (environment, during %s): another window was above the editor at (%d,%d),\n"
+                 "  so the synthetic clicks went to it and not to the plugin. This says nothing\n"
+                 "  about the plugin.\n"
+                 "  On a GNOME Wayland session the usual culprit is the Remote Desktop\n"
+                 "  permission prompt that XTest raises: until it is approved it sits above\n"
+                 "  the editor and eats the gesture, and every run fails identically.\n"
+                 "  Run the gate on a headless display instead, which is also what CI does:\n"
+                 "    Xvfb :99 -screen 0 1600x1200x24 &  DISPLAY=:99 ctest -R UiDrag\n",
+                 phase, knobX, knobY);
+    return true;
 }
 
 } // namespace
@@ -659,25 +696,7 @@ int main(const int argc, const char* const* const argv)
 
     if (phaseA.edits == 0)
     {
-        // Distinguish "the plugin is broken" from "this machine has something
-        // else on screen". XTest delivers by position, so a window stacked over
-        // the test window takes every click and the plugin never sees one --
-        // deterministically, retry included. Under Xvfb, where CI runs this,
-        // nothing else exists and this branch cannot trigger.
-        if (phaseA.pointerBlocked)
-        {
-            std::fprintf(stderr,
-                         "\nFAIL (environment): another window stayed above the editor at (%d,%d), so\n"
-                         "  the synthetic clicks went to it and not to the plugin. This says nothing\n"
-                         "  about the plugin.\n"
-                         "  On a GNOME Wayland session the usual culprit is the Remote Desktop\n"
-                         "  permission prompt that XTest raises: until it is approved it sits above\n"
-                         "  the editor and eats the gesture, and every run fails identically.\n"
-                         "  Run the gate on a headless display instead, which is also what CI does:\n"
-                         "    Xvfb :99 -screen 0 1600x1200x24 &  DISPLAY=:99 ctest -R UiDrag\n",
-                         knobX, knobY);
-            return 1;
-        }
+        if (reportInterception(phaseA, "phase A", knobX, knobY)) return 1;
 
         std::fprintf(stderr,
                      "\nFAIL (phase A): dragging at (%d,%d) produced no parameter edit, in either\n"
@@ -691,6 +710,10 @@ int main(const int argc, const char* const* const argv)
 
     if (! phaseA.looksLikeADrag())
     {
+        // A prompt that appears after the press takes the rest of the gesture,
+        // which looks exactly like a button: edits at the start, none after.
+        if (reportInterception(phaseA, "phase A", knobX, knobY)) return 1;
+
         std::fprintf(stderr,
                      "\nFAIL (phase A): the control at (%d,%d) emitted edits, but not progressively\n"
                      "  (%zu by the halfway point, %zu in total). That is the signature of a button or\n"
@@ -720,6 +743,10 @@ int main(const int argc, const char* const* const argv)
     const size_t required = (phaseA.edits + 1) / 2;
     if (phaseB.edits < required)
     {
+        // Worth guarding hardest here: the message below names a specific
+        // framework regression, and a stolen pointer produces the same shortfall.
+        if (reportInterception(phaseB, "phase B", knobX, knobY)) return 1;
+
         std::fprintf(stderr,
                      "\nFAIL (phase B): the drag stopped working when focus changed mid-gesture.\n"
                      "  phase A produced %zu edits, phase B produced %zu, needed at least %zu.\n"


### PR DESCRIPTION
Closes #254.

## What was actually wrong

Not a timing race, which is what the issue and I both first concluded. XTest
delivers input by screen position, and this harness parents the editor into an
override-redirect window that no window manager governs, so anything a desktop
session stacks above it takes the entire gesture.

The case that happens in practice: on a GNOME Wayland session, synthetic input
raises a Remote Desktop permission prompt. Until someone approves it, that
prompt sits above the editor and every run fails identically, phase A's retry
included. That is what made a byte-identical binary pass at 10:52 and fail at
11:23, and what made two builds differing only by code that cannot execute on
Linux look like a clean 0/10 vs 10/10 split. The gate's message blamed the
plugin and the coordinate.

## Changes

- Put the editor under the pointer before pressing and confirm it is the
  top-level window there, raising it if not.
- Re-check after the gesture. A prompt that appears mid-drag takes the rest of
  it, and a check from before the drag would report everything fine.
- On a drag that produced nothing with the pointer not over the editor, fail
  with an environment message that names the prompt and gives the headless
  command instead of accusing the plugin.
- Replace the fixed four-frame settle after the press with a bounded wait
  (512 ms) on the editor acknowledging it. A loaded machine takes the time it
  needs; an idle one is no slower.
- The file header now says to run this on Xvfb even on a workstation with a
  display, since that matches CI and stops the gate fighting the user for the
  pointer.

## Verification

The failure was staged rather than argued about. A small override-redirect
window mapped over the click coordinate reproduces the old symptom exactly.
With this change the same setup reports:

```
FAIL (environment): another window stayed above the editor at (72,330), so
  the synthetic clicks went to it and not to the plugin. This says nothing
  about the plugin.
  On a GNOME Wayland session the usual culprit is the Remote Desktop
  permission prompt that XTest raises: until it is approved it sits above
  the editor and eats the gesture, and every run fails identically.
```

With the blocker gone: drag gate 4/4, and both full suites green on a headless
display (`tapemachine-2` 4/4, `multi-comp-2` 3/3).

CI is unaffected either way: under Xvfb nothing else is on screen, so the new
check always finds the editor on top.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag interactions when another window overlaps the editor.
  * Added clearer failure reporting when pointer input is blocked.
  * Increased reliability of drag testing in headless environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
