### PR TITLE
Bump the DAF pin onto pugl's fork main

### DIFF
--- a/.github/workflows/daf-au-test.yml
+++ b/.github/workflows/daf-au-test.yml
@@ -11,7 +11,7 @@ on:
       - 'tape-echo-daf-v*'
 
 env:
-  DAF_SHA: 3aa9c9d309867afda3c0400bbca8d77bf5198e00
+  DAF_SHA: 38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3
   DAFWIDGETS_SHA: 487b092aa265458feb8320308a1fa36ca0901a5b
 
 jobs:

--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -66,7 +66,7 @@ on:
 # checkouts on the pinned SHAs (docker/check_daf_pins.sh) so a hand-tested build
 # is the one CI produces.
 env:
-  DAF_REF: 3aa9c9d309867afda3c0400bbca8d77bf5198e00
+  DAF_REF: 38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3
   DAFWIDGETS_REF: 487b092aa265458feb8320308a1fa36ca0901a5b
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/.github/workflows/daf-release.yml
+++ b/.github/workflows/daf-release.yml
@@ -42,7 +42,7 @@ on:
 # daf-build.yml, daf-au-test.yml and docker/build_release.sh, and re-run the
 # dispatch matrix before tagging.
 env:
-  DAF_SHA: 3aa9c9d309867afda3c0400bbca8d77bf5198e00
+  DAF_SHA: 38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3
   DAFWIDGETS_SHA: 487b092aa265458feb8320308a1fa36ca0901a5b
   PLUGIN_DIR: plugins/sunset-circuits/daf-plugin
   SLUG: sunset-circuits

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -18,7 +18,7 @@ IMAGE_NAME="dusk-plugins-builder"
 # DAF / DAF-Widgets SHAs — keep in sync with daf-build.yml, daf-release.yml and daf-au-test.yml.
 # Both come from permanent dusk-audio hard forks (dusk-audio/DAF and
 # dusk-audio/DAF-Widgets); never fetch either from upstream DISTRHO.
-DAF_SHA="3aa9c9d309867afda3c0400bbca8d77bf5198e00"
+DAF_SHA="38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3"
 DAFWIDGETS_SHA="487b092aa265458feb8320308a1fa36ca0901a5b"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)


### PR DESCRIPTION
Last step of #266. Moves `DAF_REF` from `3aa9c9d3` to `38ed3b9d`, which brings in both
open pieces of that chain at once.

## The chain

| PR | what it did |
|---|---|
| dusk-audio/DAF#28 | moved DGL's drawing state setup (viewport, blend mode, projection, modelview) off the configure path and onto the expose path |
| dusk-audio/pugl#5 | put our three fork commits on the fork's `main`, rebased onto 78 upstream commits |
| dusk-audio/DAF#29 | moved DAF's pugl submodule from the stale `dusk/302-app-contract` to that `main` at `54e400e`, and ported the Wayland backend to the private API those commits changed |

The pin was blocked on one thing. pugl `c125c44` stopped entering the graphics context
for configure events, and DGL was setting up its viewport and projection from that
event, so moving the pin on its own produced plugins that built, passed every gate and
drew nothing at all: input works perfectly on a window with no pixels in it. #28 is what
makes this bump safe to take, and the per-quadrant rendering assertion from #270 is what
would now catch it.

Two fixes of ours that have been sitting unshipped arrive with the new pugl: `6ef2489`,
the swallowed first click on an unfocused macOS plugin view, and `5a2238c`, the X11
BadWindow crash on window repositioning. The X11 one is a no-op in our configuration
(DGL calls `puglSetPositionHint`, which already fails on an unrealized view); the macOS
one is real value for Logic and AU users.

Worth stating plainly: DAF#28 merged before this bump, so **plugins CI has been building
against a DAF without it until now**. Nothing was broken in the field, because on the old
pugl pin the old code path worked. What it means is that #28 has not been exercised by
this repo's CI, and this PR is the first build that does.

## The four files

| file | key |
|---|---|
| `.github/workflows/daf-build.yml` | `DAF_REF` |
| `.github/workflows/daf-release.yml` | `DAF_SHA` |
| `.github/workflows/daf-au-test.yml` | `DAF_SHA` |
| `docker/build_release.sh` | `DAF_SHA` |

`DAFWIDGETS_REF` stays at `487b092a`. After the change, `grep -rn 3aa9c9d3` over the
whole repo returns nothing, so no doc, manual or script still carries the old SHA.

## Verification

Built against `~/projects/DAF` at the new pin, checked out the documented way with
`docker/check_daf_pins.sh --fix`, which also moved the submodule to `54e400e`. The pin
that was built is the pin that ships: `git rev-parse HEAD` is
`38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3` and `HEAD:dgl/src/pugl-upstream` is
`54e400e988373caf9e352fb6c618d0bb84caaadb`, and that tree diffs empty against the DAF#29
head that was tested, so nothing was re-verified against a different tree than the one
CI will fetch.

Fresh build directories, full `ctest` under Xvfb, editors captured through the drag
harness and compared pixel by pixel against the same plugin built on the previous pin:

| plugin | editor | ctest | distinct colours | differing pixels |
|---|---|---|---|---|
| 4k-eq-2 | 960x640 | `100% tests passed, 0 tests failed out of 4` | 2698 | 0 of 614400 |
| tape-echo-2 | 900x340 | `100% tests passed, 0 tests failed out of 5` | 5833 | 0 of 306000 |
| sunset-circuits | 1240x780 | `100% tests passed, 0 tests failed out of 2` | 5767 | 0 of 967200 |
| multi-q-2 | 1040x680 | `100% tests passed, 0 tests failed out of 2` | 3955 | 0 of 707200 |
| tapemachine-2 | 800x470 | `100% tests passed, 0 tests failed out of 4` | 4473 | 0 of 376000 |
| multi-comp-2 | 1120x380 | `100% tests passed, 0 tests failed out of 9` | 6854 | 0 of 425600 |

Every editor is byte identical to the previous pin. The gates include the quadrant
assertion from #270, so a partial render would fail rather than pass quietly.

Windows 11 and macOS were verified on dusk-audio/DAF#29, at the identical tree this pin
names: both plugins built on each host with their own pinned-pugl control, pluginval at
strictness 10 clean on both revisions on both hosts, clap-validator identical on Windows,
and the Windows editors drawing with every quadrant in the thousands of colours on both
revisions.

## Remaining gap

The macOS editor has still not been looked at. No user is logged in at that machine's
console, so there is no window server session to open a plugin editor in: pluginval traps
immediately with GUI tests enabled there, and the macOS run is strictness 10 minus the
GUI tests. `6ef2489`'s first-click fix in particular wants a real plugin window in a real
host. Worth a console login and one manual look before the next release goes out, not a
reason to hold this pin.

Closes #266.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the pinned DAF framework revision used during testing, builds, releases, and containerized plugin packaging.
  - Ensures these workflows consistently use the newer DAF revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->