### PR TITLE
shared-daf: one printed knob ring instead of six (#246)

### DIFF
--- a/plugins/4k-eq/daf-plugin/FourKEQUI.cpp
+++ b/plugins/4k-eq/daf-plugin/FourKEQUI.cpp
@@ -19,6 +19,7 @@
 #include "FourKEQPresetRuntime.hpp"
 #include "FourKEQVersion.hpp"
 
+#include "DuskKnobRing.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
@@ -1240,14 +1241,16 @@ private:
         drawMetalKnobBody(dl, panel.P(cx, cy), r * sc(), t,
                           IM_COL32(150, 152, 156, 255), IM_COL32(30, 30, 33, 255));
         // tick dots + labels around the dial, matching the band/filter knobs.
-        for (int i = 0; i < nT; ++i)
         {
-            const float tt = range > 0.f ? (TV[i] - minV) / range : 0.f;
-            const float a = duskdaf::DuskPanel::knobAngle(tt);
-            const float dx = std::sin(a), dy = -std::cos(a);
-            dl->AddCircleFilled(panel.P(cx + dx * (r + 9.f), cy + dy * (r + 9.f)), 1.6f * sc(), IM_COL32(150, 152, 156, 255), 8);
-            const int align = dx < -0.25f ? 1 : (dx > 0.25f ? -1 : 0);
-            panel.text(dl, cx + dx * (r + 20.f), cy + dy * (r + 20.f) - 5.f, 10.5f, IM_COL32(206, 208, 212, 255), TL[i], align, true);
+            duskdaf::KnobRingStyle ring;
+            ring.dotMarks = true;
+            ring.markOuter = 9.0f;
+            ring.labelOffset = 20.0f;
+            duskdaf::drawKnobRing(panel, dl, cx, cy, r, TV, TL, nT, nullptr, 0,
+                                  [minV, range](float v) {
+                                      return range > 0.f ? (v - minV) / range : 0.f;
+                                  },
+                                  ring);
         }
         panel.text(dl, cx, cy + r + 10.f, 11.0f, IM_COL32(206, 208, 212, 255), name, 0, true);
         // gestures + value read-out on top (no body drawn)
@@ -1473,13 +1476,15 @@ private:
         }
 
         // detent dots + labels
-        for (int i = 0; i < 7; ++i)
         {
-            const float a = duskdaf::DuskPanel::knobAngle(stepLT(i));
-            const float dx = std::sin(a), dy = -std::cos(a);
-            dl->AddCircleFilled(panel.P(cx + dx * (R + 9.f), cy + dy * (R + 9.f)), 1.7f * s, IM_COL32(150, 152, 156, 255), 8);
-            const int align = dx < -0.25f ? 1 : (dx > 0.25f ? -1 : 0);
-            panel.text(dl, cx + dx * (R + 20.f), cy + dy * (R + 20.f) - 5.f, 11.f, IM_COL32(206, 208, 212, 255), labels[i], align, true);
+            duskdaf::KnobRingStyle ring;
+            ring.dotMarks = true;
+            ring.markOuter = 9.0f;
+            ring.dotRadius = 1.7f;
+            ring.labelOffset = 20.0f;
+            ring.labelSize = 11.0f;
+            for (int i = 0; i < 7; ++i)
+                duskdaf::drawKnobRingMark(panel, dl, cx, cy, R, stepLT(i), labels[i], ring);
         }
 
         // brushed-metal body: silver cap + dark pointer for the filter knobs.
@@ -1676,26 +1681,22 @@ private:
         // around the top detent, so add one unlabeled minor dot at each midpoint
         // (e.g. LF 75→200 and 200→338). This is visual only: interpolation
         // and the labeled parameter detents remain exactly as before.
+        duskdaf::KnobRingStyle ring;
+        ring.dotMarks = true;
+        ring.markOuter = 9.0f;   ring.minorOuter = 9.0f;
+        ring.dotRadius = 1.6f;   ring.minorDotRadius = 1.45f;
+        ring.labelOffset = 20.0f;
+
+        // An unlabelled dot halfway across a wide gap, so the ring reads evenly
+        // where the detents are far apart.
         if (addWideGapDots)
             for (int i = 0; i < n - 1; ++i)
                 if (T[i + 1] - T[i] >= 0.20f)
-                {
-                    const float mt = 0.5f * (T[i] + T[i + 1]);
-                    const float ma = duskdaf::DuskPanel::knobAngle(mt);
-                    const float mdx = std::sin(ma), mdy = -std::cos(ma);
-                    dl->AddCircleFilled(
-                        panel.P(cx + mdx * (R + 9.f), cy + mdy * (R + 9.f)),
-                        1.45f * s, IM_COL32(150, 152, 156, 255), 8);
-                }
+                    duskdaf::drawKnobRingMark(panel, dl, cx, cy, R,
+                                              0.5f * (T[i] + T[i + 1]), nullptr, ring, true);
 
         for (int i = 0; i < n; ++i)
-        {
-            const float a = duskdaf::DuskPanel::knobAngle(T[i]);
-            const float dx = std::sin(a), dy = -std::cos(a);
-            dl->AddCircleFilled(panel.P(cx + dx * (R + 9.f), cy + dy * (R + 9.f)), 1.6f * s, IM_COL32(150, 152, 156, 255), 8);
-            const int align = dx < -0.25f ? 1 : (dx > 0.25f ? -1 : 0);
-            panel.text(dl, cx + dx * (R + 20.f), cy + dy * (R + 20.f) - 5.f, 10.5f, IM_COL32(206, 208, 212, 255), labels[i], align, true);
-        }
+            duskdaf::drawKnobRingMark(panel, dl, cx, cy, R, T[i], labels[i], ring);
 
         drawMetalKnobBody(dl, c, RR, t, capCol, IM_COL32(245, 245, 245, 255));
         panel.text(dl, cx, cy + R + 16.f, 12.f, IM_COL32(210, 212, 216, 255), unit, 0, true);

--- a/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
+++ b/plugins/multi-comp/daf-plugin/MultiCompUI.cpp
@@ -280,6 +280,7 @@ inline void refreshParameterMirror(std::array<float, N>& values,
 #include "MultiCompVersion.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiWidgets.hpp"
+#include "DuskKnobRing.hpp"
 #include "DuskVuMeter.hpp"
 #include "DuskSupportersOverlay.hpp"
 #include "DuskUserPresetStore.hpp"
@@ -1468,31 +1469,27 @@ private:
         constexpr std::array<const char*, 11> scaleLabels{{
             "0", "10", "20", "30", "40", "50",
             "60", "70", "80", "90", "100"}};
+        // Three tiers of mark, so the styles differ only by how far in they
+        // start; the placement comes from the shared ring either way.
+        duskdaf::KnobRingStyle ring;
+        ring.markOuter = 12.0f;   ring.minorOuter = 12.0f;
+        ring.markInner = 4.0f;    ring.markThickness = 1.45f;
+        ring.minorThickness = 0.75f;
+        ring.markColor = kOptoInk;
+        ring.labelOffset = 23.0f; ring.labelNudgeY = -4.0f; ring.labelSize = 7.8f;
+        ring.labelColor = kOptoInk;
+        ring.labelCentred = true;
+        duskdaf::KnobRingStyle medium = ring;   medium.minorInner = 6.0f;
+        duskdaf::KnobRingStyle fine = ring;     fine.minorInner = 8.0f;
+
         for (int tick = 0; tick <= 50; ++tick)
         {
-            const float angle = duskdaf::DuskPanel::knobAngle(
-                static_cast<float>(tick) / 50.0f);
-            const ImVec2 direction(std::sin(angle), -std::cos(angle));
-            const bool major = tick % 5 == 0;
-            const bool medium = tick % 5 == 0 || tick % 5 == 2;
-            const float inner = scaledRadius
-                + (major ? 4.0f : medium ? 6.0f : 8.0f) * panel.scale();
-            const float outer = scaledRadius + 12.0f * panel.scale();
-            dl->AddLine(ImVec2(center.x + direction.x * inner,
-                               center.y + direction.y * inner),
-                        ImVec2(center.x + direction.x * outer,
-                               center.y + direction.y * outer),
-                        kOptoInk, (major ? 1.45f : 0.75f) * panel.scale());
-            if (major)
-            {
-                const int labelIndex = tick / 5;
-                const float labelRadius = radius + 23.0f;
-                panel.text(dl,
-                           x + direction.x * labelRadius,
-                           y + direction.y * labelRadius - 4.0f,
-                           7.8f, kOptoInk,
-                           scaleLabels[static_cast<size_t>(labelIndex)], 0, true);
-            }
+            const bool isMajor = tick % 5 == 0;
+            const bool isMedium = tick % 5 == 2;
+            duskdaf::drawKnobRingMark(
+                panel, dl, x, y, radius, static_cast<float>(tick) / 50.0f,
+                isMajor ? scaleLabels[static_cast<size_t>(tick / 5)] : nullptr,
+                isMajor ? ring : (isMedium ? medium : fine), !isMajor);
         }
 
         const ImVec2 shadowCenter(center.x + 3.0f * panel.scale(),
@@ -1838,45 +1835,41 @@ private:
         {
             constexpr std::array<const char*, 9> labels{{
                 "INF", "48", "36", "30", "24", "18", "12", "6", "0"}};
+            duskdaf::KnobRingStyle ring;
+            ring.markInner = 4.0f;   ring.markOuter = 10.0f;  ring.markThickness = 1.25f;
+            ring.minorInner = 7.0f;  ring.minorOuter = 10.0f; ring.minorThickness = 0.75f;
+            ring.markColor = IM_COL32(229, 230, 219, 240);
+            ring.labelOffset = 19.0f; ring.labelNudgeY = -3.0f; ring.labelSize = 7.3f;
+            ring.labelColor = IM_COL32(232, 232, 220, 255);
+            ring.labelCentred = true;
             for (int tick = 0; tick <= 16; ++tick)
             {
-                const float tickT = static_cast<float>(tick) / 16.0f;
-                const float angle = duskdaf::DuskPanel::knobAngle(tickT);
-                const ImVec2 direction(std::sin(angle), -std::cos(angle));
                 const bool major = tick % 2 == 0;
-                const float inner = r + (major ? 4.0f : 7.0f) * scale;
-                const float outer = r + 10.0f * scale;
-                dl->AddLine(ImVec2(center.x + direction.x * inner,
-                                   center.y + direction.y * inner),
-                            ImVec2(center.x + direction.x * outer,
-                                   center.y + direction.y * outer),
-                            IM_COL32(229, 230, 219, 240),
-                            (major ? 1.25f : 0.75f) * scale);
-                if (major)
-                    panel.text(dl, x + direction.x * (radius + 19.0f),
-                               y + direction.y * (radius + 19.0f) - 3.0f,
-                               7.3f, IM_COL32(232, 232, 220, 255),
-                               labels[static_cast<size_t>(tick / 2)], 0, true);
+                duskdaf::drawKnobRingMark(
+                    panel, dl, x, y, radius, static_cast<float>(tick) / 16.0f,
+                    major ? labels[static_cast<size_t>(tick / 2)] : nullptr,
+                    ring, !major);
             }
         }
         else
         {
             constexpr std::array<const char*, 4> labels{{"1", "3", "5", "7"}};
+            duskdaf::KnobRingStyle ring;
+            ring.dotMarks = true;
+            ring.markOuter = 7.0f;   ring.minorOuter = 7.0f;
+            ring.dotRadius = 1.45f;  ring.minorDotRadius = 0.85f;
+            ring.dotSegments = 10;
+            ring.markColor = IM_COL32(230, 230, 218, 255);
+            ring.labelOffset = 15.0f; ring.labelNudgeY = -3.0f; ring.labelSize = 7.0f;
+            ring.labelColor = IM_COL32(232, 232, 220, 255);
+            ring.labelCentred = true;
             for (int tick = 0; tick <= 6; ++tick)
             {
-                const float tickT = static_cast<float>(tick) / 6.0f;
-                const float angle = duskdaf::DuskPanel::knobAngle(tickT);
-                const ImVec2 direction(std::sin(angle), -std::cos(angle));
                 const bool major = tick % 2 == 0;
-                dl->AddCircleFilled(ImVec2(center.x + direction.x * (r + 7.0f * scale),
-                                           center.y + direction.y * (r + 7.0f * scale)),
-                                    (major ? 1.45f : 0.85f) * scale,
-                                    IM_COL32(230, 230, 218, 255), 10);
-                if (major)
-                    panel.text(dl, x + direction.x * (radius + 15.0f),
-                               y + direction.y * (radius + 15.0f) - 3.0f,
-                               7.0f, IM_COL32(232, 232, 220, 255),
-                               labels[static_cast<size_t>(tick / 2)], 0, true);
+                duskdaf::drawKnobRingMark(
+                    panel, dl, x, y, radius, static_cast<float>(tick) / 6.0f,
+                    major ? labels[static_cast<size_t>(tick / 2)] : nullptr,
+                    ring, !major);
             }
         }
 
@@ -2086,23 +2079,7 @@ private:
     void spacedText(ImDrawList* dl, float x, float y, float size, ImU32 col,
                     const char* text, int align, float tracking = 0.16f)
     {
-        const float s = panel.scale();
-        const float px = size * s;
-        ImFont* font = panel.pickFont(px);
-        const float gap = tracking * px;
-        float total = 0.0f;
-        for (const char* c = text; *c; ++c)
-            total += font->CalcTextSizeA(px, FLT_MAX, 0.0f, c, c + 1).x + (c[1] ? gap : 0.0f);
-        ImVec2 pos = panel.P(x, y);
-        if (align == 0) pos.x -= 0.5f * total;
-        if (align == 1) pos.x -= total;
-        pos.x = std::floor(pos.x + 0.5f);
-        pos.y = std::floor(pos.y + 0.5f);
-        for (const char* c = text; *c; ++c)
-        {
-            dl->AddText(font, px, pos, col, c, c + 1);
-            pos.x += font->CalcTextSizeA(px, FLT_MAX, 0.0f, c, c + 1).x + gap;
-        }
+        duskdaf::spacedText(panel, dl, x, y, size, col, text, align, tracking);
     }
 
     void drawVca(ImDrawList* dl)
@@ -2421,15 +2398,20 @@ private:
                         ImVec2(center.x + d.x * (r + 13.0f * scale), center.y + d.y * (r + 13.0f * scale)),
                         IM_COL32(214, 215, 210, 220), 1.1f * scale);
         }
-        for (int i = 0; i < majorCount; ++i)
         {
-            const float angle = duskdaf::DuskPanel::knobAngle(ringT(majorValues[i]));
-            const ImVec2 d(std::sin(angle), -std::cos(angle));
-            dl->AddLine(ImVec2(center.x + d.x * (r + 7.0f * scale), center.y + d.y * (r + 7.0f * scale)),
-                        ImVec2(center.x + d.x * (r + 15.0f * scale), center.y + d.y * (r + 15.0f * scale)),
-                        kVcaInk, 1.7f * scale);
-            spacedText(dl, x + d.x * (radius + 27.0f), y + d.y * (radius + 27.0f) - 5.5f,
-                       10.5f, kVcaInk, majorLabels[i], 0, 0.06f);
+            duskdaf::KnobRingStyle ring;
+            ring.markInner = 7.0f;
+            ring.markOuter = 15.0f;
+            ring.markThickness = 1.7f;
+            ring.markColor = kVcaInk;
+            ring.labelOffset = 27.0f;
+            ring.labelNudgeY = -5.5f;
+            ring.labelColor = kVcaInk;
+            ring.labelCentred = true;
+            ring.labelTracking = 0.06f;
+            duskdaf::drawKnobRing(panel, dl, x, y, radius,
+                                  majorValues, majorLabels, majorCount, nullptr, 0,
+                                  ringT, ring);
         }
 
         // Drop shadow, black serrated skirt, silver dome with radial brushing

--- a/plugins/shared-daf/ui/DuskKnobRing.hpp
+++ b/plugins/shared-daf/ui/DuskKnobRing.hpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+//
+// DuskKnobRing.hpp — the printed ring around a hardware knob.
+//
+// DuskPanel::knob owns gestures, the read-out and type-entry, but its only ring
+// is an unlabelled 11-tick circle. Every hardware faceplate therefore escapes
+// with bodyless=true and re-implements the labelled ring: 4K EQ 2 three times,
+// Multi-Comp 2 three times (issue #246). The six copies differ in what they
+// draw -- a dot or a radial tick, a plain or a letter-spaced label, aligned by
+// direction or centred -- but the placement is identical everywhere:
+//
+//     t -> DuskPanel::knobAngle(t) -> direction (sin a, -cos a)
+//     mark between radius+inner and radius+outer, label at radius+labelOffset
+//
+// So the geometry lives here and the body stays with the plugin, which is the
+// split issue #246 asks for.
+//
+// The value -> t mapping is a callable the caller supplies rather than a
+// min/max pair, because that is the part a face gets wrong. A skewed parameter
+// whose ring is placed linearly prints marks that do not line up with the
+// pointer; passing the parameter's own law makes the printed ring and the
+// pointer agree by construction, which is what Multi-Comp's VCA knob already
+// did locally.
+
+#pragma once
+
+#include <cmath>
+
+#include "DuskImGuiWidgets.hpp"
+
+namespace duskdaf
+{
+
+struct KnobRingStyle
+{
+    // Marks. A dot sits at markOuter; a tick spans markInner..markOuter. Both
+    // are measured outward from the knob radius, in design pixels.
+    bool dotMarks = false;
+    float markInner = 7.0f;
+    float markOuter = 15.0f;
+    float markThickness = 1.7f;
+    float dotRadius = 1.6f;
+    int dotSegments = 8;
+    ImU32 markColor = IM_COL32(150, 152, 156, 255);
+
+    // Minor marks: the same shape with its own metrics. minorColor 0 follows
+    // markColor.
+    float minorInner = 9.0f;
+    float minorOuter = 14.0f;
+    float minorThickness = 1.0f;
+    float minorDotRadius = 0.0f;   // 0 = dotRadius
+    ImU32 minorColor = 0;
+
+    // Labels.
+    float labelOffset = 20.0f;
+    float labelNudgeY = -5.0f;
+    float labelSize = 10.5f;
+    ImU32 labelColor = IM_COL32(206, 208, 212, 255);
+    bool labelBold = true;
+    // Centred, or aligned so labels on the left of the dial end at the dial and
+    // labels on the right start at it. Hardware panels do both.
+    bool labelCentred = false;
+    // Letter spacing as a fraction of the pixel size; 0 draws ordinary text.
+    float labelTracking = 0.0f;
+};
+
+// Letter-spaced text, which ImGui does not do: each glyph placed by its own
+// advance plus a tracking gap. align: -1 left, 0 centred, 1 right. Shared
+// because the silkscreen lettering on a faceplate needs it wherever it appears,
+// not only on a ring.
+inline void spacedText(const DuskPanel& panel, ImDrawList* dl, float x, float y,
+                       float size, ImU32 col, const char* text, int align,
+                       float tracking = 0.16f)
+{
+    const float s = panel.scale();
+    const float px = size * s;
+    ImFont* font = panel.pickFont(px);
+    const float gap = tracking * px;
+
+    float total = 0.0f;
+    for (const char* c = text; *c; ++c)
+        total += font->CalcTextSizeA(px, FLT_MAX, 0.0f, c, c + 1).x + (c[1] ? gap : 0.0f);
+
+    ImVec2 pos = panel.P(x, y);
+    if (align == 0) pos.x -= 0.5f * total;
+    if (align == 1) pos.x -= total;
+    pos.x = std::floor(pos.x + 0.5f);
+    pos.y = std::floor(pos.y + 0.5f);
+
+    for (const char* c = text; *c; ++c)
+    {
+        dl->AddText(font, px, pos, col, c, c + 1);
+        pos.x += font->CalcTextSizeA(px, FLT_MAX, 0.0f, c, c + 1).x + gap;
+    }
+}
+
+// One mark, plus its label if it has one. Exposed so a face with a mark that
+// does not come from a value list (a centre detent, an INF stop) places it the
+// same way as the rest of its ring instead of by hand.
+inline void drawKnobRingMark(const DuskPanel& panel, ImDrawList* dl,
+                             float cx, float cy, float radius, float t,
+                             const char* label, const KnobRingStyle& style,
+                             bool minor = false)
+{
+    const float s = panel.scale();
+    const float angle = DuskPanel::knobAngle(t);
+    const float dx = std::sin(angle), dy = -std::cos(angle);
+    const ImVec2 c = panel.P(cx, cy);
+    const float r = radius * s;
+
+    const float inner = minor ? style.minorInner : style.markInner;
+    const float outer = minor ? style.minorOuter : style.markOuter;
+    const ImU32 color = minor ? (style.minorColor != 0 ? style.minorColor : style.markColor)
+                              : style.markColor;
+
+    if (style.dotMarks)
+    {
+        const float dotR = (minor && style.minorDotRadius > 0.0f) ? style.minorDotRadius
+                                                                  : style.dotRadius;
+        dl->AddCircleFilled(panel.P(cx + dx * (radius + outer), cy + dy * (radius + outer)),
+                            dotR * s, color, style.dotSegments);
+    }
+    else
+    {
+        dl->AddLine(ImVec2(c.x + dx * (r + inner * s), c.y + dy * (r + inner * s)),
+                    ImVec2(c.x + dx * (r + outer * s), c.y + dy * (r + outer * s)),
+                    color, (minor ? style.minorThickness : style.markThickness) * s);
+    }
+
+    if (label == nullptr)
+        return;
+
+    const float lx = cx + dx * (radius + style.labelOffset);
+    const float ly = cy + dy * (radius + style.labelOffset) + style.labelNudgeY;
+
+    if (style.labelTracking > 0.0f)
+    {
+        spacedText(panel, dl, lx, ly, style.labelSize, style.labelColor, label,
+                   style.labelCentred ? 0 : (dx < -0.25f ? 1 : (dx > 0.25f ? -1 : 0)),
+                   style.labelTracking);
+    }
+    else
+    {
+        const int align = style.labelCentred ? 0 : (dx < -0.25f ? 1 : (dx > 0.25f ? -1 : 0));
+        panel.text(dl, lx, ly, style.labelSize, style.labelColor, label, align, style.labelBold);
+    }
+}
+
+// The whole ring. `valueToT` maps a printed value to its 0..1 position on the
+// dial; pass the parameter's own law so the marks land where the pointer does.
+template <typename ValueToT>
+inline void drawKnobRing(const DuskPanel& panel, ImDrawList* dl,
+                         float cx, float cy, float radius,
+                         const float* majorValues, const char* const* majorLabels,
+                         int majorCount,
+                         const float* minorValues, int minorCount,
+                         ValueToT valueToT, const KnobRingStyle& style)
+{
+    for (int i = 0; i < minorCount; ++i)
+        drawKnobRingMark(panel, dl, cx, cy, radius, valueToT(minorValues[i]),
+                         nullptr, style, true);
+
+    for (int i = 0; i < majorCount; ++i)
+        drawKnobRingMark(panel, dl, cx, cy, radius, valueToT(majorValues[i]),
+                         majorLabels != nullptr ? majorLabels[i] : nullptr, style, false);
+}
+
+} // namespace duskdaf


### PR DESCRIPTION
Issue #246. `DuskPanel::knob` owns gestures, the read-out and type-entry, but
its only ring is an unlabelled 11-tick circle, so every hardware faceplate
escaped with `bodyless=true` and re-implemented the labelled ring: three times
in 4K EQ 2 (`colMetalKnob`, `steppedFilterKnob`, `consoleDetentKnob`), three
times in Multi-Comp 2 (`optoKnob`, `fetKnob` twice over, `vcaKnob`).

The six differ in what they draw — dot or radial tick, plain or letter-spaced
label, aligned by direction or centred, one tier of mark or three — but the
placement was identical in all of them:

```
t -> knobAngle(t) -> direction (sin a, -cos a)
mark between radius+inner and radius+outer, label at radius+labelOffset
```

`DuskKnobRing.hpp` holds that, with a `KnobRingStyle` for the differences.
Bodies stay with their plugins, which is the split the issue asks for.

**The mapping is a callable, not a min/max pair.** That is the part a face gets
wrong: a skewed parameter whose ring is placed linearly prints marks the pointer
never reaches. Passing the parameter's own law makes the printed ring and the
pointer agree by construction — what `vcaKnob` did locally, now available to the
rest.

**`drawKnobRingMark` is public** next to the whole-ring call, because half these
rings are not value lists: the Opto dial marks 51 positions in three tiers, the
FET dials mark a fixed grid, and the console knob adds an unlabelled dot halfway
across a wide detent gap. Those keep their loops and place each mark through the
shared geometry.

`MultiCompUI`'s local `spacedText` now delegates to a shared one — letter-spaced
silkscreen is wanted wherever it appears, not only on a ring.

## Verification

Every affected faceplate captured from the built plugins, before and after,
and compared pixel by pixel:

```
Multi-Comp Opto face     (1120, 380)  differing pixels: 0
Multi-Comp FET face      (1120, 380)  differing pixels: 0
Multi-Comp VCA face      (1120, 380)  differing pixels: 0
4K EQ face                (960, 640)  differing pixels: 0
```

Suites green: `multi-comp-2` 3/3, `4k-eq-2` 4/4, `tapemachine-2` 4/4.

## Not included

The optional detent snapping the issue also proposes. The knobs that snap own
their gesture handling locally (`consoleDetentKnob`'s
`detentValToPos`/`detentPosToVal`), so moving snapping into the shared knob is a
gesture change rather than a drawing one and belongs in its own diff. Happy to
do it next if you want #246 closed rather than trimmed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated knob displays across 4K EQ and MultiComp with consistent tick rings, detent dots, and labels.
  * Refined stepped, brushed-metal, console, Opto, FET, and VCA knob markings while preserving their existing visual layouts.
  * Improved letter-spaced text rendering for knob labels.
  * Adjusted Opto medium tick placement to prevent overlap with major ticks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->