### PR TITLE
shared-daf: share the detent laws, and Multi-Q's ring with them (#246)

### DIFF
--- a/plugins/4k-eq/daf-plugin/FourKEQUI.cpp
+++ b/plugins/4k-eq/daf-plugin/FourKEQUI.cpp
@@ -1568,30 +1568,6 @@ private:
     // 0 at top, +-15 dB; LF FREQ 30-450 Hz with 200 at top). Maroon cap, white
     // pointer, unit beneath.
     //========================================================================
-    static float detentPosToVal(const float* T, const float* V, int n, float t)
-    {
-        if (t <= T[0]) return V[0];
-        if (t >= T[n - 1]) return V[n - 1];
-        for (int i = 0; i < n - 1; ++i)
-            if (t <= T[i + 1]) { const float a = (t - T[i]) / (T[i + 1] - T[i]); return V[i] + (V[i + 1] - V[i]) * a; }
-        return V[n - 1];
-    }
-    static float detentValToPos(const float* T, const float* V, int n, float v)
-    {
-        // clamp to the value range (works whether V ascends or descends)
-        float lo = V[0], hi = V[0];
-        for (int i = 1; i < n; ++i) { lo = std::min(lo, V[i]); hi = std::max(hi, V[i]); }
-        v = v < lo ? lo : (v > hi ? hi : v);
-        for (int i = 0; i < n - 1; ++i)
-            if ((v - V[i]) * (v - V[i + 1]) <= 0.f) // v lies within this segment
-            {
-                const float d = V[i + 1] - V[i];
-                const float a = d != 0.f ? (v - V[i]) / d : 0.f;
-                return T[i] + (T[i + 1] - T[i]) * a;
-            }
-        return T[n - 1];
-    }
-
     void consoleDetentKnob(ImDrawList* dl, const char* id, float cx, float cy, float R,
                            uint32_t paramId, const float* T, const float* V,
                            const char* const* labels, int n, ImU32 capCol,
@@ -1627,7 +1603,7 @@ private:
             V = calibratedLegend;
         }
 
-        float t = detentValToPos(T, V, n,
+        float t = duskdaf::knobDetentValueToPos(T, V, n,
                                 frequencyKnob ? displayValue(paramId)
                                               : values[paramId]);
 
@@ -1637,7 +1613,7 @@ private:
         const bool editing = panel.isEditingValue(id);
         const bool modKey = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
         auto setFromT = [&](float tt) {
-            const float shown = detentPosToVal(T, V, n, tt);
+            const float shown = duskdaf::knobDetentPosToValue(T, V, n, tt);
             const float nv = normalizeParamValue(
                 paramId, frequencyKnob ? dialForCalibrated(paramId, shown)
                                        : shown);
@@ -1649,7 +1625,7 @@ private:
             values[paramId] = kDefault(paramId);
             setParameterValue(paramId, kDefault(paramId));
             editParameter(paramId, false);
-            t = detentValToPos(T, V, n,
+            t = duskdaf::knobDetentValueToPos(T, V, n,
                               frequencyKnob ? displayValue(paramId)
                                             : values[paramId]);
         };

--- a/plugins/multi-q/daf-plugin/MultiQUI.cpp
+++ b/plugins/multi-q/daf-plugin/MultiQUI.cpp
@@ -25,6 +25,7 @@
 #include "FourKEQDSP.hpp"
 #include "MultiQFilters.hpp"  // amb:: analog-matched designers + MqBiquadCoeffs (Digital curve)
 
+#include "DuskKnobRing.hpp"
 #include "DuskImGuiFont.hpp"
 #include "DuskImGuiTextInput.hpp"
 #include "DuskImGuiWidgets.hpp"
@@ -4034,29 +4035,6 @@ private:
     //========================================================================
     // British-style console band knob (continuous over (t,value) breakpoints)
     //========================================================================
-    static float detentPosToVal(const float* T, const float* V, int n, float t)
-    {
-        if (t <= T[0]) return V[0];
-        if (t >= T[n - 1]) return V[n - 1];
-        for (int i = 0; i < n - 1; ++i)
-            if (t <= T[i + 1]) { const float a = (t - T[i]) / (T[i + 1] - T[i]); return V[i] + (V[i + 1] - V[i]) * a; }
-        return V[n - 1];
-    }
-    static float detentValToPos(const float* T, const float* V, int n, float v)
-    {
-        float lo = V[0], hi = V[0];
-        for (int i = 1; i < n; ++i) { lo = std::min(lo, V[i]); hi = std::max(hi, V[i]); }
-        v = v < lo ? lo : (v > hi ? hi : v);
-        for (int i = 0; i < n - 1; ++i)
-            if ((v - V[i]) * (v - V[i + 1]) <= 0.f)
-            {
-                const float d = V[i + 1] - V[i];
-                const float a = d != 0.f ? (v - V[i]) / d : 0.f;
-                return T[i] + (T[i + 1] - T[i]) * a;
-            }
-        return T[n - 1];
-    }
-
     void consoleDetentKnob(ImDrawList* dl, const char* id, float cx, float cy, float R,
                            uint32_t paramId, const float* T, const float* V,
                            const char* const* labels, int n, ImU32 capCol,
@@ -4067,15 +4045,15 @@ private:
         const float RR = R * s;
         auto c01 = [](float v) { return v < 0.f ? 0.f : (v > 1.f ? 1.f : v); };
 
-        float t = detentValToPos(T, V, n, values[paramId]);
+        float t = duskdaf::knobDetentValueToPos(T, V, n, values[paramId]);
 
         ImGui::SetCursorScreenPos(ImVec2(c.x - RR, c.y - RR));
         ImGui::InvisibleButton(id, ImVec2(2.f * RR, 2.f * RR));
         const bool hov = ImGui::IsItemHovered(), act = ImGui::IsItemActive();
         const bool editing = panel.isEditingValue(id);
         const bool modKey = ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeySuper;
-        auto setFromT = [&](float tt) { const float nv = detentPosToVal(T, V, n, tt); values[paramId] = nv; setParameterValue(paramId, nv); };
-        auto resetDefault = [&] { editParameter(paramId, true); values[paramId] = mqDef(paramId); setParameterValue(paramId, mqDef(paramId)); editParameter(paramId, false); t = detentValToPos(T, V, n, values[paramId]); };
+        auto setFromT = [&](float tt) { const float nv = duskdaf::knobDetentPosToValue(T, V, n, tt); values[paramId] = nv; setParameterValue(paramId, nv); };
+        auto resetDefault = [&] { editParameter(paramId, true); values[paramId] = mqDef(paramId); setParameterValue(paramId, mqDef(paramId)); editParameter(paramId, false); t = duskdaf::knobDetentValueToPos(T, V, n, values[paramId]); };
         if (!editing)
         {
             if (ImGui::IsItemActivated())
@@ -4099,13 +4077,13 @@ private:
             }
         }
 
-        for (int i = 0; i < n; ++i)
         {
-            const float a = duskdaf::DuskPanel::knobAngle(T[i]);
-            const float dx = std::sin(a), dy = -std::cos(a);
-            dl->AddCircleFilled(panel.P(cx + dx * (R + 9.f), cy + dy * (R + 9.f)), 1.6f * s, IM_COL32(150, 152, 156, 255), 8);
-            const int align = dx < -0.25f ? 1 : (dx > 0.25f ? -1 : 0);
-            panel.text(dl, cx + dx * (R + 20.f), cy + dy * (R + 20.f) - 5.f, 10.5f, IM_COL32(206, 208, 212, 255), labels[i], align, true);
+            duskdaf::KnobRingStyle ring;
+            ring.dotMarks = true;
+            ring.markOuter = 9.0f;
+            ring.labelOffset = 20.0f;
+            for (int i = 0; i < n; ++i)
+                duskdaf::drawKnobRingMark(panel, dl, cx, cy, R, T[i], labels[i], ring);
         }
 
         drawMetalKnobBody(dl, c, RR, t, capCol, IM_COL32(245, 245, 245, 255));

--- a/plugins/shared-daf/ui/DuskKnobRing.hpp
+++ b/plugins/shared-daf/ui/DuskKnobRing.hpp
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 #include "DuskImGuiWidgets.hpp"
@@ -92,6 +93,47 @@ inline void spacedText(const DuskPanel& panel, ImDrawList* dl, float x, float y,
         dl->AddText(font, px, pos, col, c, c + 1);
         pos.x += font->CalcTextSizeA(px, FLT_MAX, 0.0f, c, c + 1).x + gap;
     }
+}
+
+// Detent laws. A console knob's travel is not linear in its printed value: the
+// legend names n positions, and the dial interpolates between them, so the same
+// piecewise map converts both ways. 4K EQ 2 and Multi-Q 2 carried
+// character-identical copies of this pair.
+//
+//   T[] positions on the dial, 0..1, ascending
+//   V[] the printed value at each position, ascending or descending
+//
+// Placing a ring through knobDetentValueToPos is what keeps a detented dial's
+// marks under its pointer.
+inline float knobDetentPosToValue(const float* T, const float* V, int n, float t)
+{
+    if (n <= 0) return 0.0f;
+    if (t <= T[0]) return V[0];
+    if (t >= T[n - 1]) return V[n - 1];
+    for (int i = 0; i < n - 1; ++i)
+        if (t <= T[i + 1])
+        {
+            const float a = (t - T[i]) / (T[i + 1] - T[i]);
+            return V[i] + (V[i + 1] - V[i]) * a;
+        }
+    return V[n - 1];
+}
+
+inline float knobDetentValueToPos(const float* T, const float* V, int n, float v)
+{
+    if (n <= 0) return 0.0f;
+    // Clamp to the value range, which works whether V ascends or descends.
+    float lo = V[0], hi = V[0];
+    for (int i = 1; i < n; ++i) { lo = std::min(lo, V[i]); hi = std::max(hi, V[i]); }
+    v = v < lo ? lo : (v > hi ? hi : v);
+    for (int i = 0; i < n - 1; ++i)
+        if ((v - V[i]) * (v - V[i + 1]) <= 0.0f)   // v lies within this segment
+        {
+            const float d = V[i + 1] - V[i];
+            const float a = d != 0.0f ? (v - V[i]) / d : 0.0f;
+            return T[i] + (T[i + 1] - T[i]) * a;
+        }
+    return T[n - 1];
 }
 
 // One mark, plus its label if it has one. Exposed so a face with a mark that


### PR DESCRIPTION
Follow-up to #260, closing the rest of #246.

The issue proposed optional detent snapping on the shared knob. Looking at what
is actually duplicated, the snapping *gestures* are not — each console knob
drives its own drag, and moving that would be a behaviour change for one caller.
The detent *laws* are duplicated, character for character: 4K EQ 2 and Multi-Q 2
both carried the same `detentPosToVal` / `detentValToPos` pair. A console knob's
travel is not linear in its printed value, so the same piecewise map converts
both ways, and placing a ring through it is what keeps a detented dial's marks
under its pointer.

Those two now live beside the ring they serve, as `knobDetentPosToValue` and
`knobDetentValueToPos`, with an empty-table guard neither copy had.

Multi-Q also carries its own `consoleDetentKnob`, which #246 did not mention.
Its ring loop was identical to the 4K EQ one, so it moves to the shared ring
too.

## Verification

Faces captured from the built plugins and compared against main:

```
4K EQ face       (960, 640)   differing pixels: 0
Multi-Q face    (1040, 680)   differing pixels: 0
```

`4k-eq-2` suite 4/4.

## A gap this turned up

`multi-q-2` registers **no ctest gates at all**, and `multi-comp-2` registers no
UI ones:

```
4k-eq            3
multi-comp       0   (has core/plugin-layer tests, but no UI drag or resize gate)
multi-q          0
sunset-circuits  2
tape-echo        3
TapeMachine      3
```

So this change is verified on Multi-Q by build and face comparison rather than
by a suite. The drag gate exists because a DAF-Widgets bump broke dragging in
every plugin's editor and shipped through four green releases — two plugins
being outside it is worth closing. Multi-Q's share of that belongs to #148; I
can add the drag and resize gates to both as a small follow-up if you want.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency and reliability of console-style detent knobs across supported plugins.
  * Detent controls now maintain accurate value-to-position mapping across their full ranges, including boundary values.
  * Updated knob markings preserve the existing visual layout and labeling while ensuring consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->