### PR TITLE
Bump the DAF pin onto the pugl first-mouse fix

### DIFF
--- a/.github/workflows/daf-au-test.yml
+++ b/.github/workflows/daf-au-test.yml
@@ -11,7 +11,7 @@ on:
       - 'tape-echo-daf-v*'
 
 env:
-  DAF_SHA: 38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3
+  DAF_SHA: 22b8282461c5847057aa31b7f210bc9e0652366e
   DAFWIDGETS_SHA: 487b092aa265458feb8320308a1fa36ca0901a5b
 
 jobs:

--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -66,7 +66,7 @@ on:
 # checkouts on the pinned SHAs (docker/check_daf_pins.sh) so a hand-tested build
 # is the one CI produces.
 env:
-  DAF_REF: 38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3
+  DAF_REF: 22b8282461c5847057aa31b7f210bc9e0652366e
   DAFWIDGETS_REF: 487b092aa265458feb8320308a1fa36ca0901a5b
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk

--- a/.github/workflows/daf-release.yml
+++ b/.github/workflows/daf-release.yml
@@ -42,7 +42,7 @@ on:
 # daf-build.yml, daf-au-test.yml and docker/build_release.sh, and re-run the
 # dispatch matrix before tagging.
 env:
-  DAF_SHA: 38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3
+  DAF_SHA: 22b8282461c5847057aa31b7f210bc9e0652366e
   DAFWIDGETS_SHA: 487b092aa265458feb8320308a1fa36ca0901a5b
   PLUGIN_DIR: plugins/sunset-circuits/daf-plugin
   SLUG: sunset-circuits

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -18,7 +18,7 @@ IMAGE_NAME="dusk-plugins-builder"
 # DAF / DAF-Widgets SHAs — keep in sync with daf-build.yml, daf-release.yml and daf-au-test.yml.
 # Both come from permanent dusk-audio hard forks (dusk-audio/DAF and
 # dusk-audio/DAF-Widgets); never fetch either from upstream DISTRHO.
-DAF_SHA="38ed3b9d6e0257588a481bed8aa87d9ca4c5e3e3"
+DAF_SHA="22b8282461c5847057aa31b7f210bc9e0652366e"
 DAFWIDGETS_SHA="487b092aa265458feb8320308a1fa36ca0901a5b"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)


### PR DESCRIPTION
Last link of the #266 chain, and the one that actually fixes the macOS first click.
Moves `DAF_REF` from `38ed3b9d` to `22b82824`.

## What it carries

dusk-audio/DAF#30, which moves DAF's pugl submodule from `54e400e` to `d46e7871`, that is
pugl fork PR #6. The whole pugl delta is 32 added lines across four Objective-C files, and
no header, public or private, changes:

```
$ git diff --stat 54e400e d46e7871 -- src/platform.h src/internal.h src/types.h
$
```

## The previous pin did not fix what it said

`6ef2489`, which PR #272 brought in, added `acceptsFirstMouse:` to `PuglWrapperView`.
AppKit never asks that view. `puglRealize` adds the backend draw view as a subview of the
wrapper and sizes it to the wrapper's bounds, nothing in pugl overrides `hitTest:`, so the
deepest view under the pointer is the hit view: for any click inside the editor, the draw
view. AppKit sends `acceptsFirstMouse:` to that view, got `NSView`'s default of NO from
`PuglOpenGLView`, `PuglCairoView`, `PuglStubView` and `PuglVulkanView`, and swallowed the
click that activates an unfocused window. Mouse handling lives on the wrapper and is
reached through the responder chain, which is why clicks work once the window has focus;
the responder chain only matters after a click is delivered, and delivery was the half
that failed.

pugl #6 overrides `acceptsFirstMouse:` on all four draw view classes and keeps the
wrapper's override for the case where the wrapper is the hit view.

Both halves were established by hand rather than by reading the patch. At the previous
pin, with `6ef2489` present, a press and drag on an unfocused editor in REAPER on macOS
26.6.1 still did nothing while the same gesture worked with focus. That is the symptom
`6ef2489` said it fixed, on a build containing it. The result is in #266.

The object files agree. At `9580fef`, before `6ef2489`, a built plugin has no
`acceptsFirstMouse:` implementation at all; at `54e400e` it has exactly one, on
`PuglWrapperView`; at this pin it has one for every view class the macOS build compiles.

## The four files

| file | key |
|---|---|
| `.github/workflows/daf-build.yml` | `DAF_REF` |
| `.github/workflows/daf-release.yml` | `DAF_SHA` |
| `.github/workflows/daf-au-test.yml` | `DAF_SHA` |
| `docker/build_release.sh` | `DAF_SHA` |

`DAFWIDGETS_REF` stays at `487b092a`. After the change, `grep -rn 38ed3b9d` over the whole
repo returns nothing.

## Verification

Built against `~/projects/DAF` at the new pin, checked out with
`docker/check_daf_pins.sh --fix`, which also moved the submodule to `d46e7871`. The pin
that was built is the pin that ships: `git rev-parse HEAD` is
`22b8282461c5847057aa31b7f210bc9e0652366e` and `HEAD:dgl/src/pugl-upstream` is
`d46e787109378e04b9a8d1474f3a4123d28cd9fb`, and that tree diffs empty against the DAF#30
head that was tested.

Fresh build directories, full `ctest` under Xvfb, editors compared pixel by pixel against
the same plugin on the previous pin:

| plugin | editor | ctest | distinct colours | differing pixels |
|---|---|---|---|---|
| 4k-eq-2 | 960x640 | `100% tests passed, 0 tests failed out of 4` | 2698 | 0 of 614400 |
| tape-echo-2 | 900x340 | `100% tests passed, 0 tests failed out of 5` | 5833 | 0 of 306000 |
| sunset-circuits | 1240x780 | `100% tests passed, 0 tests failed out of 2` | 5767 | 0 of 967200 |
| multi-q-2 | 1040x680 | `100% tests passed, 0 tests failed out of 2` | 3955 | 0 of 707200 |
| tapemachine-2 | 800x470 | `100% tests passed, 0 tests failed out of 4` | 4473 | 0 of 376000 |
| multi-comp-2 | 1120x380 | `100% tests passed, 0 tests failed out of 9` | 6854 | 0 of 425600 |

Linux compiles none of the changed files, so identical editors are the expected result.
Measured rather than assumed, since the cost of measuring is a few minutes and the cost of
assuming was this whole chain.

The forced Wayland configuration, DAF's own test suite, and the macOS build, gates and
pluginval run were all covered on dusk-audio/DAF#30 at this same tree. Windows is CI only
for this one: the pugl diff is Objective-C that no Windows build compiles.

Refs #266.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned DAF framework revision used by macOS testing, builds, releases, and container packaging.
  * Ensures automated processes use the same updated framework version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->