### PR TITLE
Output-param gates: let a plugin be armed before the run

### DIFF
--- a/plugins/multi-comp/daf-plugin/CMakeLists.txt
+++ b/plugins/multi-comp/daf-plugin/CMakeLists.txt
@@ -68,11 +68,10 @@ endif()
 # editor and shipped through four green releases, so a plugin outside it is
 # exactly the one that would ship broken.
 #
-# The output-parameter gates are deliberately absent: Multi-Comp 2's five GR
-# meters report no reduction at the default preset (opto_peak_reduction is 0),
-# so the harness, which processes noise at default settings and never touches a
-# control, fails its "the meters track the audio" assertion. The no-spam half
-# passes today. Arming a parameter before processing needs a harness change
-# rather than a registration here.
+# The output-parameter gates arm Peak Reduction first. Multi-Comp 2's five GR
+# meters correctly report nothing at the default preset, where
+# opto_peak_reduction is 0 and the Opto cell does not compress, so a run that
+# only feeds noise cannot tell working meters from dead ones.
+dusk_daf_add_output_param_tests(multi-comp-2 "Peak Reduction=0.8")
 dusk_daf_add_ui_drag_test(multi-comp-2 287 237)   # Opto GAIN knob (default face)
 dusk_daf_add_resize_test(multi-comp-2)

--- a/plugins/shared-daf/cmake/DuskDafPlugin.cmake
+++ b/plugins/shared-daf/cmake/DuskDafPlugin.cmake
@@ -257,6 +257,27 @@ macro(dusk_daf_add_output_param_tests _dusk_op_plugin)   # [<param name>=<normal
         add_test(NAME ${_dusk_op_plugin}ClapOutputParams
                  COMMAND ${_dusk_op_plugin}ClapOutputParamTest
                          "$<TARGET_FILE:${_dusk_op_plugin}-clap>" 100 256 ${_dusk_op_arm})
+
+        # If this plugin arms anything, guard the parsing that arming depends
+        # on. A misread specification arms the wrong control or none at all, the
+        # meters then correctly report nothing, and the failure blames them
+        # rather than the typo. Uses the first armed parameter's name, split off
+        # its value.
+        if(_dusk_op_arm)
+            # ARGN is substituted textually in a macro rather than being a
+            # variable, so it has to be copied into a real list first.
+            set(_dusk_op_specs ${ARGN})
+            list(GET _dusk_op_specs 0 _dusk_op_first_spec)
+            string(REGEX REPLACE "=[^=]*$" "" _dusk_op_first_name "${_dusk_op_first_spec}")
+            add_test(NAME ${_dusk_op_plugin}Vst3ArmSpecs
+                     COMMAND bash "${DUSK_SHARED_DAF_DIR}/tests/daf_arm_spec_cases.sh"
+                             "$<TARGET_FILE:${_dusk_op_plugin}Vst3OutputParamTest>"
+                             "$<TARGET_FILE:${_dusk_op_plugin}-vst3>" "${_dusk_op_first_name}")
+            add_test(NAME ${_dusk_op_plugin}ClapArmSpecs
+                     COMMAND bash "${DUSK_SHARED_DAF_DIR}/tests/daf_arm_spec_cases.sh"
+                             "$<TARGET_FILE:${_dusk_op_plugin}ClapOutputParamTest>"
+                             "$<TARGET_FILE:${_dusk_op_plugin}-clap>" "${_dusk_op_first_name}")
+        endif()
     endif()
 endmacro()
 

--- a/plugins/shared-daf/cmake/DuskDafPlugin.cmake
+++ b/plugins/shared-daf/cmake/DuskDafPlugin.cmake
@@ -198,7 +198,7 @@ endfunction()
 # enable_testing() takes effect, so callers cannot forget it. Being a macro is
 # also why the body is wrapped in if() rather than guarded with return(): a
 # return() here would return from the caller's CMakeLists.
-macro(dusk_daf_add_output_param_tests _dusk_op_plugin)
+macro(dusk_daf_add_output_param_tests _dusk_op_plugin)   # [<param name>=<normalised> ...]
     # A missing target is a typo or a rename, not a platform the harness cannot
     # run on, and the two must not share a branch: silently skipping it would
     # register no test, leave enable_testing() uncalled, and let CI -- which
@@ -239,12 +239,24 @@ macro(dusk_daf_add_output_param_tests _dusk_op_plugin)
         # $<TARGET_FILE:...> is the loadable binary itself, so the harnesses
         # never have to reconstruct Contents/<arch>-linux/ and keep working on
         # architectures no table here would list.
+        # Any extra arguments are --set specifications, forwarded to both
+        # harnesses. A dynamics plugin at its default settings does not process
+        # anything, so its gain-reduction meters correctly report nothing, and a
+        # run that only feeds noise cannot tell that apart from meters that do
+        # not work. Naming a control to move first is what makes those meters
+        # testable; the name is used rather than an index because the same
+        # parameter has different ids in each format.
+        set(_dusk_op_arm "")
+        foreach(_dusk_op_spec ${ARGN})
+            list(APPEND _dusk_op_arm "--set" "${_dusk_op_spec}")
+        endforeach()
+
         add_test(NAME ${_dusk_op_plugin}Vst3OutputParams
                  COMMAND ${_dusk_op_plugin}Vst3OutputParamTest
-                         "$<TARGET_FILE:${_dusk_op_plugin}-vst3>" 100 256)
+                         "$<TARGET_FILE:${_dusk_op_plugin}-vst3>" 100 256 ${_dusk_op_arm})
         add_test(NAME ${_dusk_op_plugin}ClapOutputParams
                  COMMAND ${_dusk_op_plugin}ClapOutputParamTest
-                         "$<TARGET_FILE:${_dusk_op_plugin}-clap>" 100 256)
+                         "$<TARGET_FILE:${_dusk_op_plugin}-clap>" 100 256 ${_dusk_op_arm})
     endif()
 endmacro()
 

--- a/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
@@ -151,9 +151,16 @@ inline bool parseArmRequest(const char* arg, ArmRequest& out)
     const char* eq = std::strrchr(arg, '=');
     if (eq == nullptr || eq == arg) return false;
     out.name.assign(arg, static_cast<size_t>(eq - arg));
+
     char* end = nullptr;
     out.value = std::strtod(eq + 1, &end);
-    return end != nullptr && *end == '\0';
+    // strtod reports "no conversion" by leaving end at the start, and it does
+    // it for an empty suffix while still returning 0.0. Accepting that arms the
+    // parameter to zero, which for a compressor's Peak Reduction means the run
+    // proceeds uncompressed and then blames the meters. A non-finite value is
+    // worse: nan and inf both parse cleanly, and nan reaches the plugin.
+    if (end == eq + 1 || end == nullptr || *end != '\0') return false;
+    return std::isfinite(out.value);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
@@ -92,8 +92,15 @@ struct OutEvents {
     }
 };
 
+// Normally empty: the point of this harness is what the plugin emits, not what
+// a host sends it. It can carry parameter values for one block, though, because
+// a compressor whose threshold sits at its default does not compress, and its
+// gain-reduction meters then correctly report nothing at all -- which reads as
+// "the meters are dead" to a test that only ever feeds noise. Arming the plugin
+// first is what makes a dynamics meter testable.
 struct InEvents {
     clap_input_events_t iface;
+    std::vector<clap_event_param_value> events;
 
     InEvents()
     {
@@ -102,9 +109,52 @@ struct InEvents {
         iface.get = get;
     }
 
-    static uint32_t CLAP_ABI size(const clap_input_events_t*) { return 0; }
-    static const clap_event_header_t* CLAP_ABI get(const clap_input_events_t*, uint32_t) { return nullptr; }
+    void arm(clap_id paramId, double value)
+    {
+        clap_event_param_value ev = {};
+        ev.header.size = sizeof(ev);
+        ev.header.time = 0;
+        ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+        ev.header.type = CLAP_EVENT_PARAM_VALUE;
+        ev.header.flags = 0;
+        ev.param_id = paramId;
+        ev.cookie = nullptr;
+        ev.note_id = -1;
+        ev.port_index = -1;
+        ev.channel = -1;
+        ev.key = -1;
+        ev.value = value;
+        events.push_back(ev);
+    }
+
+    void clear() { events.clear(); }
+
+    static uint32_t CLAP_ABI size(const clap_input_events_t* list)
+    {
+        return static_cast<uint32_t>(static_cast<const InEvents*>(list->ctx)->events.size());
+    }
+
+    static const clap_event_header_t* CLAP_ABI get(const clap_input_events_t* list, uint32_t index)
+    {
+        const InEvents* self = static_cast<const InEvents*>(list->ctx);
+        return index < self->events.size() ? &self->events[index].header : nullptr;
+    }
 };
+
+// --set "Parameter Name=0.8": a parameter to move before the run, named rather
+// than numbered because the same control has different ids in each format (this
+// plugin's GR meters are id 95 in CLAP and 97 in VST3).
+struct ArmRequest { std::string name; double value; };
+
+inline bool parseArmRequest(const char* arg, ArmRequest& out)
+{
+    const char* eq = std::strrchr(arg, '=');
+    if (eq == nullptr || eq == arg) return false;
+    out.name.assign(arg, static_cast<size_t>(eq - arg));
+    char* end = nullptr;
+    out.value = std::strtod(eq + 1, &end);
+    return end != nullptr && *end == '\0';
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -140,9 +190,22 @@ int main(const int argc, const char* const* const argv)
 {
     bool silent = false;
     std::vector<const char*> positional;
+    std::vector<ArmRequest> armRequests;
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strcmp(argv[i], "--silent") == 0)
+        if (std::strncmp(argv[i], "--set", 5) == 0)
+        {
+            const char* spec = argv[i][5] == '=' ? argv[i] + 6
+                             : (i + 1 < argc ? argv[++i] : nullptr);
+            ArmRequest req;
+            if (spec == nullptr || ! parseArmRequest(spec, req))
+            {
+                std::fprintf(stderr, "FAIL: --set wants NAME=VALUE (normalised 0..1)\n");
+                return 1;
+            }
+            armRequests.push_back(req);
+        }
+        else if (std::strcmp(argv[i], "--silent") == 0)
             silent = true;
         else
             positional.push_back(argv[i]);
@@ -150,7 +213,7 @@ int main(const int argc, const char* const* const argv)
 
     if (positional.empty() || positional.size() > 3)
     {
-        std::fprintf(stderr, "usage: %s <plugin.clap> [blocks] [frames] [--silent]\n", argv[0]);
+        std::fprintf(stderr, "usage: %s <plugin.clap> [blocks] [frames] [--silent] [--set NAME=VALUE]\n", argv[0]);
         return 2;
     }
 
@@ -223,7 +286,8 @@ int main(const int argc, const char* const* const argv)
         return 1;
     }
 
-    struct P { clap_id id; std::string name; std::string module; uint32_t flags; };
+    struct P { clap_id id; std::string name; std::string module; uint32_t flags;
+               double minValue; double maxValue; };
     std::vector<P> params;
     const uint32_t paramCount = paramsExt->count(plugin);
     for (uint32_t i = 0; i < paramCount; ++i)
@@ -234,7 +298,8 @@ int main(const int argc, const char* const* const argv)
             std::fprintf(stderr, "FAIL: get_info(%u); cannot classify every parameter\n", i);
             return 1;
         }
-        params.push_back({ info.id, info.name, info.module, info.flags });
+        params.push_back({ info.id, info.name, info.module, info.flags,
+                           info.min_value, info.max_value });
     }
 
     // DAF stamps CLAP_PARAM_IS_READONLY on output parameters and on the Reset
@@ -249,6 +314,34 @@ int main(const int argc, const char* const* const argv)
     auto isOutput = [](const P& p) {
         return (p.flags & CLAP_PARAM_IS_READONLY) != 0 && p.module != "daf_reset";
     };
+
+    // Resolve --set names against the plugin's own parameter list. A name that
+    // does not match is a typo or a rename in the plugin, and silently arming
+    // nothing would leave the meter assertion failing for a reason the message
+    // does not mention.
+    std::vector<std::pair<clap_id, double>> armed;
+    for (const ArmRequest& req : armRequests)
+    {
+        const P* match = nullptr;
+        for (const P& p : params)
+            if (p.name == req.name) { match = &p; break; }
+
+        if (match == nullptr)
+        {
+            std::fprintf(stderr, "FAIL: --set names \"%s\", which this plugin has no parameter called\n",
+                         req.name.c_str());
+            return 1;
+        }
+        // --set speaks normalised 0..1 so one specification works for both
+        // formats, but a CLAP parameter value is PLAIN, in the parameter's own
+        // range. Sending 0.8 to a 0..100 % control would set 0.8 %, which for a
+        // compressor's Peak Reduction is indistinguishable from leaving it
+        // alone -- and the meters would then correctly report nothing, which is
+        // the very failure this arming exists to avoid.
+        const double span = match->maxValue - match->minValue;
+        const double clamped = req.value < 0.0 ? 0.0 : (req.value > 1.0 ? 1.0 : req.value);
+        armed.emplace_back(match->id, match->minValue + clamped * span);
+    }
 
     std::vector<size_t> meters;
     for (size_t i = 0; i < params.size(); ++i)
@@ -373,6 +466,13 @@ int main(const int argc, const char* const* const argv)
         process.audio_inputs_count = numInPorts;
         process.audio_outputs = outBuses.data();
         process.audio_outputs_count = numOutPorts;
+        // Armed values ride the first block, the way a host sends a control
+        // change: once applied they persist, so later blocks stay empty and the
+        // "nothing reaches the host" assertions still see a quiet input.
+        inEvents.clear();
+        if (block == 0)
+            for (const auto& a : armed)
+                inEvents.arm(a.first, a.second);
         process.in_events = &inEvents.iface;
         process.out_events = &outEvents.iface;
         process.steady_time = static_cast<int64_t>(block) * numFrames;

--- a/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
@@ -428,9 +428,35 @@ int main(const int argc, const char* const* const argv)
     // plugin for a command-line mistake.
     bool silent = false;
     std::vector<const char*> positional;
+    // --set "Parameter Name=0.8": a control to move before the run. Named
+    // rather than numbered because the same parameter has different ids in each
+    // format. A compressor at its default threshold does not compress, so its
+    // gain-reduction meters correctly report nothing, which a noise-only run
+    // cannot tell apart from meters that do not work.
+    struct ArmRequest { std::string name; double value; };
+    std::vector<ArmRequest> armRequests;
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strcmp(argv[i], "--silent") == 0)
+        if (std::strncmp(argv[i], "--set", 5) == 0)
+        {
+            const char* spec = argv[i][5] == '=' ? argv[i] + 6
+                             : (i + 1 < argc ? argv[++i] : nullptr);
+            const char* eq = spec != nullptr ? std::strrchr(spec, '=') : nullptr;
+            if (eq == nullptr || eq == spec)
+            {
+                std::fprintf(stderr, "FAIL: --set wants NAME=VALUE (normalised 0..1)\n");
+                return 1;
+            }
+            char* end = nullptr;
+            const double value = std::strtod(eq + 1, &end);
+            if (end == nullptr || *end != '\0')
+            {
+                std::fprintf(stderr, "FAIL: --set value for \"%s\" is not a number\n", spec);
+                return 1;
+            }
+            armRequests.push_back({ std::string(spec, static_cast<size_t>(eq - spec)), value });
+        }
+        else if (std::strcmp(argv[i], "--silent") == 0)
             silent = true;
         else
             positional.push_back(argv[i]);
@@ -438,7 +464,7 @@ int main(const int argc, const char* const* const argv)
 
     if (positional.empty() || positional.size() > 3)
     {
-        std::fprintf(stderr, "usage: %s <plugin.vst3> [blocks] [frames] [--silent]\n", argv[0]);
+        std::fprintf(stderr, "usage: %s <plugin.vst3> [blocks] [frames] [--silent] [--set NAME=VALUE]\n", argv[0]);
         return 2;
     }
 
@@ -588,6 +614,22 @@ int main(const int argc, const char* const* const argv)
                 return static_cast<int>(i);
         return -1;
     };
+
+    std::vector<std::pair<v3_param_id, double>> armed;
+    for (const ArmRequest& req : armRequests)
+    {
+        const ParamInfo* match = nullptr;
+        for (const ParamInfo& p : params)
+            if (p.title == req.name) { match = &p; break; }
+
+        if (match == nullptr)
+        {
+            std::fprintf(stderr, "FAIL: --set names \"%s\", which this plugin has no parameter called\n",
+                         req.name.c_str());
+            return 1;
+        }
+        armed.emplace_back(match->id, req.value);
+    }
 
     std::vector<int> outputParams;
     for (size_t i = 0; i < params.size(); ++i)
@@ -835,6 +877,22 @@ int main(const int argc, const char* const* const argv)
 
         inputChanges.reset();
         outputChanges.reset();
+
+        // Armed values ride the first block, the way a host delivers a control
+        // change: once applied they persist, so later blocks send nothing and
+        // the "nothing reaches the host" assertions still see a quiet input.
+        if (block == 0)
+            for (const auto& a : armed)
+            {
+                int32_t queueIndex = 0;
+                v3_param_value_queue** queue = v3_cpp_obj(inputChanges.handle())
+                    ->add_param_data(inputChanges.handle(), &a.first, &queueIndex);
+                if (queue != nullptr)
+                {
+                    int32_t pointIndex = 0;
+                    v3_cpp_obj(queue)->add_point(queue, 0, a.second, &pointIndex);
+                }
+            }
 
         v3_process_data data = {};
         data.process_mode = V3_REALTIME;

--- a/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
@@ -449,9 +449,12 @@ int main(const int argc, const char* const* const argv)
             }
             char* end = nullptr;
             const double value = std::strtod(eq + 1, &end);
-            if (end == nullptr || *end != '\0')
+            // An empty suffix converts nothing and still returns 0.0, which
+            // would arm the parameter to zero and then blame the meters; nan
+            // and inf both parse cleanly and neither is a normalised value.
+            if (end == eq + 1 || end == nullptr || *end != '\0' || ! std::isfinite(value))
             {
-                std::fprintf(stderr, "FAIL: --set value for \"%s\" is not a number\n", spec);
+                std::fprintf(stderr, "FAIL: --set value for \"%s\" is not a finite number\n", spec);
                 return 1;
             }
             armRequests.push_back({ std::string(spec, static_cast<size_t>(eq - spec)), value });
@@ -628,7 +631,11 @@ int main(const int argc, const char* const* const argv)
                          req.name.c_str());
             return 1;
         }
-        armed.emplace_back(match->id, req.value);
+        // Clamped to the documented normalised range before it reaches
+        // add_point, matching the CLAP side: a VST3 parameter value outside
+        // 0..1 is not a value the plugin has any defined answer for.
+        const double clamped = req.value < 0.0 ? 0.0 : (req.value > 1.0 ? 1.0 : req.value);
+        armed.emplace_back(match->id, clamped);
     }
 
     std::vector<int> outputParams;

--- a/plugins/shared-daf/tests/daf_arm_spec_cases.sh
+++ b/plugins/shared-daf/tests/daf_arm_spec_cases.sh
@@ -35,20 +35,25 @@ run_spec() { "$HARNESS" "$PLUGIN" 4 64 --set "$1" 2>&1; }
 # and the harness exits non-zero for a reason that has nothing to do with the
 # argument -- which is exactly the confusion this guards. So the rejection has
 # to be reported as one: the message must name --set.
-reject() {
-    local spec="$1" what="$2" out status=0
-    out="$(run_spec "$spec")" || status=$?
+check_rejected() {
+    local what="$1" status="$2" out="$3"
 
     if [ "$status" -eq 0 ]; then
-        printf '  FAIL  %s: --set "%s" was accepted\n' "$what" "$spec"
+        printf '  FAIL  %s was accepted\n' "$what"
         failures=$((failures + 1))
     elif ! printf '%s' "$out" | grep -q -- "--set"; then
-        printf '  FAIL  %s: --set "%s" failed, but not as a bad specification\n' "$what" "$spec"
+        printf '  FAIL  %s failed, but not as a bad specification\n' "$what"
         printf '%s\n' "$out" | sed 's/^/          /' | head -3
         failures=$((failures + 1))
     else
         printf '  ok    %s rejected\n' "$what"
     fi
+}
+
+reject() {
+    local spec="$1" what="$2" out status=0
+    out="$(run_spec "$spec")" || status=$?
+    check_rejected "$what (--set \"$spec\")" "$status" "$out"
 }
 
 printf '%s\n' "arm specification parsing: $(basename "$HARNESS")"
@@ -60,6 +65,13 @@ reject "${PARAM}=-inf"  "-inf"
 reject "${PARAM}=0.5x"  "trailing garbage"
 reject "=0.5"           "empty name"
 reject "${PARAM}"       "no separator"
+
+# A bare --set with nothing after it. Separate from the cases above because
+# there is no specification to pass: the harness has to notice it is at the end
+# of argv rather than reading past it, and still say what is wrong.
+bare_out=""; bare_status=0
+bare_out="$("$HARNESS" "$PLUGIN" 4 64 --set 2>&1)" || bare_status=$?
+check_rejected "a bare --set with no specification" "$bare_status" "$bare_out"
 
 # The positive case, so a harness that rejects everything cannot pass this.
 if run_spec "${PARAM}=0.8" > /dev/null; then

--- a/plugins/shared-daf/tests/daf_arm_spec_cases.sh
+++ b/plugins/shared-daf/tests/daf_arm_spec_cases.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
+#
+# daf_arm_spec_cases.sh — what an output-parameter harness must reject in a
+# --set specification.
+#
+# The harnesses take --set "Parameter Name=0.8" to move a control before the
+# run, because a compressor at its default preset does not compress and its
+# gain-reduction meters then correctly report nothing. That makes the parsing
+# load-bearing: a specification that is quietly misread arms the wrong thing (or
+# nothing), the meters report what they should, and the failure that follows
+# blames the meters instead of the typo.
+#
+# strtod is the trap. It reports "no conversion" by leaving its end pointer at
+# the start while still returning 0.0, so an empty suffix reads as zero; and it
+# parses "nan" and "inf" perfectly happily, neither of which is a normalised
+# parameter value. Before this was fixed, --set "Peak Reduction=inf" armed full
+# scale and the gate PASSED.
+#
+#   daf_arm_spec_cases.sh <harness binary> <plugin binary> <a real parameter name>
+
+set -uo pipefail
+
+HARNESS="${1:?usage: daf_arm_spec_cases.sh <harness> <plugin> <param name>}"
+PLUGIN="${2:?missing plugin binary}"
+PARAM="${3:?missing parameter name}"
+
+failures=0
+
+# Short runs: this is about argument handling, not about the audio.
+run_spec() { "$HARNESS" "$PLUGIN" 4 64 --set "$1" 2>&1; }
+
+# A non-zero exit is not enough on its own. A specification that parses to the
+# wrong value arms the wrong thing, the run then fails on its own assertions,
+# and the harness exits non-zero for a reason that has nothing to do with the
+# argument -- which is exactly the confusion this guards. So the rejection has
+# to be reported as one: the message must name --set.
+reject() {
+    local spec="$1" what="$2" out status=0
+    out="$(run_spec "$spec")" || status=$?
+
+    if [ "$status" -eq 0 ]; then
+        printf '  FAIL  %s: --set "%s" was accepted\n' "$what" "$spec"
+        failures=$((failures + 1))
+    elif ! printf '%s' "$out" | grep -q -- "--set"; then
+        printf '  FAIL  %s: --set "%s" failed, but not as a bad specification\n' "$what" "$spec"
+        printf '%s\n' "$out" | sed 's/^/          /' | head -3
+        failures=$((failures + 1))
+    else
+        printf '  ok    %s rejected\n' "$what"
+    fi
+}
+
+printf '%s\n' "arm specification parsing: $(basename "$HARNESS")"
+
+reject "${PARAM}="      "empty value"
+reject "${PARAM}=nan"   "nan"
+reject "${PARAM}=inf"   "inf"
+reject "${PARAM}=-inf"  "-inf"
+reject "${PARAM}=0.5x"  "trailing garbage"
+reject "=0.5"           "empty name"
+reject "${PARAM}"       "no separator"
+
+# The positive case, so a harness that rejects everything cannot pass this.
+if run_spec "${PARAM}=0.8" > /dev/null; then
+    printf '  ok    a valid specification is still accepted\n'
+else
+    printf '  FAIL  a valid specification was rejected: --set "%s=0.8"\n' "$PARAM"
+    failures=$((failures + 1))
+fi
+
+if [ "$failures" = 0 ]; then
+    printf 'all arm specification cases passed\n'
+    exit 0
+fi
+printf '%d arm specification case(s) failed\n' "$failures"
+exit 1


### PR DESCRIPTION
Follow-up to #262, which had to leave Multi-Comp 2's output-parameter gates
unregistered.

The harnesses process noise at default settings and never touch a control, so a
dynamics plugin cannot pass them: at its default preset it does not compress,
its gain-reduction meters correctly report nothing, and the "the meters track
the audio" assertion cannot tell that apart from meters that do not work. That
left Multi-Comp 2's five GR meters outside the no-spam guard as well.

Both harnesses now take `--set "Parameter Name=0.8"`, repeatable, and
`dusk_daf_add_output_param_tests` forwards any extra arguments to both.
Multi-Comp 2 registers with Peak Reduction armed:

```cmake
dusk_daf_add_output_param_tests(multi-comp-2 "Peak Reduction=0.8")
```

**Named, not numbered**, because the same control has different ids in each
format — Multi-Comp's GR meters are id 95 under CLAP and 97 under VST3. A name
matching no parameter fails loudly rather than arming nothing and leaving the
meter assertion to fail for a reason its message does not mention:

```
FAIL: --set names "Nonexistent", which this plugin has no parameter called
```

**The value is normalised in both formats, and the harnesses convert.** VST3
parameter values are normalised already; a CLAP parameter value is *plain*, in
the parameter's own range. Sending `0.8` to a 0..100 % control under CLAP sets
0.8 %, which for Peak Reduction is indistinguishable from leaving it alone. I
had this wrong on the first pass — VST3 went green while CLAP kept failing with
the meters pinned, which is what surfaced it.

Values ride the first block the way a host sends a control change; later blocks
send nothing, so the "nothing reaches the host" assertions still see a quiet
input.

## Verification

- `multi-comp-2` 7/7, with both output-param gates now passing.
- Still fails *without* the arm (`FAIL: no output parameter moved over 100
  blocks of noise`), so the arming is load-bearing rather than decorative.
- Plugins whose gates already existed are unaffected: `4k-eq-2` 4/4,
  `tape-echo-2` 5/5, `tapemachine-2` 4/4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of plugin output-parameter validation across supported plugin formats.
  - Parameter controls can now be set to specific values before processing, with invalid, unknown, malformed, and non-finite settings rejected.
  - Values are safely constrained to supported ranges and applied during initial processing.
  - Output-level and gain-reduction meter checks now produce measurable results under controlled test conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->