### PR TITLE
Bring Multi-Comp 2 and Multi-Q 2 inside the editor gates

### DIFF
--- a/plugins/multi-comp/daf-plugin/CMakeLists.txt
+++ b/plugins/multi-comp/daf-plugin/CMakeLists.txt
@@ -62,3 +62,17 @@ if(NOT CMAKE_CROSSCOMPILING)
   target_compile_features(DuskUserPresetStoreTest PRIVATE cxx_std_17)
   add_test(NAME DuskUserPresetStore COMMAND DuskUserPresetStoreTest)
 endif()
+
+# Fleet gates. Multi-Comp 2 had none of these: nothing opened its editor. The
+# drag gate exists because a DAF-Widgets bump broke dragging in every plugin's
+# editor and shipped through four green releases, so a plugin outside it is
+# exactly the one that would ship broken.
+#
+# The output-parameter gates are deliberately absent: Multi-Comp 2's five GR
+# meters report no reduction at the default preset (opto_peak_reduction is 0),
+# so the harness, which processes noise at default settings and never touches a
+# control, fails its "the meters track the audio" assertion. The no-spam half
+# passes today. Arming a parameter before processing needs a harness change
+# rather than a registration here.
+dusk_daf_add_ui_drag_test(multi-comp-2 287 237)   # Opto GAIN knob (default face)
+dusk_daf_add_resize_test(multi-comp-2)

--- a/plugins/multi-q/daf-plugin/CMakeLists.txt
+++ b/plugins/multi-q/daf-plugin/CMakeLists.txt
@@ -47,3 +47,12 @@ target_compile_definitions(multi-q-2 PUBLIC
 # Auto-deploy the built CLAP/VST3/LV2 into the user plugin dirs after each build
 # (disable with -DDUSK_DAF_INSTALL_LOCAL=OFF).
 dusk_daf_install_local(multi-q-2 LV2_PROGRAMS)
+
+# Fleet gates. Multi-Q 2 registered no ctest at all; see #148.
+#
+# No output-parameter gates: Multi-Q 2 exposes no output parameters. Its IN/OUT
+# meters are read straight off the live DSP through MultiQAccess.hpp rather than
+# published to the host, so the harness correctly reports that it would pass
+# vacuously.
+dusk_daf_add_ui_drag_test(multi-q-2 323 618)   # Digital-mode GAIN knob
+dusk_daf_add_resize_test(multi-q-2)

--- a/plugins/shared-daf/tests/DafClapUiDragTest.cpp
+++ b/plugins/shared-daf/tests/DafClapUiDragTest.cpp
@@ -390,6 +390,15 @@ DragResult dragAt(Fixture& fx, const int rootX, const int rootY, const int stepD
     // itself mid-gesture (a permission prompt appearing, a compositor putting a
     // dialog back on top) takes the rest of it, and a snapshot from before the
     // drag would have said everything was fine.
+    //
+    // The second check asks at the coordinate the gesture STARTED from, not
+    // wherever it ended. A drag of 12 steps runs 72 px past its origin, so a
+    // coordinate near the bottom of the editor ends with the pointer over the
+    // root window, and asking there reports "something is above the editor"
+    // for what is really a coordinate aimed off the knob -- replacing the one
+    // message that would have said so.
+    XTestFakeMotionEvent(fx.display, -1, rootX, rootY, CurrentTime);
+    XSync(fx.display, False);
     result.pointerBlocked = ! onTop || topLevelUnderPointer(fx.display) != fx.parent;
     result.edits         = countFor();
     result.midEdits      = midCount;


### PR DESCRIPTION
Both plugins were outside the DAF gate suite: `multi-q-2` registered no ctest at
all, and `multi-comp-2` had core and plugin-layer tests but nothing that opened
its editor.

```
4k-eq            3        multi-comp       0
sunset-circuits  2        multi-q          0
tape-echo        3
TapeMachine      3
```

The drag gate exists because a DAF-Widgets bump broke dragging in every plugin's
editor and shipped through four green releases. The two plugins outside it were
exactly the ones that could ship that way again — and they are also the two that
are unreleased and awaiting validation (#148, and the first Multi-Comp 2 tag).

Both now register the drag and resize gates, with coordinates read off editor
dumps of the built plugins: Multi-Comp's Opto GAIN knob at `(287,237)`,
Multi-Q's Digital-mode GAIN knob at `(323,618)`.

## Why no output-parameter gates

Different reason in each case, both recorded where the registration would go:

- **multi-q-2 exposes no output parameters at all** (192 params, 0 read-only).
  Its IN/OUT meters are read from the live DSP through `MultiQAccess.hpp`
  rather than published to the host, so the harness correctly reports the test
  would pass vacuously.
- **multi-comp-2 publishes five GR meters** and already passes the no-spam half,
  but they report no reduction at the default preset because
  `opto_peak_reduction` defaults to 0. The harness processes noise at default
  settings and never touches a control, so its "the meters track the audio"
  assertion cannot pass:

```
  id=97 "GR" first=1.000000 min=1.000000 max=1.000000
  FAIL: no output parameter moved over 100 blocks of noise
  PASS: no output-parameter events reached the host.
```

  Arming a parameter before processing is a harness change rather than a
  registration, so it is not in this PR. Worth doing — it would bring every
  dynamics plugin's meters under the guard.

## A false positive I shipped in #257

Found by aiming a new gate at blank panel to check it could fail. The
post-gesture interception check asked where the pointer *ended*, and a drag runs
72 px past its origin, so a coordinate near the bottom of an editor finished over
the root window and reported "another window was above the editor" — for what is
actually a coordinate aimed off the knob, replacing the one message that would
have said so. It now asks at the coordinate the gesture started from.

Verified both directions:

```
blank coordinate  -> FAIL (phase A): dragging at (10,360) produced no parameter edit
window over it    -> FAIL (environment, during phase A): another window was above the editor
```

Suites: `multi-comp-2` 5/5, `multi-q-2` 2/2, `tapemachine-2` 4/4, `4k-eq-2` 4/4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI interaction handling during drag gestures, reducing false reports when pointer movement reaches the edge of the editor.

* **Tests**
  * Added automated UI coverage for the Multi-Comp 2 and Multi-Q 2 plugins, including knob dragging and window resizing.
  * Expanded validation of plugin interfaces while accounting for plugins whose output metering is not exposed through standard controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->