### PR TITLE
shared-daf: let a lamp carry its own colour, and drop Multi-Comp's copy (#247)

### DIFF
--- a/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
@@ -2191,8 +2191,24 @@ private:
         const float thresholdDb = plainValueForHost(P_VCA_THRESHOLD, values[P_VCA_THRESHOLD]);
         const bool above = multicompp::ui_detail::vcaSignalAboveThreshold(inputDb, thresholdDb);
         spacedText(dl, 110, 391, 9.5f, kVcaInk, "BELOW", 1);
-        vcaLamp(dl, 128, 397, !above, IM_COL32(240, 205, 70, 255), IM_COL32(240, 205, 70, 80));
-        vcaLamp(dl, 214, 397, above, IM_COL32(220, 62, 46, 255), IM_COL32(220, 62, 46, 80));
+        // The reference's two jewels: amber below the threshold, red above.
+        duskdaf::DuskPanel::LedStyle jewel;
+        jewel.bezelColor = IM_COL32(52, 52, 54, 255);
+        jewel.rimRadiusAdd = 1.2f;
+        jewel.glowRadiusAdd = 7.0f;
+        jewel.dropShadowRadiusAdd = 3.0f;
+        jewel.highlightScale = 1.5f;
+        jewel.highlightColor = IM_COL32(255, 248, 225, 220);
+        jewel.offFromOnColor = true;
+        jewel.offHighlight = true;
+
+        jewel.onColor = IM_COL32(240, 205, 70, 255);
+        jewel.glowColor = IM_COL32(240, 205, 70, 80);
+        panel.led(dl, 128, 397, !above, 7.0f, jewel);
+
+        jewel.onColor = IM_COL32(220, 62, 46, 255);
+        jewel.glowColor = IM_COL32(220, 62, 46, 80);
+        panel.led(dl, 214, 397, above, 7.0f, jewel);
         spacedText(dl, 232, 391, 9.5f, kVcaInk, "ABOVE", -1);
 
         {
@@ -2365,30 +2381,6 @@ private:
         vcaKnobSplitter.Merge(dl);
     }
 
-
-    // Domed lamp; the shared DuskPanel::led is palette-locked to one colour
-    // (plugins issue #247), so the amber/red pair is drawn here.
-    void vcaLamp(ImDrawList* dl, float x, float y, bool on, ImU32 onCol, ImU32 glowCol)
-    {
-        const float s = panel.scale();
-        const ImVec2 c = panel.P(x, y);
-        dl->AddCircleFilled(ImVec2(c.x + 1.0f * s, c.y + 1.5f * s), 10.0f * s, IM_COL32(0, 0, 0, 120), 24);
-        dl->AddCircleFilled(c, 9.5f * s, IM_COL32(52, 52, 54, 255), 24);
-        dl->AddCircleFilled(c, 8.2f * s, IM_COL32(6, 6, 6, 255), 24);
-        if (on)
-        {
-            dl->AddCircleFilled(c, 14.0f * s, glowCol, 24);
-            dl->AddCircleFilled(c, 7.0f * s, onCol, 24);
-            dl->AddCircleFilled(ImVec2(c.x - 2.2f * s, c.y - 2.4f * s), 2.4f * s, IM_COL32(255, 248, 225, 220), 12);
-        }
-        else
-        {
-            // A dark version of the lamp's own colour, like an unlit red jewel.
-            const ImU32 offCol = IM_COL32((onCol & 0xFF) / 3, ((onCol >> 8) & 0xFF) / 3, ((onCol >> 16) & 0xFF) / 3, 255);
-            dl->AddCircleFilled(c, 7.0f * s, offCol, 24);
-            dl->AddCircleFilled(ImVec2(c.x - 2.2f * s, c.y - 2.4f * s), 1.8f * s, IM_COL32(255, 255, 255, 60), 12);
-        }
-    }
 
     void vcaKnob(ImDrawList* dl, const char* id, uint32_t p,
                  float x, float y, float radius, const char* label,

--- a/plugins/shared-daf/ui/DuskImGuiWidgets.hpp
+++ b/plugins/shared-daf/ui/DuskImGuiWidgets.hpp
@@ -144,20 +144,69 @@ public:
             dl->AddText(font, sz, ImVec2(pos.x + 0.6f * s, pos.y), col, txt);
     }
 
+    // A lamp that is not the panel's indicator colour. The dbx 160 face carries
+    // an amber BELOW and a red ABOVE side by side, which one palette entry
+    // cannot say, and the jewel it uses is built a little differently from the
+    // small panel indicator: a drop shadow under the bezel, a wider glow, an
+    // unlit state tinted from its own colour rather than a flat grey, and a
+    // highlight that grows with the lamp instead of staying at indicator size.
+    //
+    // Every field is optional and defaults to the indicator, so the callers that
+    // want a plain palette LED say nothing and get exactly what they had.
+    struct LedStyle
+    {
+        ImU32 onColor = 0;          // 0 = pal.ledOn
+        ImU32 glowColor = 0;        // 0 = pal.ledGlow
+        ImU32 offColor = 0;         // 0 = pal.ledOff, unless offFromOnColor
+        float bezelRadiusAdd = 2.5f;
+        float rimRadiusAdd = 1.0f;
+        float glowRadiusAdd = 5.0f;
+        float dropShadowRadiusAdd = 0.0f;   // 0 = no drop shadow under the bezel
+        ImU32 bezelColor = IM_COL32(60, 60, 62, 255);
+        float highlightScale = 1.0f;        // scales the lit highlight's offset and size
+        ImU32 highlightColor = IM_COL32(255, 215, 205, 230);
+        bool offFromOnColor = false;        // unlit jewel = a third of its lit colour
+        bool offHighlight = false;          // a faint glint even when unlit
+    };
+
     void led(ImDrawList* dl, float x, float y, bool on, float r = 5.0f) const
     {
+        led(dl, x, y, on, r, LedStyle{});
+    }
+
+    void led(ImDrawList* dl, float x, float y, bool on, float r, const LedStyle& style) const
+    {
         const ImVec2 c = P(x, y);
-        dl->AddCircleFilled(c, (r + 2.5f) * s, IM_COL32(60, 60, 62, 255), 20);
-        dl->AddCircleFilled(c, (r + 1.0f) * s, IM_COL32(0, 0, 0, 255), 20);
+        const ImU32 onColor = style.onColor != 0 ? style.onColor : pal.ledOn;
+        const ImU32 glowColor = style.glowColor != 0 ? style.glowColor : pal.ledGlow;
+
+        if (style.dropShadowRadiusAdd > 0.0f)
+            dl->AddCircleFilled(ImVec2(c.x + 1.0f * s, c.y + 1.5f * s),
+                                (r + style.dropShadowRadiusAdd) * s, IM_COL32(0, 0, 0, 120), 24);
+
+        dl->AddCircleFilled(c, (r + style.bezelRadiusAdd) * s, style.bezelColor, 20);
+        dl->AddCircleFilled(c, (r + style.rimRadiusAdd) * s, IM_COL32(0, 0, 0, 255), 20);
         if (on)
         {
-            dl->AddCircleFilled(c, (r + 5.0f) * s, pal.ledGlow, 20);
-            dl->AddCircleFilled(c, r * s, pal.ledOn, 20);
-            dl->AddCircleFilled(ImVec2(c.x - 1.5f * s, c.y - 1.5f * s), 1.6f * s,
-                                IM_COL32(255, 215, 205, 230), 10);
+            dl->AddCircleFilled(c, (r + style.glowRadiusAdd) * s, glowColor, 20);
+            dl->AddCircleFilled(c, r * s, onColor, 20);
+            const float h = style.highlightScale;
+            dl->AddCircleFilled(ImVec2(c.x - 1.5f * h * s, c.y - 1.5f * h * s), 1.6f * h * s,
+                                style.highlightColor, 10);
         }
         else
-            dl->AddCircleFilled(c, r * s, pal.ledOff, 20);
+        {
+            ImU32 offColor = style.offColor != 0 ? style.offColor : pal.ledOff;
+            if (style.offFromOnColor)
+                offColor = IM_COL32((onColor & 0xFF) / 3, ((onColor >> 8) & 0xFF) / 3,
+                                    ((onColor >> 16) & 0xFF) / 3, 255);
+            dl->AddCircleFilled(c, r * s, offColor, 20);
+            if (style.offHighlight)
+                dl->AddCircleFilled(ImVec2(c.x - 1.5f * style.highlightScale * s,
+                                           c.y - 1.5f * style.highlightScale * s),
+                                    1.2f * style.highlightScale * s,
+                                    IM_COL32(255, 255, 255, 60), 12);
+        }
     }
 
     static float knobAngle(float t) { return (-135.0f + 270.0f * t) * kPi / 180.0f; }


### PR DESCRIPTION
Closes #247. `DuskPanel::led` drew its lit state from `Palette::ledOn/ledGlow`
only, so the dbx 160 face, which needs an amber BELOW and a red ABOVE side by
side, grew `vcaLamp` locally.

## The copy was not colour-locked geometry

Worth saying because it changes the fix. `vcaLamp` builds its jewel differently
from the small panel indicator: a drop shadow under the bezel, a wider glow, a
rim a fraction further out, an unlit state tinted from its own colour instead of
a flat grey, and a highlight that grows with the lamp rather than staying at
indicator size. An `onColor`/`glowColor` overload alone would have deleted the
copy by silently changing how that face looks.

So the shared LED takes an optional `LedStyle` carrying those properties, each
defaulting to the indicator. The five existing callers pass nothing and are
unaffected by construction; the VCA face describes its jewel and calls the
shared widget.

## What changed on screen

Measured, not eyeballed. Editor dumps of the VCA face before and after:

```
differing pixels: 414 of 425600   bbox=(114, 109, 224, 137)   max channel delta: 25
```

Entirely inside the two lamp circles. The residue is anti-aliasing: the local
copy drew its circles with 24 segments and put the lit glint at `(-2.2,-2.4)`
r2.4; the shared one uses 20 segments and a scaled `(-2.25,-2.25)` r2.4.
Invisible at 1x, visible at 4x if you go looking. Closing it exactly means
encoding segment counts and an asymmetric glint offset, which is four more
fields on a shared widget for a difference you cannot see — I stopped short of
that, and it is a one-line ask if you would rather have zero.

## Verification

Everything that draws an LED builds and gates green: `multi-comp-2` 3/3,
`tapemachine-2` 4/4, `tape-echo-2` 5/5 (the other callers are Tape Echo 2 and
Sunset Circuits).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable LED indicator styling, including colors, glow, rim, shadows, highlights, and unlit appearance.
  - VCA threshold indicators now use distinct amber and red styles for below- and above-threshold states.

- **Visual Improvements**
  - Preserved the existing default LED appearance while enabling more precise indicator customization.
  - Improved clarity of VCA threshold status through differentiated indicator colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->