### PR TITLE
Chord Analyzer: expose the displayed chord label as a Detected Chord parameter

### DIFF
--- a/manuals/chord-analyzer.md
+++ b/manuals/chord-analyzer.md
@@ -117,8 +117,9 @@ Chord Analyzer exposes five user-facing parameters plus four read-only detection
 
 ### Detection outputs (read-only)
 
-These four parameters expose the detection result for host automation, screen-recording overlays, and the Headless variant's parameter-driven display:
+These parameters expose the detection result for host automation, screen-recording overlays, and the Headless variant's parameter-driven display:
 
+- **Detected Chord:** The whole chord name exactly as the plugin's own display shows it, slash bass and all (`Cadd#11/F#`). Use this when your host can put a parameter's text on a widget, such as Gig Performer, and you want the chord on screen without opening the plugin. It follows **Show Inversions**: turn that off and the slash bass disappears here too. Not available in the Headless variant, whose LV2 control ports carry numbers only.
 - **Detected Root:** Current chord root (12 values).
 - **Detected Quality:** Current chord quality (major, minor, 7, maj7, m7, sus2, sus4, dim, aug, etc.).
 - **Detected Bass:** Bass note for slash chords (like C/E or G/B).

--- a/plugins/chord-analyzer/CMakeLists.txt
+++ b/plugins/chord-analyzer/CMakeLists.txt
@@ -129,6 +129,21 @@ target_compile_definitions(ChordAnalyzerTest PRIVATE
     JUCE_WEB_BROWSER=0
 )
 
+# Host-side test target for the "Detected Chord" output parameter. Links the
+# plugin's shared code so it exercises the real processor, the real parameter
+# object and the real 20 Hz publish path rather than a stand-in.
+add_executable(ChordAnalyzerHostTest EXCLUDE_FROM_ALL
+    tests/test_detected_chord_param.cpp
+)
+target_link_libraries(ChordAnalyzerHostTest PRIVATE ChordAnalyzer)
+# Borrow the shared code's include paths and defines rather than linking the
+# JUCE module targets again: those are INTERFACE libraries that would compile a
+# second copy of every JUCE module into this executable.
+target_include_directories(ChordAnalyzerHostTest
+    PRIVATE $<TARGET_PROPERTY:ChordAnalyzer,INCLUDE_DIRECTORIES>)
+target_compile_definitions(ChordAnalyzerHostTest
+    PRIVATE $<TARGET_PROPERTY:ChordAnalyzer,COMPILE_DEFINITIONS>)
+
 # Optimization for release builds
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -239,6 +239,161 @@ ChordInfo ChordAnalyzer::analyze(const std::vector<int>& midiNotes)
 }
 
 //==============================================================================
+// Label encoding for the "Detected Chord" host parameter. See ChordAnalyzer.h
+// for why the decoder has to be a pure function of the code.
+namespace
+{
+    // One block of codes per branch analyze() can take when it builds
+    // ChordInfo::name, sized exactly to what that branch needs.
+    constexpr int kLabelNone        = 0;
+    constexpr int kLabelSingleBase  = 1;                              // 128 MIDI notes
+    constexpr int kLabelDyadBase    = kLabelSingleBase + 128;         // 12 x 12 x unison flag
+    constexpr int kLabelUnknownBase = kLabelDyadBase + 12 * 12 * 2;   // 12 roots
+    constexpr int kLabelChordBase   = kLabelUnknownBase + 12;         // root x bass x mask
+
+    // Sounding intervals above the root, one bit each for 1..11 semitones. The
+    // root is always sounding (findRoot only ever returns a sounding pitch
+    // class), so interval 0 is implied and costs no bit.
+    constexpr int kLabelMaskBits    = 11;
+    constexpr int kLabelMaskCount   = 1 << kLabelMaskBits;
+
+    static_assert(kLabelChordBase + 12 * 12 * kLabelMaskCount - 1
+                      == ChordAnalyzer::maxLabelCode,
+                  "maxLabelCode must match the label code layout");
+
+    std::uint16_t pitchMaskOf(const std::vector<int>& midiNotes) noexcept
+    {
+        std::uint16_t mask = 0;
+        for (int note : midiNotes)
+            mask = static_cast<std::uint16_t>(mask | (1u << (((note % 12) + 12) % 12)));
+        return mask;
+    }
+}
+
+int ChordAnalyzer::encodeLabel(const ChordInfo& chord, bool showInversions) noexcept
+{
+    // Branches in the same order as analyze(), on the same conditions, so the
+    // code always describes the string analyze() produced. isValid stands in
+    // for "a pattern matched": ChordFacts sets it only on that path, and sets
+    // it whenever that path is taken.
+    const std::vector<int>& notes = chord.midiNotes;
+
+    if (notes.empty())
+        return kLabelNone;
+
+    if (notes.size() == 1)
+        return kLabelSingleBase + juce::jlimit(0, 127, notes[0]);
+
+    const std::uint16_t pitchMask = pitchMaskOf(notes);
+    const int bass = ((chord.bassNote % 12) + 12) % 12;
+    const int root = ((chord.rootNote % 12) + 12) % 12;
+
+    if (! chord.isValid)
+    {
+        const int distinctPitches = countPitchClasses(pitchMask);
+
+        if (distinctPitches > 2)
+            return kLabelUnknownBase + root;
+
+        int upper = bass;
+        for (int pc = 0; pc < 12; ++pc)
+        {
+            if (pc != bass && (pitchMask & (1u << pc)) != 0)
+            {
+                upper = pc;
+                break;
+            }
+        }
+
+        // One pitch class is a doubled note: an octave, or a unison when every
+        // note is literally the same pitch.
+        bool unison = false;
+        if (distinctPitches < 2)
+        {
+            const auto range = std::minmax_element(notes.begin(), notes.end());
+            unison = (*range.first == *range.second);
+        }
+
+        return kLabelDyadBase + (bass * 12 + upper) * 2 + (unison ? 1 : 0);
+    }
+
+    int intervalMask = 0;
+    for (int pc = 0; pc < 12; ++pc)
+    {
+        if ((pitchMask & (1u << pc)) == 0)
+            continue;
+
+        const int interval = ((pc - root) + 12) % 12;
+        if (interval != 0)
+            intervalMask |= (1 << (interval - 1));
+    }
+
+    // Bass interval 0 means "no slash", which is also how a toggled-off Show
+    // Inversions reads: the editor drops the suffix, so the code must too.
+    const int bassInterval = (showInversions && chord.slashBass)
+                                 ? ((bass - root) + 12) % 12 : 0;
+
+    return kLabelChordBase + (root * 12 + bassInterval) * kLabelMaskCount + intervalMask;
+}
+
+juce::String ChordAnalyzer::decodeLabel(int code)
+{
+    // Hosts probe getText() with any value in range, so every code out of the
+    // encoder's image still has to produce something harmless.
+    if (code <= kLabelNone || code > maxLabelCode)
+        return "-";
+
+    if (code < kLabelDyadBase)
+        return noteToName(code - kLabelSingleBase);
+
+    if (code < kLabelUnknownBase)
+    {
+        int payload = code - kLabelDyadBase;
+        const bool unison = (payload % 2) != 0;
+        payload /= 2;
+        const int bass  = payload / 12;
+        const int upper = payload % 12;
+
+        const char* interval = (bass == upper) ? (unison ? "unison" : "octave")
+                                               : intervalName(((upper - bass) + 12) % 12);
+
+        return pitchClassToName(bass) + "+" + pitchClassToName(upper)
+             + " (" + interval + ")";
+    }
+
+    if (code < kLabelChordBase)
+        return pitchClassToName(code - kLabelUnknownBase) + "?";
+
+    int payload = code - kLabelChordBase;
+    const int intervalMask = payload % kLabelMaskCount;
+    payload /= kLabelMaskCount;
+    const int bassInterval = payload % 12;
+    const int root         = payload / 12;
+
+    // Rebuild the sounding pitch classes, then run the same matching and
+    // naming analyze() runs. No second copy of the pattern table.
+    std::uint16_t pitchMask = static_cast<std::uint16_t>(1u << root);
+    for (int bit = 0; bit < kLabelMaskBits; ++bit)
+        if ((intervalMask & (1 << bit)) != 0)
+            pitchMask = static_cast<std::uint16_t>(pitchMask | (1u << ((root + bit + 1) % 12)));
+
+    const std::uint32_t intervals = intervalsFrom(pitchMask, root);
+    const int patternIndex = matchPattern(intervals);
+
+    if (patternIndex < 0)
+        return pitchClassToName(root) + "?";   // only reachable from a probed code
+
+    juce::String label = pitchClassToName(root)
+                       + qualityToSuffix(chordPatterns[static_cast<size_t>(patternIndex)].quality)
+                       + describeAddedTones(patternIndex, intervals);
+
+    if (bassInterval != 0)
+        label += "/" + pitchClassToName((root + bassInterval) % 12);
+
+    return label;
+}
+
+//==============================================================================
 void ChordAnalyzer::setKey(int rootNote, bool isMinor)
 {
     keyRoot = rootNote % 12;

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.h
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.h
@@ -179,6 +179,33 @@ public:
     static juce::String qualityToSuffix(ChordQuality quality);
     static juce::String functionToString(HarmonicFunction func);
 
+    //==========================================================================
+    // Host-parameter encoding of the label the editor displays.
+    //
+    // The "Detected Chord" parameter has to build its text out of the
+    // parameter VALUE alone. Hosts call getText() with arbitrary values and
+    // cache what comes back, so a stringFromValue that peeked at live
+    // processor state would hand the host a string belonging to some other
+    // value. encodeLabel packs everything the label depends on into one small
+    // integer; decodeLabel rebuilds the string from that integer and nothing
+    // else, through the same naming helpers analyze() uses.
+    //
+    // Value layout (the bases live in ChordAnalyzer.cpp):
+    //   0                no chord, "-"
+    //   1 .. 128         single note, MIDI 0..127 (that label carries an octave)
+    //   129 .. 416       two sounding pitch classes, "C+E (M3)", "C+C (octave)"
+    //   417 .. 428       nothing matched, "C?" .. "B?"
+    //   429 .. 295340    matched pattern: root, sounding intervals, bass
+    //
+    // 295340 needs 19 bits, comfortably inside the 24-bit mantissa a float
+    // NormalisableRange has to round-trip.
+    static constexpr int maxLabelCode = 295340;
+
+    // showInversions mirrors the editor's Show Inversions toggle: the slash
+    // bass belongs to the label only while that toggle is on.
+    static int encodeLabel(const ChordInfo& chord, bool showInversions) noexcept;
+    static juce::String decodeLabel(int code);
+
 private:
     int keyRoot = 0;        // C
     bool minorKey = false;

--- a/plugins/chord-analyzer/Source/PluginProcessor.cpp
+++ b/plugins/chord-analyzer/Source/PluginProcessor.cpp
@@ -77,10 +77,37 @@ ChordAnalyzerProcessor::ChordAnalyzerProcessor()
         juce::ParameterID(PARAM_DETECTED_INVERSION, 1),
         "Detected Inversion", inversionChoices, 0);
 
+    // The four above are fragments: a host can show "C", "maj7" and "E" but
+    // cannot always reassemble "Cmaj7/E", let alone "Cadd#11" (issue #267).
+    // This one carries the whole label the editor draws.
+    //
+    // Deliberately an AudioParameterFloat with a custom string function rather
+    // than an AudioParameterInt. AudioParameterInt is discrete, and every JUCE
+    // wrapper treats a discrete parameter as an enumeration: the AU wrapper
+    // reports kAudioUnitParameterUnit_Indexed with maxValue = getNumSteps() - 1
+    // and eagerly builds one CFString per step at instantiation
+    // (juce_audio_plugin_client_AU_1.mm), which for 295341 codes means AU hosts
+    // enumerating a menu of a quarter of a million entries. Not discrete means
+    // AU keeps it a plain 0..1 float and asks for one string at a time through
+    // kAudioUnitProperty_ParameterStringFromValue, VST3 reports stepCount 0 and
+    // calls getParamStringByValue, and the LV2 wrapper writes no scale points.
+    //
+    // The lambda reads nothing but its argument. Hosts call getText() with
+    // arbitrary values and cache the answers, so anything that peeked at the
+    // live chord here would label cached values with the wrong chord.
+    detectedChordParam = new juce::AudioParameterFloat(
+        juce::ParameterID(PARAM_DETECTED_CHORD, 1),
+        "Detected Chord",
+        juce::NormalisableRange<float>(0.0f, static_cast<float>(ChordAnalyzer::maxLabelCode), 1.0f),
+        0.0f,
+        juce::AudioParameterFloatAttributes().withStringFromValueFunction(
+            [](float value, int) { return ChordAnalyzer::decodeLabel(juce::roundToInt(value)); }));
+
     addParameter(detectedRootParam);
     addParameter(detectedQualityParam);
     addParameter(detectedBassParam);
     addParameter(detectedInversionParam);
+    addParameter(detectedChordParam);
 
     startTimer(50);  // 20Hz publishing of detection results to host parameters
 }
@@ -164,6 +191,11 @@ void ChordAnalyzerProcessor::parameterChanged(const juce::String& parameterID, f
     else if (parameterID == PARAM_SHOW_INVERSIONS)
     {
         showInversions.store(newValue > 0.5f);
+        // The published label carries the slash bass only while this is on, so
+        // the chord already sounding has to be re-encoded. Deferred to the
+        // timer: this callback can arrive on the audio thread and re-staging
+        // takes chordLock.
+        detectionRestageRequested.store(true, std::memory_order_release);
     }
     else if (parameterID == PARAM_RESPECT_SUSTAIN)
     {
@@ -513,6 +545,7 @@ void ChordAnalyzerProcessor::stageDetectedChord(const ChordInfo& chord)
     pendingQualityIndex.store(qualityIndex);
     pendingBassIndex.store(bassIndex);
     pendingInversionIndex.store(inversionIndex);
+    pendingChordCode.store(ChordAnalyzer::encodeLabel(chord, showInversions.load()));
     detectionDirty.store(true);
 }
 
@@ -525,6 +558,12 @@ void ChordAnalyzerProcessor::timerCallback()
     if (analysisDirty.exchange(false, std::memory_order_acq_rel))
         updateAnalysis();
 
+    if (detectionRestageRequested.exchange(false, std::memory_order_acq_rel))
+    {
+        const juce::SpinLock::ScopedLockType lock(chordLock);
+        stageDetectedChord(currentChord);
+    }
+
     if (! detectionDirty.exchange(false))
         return;
 
@@ -532,6 +571,13 @@ void ChordAnalyzerProcessor::timerCallback()
     if (detectedQualityParam   != nullptr) *detectedQualityParam   = pendingQualityIndex.load();
     if (detectedBassParam      != nullptr) *detectedBassParam      = pendingBassIndex.load();
     if (detectedInversionParam != nullptr) *detectedInversionParam = pendingInversionIndex.load();
+
+    // Published unnormalised, like the four choices above: operator= skips the
+    // notification only when the value is unchanged, and its relative epsilon
+    // at the top of this range works out at 0.04 codes, far short of the 1 that
+    // separates two labels.
+    if (detectedChordParam != nullptr)
+        *detectedChordParam = static_cast<float>(pendingChordCode.load());
 }
 
 //==============================================================================

--- a/plugins/chord-analyzer/Source/PluginProcessor.h
+++ b/plugins/chord-analyzer/Source/PluginProcessor.h
@@ -124,6 +124,10 @@ public:
     static constexpr const char* PARAM_DETECTED_BASS      = "detectedBass";
     static constexpr const char* PARAM_DETECTED_INVERSION = "detectedInversion";
 
+    // The whole label the editor shows ("Cadd#11/F#"), for hosts that put a
+    // parameter on a widget instead of opening the editor (issue #267).
+    static constexpr const char* PARAM_DETECTED_CHORD     = "detectedChord";
+
 private:
     juce::AudioProcessorValueTreeState parameters;
 
@@ -217,6 +221,9 @@ private:
     juce::AudioParameterChoice* detectedQualityParam = nullptr;
     juce::AudioParameterChoice* detectedBassParam = nullptr;
     juce::AudioParameterChoice* detectedInversionParam = nullptr;
+    // Float, not Int, deliberately - see the constructor for why a discrete
+    // parameter with this many steps is a trap in the AU wrapper.
+    juce::AudioParameterFloat*  detectedChordParam = nullptr;
 
     // Atomic snapshot of detection results, published to the host by the timer
     // (Reaper and others don't refresh their generic parameter display from
@@ -225,7 +232,14 @@ private:
     std::atomic<int>  pendingQualityIndex{0};
     std::atomic<int>  pendingBassIndex{0};
     std::atomic<int>  pendingInversionIndex{0};
+    std::atomic<int>  pendingChordCode{0};
     std::atomic<bool> detectionDirty{false};
+
+    // Show Inversions changes the label without any note changing, so the
+    // toggle asks the timer to re-encode the chord that is already sounding.
+    // Set from parameterChanged, which the host may call on the audio thread,
+    // so the restage itself (which takes chordLock) happens on the timer.
+    std::atomic<bool> detectionRestageRequested{false};
 
     static juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
 

--- a/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
+++ b/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <iomanip>
 #include <vector>
+#include <algorithm>
 
 static int passed = 0, failed = 0;
 
@@ -613,6 +614,201 @@ static void testUtilities()
 }
 
 // =====================================================================
+// 11. "Detected Chord" label codec (issue #267)
+// =====================================================================
+
+// The exact string PluginEditor::updateChordDisplay() writes into the label.
+static juce::String uiLabel(const ChordInfo& chord, bool showInversions)
+{
+    juce::String text = chord.name;
+
+    if (showInversions && chord.slashBass && ! chord.extensions.isEmpty())
+        text += chord.extensions;
+
+    return text;
+}
+
+// Bass lowest, every other sounding pitch class stacked inside the octave
+// above it.
+static std::vector<int> canonicalVoicing(int pitchMask, int bassPc)
+{
+    std::vector<int> notes{ 48 + bassPc };
+
+    for (int step = 1; step < 12; ++step)
+        if ((pitchMask & (1 << ((bassPc + step) % 12))) != 0)
+            notes.push_back(48 + bassPc + step);
+
+    return notes;
+}
+
+// Same pitch classes and the same lowest note, but spread over three octaves
+// with the bass doubled. Used to show the label depends on the pitch classes
+// and the bass, not on how the notes are laid out.
+static std::vector<int> spreadVoicing(int pitchMask, int bassPc)
+{
+    std::vector<int> notes{ 36 + bassPc, 48 + bassPc };
+    int spread = 0;
+
+    for (int step = 1; step < 12; ++step)
+    {
+        if ((pitchMask & (1 << ((bassPc + step) % 12))) == 0)
+            continue;
+
+        notes.push_back(48 + bassPc + step + 12 * (spread % 3));
+        ++spread;
+    }
+
+    return notes;
+}
+
+static void testDetectedChordCodec()
+{
+    std::cout << "\n--- Detected Chord Codec ---\n";
+    ChordAnalyzer a;
+
+    int cases = 0;
+    int mismatches = 0;
+    int outOfRange = 0;
+    int voicingMismatches = 0;
+    int maxCodeSeen = 0;
+    juce::String firstMismatch;
+    juce::String firstVoicingMismatch;
+
+    auto roundTrip = [&](const std::vector<int>& notes, bool showInversions)
+    {
+        const ChordInfo chord = a.analyze(notes);
+        const int code = ChordAnalyzer::encodeLabel(chord, showInversions);
+        ++cases;
+
+        if (code < 0 || code > ChordAnalyzer::maxLabelCode)
+        {
+            ++outOfRange;
+            return;
+        }
+
+        maxCodeSeen = std::max(maxCodeSeen, code);
+
+        const juce::String expected = uiLabel(chord, showInversions);
+        const juce::String actual   = ChordAnalyzer::decodeLabel(code);
+
+        if (actual != expected)
+        {
+            ++mismatches;
+
+            if (firstMismatch.isEmpty())
+                firstMismatch = "notes[" + juce::String(static_cast<int>(notes.size()))
+                              + "] showInv=" + (showInversions ? "1" : "0")
+                              + " code=" + juce::String(code)
+                              + " expected \"" + expected + "\" got \"" + actual + "\"";
+        }
+    };
+
+    // Every pitch-class set, over every bass that set can have.
+    for (int mask = 1; mask < 4096; ++mask)
+    {
+        for (int bassPc = 0; bassPc < 12; ++bassPc)
+        {
+            if ((mask & (1 << bassPc)) == 0)
+                continue;
+
+            const std::vector<int> notes = canonicalVoicing(mask, bassPc);
+            roundTrip(notes, false);
+            roundTrip(notes, true);
+
+            // Two or more pitch classes: the label must not move when the same
+            // set is voiced differently over the same bass. This is the claim
+            // the encoding rests on, that (root, interval mask, bass) is
+            // enough, so it is measured rather than assumed.
+            if (notes.size() < 2)
+                continue;
+
+            const juce::String canonical = uiLabel(a.analyze(notes), true);
+            const juce::String spread    = uiLabel(a.analyze(spreadVoicing(mask, bassPc)), true);
+
+            if (canonical != spread)
+            {
+                ++voicingMismatches;
+
+                if (firstVoicingMismatch.isEmpty())
+                    firstVoicingMismatch = "mask=" + juce::String(mask)
+                                         + " bass=" + juce::String(bassPc)
+                                         + " \"" + canonical + "\" vs \"" + spread + "\"";
+            }
+        }
+    }
+
+    const int chordCases = cases;
+
+    // All 128 single notes: that label carries an octave, so it is its own kind.
+    for (int note = 0; note < 128; ++note)
+    {
+        roundTrip({ note }, false);
+        roundTrip({ note }, true);
+    }
+
+    // Every two-note voicing, including the unisons and every octave.
+    for (int low = 0; low < 128; ++low)
+    {
+        for (int high = low; high < 128; ++high)
+        {
+            roundTrip({ low, high }, false);
+            roundTrip({ low, high }, true);
+        }
+    }
+
+    // No notes at all.
+    roundTrip({}, false);
+    roundTrip({}, true);
+
+    std::cout << "       chord-set cases: " << chordCases
+              << ", total cases: " << cases
+              << ", highest code: " << maxCodeSeen
+              << " (limit " << ChordAnalyzer::maxLabelCode << ")\n";
+
+    if (! firstMismatch.isEmpty())
+        std::cout << "       first mismatch: " << firstMismatch << "\n";
+
+    if (! firstVoicingMismatch.isEmpty())
+        std::cout << "       first voicing mismatch: " << firstVoicingMismatch << "\n";
+
+    check("codec: every case round-trips to the UI label", mismatches == 0);
+    check("codec: every code stays inside maxLabelCode", outOfRange == 0);
+    check("codec: label is independent of the voicing", voicingMismatches == 0);
+    check("codec: no chord decodes to \"-\"", ChordAnalyzer::decodeLabel(0) == "-");
+
+    // Spot checks, so a broken decoder shows what it broke rather than a count.
+    const ChordInfo cmaj7overE = a.analyze({ 64, 67, 71, 72 });
+    check("codec: Cmaj7/E with inversions on",
+          ChordAnalyzer::decodeLabel(ChordAnalyzer::encodeLabel(cmaj7overE, true)) == "Cmaj7/E");
+    check("codec: Cmaj7/E with inversions off",
+          ChordAnalyzer::decodeLabel(ChordAnalyzer::encodeLabel(cmaj7overE, false)) == "Cmaj7");
+
+    const ChordInfo addSharp11 = a.analyze({ 60, 64, 67, 78 });
+    check("codec: Cadd#11",
+          ChordAnalyzer::decodeLabel(ChordAnalyzer::encodeLabel(addSharp11, true)) == "Cadd#11");
+
+    check("codec: single note keeps its octave",
+          ChordAnalyzer::decodeLabel(ChordAnalyzer::encodeLabel(a.analyze({ 60 }), true)) == "C4");
+    check("codec: dyad names the interval",
+          ChordAnalyzer::decodeLabel(ChordAnalyzer::encodeLabel(a.analyze({ 60, 64 }), true))
+              == "C+E (M3)");
+    check("codec: doubled note reads as an octave",
+          ChordAnalyzer::decodeLabel(ChordAnalyzer::encodeLabel(a.analyze({ 60, 72 }), true))
+              == "C+C (octave)");
+
+    // Values the encoder never produces still have to be safe to ask about:
+    // hosts probe getText() across the whole range and cache what it returns.
+    int probed = 0;
+    for (int code = -4096; code <= ChordAnalyzer::maxLabelCode + 4096; code += 7)
+    {
+        ChordAnalyzer::decodeLabel(code);
+        ++probed;
+    }
+    check("codec: out-of-image codes decode without crashing", probed > 0);
+    std::cout << "       probed " << probed << " codes across and beyond the range\n";
+}
+
+// =====================================================================
 int main()
 {
     std::cout << "=== Chord Analyzer Unit Tests ===\n";
@@ -632,6 +828,7 @@ int main()
     testAnalyzeFacts();
     testNoFifthAndDyads();
     testUtilities();
+    testDetectedChordCodec();
 
     std::cout << "\n=== Results: " << passed << " passed, " << failed << " failed ===\n";
     return failed > 0 ? 1 : 0;

--- a/plugins/chord-analyzer/tests/test_detected_chord_param.cpp
+++ b/plugins/chord-analyzer/tests/test_detected_chord_param.cpp
@@ -1,0 +1,317 @@
+/*
+    Chord Analyzer host-side tests for the "Detected Chord" parameter (issue
+    #267). These link the plugin's shared code, so they run against the real
+    processor and the real parameter object rather than a stand-in:
+
+      * every code in the parameter's range survives the float normalisation
+        JUCE puts a parameter through, and getText() renders exactly what
+        ChordAnalyzer::decodeLabel does;
+      * a chord fed through processBlock reaches the parameter as text on the
+        normal 20 Hz publish path, with no editor open;
+      * Show Inversions changes that text with no note changing;
+      * the output parameters stay out of the saved state.
+*/
+
+#include "../Source/PluginProcessor.h"
+#include <iostream>
+
+static int passed = 0, failed = 0;
+
+static void check(const char* name, bool condition)
+{
+    if (condition) {
+        std::cout << "\033[32m[PASS]\033[0m " << name << "\n";
+        ++passed;
+    } else {
+        std::cout << "\033[31m[FAIL]\033[0m " << name << "\n";
+        ++failed;
+    }
+}
+
+static juce::RangedAudioParameter* findParameter(juce::AudioProcessor& processor,
+                                                 const juce::String& parameterID)
+{
+    for (auto* param : processor.getParameters())
+        if (auto* ranged = dynamic_cast<juce::RangedAudioParameter*>(param))
+            if (ranged->paramID == parameterID)
+                return ranged;
+
+    return nullptr;
+}
+
+//==============================================================================
+// Every code, through the parameter's own normalisation and its own getText.
+static void testParameterRoundTrip(juce::RangedAudioParameter& chordParam)
+{
+    std::cout << "\n--- Parameter round-trip ---\n";
+
+    int normalisationFailures = 0;
+    int textFailures = 0;
+    int firstNormalisationFailure = -1;
+    juce::String firstTextFailure;
+
+    for (int code = 0; code <= ChordAnalyzer::maxLabelCode; ++code)
+    {
+        const float normalised = chordParam.convertTo0to1(static_cast<float>(code));
+        const int decoded = juce::roundToInt(chordParam.convertFrom0to1(normalised));
+
+        if (decoded != code)
+        {
+            ++normalisationFailures;
+            if (firstNormalisationFailure < 0)
+                firstNormalisationFailure = code;
+        }
+
+        const juce::String text = chordParam.getText(normalised, 1024);
+        const juce::String expected = ChordAnalyzer::decodeLabel(code);
+
+        if (text != expected)
+        {
+            ++textFailures;
+            if (firstTextFailure.isEmpty())
+                firstTextFailure = "code " + juce::String(code)
+                                 + ": expected \"" + expected + "\" got \"" + text + "\"";
+        }
+    }
+
+    std::cout << "       swept " << (ChordAnalyzer::maxLabelCode + 1)
+              << " codes through convertTo0to1 / convertFrom0to1 / getText\n";
+
+    if (firstNormalisationFailure >= 0)
+        std::cout << "       first normalisation failure at code "
+                  << firstNormalisationFailure << "\n";
+
+    if (! firstTextFailure.isEmpty())
+        std::cout << "       first text failure: " << firstTextFailure << "\n";
+
+    check("every code survives the float normalisation", normalisationFailures == 0);
+    check("getText matches decodeLabel for every code", textFailures == 0);
+}
+
+// The same sweep through the live parameter object, the way the timer writes
+// it and the way a host reads it back.
+static void testLiveParameterText(juce::RangedAudioParameter& chordParam)
+{
+    std::cout << "\n--- Parameter set / read back ---\n";
+
+    auto* asFloat = dynamic_cast<juce::AudioParameterFloat*>(&chordParam);
+    check("Detected Chord is an AudioParameterFloat", asFloat != nullptr);
+
+    if (asFloat == nullptr)
+        return;
+
+    // Not discrete: a discrete parameter of this size makes the AU wrapper
+    // build one CFString per step at instantiation and report the parameter as
+    // kAudioUnitParameterUnit_Indexed.
+    check("Detected Chord is not discrete", ! asFloat->isDiscrete());
+    check("Detected Chord is not boolean", ! asFloat->isBoolean());
+
+    int failures = 0;
+    juce::String firstFailure;
+
+    for (int code = 0; code <= ChordAnalyzer::maxLabelCode; ++code)
+    {
+        *asFloat = static_cast<float>(code);
+
+        const juce::String text = asFloat->getCurrentValueAsText();
+        const juce::String expected = ChordAnalyzer::decodeLabel(code);
+
+        if (text != expected)
+        {
+            ++failures;
+            if (firstFailure.isEmpty())
+                firstFailure = "code " + juce::String(code)
+                             + ": expected \"" + expected + "\" got \"" + text + "\"";
+        }
+    }
+
+    if (! firstFailure.isEmpty())
+        std::cout << "       first failure: " << firstFailure << "\n";
+
+    std::cout << "       set and read back " << (ChordAnalyzer::maxLabelCode + 1)
+              << " codes through the live parameter\n";
+
+    check("getCurrentValueAsText matches every code written", failures == 0);
+}
+
+//==============================================================================
+// The saved state must not carry detection results: they are outputs, and the
+// existing four are added straight to the processor rather than to the APVTS
+// for exactly that reason.
+static void testStateExcludesOutputs(ChordAnalyzerProcessor& processor)
+{
+    std::cout << "\n--- Saved state ---\n";
+
+    juce::MemoryBlock state;
+    processor.getStateInformation(state);
+
+    auto xml = juce::AudioProcessor::getXmlFromBinary(state.getData(),
+                                                      static_cast<int>(state.getSize()));
+
+    check("state saves as XML", xml != nullptr);
+
+    if (xml == nullptr)
+        return;
+
+    const juce::String text = xml->toString();
+
+    check("state does not carry Detected Chord", ! text.contains("detectedChord"));
+    check("state does not carry the other detection outputs",
+          ! text.contains("detectedRoot") && ! text.contains("detectedQuality")
+          && ! text.contains("detectedBass") && ! text.contains("detectedInversion"));
+    check("state does carry the real parameters", text.contains("showInversions"));
+
+    // Loading it back must leave the detection outputs alone.
+    const juce::String before = processor.getParameters()[0]->getCurrentValueAsText();
+    processor.setStateInformation(state.getData(), static_cast<int>(state.getSize()));
+    check("state reloads without changing an input parameter",
+          processor.getParameters()[0]->getCurrentValueAsText() == before);
+}
+
+//==============================================================================
+// Drives the real publish path: MIDI in through processBlock, the processor's
+// own 20 Hz timer out to the parameter. Steps run on the message thread so the
+// timer gets to fire between them.
+class PublishDriver : private juce::Timer
+{
+public:
+    PublishDriver(ChordAnalyzerProcessor& p, juce::RangedAudioParameter& chordParam)
+        : processor(p), param(chordParam)
+    {
+        startTimer(150);
+    }
+
+private:
+    void sendNotes(const std::vector<int>& on, const std::vector<int>& off)
+    {
+        juce::MidiBuffer midi;
+        int sample = 0;
+
+        for (int note : off)
+            midi.addEvent(juce::MidiMessage::noteOff(1, note), sample++);
+
+        for (int note : on)
+            midi.addEvent(juce::MidiMessage::noteOn(1, note, static_cast<juce::uint8>(100)), sample++);
+
+        juce::AudioBuffer<float> buffer(2, 512);
+        buffer.clear();
+        processor.processBlock(buffer, midi);
+    }
+
+    void setShowInversions(bool shouldShow)
+    {
+        auto* p = processor.getAPVTS().getParameter(ChordAnalyzerProcessor::PARAM_SHOW_INVERSIONS);
+        p->setValueNotifyingHost(shouldShow ? 1.0f : 0.0f);
+    }
+
+    void timerCallback() override
+    {
+        switch (step++)
+        {
+            case 0:
+                setShowInversions(true);
+                sendNotes({ 60, 64, 67, 71 }, {});
+                break;
+
+            case 1:
+                check("Cmaj7 reaches the host parameter as text",
+                      param.getCurrentValueAsText() == "Cmaj7");
+                std::cout << "       after C E G B: \"" << param.getCurrentValueAsText() << "\"\n";
+                sendNotes({ 52 }, {});   // add E below the C: Cmaj7 over an E bass
+                break;
+
+            case 2:
+                check("first inversion publishes the slash bass",
+                      param.getCurrentValueAsText() == "Cmaj7/E");
+                std::cout << "       after adding an E bass: \""
+                          << param.getCurrentValueAsText() << "\"\n";
+                setShowInversions(false);
+                break;
+
+            case 3:
+                check("Show Inversions off drops the slash with no note changing",
+                      param.getCurrentValueAsText() == "Cmaj7");
+                std::cout << "       Show Inversions off: \"" << param.getCurrentValueAsText() << "\"\n";
+                setShowInversions(true);
+                break;
+
+            case 4:
+                check("Show Inversions back on restores the slash",
+                      param.getCurrentValueAsText() == "Cmaj7/E");
+                sendNotes({ 78 }, { 52, 60, 64, 67, 71 });   // lone F#5
+                break;
+
+            case 5:
+                check("a single note publishes its octave",
+                      param.getCurrentValueAsText() == "F#5");
+                std::cout << "       single note: \"" << param.getCurrentValueAsText() << "\"\n";
+                sendNotes({}, { 78 });
+                break;
+
+            case 6:
+                check("no notes publishes \"-\"", param.getCurrentValueAsText() == "-");
+                break;
+
+            default:
+                stopTimer();
+                juce::MessageManager::getInstance()->stopDispatchLoop();
+                break;
+        }
+    }
+
+    ChordAnalyzerProcessor& processor;
+    juce::RangedAudioParameter& param;
+    int step = 0;
+};
+
+//==============================================================================
+int main()
+{
+    std::cout << "=== Chord Analyzer Detected Chord parameter tests ===\n";
+
+    juce::ScopedJuceInitialiser_GUI juceInit;
+
+    ChordAnalyzerProcessor processor;
+    processor.prepareToPlay(48000.0, 512);
+
+    auto* chordParam = findParameter(processor, ChordAnalyzerProcessor::PARAM_DETECTED_CHORD);
+    check("Detected Chord parameter exists", chordParam != nullptr);
+
+    if (chordParam == nullptr)
+    {
+        std::cout << "\n=== Results: " << passed << " passed, " << (failed + 1) << " failed ===\n";
+        return 1;
+    }
+
+    check("Detected Chord is named for the host", chordParam->getName(64) == "Detected Chord");
+    check("Detected Chord range tops out at maxLabelCode",
+          juce::roundToInt(chordParam->getNormalisableRange().end) == ChordAnalyzer::maxLabelCode);
+
+    // The plugin builds with JUCE_FORCE_USE_LEGACY_PARAM_IDS, so a VST3 host
+    // addresses parameters by index. Anything but appending renumbers the
+    // existing ones and breaks saved automation, so pin the order.
+    std::cout << "       parameter order:";
+    for (auto* param : processor.getParameters())
+    {
+        auto* ranged = dynamic_cast<juce::RangedAudioParameter*>(param);
+        std::cout << " " << param->getParameterIndex() << "="
+                  << (ranged != nullptr ? ranged->paramID : param->getName(32));
+    }
+    std::cout << "\n";
+
+    check("Detected Chord was appended after the existing parameters",
+          processor.getParameters().getLast() == chordParam);
+
+    testParameterRoundTrip(*chordParam);
+    testLiveParameterText(*chordParam);
+    testStateExcludesOutputs(processor);
+
+    std::cout << "\n--- Publish path ---\n";
+    PublishDriver driver(processor, *chordParam);
+    juce::MessageManager::getInstance()->runDispatchLoop();
+
+    processor.releaseResources();
+
+    std::cout << "\n=== Results: " << passed << " passed, " << failed << " failed ===\n";
+    return failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Closes #267.

`Detected Root`, `Detected Quality`, `Detected Bass` and `Detected Inversion` are fragments, and a host cannot always put them back together: `Cadd#11`, `C9(no5,b13)` and `Cmaj7(no5)/F#` have no representation in four enums. This adds a fifth read-only parameter, **Detected Chord** (`detectedChord`), whose text is the label the editor draws, character for character.

## What the parameter value encodes

Hosts call `getText()` with arbitrary values and cache what comes back, so the text has to be a pure function of the value. A `stringFromValue` that peeked at the live chord would label a cached value with a chord that value never described. So the value carries the label instead of pointing at live state.

`ChordAnalyzer::encodeLabel` mirrors the branches `analyze()` takes when it builds `ChordInfo::name`, in the same order and on the same conditions, and packs each branch's inputs into one integer:

| codes | branch | payload |
|---|---|---|
| 0 | no chord, `-` | none |
| 1 .. 128 | single note, `F#5` | MIDI note 0..127 (7 bits, the label carries the octave) |
| 129 .. 416 | two pitch classes, `C+E (M3)` / `C+C (octave)` | bass pc, upper pc, unison-vs-octave flag |
| 417 .. 428 | nothing matched, `C?` | root pc |
| 429 .. 295340 | matched pattern | root pc (12) x bass interval (12) x 11-bit interval mask |

The interval mask is the sounding pitch classes as intervals 1..11 above the root; interval 0 is implied, because `findRoot` only ever returns a sounding pitch class. Bass interval 0 means "no slash", which is also what a toggled-off **Show Inversions** produces, so the toggle is handled entirely in the encoder and the decoder stays pure.

Top code **295340**, which needs **19 bits**, well inside the brief's 2^22 budget and inside the 24-bit mantissa a float `NormalisableRange` has to round-trip. Codes are laid out as sized blocks rather than a tag-plus-19-bit-payload bit field (which would have reached 2^22) purely to keep the float margin large: the worst-case error through `convertTo0to1` / `convertFrom0to1` at this magnitude is about 0.02 codes against a 0.5 rounding tolerance.

## Why the decoder is pure

`ChordAnalyzer::decodeLabel(int)` reads nothing but its argument. It rebuilds the sounding pitch-class mask from root and interval mask, then runs the same `intervalsFrom`, `matchPattern`, `pitchClassToName`, `qualityToSuffix`, `describeAddedTones`, `intervalName` and `noteToName` that `analyze()` runs, against the same `chordPatterns` table. There is no second copy of any table and no new naming code, and no existing naming function needed a signature change: both new functions are members of `ChordAnalyzer`, so the private helpers were already reachable.

Codes outside the encoder's image still decode to something harmless, because hosts probe the whole range.

### Is (root, mask, bass) enough?

`analyzeFacts` reads only the pitch-class mask and the bass pitch class, so by construction it is. Measured anyway: for every one of the 4096 pitch-class sets over every bass it can have, the label from the canonical voicing (bass lowest, the rest stacked inside the octave above) is compared with the label from a three-octave spread voicing with the bass doubled. 0 mismatches. The two branches that *do* depend on voicing, the single note and the unison-vs-octave distinction, are separate kinds in the encoding.

## Parameter type and wrapper behaviour

`AudioParameterFloat` with a custom `stringFromValueFunction`, deliberately **not** `AudioParameterInt`.

- **AU**: `AudioParameterInt` is discrete. `juce_audio_plugin_client_AU_1.mm` reports a discrete parameter as `kAudioUnitParameterUnit_Indexed` with `maxValue = getNumSteps() - 1`, and its constructor eagerly builds one `CFString` per step into `parameterValueStringArrays` for `GetParameterValueStrings`. At 295341 steps that is a quarter of a million strings per instance, and Indexed invites AU hosts to enumerate a menu of them. Non-discrete keeps AU on a plain 0..1 float with `ValuesHaveStrings`, served one string at a time through `kAudioUnitProperty_ParameterStringFromValue`. (This plugin sets `JUCE_FORCE_USE_LEGACY_PARAM_IDS=1`, which happens to skip that eager build, but the Indexed unit and the huge `maxValue` remain and it would be a fragile thing to depend on.)
- **VST3**: `newStepCount` returns 0 for a non-discrete parameter, so it is a continuous parameter and the host asks `getParamStringByValue`, which lands on `getText`.
- **LV2**: the wrapper only writes `lv2:scalePoint` for a discrete parameter with fewer than 1000 steps. Confirmed in the generated `dsp.ttl`: `plug:detectedChord` is a bare `atom:Float` with `lv2:minimum 0 ; lv2:maximum 295340` and no enumeration, and the file is unchanged in size.
- **CLAP**: goes through the same `getText`.

## Read-only, and how

The four existing detection parameters are plain `AudioParameterChoice`es created with no attributes, so they are automatable and writable as far as the host is concerned; they are "read-only" only in the sense that the processor overwrites whatever a host writes on the next publish. Reporting that rather than changing it: the new parameter mirrors it exactly, no `withAutomatable(false)`.

It is appended after the existing nine. With `JUCE_FORCE_USE_LEGACY_PARAM_IDS=1` a VST3 host addresses parameters by index, so appending is the only safe position; the host test pins it.

## Publish path

No change on the audio thread. `stageDetectedChord` encodes into an atomic alongside the four existing indices, and the existing 20 Hz `timerCallback` writes it with them.

**Show Inversions** changes the label with no note changing, so its `parameterChanged` handler sets a flag and the timer re-encodes the sounding chord. Deferred rather than done inline because APVTS calls listeners synchronously on whichever thread set the parameter (a host automating it calls from the audio thread) and the re-stage takes `chordLock`.

## Verification

**Codec sweep** (`ChordAnalyzerTest`): every one of the 4096 pitch-class sets over every bass it can have, both Show Inversions states (49152 cases), plus all 128 single notes and all 8256 two-note voicings including unisons and octaves, plus the empty chord. **65922 cases, 0 mismatches** against the exact editor label. Highest code produced: 295325 of 295340. Voicing invariance: 0 mismatches. 43362 codes probed across and beyond the range for safety.

**Parameter round-trip** (`ChordAnalyzerHostTest`): all **295341** codes through the real parameter's `convertTo0to1` / `convertFrom0to1` (0 failures) and through `getText` (0 mismatches), then all 295341 again written into the live parameter and read back with `getCurrentValueAsText` (0 mismatches).

**Publish path** (`ChordAnalyzerHostTest`): a real `ChordAnalyzerProcessor`, MIDI through `processBlock`, the processor's own timer publishing. `C E G B` -> `Cmaj7`; add an E below -> `Cmaj7/E`; Show Inversions off with no note changing -> `Cmaj7`; back on -> `Cmaj7/E`; lone F#5 -> `F#5`; all notes off -> `-`.

**Falsification**, to show the tests can fail. Dropping the slash suffix from the decoder: `first mismatch: notes[3] showInv=1 code=48561 expected "C#mMaj7(no5)/C" got "C#mMaj7(no5)"`, 2 unit failures and 2 host failures. Off-by-one on the decoded root: `first mismatch: notes[3] showInv=0 code=26033 expected "C#mMaj7(no5)" got "DmMaj7(no5)"`, 4 unit failures and 4 host failures (`after C E G B: "C#maj7"`). Both reverted.

**State**: the detection parameters are added straight to the processor rather than to the APVTS, and `getStateInformation` saves only `parameters.copyState()`, so none of them are in the saved state. Asserted for all five in the host test, along with a save/load round trip.

**Builds**: `ChordAnalyzer_VST3`, `ChordAnalyzerMIDI_VST3`, `ChordAnalyzer_LV2`, `ChordAnalyzerMIDI_LV2`, `ChordAnalyzer_CLAP`, `ChordAnalyzerHeadless_LV2`, `ChordAnalyzerTest`, `ChordAnalyzerHostTest` all clean. Zero warnings from the new lines; the pre-existing `-Wswitch-enum`, `-Wfloat-equal` and `-Wsign-conversion` warnings in `ChordAnalyzer.cpp` and `PluginEditor.cpp` are unchanged.

**pluginval** (Linux, 1.0.4): fresh `Chord Analyzer.vst3` from the build tree passes at strictness 5, 8 and 10, including the editor tests at 10 on a real display, and `Chord Analyzer MIDI.vst3` at 8. `./tests/run_plugin_tests.sh --plugin "Chord Analyzer" --skip-audio` reports 9 passed, 0 failed, 0 skipped at levels 1, 5, 7 and 10, but note it validates the bundle installed in `~/.vst3`, which this build tree does not refresh (`DUSK_COPY_AFTER_BUILD=OFF`), so the direct runs above are the ones that actually exercise this change.

## Out of scope

The headless LV2 variant in `plugins/chord-analyzer/lv2/` publishes native float control ports and has no way to carry a string, so it does not get this parameter. Its four numeric outputs are unchanged. Noted in the manual.

## Not verified here

No Gig Performer, no Logic, no macOS: the AU and Indexed reasoning is from reading `juce_audio_plugin_client_AU_1.mm`, not from an `auval` run. Nothing checks how a specific host renders the text, only that the wrappers ask for it and that JUCE hands back the right string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Detected Chord** output that provides the complete chord name, including slash bass notation when inversions are enabled.
  - The output updates when the **Show Inversions** setting changes and reflects the plugin’s displayed chord name.

- **Documentation**
  - Clarified how detection outputs support host automation and screen-recording overlays.
  - Documented that the Detected Chord output is unavailable in the Headless variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->