### PR TITLE
TapeMachine 2: put calibration on the faceplate (#144)

### DIFF
--- a/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
@@ -932,11 +932,16 @@ private:
         // No OVERSAMPLING cell: the OS param is pinned at the tuned 2x core (DSP ignores it),
         // matching the reference decks which have no OS control (see TapeMachineDSP::factorFromChoice).
         struct Sel { const char* id; uint32_t p; const char* t; int n; };
-        Sel cells[6];
+        Sel cells[7];
         int nc = 0;
         cells[nc++] = { "##machine", kParamTapeMachine, "MACHINE",     2 };
         cells[nc++] = { "##speed",   kParamTapeSpeed,   "TAPE SPEED",  classic ? 4 : 3 };
         cells[nc++] = { "##type",    kParamTapeType,    "TAPE TYPE",   4 };
+        // Operating level. The DSP has always taken it (kParamCalibration ->
+        // setCalibration, +3/+6/+7.5/+9 dB over the reference flux), and it was
+        // reachable only from a host's generic parameter list; a deck's
+        // calibration belongs next to its tape and EQ standard (#144).
+        cells[nc++] = { "##cal",     kParamCalibration, "CALIBRATION", 4 };
         cells[nc++] = { "##path",    kParamSignalPath,  "SIGNAL PATH", 4 };
         cells[nc++] = { "##eq",      kParamEqStandard,  "EQ STANDARD", 2 };
         if (classic)
@@ -946,7 +951,12 @@ private:
         // as an even grid instead of ragged per-option boxes. Centres are distributed inside
         // the shelf (68..732) with an 8 px inner margin so no box touches the shelf border,
         // in either the 5-cell (Swiss) or 6-cell (American) layout.
-        const float x0 = 76.f, x1 = 724.f, selW = 100.f;
+        // 100 px wide wherever it fits, which is every layout up to six cells;
+        // the seven-cell American row is narrower than that, so the width
+        // follows the spacing and keeps the 8 px gap rather than overlapping.
+        const float x0 = 76.f, x1 = 724.f;
+        const float spacing = (x1 - x0) / (float) nc;
+        const float selW = spacing - 8.f < 100.f ? spacing - 8.f : 100.f;
         for (int i = 0; i < nc; ++i)
         {
             const float cx = x0 + (x1 - x0) * ((float)i + 0.5f) / (float)nc;

--- a/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
+++ b/plugins/TapeMachine/daf-plugin/TapeMachineUI.cpp
@@ -927,8 +927,8 @@ private:
         // Shelf spans the VU-meter width exactly (left meter x0=68 .. right meter x1=732).
         drawSelectorShelf(dl, 68.0f, 206.0f, 732.0f, 259.0f);
 
-        // The selector row reflows per machine: the American adds a HEAD WIDTH cell (6
-        // cells); the Swiss omits it (5). TAPE SPEED exposes 3.75 IPS on the American only.
+        // The selector row reflows per machine: the American adds a HEAD WIDTH cell (7
+        // cells); the Swiss omits it (6). TAPE SPEED exposes 3.75 IPS on the American only.
         // No OVERSAMPLING cell: the OS param is pinned at the tuned 2x core (DSP ignores it),
         // matching the reference decks which have no OS control (see TapeMachineDSP::factorFromChoice).
         struct Sel { const char* id; uint32_t p; const char* t; int n; };


### PR DESCRIPTION
Closes #144.

The operating level was already a parameter and already wired:
`kParamCalibration` -> `setCalibration`, +3 / +6 / +7.5 / +9 dB over the
reference flux, with every factory preset carrying its own value
(`TapeMachinePresets.hpp` sets it per preset). It simply had no control, so the
only way to reach it was a host's generic parameter list, and the only way to
change a preset's calibration was to pick a different preset.

It now sits in the selector row between TAPE TYPE and SIGNAL PATH. A deck's
calibration belongs with its tape and its EQ standard rather than in the
ADVANCED modal, which holds repro-head EQ and output electronics.

## The layout consequence

That makes the row six cells on the Swiss and seven on the American, and the
fixed 100 px cells only fit up to six: at seven the spacing is 92.6 px, so
100 px boxes would overlap by 7. The width now follows the spacing when it has
to — 100 px wherever it fits, which is every layout the plugin had until now,
and spacing minus the 8 px gap beyond that. The Swiss row keeps its width; the
American row narrows to 84.6 px.

Both rendered from the built plugin and checked rather than assumed: labels and
boxes clear each other in the six-cell Swiss row and the seven-cell American
one (screenshot in the thread).

`tapemachine-2` 4/4.

## Worth a second opinion

Calibration is a *response* control, not just a level: higher settings saturate
earlier, and the presets were fitted at their own values. Exposing it means a
user can move a preset off the operating point it was calibrated at, which is
the point of the request but does change what a preset sounds like when they
do. If you would rather it sat in ADVANCED, behind the same "this is deck setup,
not a performance control" reasoning as CROSSTALK and XFMR, it is a two-line
move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a front-panel **Calibration** selector with four operating-level options, making calibration settings directly accessible from the plugin interface.
  - Improved selector spacing so controls remain clearly separated across supported panel arrangements.

- **Bug Fixes**
  - Strengthened output-parameter validation for dynamics controls, including reliable handling of peak-reduction settings and parameter changes before processing.
  - Improved validation feedback for invalid parameter adjustment requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->