### PR TITLE
Drag gate: require every quadrant to draw, not just the window

### DIFF
--- a/plugins/shared-daf/tests/DafClapUiDragTest.cpp
+++ b/plugins/shared-daf/tests/DafClapUiDragTest.cpp
@@ -505,11 +505,16 @@ RenderCoverage renderCoverage(Display* const display, const Window window,
     return cov;
 }
 
-// Where the drawn pixels are, for the failure message only. On a window this
-// check is complaining about the most frequent sampled colour is the background
-// by definition, so the bounding box of everything else is the region the plugin
-// actually painted, and its share of the window is the number that says "a
-// quarter of it" out loud. Grid-aligned like the counts above.
+// Where the drawn pixels are, for the failure message only. The background is
+// read off the quadrants that came up blank, which is what "blank" means, and
+// the bounding box of every sample that is not that colour is the region the
+// plugin did manage to paint; its share of the window is the number that says
+// "a quarter of it" out loud. Grid-aligned like the counts above.
+//
+// Read off the blank quadrants rather than off the window, because the most
+// frequent colour of the whole window is only the background when the painted
+// region is the smaller part, and a window can fail this check with three
+// quadrants blank or with one. The blank quadrants are unambiguous either way.
 struct DrawnExtent
 {
     bool any;
@@ -525,7 +530,8 @@ struct DrawnExtent
 };
 
 DrawnExtent drawnExtent(Display* const display, const Window window,
-                        const unsigned width, const unsigned height)
+                        const unsigned width, const unsigned height,
+                        const RenderCoverage& coverage)
 {
     DrawnExtent ext = { false, 0, 0, 0, 0 };
 
@@ -533,22 +539,31 @@ DrawnExtent drawnExtent(Display* const display, const Window window,
     if (img == nullptr)
         return ext;
 
-    unsigned long value[64] = {};
-    unsigned tally[64] = {};
+    const unsigned midX = width / 2, midY = height / 2;
+
+    // Every colour the blank quadrants hold, exactly. A quadrant is only blank
+    // when it showed fewer than kColourBar distinct colours, so together they
+    // hold at most kQuadrants * (kColourBar - 1) and this table cannot fill; the
+    // guard below is the proof standing watch, not a case that arises.
+    constexpr unsigned kBackgroundKinds = kQuadrants * kColourBar;
+    unsigned long value[kBackgroundKinds] = {};
+    unsigned tally[kBackgroundKinds] = {};
     unsigned kinds = 0;
 
     for (unsigned y = 0; y < height; y += kSampleStep)
         for (unsigned x = 0; x < width; x += kSampleStep)
         {
+            const unsigned quadrant = (y >= midY ? 2u : 0u) + (x >= midX ? 1u : 0u);
+            if ((unsigned) coverage.quadrant[quadrant] >= kColourBar)
+                continue;
+
             const unsigned long px = XGetPixel(img, (int) x, (int) y);
             unsigned i = 0;
             for (; i < kinds; ++i)
                 if (value[i] == px) break;
             if (i == kinds)
             {
-                // Table full: the dominant colour of a near-empty window is long
-                // since in it, and a 65th shade cannot become the majority now.
-                if (kinds == 64)
+                if (kinds == kBackgroundKinds)
                     continue;
                 value[kinds++] = px;
             }
@@ -963,7 +978,7 @@ int main(const int argc, const char* const* const argv)
                 used += (unsigned) std::snprintf(empty + used, sizeof(empty) - used,
                                                  "%s%s", used != 0 ? ", " : "", kQuadrantNames[i]);
 
-        const DrawnExtent ext = drawnExtent(fx.display, sampled, width, height);
+        const DrawnExtent ext = drawnExtent(fx.display, sampled, width, height, coverage);
 
         std::fprintf(stderr,
                      "\nFAIL: the editor is drawing into part of its window. After three seconds of\n"

--- a/plugins/shared-daf/tests/DafClapUiDragTest.cpp
+++ b/plugins/shared-daf/tests/DafClapUiDragTest.cpp
@@ -406,44 +406,181 @@ DragResult dragAt(Fixture& fx, const int rootX, const int rootY, const int stepD
     return result;
 }
 
-// How many distinct colours the editor is showing. A window that never draws is
-// one flat colour, and a window that draws its background and nothing else is
-// two -- which is exactly what a broken GL path produces, and exactly what this
-// harness used to accept: the drag phases assert that parameters move, and an
-// editor can answer pointer input perfectly while painting nothing.
+// How much of the editor is showing, counted in distinct colours. A window that
+// never draws is one flat colour, and a window that draws its background and
+// nothing else is two -- which is exactly what a broken GL path produces, and
+// exactly what this harness used to accept: the drag phases assert that
+// parameters move, and an editor can answer pointer input perfectly while
+// painting nothing.
+//
+// Counted per quadrant as well as over the whole window, because a dead GL path
+// is not the only shape that failure takes. When DGL was still setting up its
+// viewport and projection from the configure event, which pugl stopped running
+// inside the graphics context, multi-comp-2 drew its entire faceplate into the
+// top-right quarter of its window: 61 distinct colours overall, comfortably past
+// a whole-window bar of 8, so this gate passed an editor that was visibly wrong
+// (dusk-audio/DAF#28, issue #266). Every quadrant of a real faceplate is full of
+// detail, so asking each of them to clear the same bar costs nothing here and
+// makes a viewport regression read as one.
 //
 // Sampled on a grid rather than per pixel: the question is "is there a UI here",
 // and 8 distinct colours separates a real faceplate (thousands) from a blank or
-// background-only window (one or two) with room to spare.
+// background-only region (one or two) with room to spare. The grid is the
+// window's and not each quadrant's, so the whole-window count is exactly the
+// number this gate has always judged.
 //
 // kCaptureFailed is distinct from a count, because "X would not give us the
 // pixels" and "the pixels are all one colour" are different findings and only
 // the second one is about the plugin.
 constexpr int kCaptureFailed = -1;
+constexpr unsigned kColourBar = 8;
+constexpr unsigned kSampleStep = 8;
+constexpr unsigned kQuadrants = 4;
 
-int distinctColours(Display* const display, const Window window,
-                    const unsigned width, const unsigned height,
-                    const unsigned cap)
+// Indexed as (y >= midY) * 2 + (x >= midX), which is the order these are built in.
+const char* const kQuadrantNames[kQuadrants] = { "NW", "NE", "SW", "SE" };
+
+struct RenderCoverage
 {
+    int whole;                     // distinct colours over the whole window, or kCaptureFailed
+    int quadrant[kQuadrants];      // distinct colours within each quadrant
+    unsigned samples[kQuadrants];  // grid points that landed in each quadrant
+
+    bool captureFailed() const { return whole == kCaptureFailed; }
+
+    // A quadrant with no sample in it cannot be judged, which only happens on a
+    // window narrower or shorter than the sampling step. Nothing in this fleet
+    // is, and an editor that small has no knob to drag either way.
+    bool everyQuadrantDraws() const
+    {
+        for (unsigned i = 0; i < kQuadrants; ++i)
+            if (samples[i] != 0 && (unsigned) quadrant[i] < kColourBar)
+                return false;
+        return true;
+    }
+};
+
+RenderCoverage renderCoverage(Display* const display, const Window window,
+                              const unsigned width, const unsigned height)
+{
+    RenderCoverage cov = {};
+
     XImage* const img = XGetImage(display, window, 0, 0, width, height, AllPlanes, ZPixmap);
     if (img == nullptr)
-        return kCaptureFailed;
+    {
+        cov.whole = kCaptureFailed;
+        return cov;
+    }
 
-    unsigned long seen[64];
-    unsigned count = 0;
-    for (unsigned y = 0; y < height && count < cap; y += 8)
-        for (unsigned x = 0; x < width && count < cap; x += 8)
+    // Region 0 is the whole window, regions 1 to 4 the quadrants.
+    unsigned long seen[1 + kQuadrants][kColourBar];
+    unsigned count[1 + kQuadrants] = {};
+    const unsigned midX = width / 2, midY = height / 2;
+
+    for (unsigned y = 0; y < height; y += kSampleStep)
+        for (unsigned x = 0; x < width; x += kSampleStep)
         {
             const unsigned long px = XGetPixel(img, (int) x, (int) y);
-            bool known = false;
-            for (unsigned i = 0; i < count; ++i)
-                if (seen[i] == px) { known = true; break; }
-            if (! known && count < 64)
-                seen[count++] = px;
+            const unsigned quadrant = (y >= midY ? 2u : 0u) + (x >= midX ? 1u : 0u);
+            ++cov.samples[quadrant];
+
+            const unsigned regions[2] = { 0, 1 + quadrant };
+            for (unsigned r = 0; r < 2; ++r)
+            {
+                unsigned& n = count[regions[r]];
+                unsigned long* const set = seen[regions[r]];
+                bool known = false;
+                for (unsigned i = 0; i < n; ++i)
+                    if (set[i] == px) { known = true; break; }
+                if (! known && n < kColourBar)
+                    set[n++] = px;
+            }
         }
 
     XDestroyImage(img);
-    return (int) count;
+
+    cov.whole = (int) count[0];
+    for (unsigned i = 0; i < kQuadrants; ++i)
+        cov.quadrant[i] = (int) count[1 + i];
+    return cov;
+}
+
+// Where the drawn pixels are, for the failure message only. On a window this
+// check is complaining about the most frequent sampled colour is the background
+// by definition, so the bounding box of everything else is the region the plugin
+// actually painted, and its share of the window is the number that says "a
+// quarter of it" out loud. Grid-aligned like the counts above.
+struct DrawnExtent
+{
+    bool any;
+    unsigned x0, y0, x1, y1;
+
+    unsigned percentOf(const unsigned width, const unsigned height) const
+    {
+        if (! any || width == 0 || height == 0)
+            return 0;
+        return (unsigned) ((unsigned long) (x1 - x0 + 1) * (y1 - y0 + 1) * 100
+                           / ((unsigned long) width * height));
+    }
+};
+
+DrawnExtent drawnExtent(Display* const display, const Window window,
+                        const unsigned width, const unsigned height)
+{
+    DrawnExtent ext = { false, 0, 0, 0, 0 };
+
+    XImage* const img = XGetImage(display, window, 0, 0, width, height, AllPlanes, ZPixmap);
+    if (img == nullptr)
+        return ext;
+
+    unsigned long value[64] = {};
+    unsigned tally[64] = {};
+    unsigned kinds = 0;
+
+    for (unsigned y = 0; y < height; y += kSampleStep)
+        for (unsigned x = 0; x < width; x += kSampleStep)
+        {
+            const unsigned long px = XGetPixel(img, (int) x, (int) y);
+            unsigned i = 0;
+            for (; i < kinds; ++i)
+                if (value[i] == px) break;
+            if (i == kinds)
+            {
+                // Table full: the dominant colour of a near-empty window is long
+                // since in it, and a 65th shade cannot become the majority now.
+                if (kinds == 64)
+                    continue;
+                value[kinds++] = px;
+            }
+            ++tally[i];
+        }
+
+    unsigned dominant = 0;
+    for (unsigned i = 1; i < kinds; ++i)
+        if (tally[i] > tally[dominant])
+            dominant = i;
+
+    if (kinds != 0)
+        for (unsigned y = 0; y < height; y += kSampleStep)
+            for (unsigned x = 0; x < width; x += kSampleStep)
+            {
+                if (XGetPixel(img, (int) x, (int) y) == value[dominant])
+                    continue;
+                if (! ext.any)
+                {
+                    ext.any = true;
+                    ext.x0 = ext.x1 = x;
+                    ext.y0 = ext.y1 = y;
+                    continue;
+                }
+                if (x < ext.x0) ext.x0 = x;
+                if (x > ext.x1) ext.x1 = x;
+                if (y < ext.y0) ext.y0 = y;
+                if (y > ext.y1) ext.y1 = y;
+            }
+
+    XDestroyImage(img);
+    return ext;
 }
 
 // The editor renders into the child window the plugin creates under the host
@@ -693,20 +830,22 @@ int main(const int argc, const char* const* const argv)
         std::printf("debug       : host parent %dx%d at (%d,%d) map_state=%d\n",
                     pa.width, pa.height, pa.x, pa.y, pa.map_state);
 
-        // Is anything actually being drawn? An editor that never renders has no
-        // ImGui widget rectangles to hit-test against, and every drag would miss
-        // for a reason that has nothing to do with input delivery.
+        // Is anything actually being drawn, and over how much of the window? The
+        // same counts the assertion below judges, printed rather than asserted on,
+        // because an editor that never renders has no widget rectangles to hit-test
+        // against and every drag would miss for a reason that has nothing to do
+        // with input delivery.
         if (XImage* const img = XGetImage(fx.display, parent, 0, 0, width, height, AllPlanes, ZPixmap))
         {
-            unsigned long first = XGetPixel(img, 0, 0);
-            bool uniform = true;
-            for (unsigned int y = 0; y < height && uniform; y += 8)
-                for (unsigned int x = 0; x < width && uniform; x += 8)
-                    if (XGetPixel(img, (int) x, (int) y) != first)
-                        uniform = false;
-            std::printf("debug       : editor pixels %s (first pixel 0x%lx)\n",
-                        uniform ? "UNIFORM -- nothing is being rendered" : "vary -- the editor is drawing",
-                        first);
+            const RenderCoverage dbg = renderCoverage(fx.display, parent, width, height);
+            std::printf("debug       : editor colours %d overall, %d/%d/%d/%d by quadrant NW/NE/SW/SE"
+                        " (bar is %u each): %s\n",
+                        dbg.whole, dbg.quadrant[0], dbg.quadrant[1], dbg.quadrant[2], dbg.quadrant[3],
+                        kColourBar,
+                        dbg.captureFailed()      ? "capture FAILED"
+                        : dbg.whole < (int) kColourBar ? "nothing is being rendered"
+                        : dbg.everyQuadrantDraws()     ? "the editor is drawing"
+                                                       : "PART of the window is being rendered");
 
             // DUSK_UI_DRAG_DUMP writes the editor as a PPM so a human (or a
             // model) can look at what the harness is dragging on. Worth keeping:
@@ -773,13 +912,13 @@ int main(const int argc, const char* const* const argv)
     const Window drawn = renderedChildOf(fx.display, parent);
     const Window sampled = drawn != None ? drawn : parent;
 
-    int colours = 0;
+    RenderCoverage coverage = {};
     fx.pumpUntil([&] {
-        colours = distinctColours(fx.display, sampled, width, height, 8);
-        return colours >= 8 || colours == kCaptureFailed;
+        coverage = renderCoverage(fx.display, sampled, width, height);
+        return coverage.captureFailed() || coverage.everyQuadrantDraws();
     }, 3000);
 
-    if (colours == kCaptureFailed)
+    if (coverage.captureFailed())
     {
         // Not a verdict on the plugin: X refused to hand over the pixels, so
         // there is nothing to judge. Reported separately so it cannot be read
@@ -799,7 +938,7 @@ int main(const int argc, const char* const* const argv)
         return 1;
     }
 
-    if (colours < 8)
+    if (coverage.whole < (int) kColourBar)
     {
         std::fprintf(stderr,
                      "\nFAIL: the editor is not drawing. After three seconds of frames window 0x%lx is\n"
@@ -807,7 +946,39 @@ int main(const int argc, const char* const* const argv)
                      "  below would still pass, because widgets hit-test and emit parameter edits\n"
                      "  whether or not anything reaches the screen -- so this is checked first. Look at\n"
                      "  it with DUSK_UI_DRAG_DUMP=/tmp/editor.ppm; a framework bump is the usual cause.\n",
-                     (unsigned long) sampled, colours);
+                     (unsigned long) sampled, coverage.whole);
+        return 1;
+    }
+
+    if (! coverage.everyQuadrantDraws())
+    {
+        // Drawing, but not everywhere. Name the empty quadrants and the box the
+        // painted pixels fit in, because "a quarter of the window, in the top
+        // right" is the whole diagnosis for a lost viewport or projection.
+        // Four names of two letters plus separators, so 32 is far more than enough.
+        char empty[32] = {};
+        unsigned used = 0;
+        for (unsigned i = 0; i < kQuadrants; ++i)
+            if (coverage.samples[i] != 0 && (unsigned) coverage.quadrant[i] < kColourBar)
+                used += (unsigned) std::snprintf(empty + used, sizeof(empty) - used,
+                                                 "%s%s", used != 0 ? ", " : "", kQuadrantNames[i]);
+
+        const DrawnExtent ext = drawnExtent(fx.display, sampled, width, height);
+
+        std::fprintf(stderr,
+                     "\nFAIL: the editor is drawing into part of its window. After three seconds of\n"
+                     "  frames window 0x%lx (%ux%u) shows %d distinct colour(s) overall, but by quadrant\n"
+                     "  NW/NE/SW/SE it shows %d/%d/%d/%d against a bar of %u each, so %s %s effectively\n"
+                     "  blank. Everything that is not the background colour fits inside x[%u,%u] y[%u,%u],\n"
+                     "  which is %u%% of the window. A faceplate covers all of its window, so this is a\n"
+                     "  viewport or projection regression rather than a blank editor, and the drag phases\n"
+                     "  below would still pass either way. Look at it with DUSK_UI_DRAG_DUMP=/tmp/e.ppm.\n",
+                     (unsigned long) sampled, width, height, coverage.whole,
+                     coverage.quadrant[0], coverage.quadrant[1], coverage.quadrant[2], coverage.quadrant[3],
+                     kColourBar, empty, std::strchr(empty, ',') != nullptr ? "are" : "is",
+                     ext.any ? ext.x0 : 0u, ext.any ? ext.x1 : 0u,
+                     ext.any ? ext.y0 : 0u, ext.any ? ext.y1 : 0u,
+                     ext.percentOf(width, height));
         return 1;
     }
 


### PR DESCRIPTION
## The blind spot

The rendering assertion from #265 counts distinct colours over the whole editor
window and requires 8. It was built to catch an editor that draws nothing, and it
does. It does not catch an editor that draws in the wrong place.

Found while fixing the DGL side of #266. With DGL still setting up its viewport and
projection from the configure event, which pugl stopped dispatching inside the
graphics context, multi-comp-2 painted its whole faceplate into the top-right
quarter of its window and left the rest flat background:

| plugin | editor | distinct colours | drawn area | UiDrag verdict, before this PR |
|---|---|---|---|---|
| tapemachine-2 | 800x470 | 2 | none | FAIL, correctly |
| multi-comp-2 | 1120x380 | 61 | x[560,1119] y[0,189], 25% of the window | **PASS**, 9/9 |

61 clears a bar of 8 comfortably, so the gate reported green for a plugin that was
visibly broken. Every other assertion in the harness is about input, and input was
fine; that is the whole reason the rendering assertion exists, and it was only half
sensitive.

## The criterion

The same 8-colour bar, applied to each quadrant of the sampled window as well as to
the window. One criterion, the same number, four more places it has to hold.

The sampling grid stays the window's rather than each quadrant's, so the
whole-window count is exactly the number this gate has always judged and the
existing `the editor is not drawing` message keeps its meaning for a window that is
blank everywhere. A window that clears the bar overall but not in every quadrant is
a different finding and gets its own message, which names the empty quadrants and
the bounding box of every pixel that is not the dominant (background) colour,
because "a quarter of the window, in the top right" is the entire diagnosis for a
lost viewport or projection.

The alternative considered was a bounding-box span test, requiring the non-background
box to cover at least 90% of each dimension. Rejected: it needs a second threshold
with no evidence behind it, it says nothing about a window whose content is spread
out but sparse, and a plugin that legitimately leaves a margin would have to argue
with a percentage rather than with "this quadrant has detail in it". The quadrant
form reuses the bar that is already justified and already tuned.

The box is still computed, but only to print, where being approximate costs nothing.

## Falsification

Not argued, measured: rebuilt against a DGL without the fix from dusk-audio/DAF#28
(pugl rebased onto its own main, which contains `c125c44`), so the framework is
genuinely broken under it.

multi-comp-2, which used to pass:

```
1/1 Test #8: multi-comp-2UiDrag ...............***Failed    3.60 sec

FAIL: the editor is drawing into part of its window. After three seconds of
  frames window 0x200002 (1120x380) shows 8 distinct colour(s) overall, but by quadrant
  NW/NE/SW/SE it shows 1/8/1/1 against a bar of 8 each, so NW, SW, SE are effectively
  blank. Everything that is not the background colour fits inside x[560,1112] y[0,184],
  which is 24% of the window. A faceplate covers all of its window, so this is a
  viewport or projection regression rather than a blank editor, and the drag phases
  below would still pass either way. Look at it with DUSK_UI_DRAG_DUMP=/tmp/e.ppm.
```

tapemachine-2, which already failed, still fails on the whole-window branch, so the
two findings stay distinguishable:

```
FAIL: the editor is not drawing. After three seconds of frames window 0x200002 is
  showing 2 distinct colour(s); a drawn faceplate has thousands.
```

The box the gate reports, x[560,1112] y[0,184] at 24%, matches an independent
offline analysis of the dumped PPM, x[560,1119] y[0,189] at 25%, to within the
8 pixel sampling step.

## Positive control, both pugl revisions

With the DAF fix in place, against `daf-266` (the dusk-audio/DAF#28 branch):

| build | pugl | result |
|---|---|---|
| tapemachine-2 | pinned 9580fef | `100% tests passed, 0 tests failed out of 4` |
| multi-comp-2 | pinned 9580fef | `100% tests passed, 0 tests failed out of 9` |
| tapemachine-2 | rebased onto pugl main | `100% tests passed, 0 tests failed out of 4` |
| multi-comp-2 | rebased onto pugl main | `100% tests passed, 0 tests failed out of 9` |

## Fleet, on the shipped pin

Fresh build directories per plugin against stock `~/projects/DAF` (3aa9c9d3) and
`~/projects/DAF-Widgets` (487b092a), full ctest under `DISPLAY=:99`. Distinct
colours are measured on the gate's own sampling grid, uncapped, from the dumped
editor.

| plugin | editor | ctest | whole | NW/NE/SW/SE | thinnest quadrant |
|---|---|---|---|---|---|
| 4k-eq-2 | 960x640 | `100% tests passed, 0 tests failed out of 4` | 364 | 137/120/129/108 | 108 |
| tape-echo-2 | 900x340 | `100% tests passed, 0 tests failed out of 5` | 598 | 233/155/167/157 | 155 |
| sunset-circuits | 1240x780 | `100% tests passed, 0 tests failed out of 2` | 757 | 294/215/273/257 | 215 |
| multi-q-2 | 1040x680 | `100% tests passed, 0 tests failed out of 2` | 327 | 79/78/118/138 | 78 |
| tapemachine-2 | 800x470 | `100% tests passed, 0 tests failed out of 4` | 468 | 159/173/164/168 | 159 |
| multi-comp-2 | 1120x380 | `100% tests passed, 0 tests failed out of 9` | 1041 | 300/311/354/366 | 300 |

No faceplate in the fleet has a flat quadrant, and nothing is close to the bar: the
thinnest is multi-q's NE at 78, about ten times 8. The bar did not need loosening
and was not loosened.

Stability: multi-q-2, the thinnest margin in the fleet, run three times in a row,
`100% tests passed` each time.

## Follow-up in this branch

The first revision read the background as the most frequent colour of the whole
window, from a table capped at 64 entries filled in raster order. CodeRabbit was
right that a window with more than 64 sampled colours drops the later ones, so a
background first met after the table filled is never tallied, and the reported box
would then be measured against a painted colour. Second commit reads it off the
blank quadrants instead, which is what blank means and which bounds the table by
construction at four times the bar. The verdict is untouched (this code only runs
after the criterion has already failed) and the reported numbers are unchanged.

## Also in this change

The `DUSK_UI_DRAG_DEBUG` print used its own uniform-pixel scan and called the broken
multi-comp-2 window "vary, the editor is drawing", which is exactly the wrong
conclusion sitting next to the new failure. It now reports the same counts the
assertion judges.

## Not verified

Linux and Xvfb only, which is where these gates run. Nothing here depends on the
platform beyond X11 itself.

Refs #266, dusk-audio/DAF#28.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UI rendering checks to more accurately detect partially rendered windows.
  - Diagnostics now report the extent of the content that was actually painted.
  - Enhanced background-color detection reduces incorrect partial-rendering classifications and improves failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->