### PR TITLE
Provenance guards: check the checkout, not just the config (#243)

### DIFF
--- a/.github/scripts/check_fork_sources.sh
+++ b/.github/scripts/check_fork_sources.sh
@@ -65,6 +65,25 @@ fi
 # checkout made before a fork was repointed keeps its old origin, and a correct
 # .gitmodules sitting next to it makes the tree look clean. So when a checkout
 # path is supplied, ask the checkout.
+# Reduce a remote URL to the "owner/repo" it names on github.com, or to nothing
+# if it names something else. Matching a substring instead accepts far too much:
+# not-dusk-audio/pugl, gitlab.com/dusk-audio/pugl and
+# github.com/attacker/mirror-dusk-audio/pugl all contain "dusk-audio/pugl".
+# Twin of the function in docker/check_daf_pins.sh; keep the two in step.
+github_repo_of() {
+    local url="$1" path=""
+    case "$url" in
+        git@github.com:*)       path="${url#git@github.com:}" ;;
+        ssh://git@github.com/*) path="${url#ssh://git@github.com/}" ;;
+        https://github.com/*)   path="${url#https://github.com/}" ;;
+        http://github.com/*)    path="${url#http://github.com/}" ;;
+        *) return 0 ;;
+    esac
+    path="${path%/}"
+    path="${path%.git}"
+    printf '%s' "${path%/}"
+}
+
 check_checkout_origin() {
     local name="$1" path="$2" expect="$3"
 
@@ -77,14 +96,11 @@ check_checkout_origin() {
 
     local remote
     remote="$(git -C "$path" remote get-url origin 2>/dev/null || echo '(none)')"
-    case "$remote" in
-        *"$expect"*) ;;
-        *)
-            echo "FAIL  $name checkout compiles from $remote, expected $expect"
-            echo "        this is the tree being built, not a .gitmodules entry"
-            failed=1
-            ;;
-    esac
+    if [ "$(github_repo_of "$remote")" != "$expect" ]; then
+        echo "FAIL  $name checkout compiles from $remote, expected github.com/$expect"
+        echo "        this is the tree being built, not a .gitmodules entry"
+        failed=1
+    fi
 }
 
 check_checkout_origin "DAF" "$DAF_CHECKOUT" "dusk-audio/DAF"
@@ -100,7 +116,19 @@ if [ -n "$DAF_CHECKOUT" ] && [ -e "$DAF_CHECKOUT/.git" ]; then
     if [ -e "$pugl_path/.git" ]; then
         pugl_pin="$(git -C "$DAF_CHECKOUT" rev-parse -q --verify HEAD:dgl/src/pugl-upstream 2>/dev/null || echo '')"
         pugl_head="$(git -C "$pugl_path" rev-parse HEAD 2>/dev/null || echo '')"
-        if [ -n "$pugl_pin" ] && [ -n "$pugl_head" ] && [ "$pugl_pin" != "$pugl_head" ]; then
+
+        # An empty pin with a checkout present is not "nothing to compare": it
+        # means DAF records no gitlink at that path, so whatever is sitting
+        # there is unpinned source that no revision check can vouch for.
+        # Skipping the comparison would let it through unverified.
+        if [ -z "$pugl_pin" ]; then
+            echo "FAIL  pugl checkout exists at $pugl_path, but DAF records no gitlink there"
+            echo "        nothing pins this source, so its revision cannot be verified"
+            failed=1
+        elif [ -z "$pugl_head" ]; then
+            echo "FAIL  pugl checkout at $pugl_path has no readable HEAD"
+            failed=1
+        elif [ "$pugl_pin" != "$pugl_head" ]; then
             echo "FAIL  pugl checkout is at ${pugl_head:0:12}, but DAF pins ${pugl_pin:0:12}"
             echo "        run git submodule update --init --recursive in the DAF checkout"
             failed=1

--- a/.github/scripts/check_fork_sources.sh
+++ b/.github/scripts/check_fork_sources.sh
@@ -12,14 +12,18 @@
 #   - the `url` in the fork's own .gitmodules, which GitHub copies verbatim when
 #     a fork is created, so pugl kept pointing at DISTRHO long after the fork.
 #
-#   ./.github/scripts/check_fork_sources.sh [daf-checkout-path]
+#   ./.github/scripts/check_fork_sources.sh [daf-checkout-path] [daf-widgets-path]
 #
-# The optional argument points at a checked-out DAF so the submodule URL is
-# checked too; without it only this repository's build config is scanned.
+# The optional arguments point at checked-out framework trees. With them the
+# guard also inspects what those trees actually are -- their origin remotes, and
+# pugl's revision against the gitlink DAF records -- rather than only the config
+# that describes a future fetch. Without them only this repository's build
+# config is scanned.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DAF_CHECKOUT="${1:-}"
+DAFWIDGETS_CHECKOUT="${2:-}"
 
 # Scan the files that decide where source comes from. Documentation may discuss
 # upstream freely, so it is deliberately out of scope.
@@ -53,6 +57,54 @@ if [ -n "$DAF_CHECKOUT" ] && [ -f "$DAF_CHECKOUT/.gitmodules" ]; then
         echo "$hits" | sed 's/^/        /'
         echo "        fix it in dusk-audio/DAF, not here: a fork inherits this file"
         failed=1
+    fi
+fi
+
+# Everything above reads configuration, which describes what a future fetch
+# would do. It cannot tell you what the tree in front of you was built from: a
+# checkout made before a fork was repointed keeps its old origin, and a correct
+# .gitmodules sitting next to it makes the tree look clean. So when a checkout
+# path is supplied, ask the checkout.
+check_checkout_origin() {
+    local name="$1" path="$2" expect="$3"
+
+    [ -n "$path" ] || return 0
+    if [ ! -e "$path/.git" ]; then
+        echo "FAIL  $name: no git checkout at $path, so its source cannot be verified"
+        failed=1
+        return 0
+    fi
+
+    local remote
+    remote="$(git -C "$path" remote get-url origin 2>/dev/null || echo '(none)')"
+    case "$remote" in
+        *"$expect"*) ;;
+        *)
+            echo "FAIL  $name checkout compiles from $remote, expected $expect"
+            echo "        this is the tree being built, not a .gitmodules entry"
+            failed=1
+            ;;
+    esac
+}
+
+check_checkout_origin "DAF" "$DAF_CHECKOUT" "dusk-audio/DAF"
+check_checkout_origin "DAF-Widgets" "$DAFWIDGETS_CHECKOUT" "dusk-audio/DAF-Widgets"
+
+# pugl lives inside the DAF checkout, and its revision matters as well as its
+# origin: a submodule left at some other commit compiles source DAF does not
+# pin, which is exactly as wrong as fetching it from upstream.
+if [ -n "$DAF_CHECKOUT" ] && [ -e "$DAF_CHECKOUT/.git" ]; then
+    pugl_path="$DAF_CHECKOUT/dgl/src/pugl-upstream"
+    check_checkout_origin "pugl" "$pugl_path" "dusk-audio/pugl"
+
+    if [ -e "$pugl_path/.git" ]; then
+        pugl_pin="$(git -C "$DAF_CHECKOUT" rev-parse -q --verify HEAD:dgl/src/pugl-upstream 2>/dev/null || echo '')"
+        pugl_head="$(git -C "$pugl_path" rev-parse HEAD 2>/dev/null || echo '')"
+        if [ -n "$pugl_pin" ] && [ -n "$pugl_head" ] && [ "$pugl_pin" != "$pugl_head" ]; then
+            echo "FAIL  pugl checkout is at ${pugl_head:0:12}, but DAF pins ${pugl_pin:0:12}"
+            echo "        run git submodule update --init --recursive in the DAF checkout"
+            failed=1
+        fi
     fi
 fi
 

--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -100,6 +100,10 @@ jobs:
         shell: bash
         run: ./tests/check_daf_plugin_names.sh
 
+      - name: Test the framework provenance guards
+        shell: bash
+        run: ./tests/check_provenance_guards.sh
+
       - name: Resolve build set + release info
         id: plan
         shell: bash
@@ -298,11 +302,14 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      # Runs after the checkouts so it can inspect the fork's own .gitmodules,
-      # which is where pugl silently kept pointing at upstream. Cheap, so it
-      # gates the expensive build instead of reporting after it.
+      # Runs after the checkouts so it can inspect the trees themselves: their
+      # origin remotes and pugl's revision against the gitlink DAF records, not
+      # just the config that says where a fetch would go. Cheap, so it gates the
+      # expensive build instead of reporting after it.
       - name: Check framework sources are our forks
-        run: ./.github/scripts/check_fork_sources.sh "${GITHUB_WORKSPACE}/DAF"
+        run: |
+          ./.github/scripts/check_fork_sources.sh \
+            "${GITHUB_WORKSPACE}/DAF" "${GITHUB_WORKSPACE}/DAF-Widgets"
 
       - name: Install Linux dependencies
         env:

--- a/docker/check_daf_pins.sh
+++ b/docker/check_daf_pins.sh
@@ -84,9 +84,50 @@ check_one "DAF-Widgets" "$DAFWIDGETS_PATH"  "$DAFWIDGETS_PIN"  "dusk-audio/DAF-W
 if [ -f "$DAF_PATH/.gitmodules" ]; then
     pugl_url="$(git -C "$DAF_PATH" config -f .gitmodules --get submodule.dgl/src/pugl-upstream.url || echo '')"
     case "$pugl_url" in
-        *dusk-audio/pugl*) echo "OK       pugl submodule: dusk-audio/pugl" ;;
-        *)                 echo "REMOTE   pugl submodule: $pugl_url, expected dusk-audio/pugl"; drift=1 ;;
+        *dusk-audio/pugl*) echo "OK       pugl .gitmodules: dusk-audio/pugl" ;;
+        *)                 echo "REMOTE   pugl .gitmodules: $pugl_url, expected dusk-audio/pugl"; drift=1 ;;
     esac
+fi
+
+# ...and .gitmodules only describes the next fetch. What a build actually
+# compiles is whatever sits in the working tree now, which can be a different
+# remote at a different revision: a checkout created before the fork was
+# repointed keeps its old origin forever, and .gitmodules saying the right thing
+# hides it. Check the checkout itself against the gitlink DAF records.
+PUGL_PATH="$DAF_PATH/dgl/src/pugl-upstream"
+if [ -d "$DAF_PATH/.git" ]; then
+    pugl_pin="$(git -C "$DAF_PATH" rev-parse -q --verify HEAD:dgl/src/pugl-upstream 2>/dev/null || echo '')"
+
+    if [ -z "$pugl_pin" ]; then
+        echo "MISSING  pugl checkout: DAF records no gitlink at dgl/src/pugl-upstream"
+        drift=1
+    elif [ ! -e "$PUGL_PATH/.git" ]; then
+        echo "MISSING  pugl checkout: nothing at $PUGL_PATH; run git submodule update --init --recursive"
+        drift=1
+    else
+        pugl_head="$(git -C "$PUGL_PATH" rev-parse HEAD)"
+        pugl_remote="$(git -C "$PUGL_PATH" remote get-url origin 2>/dev/null || echo '(none)')"
+
+        case "$pugl_remote" in
+            *dusk-audio/pugl*) ;;
+            *)
+                echo "REMOTE   pugl checkout: origin is $pugl_remote, expected dusk-audio/pugl"
+                echo "         .gitmodules is not evidence: this tree compiles from that remote"
+                drift=1
+                ;;
+        esac
+
+        if [ "$pugl_head" != "$pugl_pin" ]; then
+            echo "DRIFT    pugl checkout: local $(echo "$pugl_head" | cut -c1-12), DAF pins $(echo "$pugl_pin" | cut -c1-12)"
+            drift=1
+            if [ "$FIX" = "1" ]; then
+                echo "         checking out the pinned commit"
+                git -C "$DAF_PATH" submodule update -q --init --recursive
+            fi
+        else
+            echo "OK       pugl checkout: $(echo "$pugl_head" | cut -c1-12)"
+        fi
+    fi
 fi
 
 echo

--- a/docker/check_daf_pins.sh
+++ b/docker/check_daf_pins.sh
@@ -19,6 +19,25 @@ DAFWIDGETS_PATH="${DAFWIDGETS_PATH:-$REPO_ROOT/../DAF-Widgets}"
 FIX=0
 [ "${1:-}" = "--fix" ] && FIX=1
 
+# Reduce a remote URL to the "owner/repo" it names on github.com, or to nothing
+# if it names something else. A substring test accepts far too much:
+# not-dusk-audio/pugl, gitlab.com/dusk-audio/pugl and
+# github.com/attacker/mirror-dusk-audio/pugl all contain "dusk-audio/pugl".
+# Twin of the function in .github/scripts/check_fork_sources.sh.
+github_repo_of() {
+    local url="$1" path=""
+    case "$url" in
+        git@github.com:*)       path="${url#git@github.com:}" ;;
+        ssh://git@github.com/*) path="${url#ssh://git@github.com/}" ;;
+        https://github.com/*)   path="${url#https://github.com/}" ;;
+        http://github.com/*)    path="${url#http://github.com/}" ;;
+        *) return 0 ;;
+    esac
+    path="${path%/}"
+    path="${path%.git}"
+    printf '%s' "${path%/}"
+}
+
 pin_from_workflow() {
     grep -E "^\s+$1:" "$WORKFLOW" | head -1 | awk '{print $2}'
 }
@@ -44,22 +63,27 @@ check_one() {
     # against "0" is always false and every checkout reports DIRTY.
     dirty="$(git -C "$path" status --porcelain | wc -l | tr -d "[:space:]")"
 
-    case "$remote" in
-        *"$expect_remote"*) ;;
-        *)
-            echo "REMOTE   $name: origin is $remote, expected $expect_remote"
-            drift=1
-            ;;
-    esac
+    if [ "$(github_repo_of "$remote")" != "$expect_remote" ]; then
+        echo "REMOTE   $name: origin is $remote, expected github.com/$expect_remote"
+        drift=1
+    fi
 
     if [ "$head" != "$pin" ]; then
         echo "DRIFT    $name: local $(echo "$head" | cut -c1-12), CI builds $(echo "$pin" | cut -c1-12)"
         drift=1
         if [ "$FIX" = "1" ]; then
             echo "         checking out the pinned commit"
-            git -C "$path" fetch -q origin
-            git -C "$path" checkout -q "$pin"
-            git -C "$path" submodule update -q --init --recursive
+            # Report rather than die. set -e would otherwise abort the whole run
+            # on an offline machine, halfway through, with no explanation and
+            # the remaining checks never reported.
+            if ! git -C "$path" fetch -q origin 2>/dev/null; then
+                echo "         (could not reach origin; trying with the objects already here)"
+            fi
+            if ! git -C "$path" checkout -q "$pin" 2>/dev/null; then
+                echo "         could not check out $pin: fetch it and re-run"
+            else
+                git -C "$path" submodule update -q --init --recursive 2>/dev/null || true
+            fi
         fi
     else
         echo "OK       $name: $(echo "$head" | cut -c1-12)"
@@ -83,10 +107,12 @@ check_one "DAF-Widgets" "$DAFWIDGETS_PATH"  "$DAFWIDGETS_PIN"  "dusk-audio/DAF-W
 # source from a repository we do not control.
 if [ -f "$DAF_PATH/.gitmodules" ]; then
     pugl_url="$(git -C "$DAF_PATH" config -f .gitmodules --get submodule.dgl/src/pugl-upstream.url || echo '')"
-    case "$pugl_url" in
-        *dusk-audio/pugl*) echo "OK       pugl .gitmodules: dusk-audio/pugl" ;;
-        *)                 echo "REMOTE   pugl .gitmodules: $pugl_url, expected dusk-audio/pugl"; drift=1 ;;
-    esac
+    if [ "$(github_repo_of "$pugl_url")" = "dusk-audio/pugl" ]; then
+        echo "OK       pugl .gitmodules: dusk-audio/pugl"
+    else
+        echo "REMOTE   pugl .gitmodules: $pugl_url, expected github.com/dusk-audio/pugl"
+        drift=1
+    fi
 fi
 
 # ...and .gitmodules only describes the next fetch. What a build actually
@@ -107,25 +133,35 @@ if [ -d "$DAF_PATH/.git" ]; then
     else
         pugl_head="$(git -C "$PUGL_PATH" rev-parse HEAD)"
         pugl_remote="$(git -C "$PUGL_PATH" remote get-url origin 2>/dev/null || echo '(none)')"
+        pugl_remote_wrong=0
+        pugl_sha_wrong=0
 
-        case "$pugl_remote" in
-            *dusk-audio/pugl*) ;;
-            *)
-                echo "REMOTE   pugl checkout: origin is $pugl_remote, expected dusk-audio/pugl"
-                echo "         .gitmodules is not evidence: this tree compiles from that remote"
-                drift=1
-                ;;
-        esac
+        if [ "$(github_repo_of "$pugl_remote")" != "dusk-audio/pugl" ]; then
+            echo "REMOTE   pugl checkout: origin is $pugl_remote, expected github.com/dusk-audio/pugl"
+            echo "         .gitmodules is not evidence: this tree compiles from that remote"
+            drift=1
+            pugl_remote_wrong=1
+        fi
 
         if [ "$pugl_head" != "$pugl_pin" ]; then
             echo "DRIFT    pugl checkout: local $(echo "$pugl_head" | cut -c1-12), DAF pins $(echo "$pugl_pin" | cut -c1-12)"
             drift=1
-            if [ "$FIX" = "1" ]; then
-                echo "         checking out the pinned commit"
-                git -C "$DAF_PATH" submodule update -q --init --recursive
-            fi
-        else
+            pugl_sha_wrong=1
+        elif [ "$pugl_remote_wrong" = "0" ]; then
             echo "OK       pugl checkout: $(echo "$pugl_head" | cut -c1-12)"
+        fi
+
+        # Repair both kinds of drift, not just the revision. A submodule whose
+        # remote is stale keeps fetching from the old URL however many times it
+        # is updated, because update reads .git/config rather than .gitmodules;
+        # sync is what copies the declared URL across. So sync first, then
+        # update, whenever either half is wrong.
+        if [ "$FIX" = "1" ] && { [ "$pugl_remote_wrong" = "1" ] || [ "$pugl_sha_wrong" = "1" ]; }; then
+            echo "         syncing the submodule URL and checking out the pinned commit"
+            git -C "$DAF_PATH" submodule sync -q --recursive
+            if ! git -C "$DAF_PATH" submodule update -q --init --recursive 2>/dev/null; then
+                echo "         (URL synced; the pinned commit still needs a reachable remote)"
+            fi
         fi
     fi
 fi

--- a/tests/check_provenance_guards.sh
+++ b/tests/check_provenance_guards.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+#
+# check_provenance_guards.sh — tests for the two framework-provenance guards.
+#
+# docker/check_daf_pins.sh and .github/scripts/check_fork_sources.sh decide
+# whether a build tree is made of the source we think it is. Both used to answer
+# that from configuration alone: workflow fields and .gitmodules. Configuration
+# describes the next fetch, not the tree in front of you, so a checkout created
+# before a fork was repointed kept its old origin and both guards approved it
+# (issue #243).
+#
+# These fixtures are throwaway git repositories, so the cases below can be built
+# exactly: a correct checkout, one on the wrong remote, one at the wrong
+# revision, and the case that motivated the issue -- a .gitmodules that names our
+# fork sitting next to a checkout that does not come from it.
+#
+# No network: remotes are set with `git remote add` and never fetched.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PIN_GUARD="$REPO_ROOT/docker/check_daf_pins.sh"
+FORK_GUARD="$REPO_ROOT/.github/scripts/check_fork_sources.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+failures=0
+
+pass() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+
+git_q() { git -c user.email=t@t -c user.name=t -c init.defaultBranch=main -c commit.gpgsign=false "$@"; }
+
+# A minimal repository with one commit and a named origin.
+make_repo() {
+    local dir="$1" origin="$2"
+    mkdir -p "$dir"
+    git_q -C "$dir" init -q
+    echo seed > "$dir/file.txt"
+    git_q -C "$dir" add file.txt
+    git_q -C "$dir" commit -qm seed
+    git_q -C "$dir" remote add origin "$origin"
+}
+
+# A DAF-shaped tree: .gitmodules for pugl, a nested pugl checkout, and a gitlink
+# recorded at whichever pugl commit is asked for. Built with update-index rather
+# than `git submodule add` so the recorded revision can disagree with the
+# checkout, which is the whole point of two of the cases.
+#   $1 dir  $2 DAF origin  $3 pugl origin  $4 gitmodules url  $5 pin=head|stale
+make_daf() {
+    local dir="$1" dafOrigin="$2" puglOrigin="$3" modulesUrl="$4" pinMode="$5"
+    make_repo "$dir" "$dafOrigin"
+
+    mkdir -p "$dir/dgl/src"
+    local pugl="$dir/dgl/src/pugl-upstream"
+    make_repo "$pugl" "$puglOrigin"
+    local puglHead stalePin
+    puglHead="$(git_q -C "$pugl" rev-parse HEAD)"
+    echo second > "$pugl/file.txt"
+    git_q -C "$pugl" commit -qam second
+    stalePin="$puglHead"                       # the first commit, now behind
+    puglHead="$(git_q -C "$pugl" rev-parse HEAD)"
+
+    cat > "$dir/.gitmodules" <<EOF
+[submodule "dgl/src/pugl-upstream"]
+	path = dgl/src/pugl-upstream
+	url = $modulesUrl
+EOF
+
+    local recorded="$puglHead"
+    [ "$pinMode" = stale ] && recorded="$stalePin"
+    git_q -C "$dir" update-index --add --cacheinfo "160000,$recorded,dgl/src/pugl-upstream"
+    git_q -C "$dir" add .gitmodules
+    git_q -C "$dir" commit -qm "record pugl"
+}
+
+# The pin guard reports on DAF and DAF-Widgets too, and those rows will always
+# read DRIFT against fixtures, since the fixture SHAs are not the CI pins. Only
+# the pugl lines are under test here, so assert on those.
+pin_guard_says() {
+    local dafPath="$1" expected="$2" label="$3"
+    local out
+    out="$(DAF_PATH="$dafPath" DAFWIDGETS_PATH="$dafPath" "$PIN_GUARD" 2>&1 || true)"
+    if printf '%s' "$out" | grep -q "$expected"; then
+        pass "$label"
+    else
+        fail "$label -- expected a line matching: $expected"
+        printf '%s\n' "$out" | sed 's/^/        /'
+    fi
+}
+
+fork_guard_exits() {
+    local dafPath="$1" widgetsPath="$2" wantFail="$3" label="$4" expected="${5:-}"
+    local out status=0
+    out="$("$FORK_GUARD" "$dafPath" "$widgetsPath" 2>&1)" || status=$?
+
+    if [ "$wantFail" = yes ] && [ "$status" -eq 0 ]; then
+        fail "$label -- guard passed, expected failure"
+        printf '%s\n' "$out" | sed 's/^/        /'
+        return
+    fi
+    if [ "$wantFail" = no ] && [ "$status" -ne 0 ]; then
+        fail "$label -- guard failed, expected pass"
+        printf '%s\n' "$out" | sed 's/^/        /'
+        return
+    fi
+    if [ -n "$expected" ] && ! printf '%s' "$out" | grep -q "$expected"; then
+        fail "$label -- expected a line matching: $expected"
+        printf '%s\n' "$out" | sed 's/^/        /'
+        return
+    fi
+    pass "$label"
+}
+
+echo "provenance guards"
+
+# --- 1. a correct checkout is approved ------------------------------------
+make_daf "$WORK/good" "git@github.com:dusk-audio/DAF.git" \
+         "https://github.com/dusk-audio/pugl.git" \
+         "https://github.com/dusk-audio/pugl.git" head
+make_repo "$WORK/widgets-good" "https://github.com/dusk-audio/DAF-Widgets.git"
+
+pin_guard_says "$WORK/good" "OK       pugl checkout:" "pin guard accepts a matching pugl checkout"
+fork_guard_exits "$WORK/good" "$WORK/widgets-good" no "fork guard accepts checkouts from our forks"
+
+# --- 2. wrong origin ------------------------------------------------------
+make_daf "$WORK/badremote" "git@github.com:dusk-audio/DAF.git" \
+         "https://github.com/DISTRHO/pugl.git" \
+         "https://github.com/DISTRHO/pugl.git" head
+
+pin_guard_says "$WORK/badremote" "REMOTE   pugl checkout:" "pin guard rejects a pugl checkout from upstream"
+fork_guard_exits "$WORK/badremote" "$WORK/widgets-good" yes \
+    "fork guard rejects a pugl checkout from upstream" "pugl checkout compiles from"
+
+# --- 3. wrong revision ----------------------------------------------------
+make_daf "$WORK/badsha" "git@github.com:dusk-audio/DAF.git" \
+         "https://github.com/dusk-audio/pugl.git" \
+         "https://github.com/dusk-audio/pugl.git" stale
+
+pin_guard_says "$WORK/badsha" "DRIFT    pugl checkout:" "pin guard rejects a pugl checkout at the wrong revision"
+fork_guard_exits "$WORK/badsha" "$WORK/widgets-good" yes \
+    "fork guard rejects a pugl checkout at the wrong revision" "but DAF pins"
+
+# --- 4. the case from #243: honest .gitmodules, dishonest checkout --------
+make_daf "$WORK/misleading" "git@github.com:dusk-audio/DAF.git" \
+         "https://github.com/DISTRHO/pugl.git" \
+         "https://github.com/dusk-audio/pugl.git" head
+
+pin_guard_says "$WORK/misleading" "OK       pugl .gitmodules:" \
+    "pin guard still reads .gitmodules as declared"
+pin_guard_says "$WORK/misleading" "REMOTE   pugl checkout:" \
+    "pin guard rejects an upstream checkout that .gitmodules vouches for"
+fork_guard_exits "$WORK/misleading" "$WORK/widgets-good" yes \
+    "fork guard rejects an upstream checkout that .gitmodules vouches for" \
+    "pugl checkout compiles from"
+
+# --- 5. a DAF-Widgets checkout from upstream ------------------------------
+make_repo "$WORK/widgets-bad" "https://github.com/DISTRHO/DPF-Widgets.git"
+fork_guard_exits "$WORK/good" "$WORK/widgets-bad" yes \
+    "fork guard rejects a DAF-Widgets checkout from upstream" "DAF-Widgets checkout compiles from"
+
+# --- 6. no paths supplied: config-only scan still works -------------------
+fork_guard_exits "" "" no "fork guard still scans config alone when given no paths"
+
+echo
+if [ "$failures" = 0 ]; then
+    echo "all provenance guard tests passed"
+else
+    echo "$failures provenance guard test(s) failed"
+    exit 1
+fi

--- a/tests/check_provenance_guards.sh
+++ b/tests/check_provenance_guards.sh
@@ -161,7 +161,66 @@ make_repo "$WORK/widgets-bad" "https://github.com/DISTRHO/DPF-Widgets.git"
 fork_guard_exits "$WORK/good" "$WORK/widgets-bad" yes \
     "fork guard rejects a DAF-Widgets checkout from upstream" "DAF-Widgets checkout compiles from"
 
-# --- 6. no paths supplied: config-only scan still works -------------------
+# --- 6. a lookalike origin ------------------------------------------------
+# The guards used to substring-match the expected "owner/repo", which accepts a
+# different account (not-dusk-audio/pugl), a different host, and a nested path
+# that merely contains the name.
+for lookalike in "https://github.com/not-dusk-audio/pugl.git" \
+                 "https://gitlab.com/dusk-audio/pugl.git" \
+                 "https://github.com/attacker/mirror-dusk-audio/pugl.git"; do
+    rm -rf "$WORK/lookalike"
+    make_daf "$WORK/lookalike" "git@github.com:dusk-audio/DAF.git" \
+             "$lookalike" "https://github.com/dusk-audio/pugl.git" head
+    pin_guard_says "$WORK/lookalike" "REMOTE   pugl checkout:" \
+        "pin guard rejects lookalike origin $lookalike"
+    fork_guard_exits "$WORK/lookalike" "$WORK/widgets-good" yes \
+        "fork guard rejects lookalike origin $lookalike" "pugl checkout compiles from"
+done
+
+# --- 7. a pugl checkout DAF does not pin at all ---------------------------
+# An empty gitlink is not "nothing to compare": it means the source sitting
+# there is pinned by nothing, so no revision check can vouch for it.
+rm -rf "$WORK/nogitlink"
+make_repo "$WORK/nogitlink" "git@github.com:dusk-audio/DAF.git"
+mkdir -p "$WORK/nogitlink/dgl/src"
+make_repo "$WORK/nogitlink/dgl/src/pugl-upstream" "https://github.com/dusk-audio/pugl.git"
+cat > "$WORK/nogitlink/.gitmodules" <<EOF
+[submodule "dgl/src/pugl-upstream"]
+	path = dgl/src/pugl-upstream
+	url = https://github.com/dusk-audio/pugl.git
+EOF
+git_q -C "$WORK/nogitlink" add .gitmodules
+git_q -C "$WORK/nogitlink" commit -qm "gitmodules without a gitlink"
+
+fork_guard_exits "$WORK/nogitlink" "$WORK/widgets-good" yes \
+    "fork guard rejects a pugl checkout DAF records no gitlink for" "records no gitlink"
+pin_guard_says "$WORK/nogitlink" "MISSING  pugl checkout:" \
+    "pin guard reports a pugl checkout DAF records no gitlink for"
+
+# --- 8. --fix repairs a stale submodule remote ----------------------------
+# submodule update reads .git/config, not .gitmodules, so a submodule whose
+# recorded URL is stale keeps fetching from the old remote however often it is
+# updated. sync is what copies the declared URL across, and --fix has to run it
+# even when the revision already matches, which is the remote-only case here.
+rm -rf "$WORK/staleremote"
+make_daf "$WORK/staleremote" "git@github.com:dusk-audio/DAF.git" \
+         "https://github.com/DISTRHO/pugl.git" \
+         "https://github.com/dusk-audio/pugl.git" head
+git_q -C "$WORK/staleremote" config submodule.dgl/src/pugl-upstream.url \
+    "https://github.com/DISTRHO/pugl.git"
+
+before="$(git_q -C "$WORK/staleremote/dgl/src/pugl-upstream" remote get-url origin)"
+DAF_PATH="$WORK/staleremote" DAFWIDGETS_PATH="$WORK/staleremote" \
+    "$PIN_GUARD" --fix > /dev/null 2>&1 || true
+after="$(git_q -C "$WORK/staleremote/dgl/src/pugl-upstream" remote get-url origin)"
+
+if [ "$before" != "$after" ] && [ "$(printf '%s' "$after" | grep -c 'dusk-audio/pugl')" = "1" ]; then
+    pass "--fix syncs a stale submodule remote to the declared URL"
+else
+    fail "--fix syncs a stale submodule remote to the declared URL -- origin went $before -> $after"
+fi
+
+# --- 9. no paths supplied: config-only scan still works -------------------
 fork_guard_exits "" "" no "fork guard still scans config alone when given no paths"
 
 echo


### PR DESCRIPTION
Closes #243.

Both guards answered "is this tree made of our source?" from configuration:
workflow fields, and the fork's `.gitmodules`. Configuration describes the next
fetch. It says nothing about the tree in front of you, so a checkout created
before a fork was repointed keeps its old origin forever, and a correct
`.gitmodules` sitting beside it reads as proof that everything is fine.

## Changes

**`docker/check_daf_pins.sh`** now inspects the nested pugl checkout: origin must
be `dusk-audio/pugl`, and HEAD must equal the gitlink DAF records, which is the
revision a build actually compiles. `--fix` runs `submodule update` for it. The
existing `.gitmodules` check stays, relabelled so the two are distinguishable in
the output, since a wrong URL there is still worth catching before the next
fetch acts on it.

**`.github/scripts/check_fork_sources.sh`** takes an optional DAF-Widgets path
next to the DAF one. Given either, it checks that checkout's origin rather than
only the config. For pugl it also compares the checkout revision against DAF's
gitlink: a submodule left on another commit compiles source we do not pin, which
is as wrong as fetching from upstream. The workflow passes both paths now, and
the guards' own tests run alongside the other cheap repo checks.

**`tests/check_provenance_guards.sh`** covers the four cases the issue lists —
correct checkout, wrong origin, wrong SHA, and a `.gitmodules` that vouches for a
checkout it does not describe — plus a DAF-Widgets checkout from upstream and
the config-only invocation. Fixtures are throwaway git repositories built with
`update-index --cacheinfo`, so a recorded gitlink can disagree with the checkout
on purpose. No network: remotes are added and never fetched.

```
provenance guards
  ok    pin guard accepts a matching pugl checkout
  ok    fork guard accepts checkouts from our forks
  ok    pin guard rejects a pugl checkout from upstream
  ok    fork guard rejects a pugl checkout from upstream
  ok    pin guard rejects a pugl checkout at the wrong revision
  ok    fork guard rejects a pugl checkout at the wrong revision
  ok    pin guard still reads .gitmodules as declared
  ok    pin guard rejects an upstream checkout that .gitmodules vouches for
  ok    fork guard rejects an upstream checkout that .gitmodules vouches for
  ok    fork guard rejects a DAF-Widgets checkout from upstream
  ok    fork guard still scans config alone when given no paths
```

Disabling the new logic fails 7 of those 11, which is how I know they are
load-bearing rather than decorative.

## It caught something immediately

The local DAF-Widgets checkout had drifted to `625fa1400f20` against the pinned
`487b092aa265`, because merging that fork's README PR earlier today moved the
working copy off the pin. The guard reported it, `--fix` restored it, and
`tapemachine-2` rebuilds green on the pinned tree (4/4).

Worth noting what this does *not* cover, since it is the neighbouring problem:
the guards check that pugl is at the revision DAF pins, not whether that
revision is sensible. `dusk/302-app-contract`, the branch we ship, is currently
~80 commits behind the fork's own `main` and is missing two of our own fixes.
That needs a decision, not a guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened build validation for framework source checkouts, including DAF, DAF-Widgets, and pugl.
  - Builds now detect mismatched repository origins and pinned submodule revisions, preventing untrusted or inconsistent sources from passing validation.
  - Added an automatic fix option to synchronize pugl with the pinned revision.

- **Tests**
  - Added coverage for valid checkouts, incorrect origins, revision mismatches, fork configurations, and missing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->