### PR TITLE
Arm specs: match the flag exactly, and quantise stepped parameters

### DIFF
--- a/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafClapOutputParamTest.cpp
@@ -200,7 +200,11 @@ int main(const int argc, const char* const* const argv)
     std::vector<ArmRequest> armRequests;
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strncmp(argv[i], "--set", 5) == 0)
+        // Exactly --set, or --set=SPEC. A prefix test also matched --setfoo and
+        // any future --set-something, and then swallowed the following argument
+        // as its specification: an unknown flag silently armed a parameter and
+        // the run passed.
+        if (std::strcmp(argv[i], "--set") == 0 || std::strncmp(argv[i], "--set=", 6) == 0)
         {
             const char* spec = argv[i][5] == '=' ? argv[i] + 6
                              : (i + 1 < argc ? argv[++i] : nullptr);
@@ -347,7 +351,17 @@ int main(const int argc, const char* const* const argv)
         // the very failure this arming exists to avoid.
         const double span = match->maxValue - match->minValue;
         const double clamped = req.value < 0.0 ? 0.0 : (req.value > 1.0 ? 1.0 : req.value);
-        armed.emplace_back(match->id, match->minValue + clamped * span);
+        double plain = match->minValue + clamped * span;
+
+        // A stepped parameter's value is an integer in CLAP, so a normalised
+        // position has to be quantised before it is queued: half way along a
+        // four-choice control is a choice, not 1.5. Rounded to nearest rather
+        // than truncated, because truncation biases every position down by up
+        // to a step and makes the last choice reachable only at exactly 1.0.
+        if ((match->flags & CLAP_PARAM_IS_STEPPED) != 0)
+            plain = std::round(plain);
+
+        armed.emplace_back(match->id, plain);
     }
 
     std::vector<size_t> meters;

--- a/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
+++ b/plugins/shared-daf/tests/DafVst3OutputParamTest.cpp
@@ -437,7 +437,11 @@ int main(const int argc, const char* const* const argv)
     std::vector<ArmRequest> armRequests;
     for (int i = 1; i < argc; ++i)
     {
-        if (std::strncmp(argv[i], "--set", 5) == 0)
+        // Exactly --set, or --set=SPEC. A prefix test also matched --setfoo and
+        // any future --set-something, and then swallowed the following argument
+        // as its specification: an unknown flag silently armed a parameter and
+        // the run passed.
+        if (std::strcmp(argv[i], "--set") == 0 || std::strncmp(argv[i], "--set=", 6) == 0)
         {
             const char* spec = argv[i][5] == '=' ? argv[i] + 6
                              : (i + 1 < argc ? argv[++i] : nullptr);

--- a/plugins/shared-daf/tests/daf_arm_spec_cases.sh
+++ b/plugins/shared-daf/tests/daf_arm_spec_cases.sh
@@ -66,6 +66,13 @@ reject "${PARAM}=0.5x"  "trailing garbage"
 reject "=0.5"           "empty name"
 reject "${PARAM}"       "no separator"
 
+# An unknown flag that merely starts with --set. It used to match and swallow
+# the next argument as its specification, so a typo armed a parameter and the
+# run passed.
+unknown_out=""; unknown_status=0
+unknown_out="$("$HARNESS" "$PLUGIN" 4 64 --setfoo "${PARAM}=0.8" 2>&1)" || unknown_status=$?
+check_rejected "an unknown --setfoo flag" "$unknown_status" "$unknown_out"
+
 # A bare --set with nothing after it. Separate from the cases above because
 # there is no specification to pass: the harness has to notice it is at the end
 # of argv rather than reading past it, and still say what is wrong.


### PR DESCRIPTION
Two review findings raised on #264, both against harness code that merged in
#263, so they land separately from the TapeMachine UI change.

## The flag was matched by prefix

`--setfoo`, `--settle` and any future `--set-something` all matched, and each
then swallowed the following argument as its specification. Measured before
fixing anything:

```
--setfoo "Peak Reduction=0.8"   ->   RESULT: PASS
```

An unknown flag silently armed a parameter and the run passed. Only `--set` and
`--set=SPEC` are accepted now, and the specification script has a case for it.

## Stepped parameters were queued fractional values

A CLAP stepped parameter's value is an integer, and the arming code queued a
normalised position scaled into the parameter's range — so half way along a
four-choice control asked for `1.5`. Stepped parameters are rounded now.

Rounded to nearest rather than truncated, which is the one place I did not
follow the finding to the letter: truncation biases every position down by up to
a step and leaves the last choice reachable only at exactly `1.0`. Nearest is
what a host does when it quantises a normalised position, and it satisfies the
same requirement — no fractional value reaches a stepped parameter.

Worth being plain about the evidence here: the only plugin arming anything today
uses a continuous control (Peak Reduction), so nothing in the fleet was sending
a fractional step — this is the next caller's bug, not a live one. It is also
the one part I could not observe from outside, since the harness reports output
parameters rather than what an input parameter received. Verified by
construction and by the suites staying green, not by a read-back.

## Verification

```
  ok    an unknown --setfoo flag rejected
  ok    a bare --set with no specification rejected
  ok    a valid specification is still accepted
```

`multi-comp-2` 9/9, `4k-eq-2` 4/4, `tape-echo-2` 5/5, `tapemachine-2` 4/4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line option validation by accepting only `--set` and `--set=...` formats.
  - Invalid variants such as `--setfoo` and `--set-something` are now rejected instead of being interpreted as parameter assignments.
  - Stepped parameters now use the nearest valid step when values are armed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->