### PR TITLE
Chord Analyzer: number the inversion off the matched chord shape

### DIFF
--- a/manuals/chord-analyzer.md
+++ b/manuals/chord-analyzer.md
@@ -123,7 +123,7 @@ These parameters expose the detection result for host automation, screen-recordi
 - **Detected Root:** Current chord root (12 values).
 - **Detected Quality:** Current chord quality (major, minor, 7, maj7, m7, sus2, sus4, dim, aug, etc.).
 - **Detected Bass:** Bass note for slash chords (like C/E or G/B).
-- **Detected Inversion:** Which inversion is currently being played.
+- **Detected Inversion:** Which inversion is currently being played, named after the degree in the bass: `Root`, `1st` (3rd in the bass), `2nd` (5th), `3rd` (7th), `4th` (9th), `5th` (11th), `6th` (13th). A bass note the chord does not contain, such as the F# under `Cadd#11/F#`, reads `Slash` rather than a numbered inversion.
 
 You cannot set these from the host; they update automatically as the plugin detects chords.
 

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.cpp
@@ -127,7 +127,7 @@ ChordFacts ChordAnalyzer::analyzeFacts(const int* midiNotes, int numNotes) const
     }
 
     facts.quality = chordPatterns[static_cast<size_t>(facts.patternIndex)].quality;
-    facts.inversion = calculateInversion(facts.bassNote, facts.rootNote);
+    facts.inversion = calculateInversion(facts.bassNote, facts.rootNote, facts.patternIndex);
     facts.slashBass = (facts.bassNote != facts.rootNote);
     facts.confidence = calculateConfidence(facts.patternIndex, facts.intervals);
     facts.isValid = true;
@@ -406,6 +406,47 @@ juce::String ChordAnalyzer::getKeyName() const
 }
 
 //==============================================================================
+namespace
+{
+    // Inversion ordinal of one pattern tone: which degree of the stacked-thirds
+    // spelling it is (see kInversionSlashBass in ChordAnalyzer.h). The interval
+    // on its own does not say - 3 semitones is the minor third of an m7 and the
+    // #9 of a 7#9, 9 semitones is the sixth of a 6 chord and the diminished
+    // seventh of a dim7 - so the whole pattern being described is passed in.
+    //
+    // The compound spellings (14, 17, 21) fold to the same ordinal as their
+    // simple forms, so a 9th in the bass numbers the same whether the pattern
+    // states it as 2 (sus2) or as 14 (every extended chord).
+    //
+    // Returns -1 for an interval no pattern is allowed to contain;
+    // buildPatternMasks asserts on it rather than letting it pass silently.
+    int degreeOrdinalOf(int interval, const std::set<int>& patternIntervals)
+    {
+        switch (interval)
+        {
+            case 0:  return 0;                        // root
+            case 1:  return 4;                        // b9
+            case 2:  return 4;                        // 9, stated simple by sus2
+            case 3:  // minor third, unless a major third is also spelled: then #9
+                return patternIntervals.count(4) != 0 ? 4 : 1;
+            case 4:  return 1;                        // major third
+            case 5:  return 5;                        // 11th, stated simple by sus4
+            case 6:  return 2;                        // b5. No pattern spells a #11 here
+            case 7:  return 2;                        // perfect fifth
+            case 8:  return 2;                        // #5. No pattern spells a b13 here
+            case 9:  // diminished seventh of a fully diminished chord, else the 6th
+                return (patternIntervals.count(3) != 0 && patternIntervals.count(6) != 0)
+                           ? 3 : 6;
+            case 10: return 3;                        // minor seventh
+            case 11: return 3;                        // major seventh
+            case 14: return 4;                        // 9th
+            case 17: return 5;                        // 11th
+            case 21: return 6;                        // 13th
+            default: return -1;
+        }
+    }
+}
+
 std::vector<ChordAnalyzer::PatternMask> ChordAnalyzer::buildPatternMasks()
 {
     std::vector<PatternMask> masks;
@@ -413,12 +454,25 @@ std::vector<ChordAnalyzer::PatternMask> ChordAnalyzer::buildPatternMasks()
 
     for (const auto& pattern : chordPatterns)
     {
-        PatternMask m { 0u, 0u, 0 };
+        PatternMask m { 0u, 0u, 0, { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 } };
 
         for (int interval : pattern.intervals)
         {
             m.intervals |= (1u << interval);
-            m.pitches = static_cast<std::uint16_t>(m.pitches | (1u << (interval % 12)));
+
+            const int pitchClass = interval % 12;
+            m.pitches = static_cast<std::uint16_t>(m.pitches | (1u << pitchClass));
+
+            const int degree = degreeOrdinalOf(interval, pattern.intervals);
+
+            // Every tone of every pattern has to number, and no pattern may
+            // spell one pitch class as two different degrees - the ordinal is
+            // looked up by pitch class, so a collision would have no answer.
+            jassert(degree >= 0);
+            jassert(m.degrees[pitchClass] < 0 || m.degrees[pitchClass] == degree);
+
+            if (degree >= 0)
+                m.degrees[pitchClass] = static_cast<std::int8_t>(degree);
         }
 
         m.pitchCount = countPitchClasses(m.pitches);
@@ -681,18 +735,31 @@ juce::String ChordAnalyzer::describeAddedTones(int patternIndex, std::uint32_t i
     return text;
 }
 
-int ChordAnalyzer::calculateInversion(int bassPitch, int root) noexcept
+int ChordAnalyzer::calculateInversion(int bassPitch, int root, int patternIndex) noexcept
 {
     if (bassPitch == root)
         return 0;
 
+    // Nothing matched, so there is no spelling to number the bass against.
+    if (patternIndex < 0 || patternIndex >= static_cast<int>(kPatternMasks.size()))
+        return 0;
+
     const int bassInterval = ((bassPitch - root) + 12) % 12;
+    const int degree = kPatternMasks[static_cast<size_t>(patternIndex)].degrees[bassInterval];
 
-    if (bassInterval == 3 || bassInterval == 4) return 1;  // Third in bass
-    if (bassInterval == 7) return 2;  // Fifth in bass
-    if (bassInterval == 10 || bassInterval == 11) return 3;  // Seventh in bass
+    // A bass the pattern does not spell is an added tension or a foreign bass,
+    // not an inversion: C E G under an F# is Cadd#11/F#, and calling that root
+    // position (which every non-chord-tone bass used to report) told the host
+    // the exact opposite of what is sounding. Issue #273.
+    return degree >= 0 ? degree : kInversionSlashBass;
+}
 
-    return 0;
+std::uint16_t ChordAnalyzer::patternPitchClasses(int patternIndex) noexcept
+{
+    if (patternIndex < 0 || patternIndex >= static_cast<int>(kPatternMasks.size()))
+        return 0;
+
+    return kPatternMasks[static_cast<size_t>(patternIndex)].pitches;
 }
 
 float ChordAnalyzer::calculateConfidence(int patternIndex, std::uint32_t intervals) noexcept

--- a/plugins/chord-analyzer/Source/ChordAnalyzer.h
+++ b/plugins/chord-analyzer/Source/ChordAnalyzer.h
@@ -69,6 +69,23 @@ enum class SuggestionCategory
 };
 
 //==============================================================================
+// Inversion numbering. An inversion is the ordinal of the bass tone in the
+// chord's stacked-thirds spelling, judged against the pattern that matched:
+//
+//   0  root      1  third      2  fifth      3  seventh
+//   4  ninth     5  eleventh   6  thirteenth
+//
+// The interval alone cannot decide it - 3 semitones above the root is the minor
+// third of an m7 and the #9 of a 7#9 - so the numbering always goes through the
+// matched pattern.
+//
+// A bass the matched pattern does not spell (an added tension, or a foreign
+// bass such as the F# under a C triad) is no inversion at all. It gets its own
+// value, sorted after the six real ordinals so the host parameter that renders
+// these can append one choice for it.
+inline constexpr int kInversionSlashBass = 7;
+
+//==============================================================================
 // Numeric analysis result: no strings, no heap, safe to compute on an audio
 // thread. The headless LV2 wrapper publishes only these fields.
 struct ChordFacts
@@ -76,7 +93,7 @@ struct ChordFacts
     int rootNote = -1;              // Root pitch class (0-11, C=0)
     int bassNote = -1;              // Lowest note pitch class
     ChordQuality quality = ChordQuality::Unknown;
-    int inversion = 0;              // 0=root, 1=first, 2=second, 3=seventh
+    int inversion = 0;              // 0..6 by degree, kInversionSlashBass otherwise
     bool slashBass = false;         // Bass is not the root
     bool isValid = false;
     float confidence = 0.0f;
@@ -104,7 +121,7 @@ struct ChordInfo
     int bassNote = -1;              // Lowest note pitch class
     ChordQuality quality = ChordQuality::Unknown;
     juce::String extensions;        // Any additional text
-    int inversion = 0;              // 0=root, 1=first, 2=second, etc.
+    int inversion = 0;              // 0..6 by degree, kInversionSlashBass otherwise
     bool slashBass = false;         // Bass is not the root - display slash notation
     bool isValid = false;
     float confidence = 0.0f;        // 0.0-1.0 confidence score
@@ -206,6 +223,12 @@ public:
     static int encodeLabel(const ChordInfo& chord, bool showInversions) noexcept;
     static juce::String decodeLabel(int code);
 
+    //==========================================================================
+    // Pitch classes the pattern at this index spells, one bit each, or 0 for an
+    // index outside the table. Public so a test can state the inversion
+    // contract in the pattern's own terms rather than restating the table.
+    static std::uint16_t patternPitchClasses(int patternIndex) noexcept;
+
 private:
     int keyRoot = 0;        // C
     bool minorKey = false;
@@ -237,6 +260,12 @@ private:
         std::uint32_t intervals;
         std::uint16_t pitches;
         int           pitchCount;
+
+        // Inversion ordinal of each pitch class in this pattern's spelling (see
+        // kInversionSlashBass above for the numbering), -1 for a pitch class the
+        // pattern does not spell. Resolved once, at static-init time, because
+        // the same interval means different degrees in different patterns.
+        std::int8_t   degrees[12];
     };
 
     static const std::vector<PatternMask> kPatternMasks;
@@ -249,7 +278,7 @@ private:
     static bool patternMatches(int patternIndex, std::uint32_t intervals) noexcept;
     static int countPitchClasses(std::uint16_t mask) noexcept;
     static int matchPattern(std::uint32_t intervals) noexcept;   // -1 if none
-    static int calculateInversion(int bassPitch, int root) noexcept;
+    static int calculateInversion(int bassPitch, int root, int patternIndex) noexcept;
     static float calculateConfidence(int patternIndex, std::uint32_t intervals) noexcept;
 
     //==========================================================================

--- a/plugins/chord-analyzer/Source/PluginProcessor.cpp
+++ b/plugins/chord-analyzer/Source/PluginProcessor.cpp
@@ -62,7 +62,19 @@ ChordAnalyzerProcessor::ChordAnalyzerProcessor()
     const juce::StringArray qualityChoices(
         qualityChoiceLabels, qualityChoiceCount);
 
-    const juce::StringArray inversionChoices{ "-", "Root", "1st", "2nd", "3rd" };
+    // Inversion choices: index 0 = "-" (no chord), 1 = root position, then one
+    // per ordinal of the bass tone in the chord's stacked-thirds spelling (3rd,
+    // 5th, 7th, 9th, 11th, 13th in the bass), and a final "Slash" for a bass the
+    // matched chord shape does not spell at all. Appended to, never reordered:
+    // a saved session addresses a choice by index.
+    static constexpr const char* inversionChoiceLabels[]{
+        "-", "Root", "1st", "2nd", "3rd", "4th", "5th", "6th", "Slash" };
+    constexpr int inversionChoiceCount =
+        static_cast<int>(sizeof(inversionChoiceLabels) / sizeof(inversionChoiceLabels[0]));
+    static_assert(inversionChoiceCount == kInversionSlashBass + 2,
+                  "Detected-inversion choices must cover \"-\", every ordinal and the slash bass");
+    const juce::StringArray inversionChoices(
+        inversionChoiceLabels, inversionChoiceCount);
 
     detectedRootParam = new juce::AudioParameterChoice(
         juce::ParameterID(PARAM_DETECTED_ROOT, 1),
@@ -538,8 +550,10 @@ void ChordAnalyzerProcessor::stageDetectedChord(const ChordInfo& chord)
         ? std::max(0, detectedQualityParam->choices.size() - 1) : 0;
     const int qualityIndex = juce::jlimit(
         0, maxQualityIndex, rawQualityIndex);
+    const int maxInversionIndex = detectedInversionParam != nullptr
+        ? std::max(0, detectedInversionParam->choices.size() - 1) : 0;
     const int inversionIndex = chord.isValid
-                                  ? juce::jlimit(0, 4, chord.inversion + 1) : 0;
+                                  ? juce::jlimit(0, maxInversionIndex, chord.inversion + 1) : 0;
 
     pendingRootIndex.store(rootIndex);
     pendingQualityIndex.store(qualityIndex);

--- a/plugins/chord-analyzer/Source/TheoryTooltips.h
+++ b/plugins/chord-analyzer/Source/TheoryTooltips.h
@@ -254,6 +254,14 @@ public:
                 return "SECOND INVERSION: The 5th is in the bass. Less stable - classically used for cadential 6/4, neighbor, or passing motion.";
             case 3:
                 return "THIRD INVERSION: The 7th is in the bass (for 7th chords). Creates strong voice leading tendency down by step.";
+            case 4:
+                return "FOURTH INVERSION: The 9th is in the bass (for 9th chords and above). Rootless, floating sound over a stepwise bass.";
+            case 5:
+                return "FIFTH INVERSION: The 11th is in the bass (for 11th chords and above). Reads as a suspension over the bass note.";
+            case 6:
+                return "SIXTH INVERSION: The 13th is in the bass (for 13th chords). Very open voicing; the bass often doubles as the relative minor root.";
+            case kInversionSlashBass:
+                return "SLASH BASS: The bass note is not part of the chord. An added colour tone under the chord rather than an inversion of it.";
             default:
                 return "";
         }

--- a/plugins/chord-analyzer/lv2/chord-analyzer-headless.ttl
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-headless.ttl
@@ -185,13 +185,17 @@
         lv2:name "Detected Inversion" ;
         lv2:default 0 ;
         lv2:minimum 0 ;
-        lv2:maximum 4 ;
+        lv2:maximum 8 ;
         lv2:portProperty lv2:integer , lv2:enumeration ;
-        lv2:scalePoint [ rdfs:label "-"    ; rdf:value 0 ] ,
-                       [ rdfs:label "Root" ; rdf:value 1 ] ,
-                       [ rdfs:label "1st"  ; rdf:value 2 ] ,
-                       [ rdfs:label "2nd"  ; rdf:value 3 ] ,
-                       [ rdfs:label "3rd"  ; rdf:value 4 ]
+        lv2:scalePoint [ rdfs:label "-"     ; rdf:value 0 ] ,
+                       [ rdfs:label "Root"  ; rdf:value 1 ] ,
+                       [ rdfs:label "1st"   ; rdf:value 2 ] ,
+                       [ rdfs:label "2nd"   ; rdf:value 3 ] ,
+                       [ rdfs:label "3rd"   ; rdf:value 4 ] ,
+                       [ rdfs:label "4th"   ; rdf:value 5 ] ,
+                       [ rdfs:label "5th"   ; rdf:value 6 ] ,
+                       [ rdfs:label "6th"   ; rdf:value 7 ] ,
+                       [ rdfs:label "Slash" ; rdf:value 8 ]
     ] , [
         a lv2:InputPort , lv2:ControlPort ;
         lv2:index 10 ;

--- a/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
+++ b/plugins/chord-analyzer/lv2/chord-analyzer-lv2.cpp
@@ -83,8 +83,11 @@ void publishDetectedChord (ChordAnalyzerLV2& self, const ChordFacts& chord)
                                  ? chord.bassNote + 1 : 0;
     const int qualityIndex   = (chord.isValid && chord.quality != ChordQuality::Unknown)
                                  ? static_cast<int> (chord.quality) + 1 : 0;
+    // 0 == "-", 1 == root position, 2..7 the six inversion ordinals, 8 a bass
+    // the matched chord shape does not spell. Mirrors the JUCE variant's
+    // "Detected Inversion" choices and the scale points in the .ttl.
     const int inversionIndex = chord.isValid
-                                 ? std::clamp (chord.inversion + 1, 0, 4) : 0;
+                                 ? std::clamp (chord.inversion + 1, 0, kInversionSlashBass + 1) : 0;
 
     if (self.detectedRoot      != nullptr) *self.detectedRoot      = static_cast<float> (rootIndex);
     if (self.detectedQuality   != nullptr) *self.detectedQuality   = static_cast<float> (qualityIndex);

--- a/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
+++ b/plugins/chord-analyzer/tests/test_chord_analyzer.cpp
@@ -164,6 +164,238 @@ static void testInversions()
 }
 
 // =====================================================================
+// 4b. Inversions past the seventh, and a bass the chord does not spell
+//
+// Issue #273: the bass used to be numbered off raw interval classes, which
+// knew the 3rd, the 5th and the 7th and called every other bass "root
+// position", so the reporter's C9 voiced over its own 9th read as root
+// position. The bass is now numbered against the matched pattern's spelling,
+// which both extends the numbering to the 9th, 11th and 13th and tells a
+// pattern tone from a bass the pattern does not spell at all.
+// =====================================================================
+static void testExtendedInversions()
+{
+    std::cout << "\n--- Extended Inversions (issue #273) ---\n";
+    ChordAnalyzer a;
+
+    // The reporter's own voicing: D3 E3 G3 Bb3 C4, a C9 over its 9th.
+    auto ninth = analyzeNotes(a, {50, 52, 55, 58, 60});
+    check("C9 with the 9th in the bass is a 4th inversion",
+          ninth.isValid && ninth.quality == ChordQuality::Dominant9
+           && ninth.rootNote == 0 && ninth.bassNote == 2 && ninth.inversion == 4);
+    std::cout << "       D3 E3 G3 Bb3 C4 -> " << ninth.name << ninth.extensions
+              << ", inversion " << ninth.inversion << "\n";
+
+    // 11th in the bass of an 11 chord: F C E G Bb D
+    auto eleventh = analyzeNotes(a, {53, 60, 64, 67, 70, 74});
+    check("C11 with the 11th in the bass is a 5th inversion",
+          eleventh.isValid && eleventh.quality == ChordQuality::Dominant11
+           && eleventh.rootNote == 0 && eleventh.bassNote == 5 && eleventh.inversion == 5);
+
+    // 13th in the bass of a 13 chord: A C E G Bb D F
+    auto thirteenth = analyzeNotes(a, {57, 60, 64, 67, 70, 74, 77});
+    check("C13 with the 13th in the bass is a 6th inversion",
+          thirteenth.isValid && thirteenth.quality == ChordQuality::Dominant13
+           && thirteenth.rootNote == 0 && thirteenth.bassNote == 9
+           && thirteenth.inversion == 6);
+
+    // The same degree stated simply rather than compound: the 13-without-9/11
+    // shape spells its 13th as 21 too, so A C E G Bb numbers the same way.
+    auto simple13 = analyzeNotes(a, {57, 60, 64, 67, 70});
+    check("C13 (no 9/11) with the 13th in the bass is a 6th inversion",
+          simple13.isValid && simple13.quality == ChordQuality::Dominant13
+           && simple13.rootNote == 0 && simple13.inversion == 6);
+
+    // b9 in the bass: Db C E G Bb
+    auto flat9 = analyzeNotes(a, {49, 60, 64, 67, 70});
+    check("C7b9 with the b9 in the bass is a 4th inversion",
+          flat9.isValid && flat9.quality == ChordQuality::Dominant7Flat9
+           && flat9.rootNote == 0 && flat9.bassNote == 1 && flat9.inversion == 4);
+
+    // #9 in the bass: Eb C E G Bb. Three semitones above the root, but this
+    // pattern also spells a major third, so the Eb is the #9 and not the third.
+    auto sharp9 = analyzeNotes(a, {51, 60, 64, 67, 70});
+    check("C7#9 with the #9 in the bass is a 4th inversion",
+          sharp9.isValid && sharp9.quality == ChordQuality::Dominant7Sharp9
+           && sharp9.rootNote == 0 && sharp9.bassNote == 3 && sharp9.inversion == 4);
+
+    // ...and the same three semitones stay a third where the pattern spells a
+    // third: Cm9 over its own Eb. A plain m7 cannot be tested this way: with
+    // the minor third in the bass, Eb G Bb C reads as Eb6 in root position.
+    auto minorThird = analyzeNotes(a, {51, 60, 67, 70, 74});
+    check("Cm9 with the minor 3rd in the bass is still a 1st inversion",
+          minorThird.isValid && minorThird.quality == ChordQuality::Minor9
+           && minorThird.rootNote == 0 && minorThird.bassNote == 3
+           && minorThird.inversion == 1);
+
+    // A triad with its 9th in the bass: D C E G Bb-less, i.e. Cadd9 over the D.
+    // add9 spells the 9th as 14, so the D is the fourth degree of the stack.
+    auto add9 = analyzeNotes(a, {50, 60, 64, 67, 74});
+    check("Cadd9 with the 9th in the bass is a 4th inversion",
+          add9.isValid && add9.quality == ChordQuality::Add9
+           && add9.rootNote == 0 && add9.bassNote == 2 && add9.inversion == 4);
+
+    // An altered fifth is still the fifth degree: C Eb Gb over the Gb.
+    auto dimFifth = analyzeNotes(a, {54, 60, 63, 66});
+    check("Cdim with the b5 in the bass is a 2nd inversion",
+          dimFifth.isValid && dimFifth.quality == ChordQuality::Diminished
+           && dimFifth.rootNote == 0 && dimFifth.bassNote == 6
+           && dimFifth.inversion == 2);
+
+    // A suspended tone numbers as the degree it is: the 4th of a sus chord is
+    // an 11th, and the 2nd of a sus2 is a 9th. The number says which degree is
+    // in the bass, so calling either of them a first inversion would claim a
+    // third that is not sounding.
+    auto sus4 = analyzeNotes(a, {53, 60, 65, 67, 70});
+    check("C7sus4 with the 4th in the bass is a 5th inversion",
+          sus4.isValid && sus4.quality == ChordQuality::Dominant7Sus4
+           && sus4.rootNote == 0 && sus4.bassNote == 5 && sus4.inversion == 5);
+
+    auto sus2 = analyzeNotes(a, {50, 60, 62, 67});
+    check("Csus2 with the 2nd in the bass is a 4th inversion",
+          sus2.isValid && sus2.quality == ChordQuality::Sus2
+           && sus2.rootNote == 0 && sus2.bassNote == 2 && sus2.inversion == 4);
+
+    // A shape that leaves the fifth out still numbers by degree, not by
+    // position in the voicing: the Bb is the seventh, so it is a 3rd inversion.
+    auto shell = analyzeNotes(a, {58, 60, 64});
+    check("C7(no5) with the 7th in the bass is a 3rd inversion",
+          shell.isValid && shell.quality == ChordQuality::Dominant7
+           && shell.rootNote == 0 && shell.bassNote == 10 && shell.inversion == 3);
+
+    // A bass the matched pattern does not spell is no inversion at all. The
+    // display already showed this one as a slash (issue #235); the number now
+    // agrees instead of claiming root position.
+    auto foreign = analyzeNotes(a, {54, 60, 64, 67});
+    check("C major over a foreign F# bass is the slash value",
+          foreign.isValid && foreign.quality == ChordQuality::Major
+           && foreign.rootNote == 0 && foreign.bassNote == 6
+           && foreign.inversion == kInversionSlashBass);
+    check("the foreign bass still displays as a slash",
+          foreign.name == "Cadd#11" && foreign.slashBass && foreign.extensions == "/F#");
+
+    // Root position is still root position, and nothing else reports 0.
+    check("root position is still 0", analyzeNotes(a, {60, 64, 67, 70, 74}).inversion == 0);
+}
+
+// =====================================================================
+// 4c. The inversion contract over every chord the analyzer can name.
+//
+// The ordinal is restated here in the contract's own terms - which degree of
+// the matched pattern the bass is - and checked against every pitch-class set
+// in every rotation. The implementation resolves the compound spellings (14,
+// 17, 21) through the pattern's raw intervals; this oracle resolves them
+// through the folded pitch classes, so the two disagree if either drifts.
+// =====================================================================
+static int expectedInversion(int bassInterval, std::uint16_t patternPitches)
+{
+    auto spells = [patternPitches](int pitchClass)
+    {
+        return (patternPitches & (1u << pitchClass)) != 0;
+    };
+
+    if (! spells(bassInterval))
+        return kInversionSlashBass;    // an added tension or a foreign bass
+
+    switch (bassInterval)
+    {
+        case 0:  return 0;                              // root
+        case 1:  return 4;                              // b9
+        case 2:  return 4;                              // 9
+        case 3:  return spells(4) ? 4 : 1;              // #9 beside a major third, else the third
+        case 4:  return 1;                              // major third
+        case 5:  return 5;                              // 11th
+        case 6:  return 2;                              // b5
+        case 7:  return 2;                              // perfect fifth
+        case 8:  return 2;                              // #5
+        case 9:  return (spells(3) && spells(6)) ? 3 : 6;   // dim 7th, else the 13th
+        case 10: return 3;                              // minor seventh
+        default: return 3;                              // major seventh
+    }
+}
+
+static void testInversionProperty()
+{
+    std::cout << "\n--- Inversion contract over every pitch-class set ---\n";
+    ChordAnalyzer a;
+
+    int checked = 0, mismatches = 0, slashCases = 0;
+    int ordinalCounts[8] = { 0 };
+    juce::String firstMismatch;
+
+    for (int mask = 0; mask < 4096; ++mask)
+    {
+        std::vector<int> pcs;
+        for (int i = 0; i < 12; ++i)
+            if (mask & (1 << i))
+                pcs.push_back(i);
+
+        if (pcs.empty())
+            continue;
+
+        // every rotation, so the bass varies over the whole set
+        for (size_t rot = 0; rot < pcs.size(); ++rot)
+        {
+            std::vector<int> notes;
+            for (size_t i = 0; i < pcs.size(); ++i)
+                notes.push_back((i < rot ? 72 : 60) + pcs[i]);
+            std::sort(notes.begin(), notes.end());
+
+            const ChordFacts facts = a.analyzeFacts(notes.data(), (int) notes.size());
+
+            if (! facts.isValid)
+                continue;
+
+            const int bassInterval = ((facts.bassNote - facts.rootNote) + 12) % 12;
+            const std::uint16_t pitches = ChordAnalyzer::patternPitchClasses(facts.patternIndex);
+            const int expected = expectedInversion(bassInterval, pitches);
+
+            ++checked;
+
+            if (facts.inversion >= 0 && facts.inversion < 8)
+                ++ordinalCounts[facts.inversion];
+
+            if (facts.inversion == kInversionSlashBass)
+                ++slashCases;
+
+            const bool rootIsBass = (bassInterval == 0);
+
+            if (facts.inversion != expected
+                || (facts.inversion == 0) != rootIsBass
+                || facts.inversion < 0 || facts.inversion > kInversionSlashBass)
+            {
+                ++mismatches;
+
+                if (firstMismatch.isEmpty())
+                {
+                    firstMismatch = "mask " + juce::String(mask) + " rot " + juce::String((int) rot)
+                                  + ": pattern " + juce::String(facts.patternIndex)
+                                  + " bass interval " + juce::String(bassInterval)
+                                  + " expected " + juce::String(expected)
+                                  + " got " + juce::String(facts.inversion);
+                }
+            }
+        }
+    }
+
+    std::cout << "       (" << checked << " named voicings checked, "
+              << slashCases << " of them over a bass the pattern does not spell)\n";
+    std::cout << "       ordinals:";
+    for (int i = 0; i <= kInversionSlashBass; ++i)
+        std::cout << " " << i << "=" << ordinalCounts[i];
+    std::cout << "\n";
+
+    if (! firstMismatch.isEmpty())
+        std::cout << "       first mismatch: " << firstMismatch << "\n";
+
+    check("every named voicing numbers its bass by the matched pattern's degrees",
+          mismatches == 0);
+    check("the slash value is reached", slashCases > 0);
+    check("every ordinal past the seventh is reached",
+          ordinalCounts[4] > 0 && ordinalCounts[5] > 0 && ordinalCounts[6] > 0);
+}
+
+// =====================================================================
 // 5. Roman numerals in C major
 // =====================================================================
 static void testRomanNumeralsMajor()
@@ -817,6 +1049,8 @@ int main()
     testSevenths();
     testSusAdd();
     testInversions();
+    testExtendedInversions();
+    testInversionProperty();
     testRomanNumeralsMajor();
     testRomanNumeralsMinor();
     testHarmonicFunctions();

--- a/plugins/chord-analyzer/tests/test_detected_chord_param.cpp
+++ b/plugins/chord-analyzer/tests/test_detected_chord_param.cpp
@@ -9,7 +9,9 @@
       * a chord fed through processBlock reaches the parameter as text on the
         normal 20 Hz publish path, with no editor open;
       * Show Inversions changes that text with no note changing;
-      * the output parameters stay out of the saved state.
+      * the output parameters stay out of the saved state;
+      * "Detected Inversion" carries every ordinal the analyzer can report,
+        including the ones added for issue #273.
 */
 
 #include "../Source/PluginProcessor.h"
@@ -135,6 +137,37 @@ static void testLiveParameterText(juce::RangedAudioParameter& chordParam)
 }
 
 //==============================================================================
+// "Detected Inversion" gained four choices for issue #273: the 4th, 5th and 6th
+// inversions the old interval-class numbering could not express, and a "Slash"
+// for a bass the matched chord shape does not spell. They are appended, so a
+// session saved before this keeps the meaning of indices 0..4.
+static void testInversionChoices(juce::AudioProcessor& processor)
+{
+    std::cout << "\n--- Detected Inversion choices ---\n";
+
+    auto* param = dynamic_cast<juce::AudioParameterChoice*>(
+        findParameter(processor, ChordAnalyzerProcessor::PARAM_DETECTED_INVERSION));
+
+    check("Detected Inversion is a choice parameter", param != nullptr);
+
+    if (param == nullptr)
+        return;
+
+    const juce::StringArray expected{ "-", "Root", "1st", "2nd", "3rd",
+                                      "4th", "5th", "6th", "Slash" };
+
+    std::cout << "       choices: " << param->choices.joinIntoString(" ") << "\n";
+
+    check("Detected Inversion has one choice per ordinal plus the slash bass",
+          param->choices.size() == kInversionSlashBass + 2);
+    check("Detected Inversion choices read as declared", param->choices == expected);
+    check("the choices existing sessions address are unchanged",
+          param->choices[0] == "-" && param->choices[1] == "Root"
+           && param->choices[2] == "1st" && param->choices[3] == "2nd"
+           && param->choices[4] == "3rd");
+}
+
+//==============================================================================
 // The saved state must not carry detection results: they are outputs, and the
 // existing four are added straight to the processor rather than to the APVTS
 // for exactly that reason.
@@ -175,8 +208,10 @@ static void testStateExcludesOutputs(ChordAnalyzerProcessor& processor)
 class PublishDriver : private juce::Timer
 {
 public:
-    PublishDriver(ChordAnalyzerProcessor& p, juce::RangedAudioParameter& chordParam)
-        : processor(p), param(chordParam)
+    PublishDriver(ChordAnalyzerProcessor& p,
+                  juce::RangedAudioParameter& chordParam,
+                  juce::RangedAudioParameter& inversionParam)
+        : processor(p), param(chordParam), inversion(inversionParam)
     {
         startTimer(150);
     }
@@ -250,6 +285,36 @@ private:
 
             case 6:
                 check("no notes publishes \"-\"", param.getCurrentValueAsText() == "-");
+                check("no notes publishes no inversion",
+                      inversion.getCurrentValueAsText() == "-");
+                // The voicing from issue #273: D3 E3 G3 Bb3 C4, a C9 over its 9th.
+                sendNotes({ 50, 52, 55, 58, 60 }, {});
+                break;
+
+            case 7:
+                check("the 9th in the bass publishes as a 4th inversion",
+                      inversion.getCurrentValueAsText() == "4th");
+                std::cout << "       D3 E3 G3 Bb3 C4: \"" << param.getCurrentValueAsText()
+                          << "\", inversion \"" << inversion.getCurrentValueAsText() << "\"\n";
+                check("the same voicing still publishes its label",
+                      param.getCurrentValueAsText() == "C9/D");
+                sendNotes({ 54, 60, 64, 67 }, { 50, 52, 55, 58, 60 });
+                break;
+
+            case 8:
+                check("a bass the chord does not spell publishes as Slash",
+                      inversion.getCurrentValueAsText() == "Slash");
+                std::cout << "       F#2 C4 E4 G4: \"" << param.getCurrentValueAsText()
+                          << "\", inversion \"" << inversion.getCurrentValueAsText() << "\"\n";
+                sendNotes({ 52, 60, 64, 67 }, { 54 });
+                break;
+
+            case 9:
+                check("the third in the bass still publishes as a 1st inversion",
+                      inversion.getCurrentValueAsText() == "1st");
+                std::cout << "       E3 C4 E4 G4: \"" << param.getCurrentValueAsText()
+                          << "\", inversion \"" << inversion.getCurrentValueAsText() << "\"\n";
+                sendNotes({}, { 52, 60, 64, 67 });
                 break;
 
             default:
@@ -261,6 +326,7 @@ private:
 
     ChordAnalyzerProcessor& processor;
     juce::RangedAudioParameter& param;
+    juce::RangedAudioParameter& inversion;
     int step = 0;
 };
 
@@ -302,12 +368,23 @@ int main()
     check("Detected Chord was appended after the existing parameters",
           processor.getParameters().getLast() == chordParam);
 
+    auto* inversionParam = findParameter(processor,
+                                         ChordAnalyzerProcessor::PARAM_DETECTED_INVERSION);
+    check("Detected Inversion parameter exists", inversionParam != nullptr);
+
+    if (inversionParam == nullptr)
+    {
+        std::cout << "\n=== Results: " << passed << " passed, " << (failed + 1) << " failed ===\n";
+        return 1;
+    }
+
     testParameterRoundTrip(*chordParam);
     testLiveParameterText(*chordParam);
+    testInversionChoices(processor);
     testStateExcludesOutputs(processor);
 
     std::cout << "\n--- Publish path ---\n";
-    PublishDriver driver(processor, *chordParam);
+    PublishDriver driver(processor, *chordParam, *inversionParam);
     juce::MessageManager::getInstance()->runDispatchLoop();
 
     processor.releaseResources();


### PR DESCRIPTION
Closes #273.

## The bug

`calculateInversion(bassPitch, root)` numbered the bass off raw interval
classes and knew three of them:

```cpp
if (bassInterval == 3 || bassInterval == 4) return 1;  // Third in bass
if (bassInterval == 7) return 2;  // Fifth in bass
if (bassInterval == 10 || bassInterval == 11) return 3;  // Seventh in bass
return 0;
```

Everything else fell through to 0, and the "Detected Inversion" parameter renders
0 as "Root". The reporter's C9 voiced D3 E3 G3 Bb3 C4 has its 9th in the bass and
published "Root". So did an 11th chord over its 11th, a 13th over its 13th, a b9
in the bass, and the upper-structure bass the display already showed as a slash
(`Cadd#11/F#`). The one case that did not read "Root" read worse: `C7#9` over its
own Eb reported a first inversion, claiming a third that is not in the chord.

## The mechanism

The bass is now numbered against the pattern that matched, which is the only
thing that can decide it. Three semitones above the root is the minor third of an
`m7` and the `#9` of a `7#9`; those are different degrees and number differently.
The ordinal is the position of the bass tone in the chord's stacked-thirds
spelling:

| Degree in the bass | Ordinal | Parameter text |
|---|---|---|
| root | 0 | `Root` |
| 3rd, major or minor | 1 | `1st` |
| 5th, perfect or altered (b5, #5) | 2 | `2nd` |
| 7th, major, minor or diminished | 3 | `3rd` |
| 9th, natural, b9 or #9 | 4 | `4th` |
| 11th, natural or #11 | 5 | `5th` |
| 13th, natural or b13 | 6 | `6th` |
| a tone the pattern does not spell | `kInversionSlashBass` (7) | `Slash` |

Each pattern's ordinal per pitch class is resolved once at static-init time into
`PatternMask`, the mask table analysis already reads. `calculateInversion` is one
array lookup, so `analyzeFacts` still allocates nothing and stays audio-thread
safe.

Two intervals are ambiguous across the pattern table and the resolution is
explicit in `degreeOrdinalOf`:

- 3 semitones is a `#9` when the pattern also spells a major third (only
  `{0,3,4,7,10}`, the `7#9`), otherwise the minor third.
- 9 semitones is a diminished 7th in a fully diminished chord (the pattern also
  spells a minor third and a b5), otherwise the 6th/13th. This one is
  theoretical: the exhaustive sweep below shows no `6`, `m6` or `dim7` voicing
  ever reaches the analyzer with that tone in the bass, because those shapes are
  symmetric or lose the root election to the bass tone (C6 over an A reads Am7,
  Cdim7 over an A reads Adim7).

Compound spellings fold to their simple form, so a 9th numbers the same whether
the pattern states it as 2 (`sus2`) or 14 (every extended chord), an 11th whether
5 (`sus4`) or 17, a 13th whether 9 or 21. The 13-without-9/11 shape spells its
13th as 21, so `A C E G Bb` numbers 6 like the full `C13` does.

## Design decisions

**Sus chords number by degree, not by position.** `C7sus4` over its F reports
`5th`, not `1st`. The number names which degree is in the bass, and the 4th of a
sus chord is an 11th: reporting `1st` would tell the host a third is sounding
when the whole point of a sus chord is that none is. Same reasoning puts `Csus2`
over its D at `4th`. `Csus4` over its F never arises (F G C elects F and reads
`Fsus2`), so only the seventh-bearing sus chords hit this.

**A triad's 9th in the bass is `4th`.** `Cadd9` spells its 9th as 14, so D in the
bass is the fourth degree of the stack. Consistent with `C9`, which the reporter
filed about.

**Slash rather than "-".** A foreign bass gets a new final choice `Slash`, not
the "no chord" value. "-" already means "nothing is detected", and a host reading
it could not tell a chord with an odd bass from silence. `Slash` lets a rig like
Gig Performer see that something other than a chord tone is under the chord
without opening the editor. The editor's own slash display is untouched: it keys
off `slashBass`, which has not changed.

**Appended, never reordered.** `"4th"`, `"5th"`, `"6th"`, `"Slash"` go on the end,
so indices 0..4 keep the meaning saved sessions and existing automation gave
them. A `static_assert` ties the choice count to `kInversionSlashBass`, and
`stageDetectedChord` now clamps against the parameter's own `choices.size()` the
way the quality index already did, rather than a literal 4.

## Verification

**Unit tests** (`ChordAnalyzerTest`): 137 passed / 0 failed before, **155 passed /
0 failed** after. The reporter's exact voicing:

```
[PASS] C9 with the 9th in the bass is a 4th inversion
       D3 E3 G3 Bb3 C4 -> C9/D, inversion 4
```

plus the 11th (5th), 13th (6th), 13-no-9/11 (6th), b9 (4th), #9 (4th), the m9
whose minor third still reads 1st, add9 with the 9th in the bass (4th), dim with
the b5 (2nd), 7sus4 (5th), sus2 (4th), the no-fifth shell with its 7th in the
bass (3rd), and `C E G` under an F# (`Slash`, still displaying `Cadd#11/F#`).

**Brute force**, all 4096 pitch-class masks in every rotation, the ordinal
checked against a restatement of the contract written in terms of the pattern's
own pitch classes (the implementation resolves compound spellings through the raw
intervals, the oracle through the folded mask, so either drifting is caught):

```
       (24136 named voicings checked, 5043 of them over a bass the pattern does not spell)
       ordinals: 0=7831 1=2631 2=2950 3=2795 4=1662 5=996 6=228 7=5043
[PASS] every named voicing numbers its bass by the matched pattern's degrees
[PASS] the slash value is reached
[PASS] every ordinal past the seventh is reached
```

Zero exceptions, and `inversion == 0` if and only if the bass is the root.

**Assertion evidence.** The two `jassert`s in `buildPatternMasks` were each broken
on their own in a debug build (`-DDEBUG=1 -O0`, since Release compiles `jassert`
out) and watched to fire, then restored. Giving the major triad an interval
`degreeOrdinalOf` does not map (`{0, 4, 7}` to `{0, 4, 7, 13}`) trips
`jassert(degree >= 0)`:

```
JUCE Assertion failure in ChordAnalyzer.cpp:471
```

Making one pattern spell a pitch class as two different degrees (`dim7`
`{0, 3, 6, 9}` to `{0, 3, 6, 9, 21}`, so pitch class 9 is both the diminished
seventh and a 13th) trips the collision guard:

```
JUCE Assertion failure in ChordAnalyzer.cpp:472
```

Restored, both are silent again.

**Falsification.** With `calculateInversion`'s old body restored and nothing else
changed, the same suite goes to 141 passed / 14 failed:

```
[FAIL] C9 with the 9th in the bass is a 4th inversion
       D3 E3 G3 Bb3 C4 -> C9/D, inversion 0
...
       first mismatch: mask 21 rot 1: pattern 35 bass interval 2 expected 4 got 0
```

**Host side** (`ChordAnalyzerHostTest`, real processor, real parameter, real 20 Hz
publish path): 31 passed / 0 failed.

```
       choices: - Root 1st 2nd 3rd 4th 5th 6th Slash
[PASS] Detected Inversion has one choice per ordinal plus the slash bass
[PASS] the 9th in the bass publishes as a 4th inversion
       D3 E3 G3 Bb3 C4: "C9/D", inversion "4th"
[PASS] a bass the chord does not spell publishes as Slash
       F#2 C4 E4 G4: "Cadd#11/F#", inversion "Slash"
[PASS] the third in the bass still publishes as a 1st inversion
       E3 C4 E4 G4: "C/E", inversion "1st"
```

**"Detected Chord" is unchanged.** Its own sweep from #269 ran unmodified: 295341
codes through `convertTo0to1`/`convertFrom0to1`/`getText` and 295341 through the
live parameter, all matching `decodeLabel`. The label does not read `inversion`.

**Build**: `ChordAnalyzer_VST3 ChordAnalyzerMIDI_VST3 ChordAnalyzerTest
ChordAnalyzerHostTest ChordAnalyzer_LV2 ChordAnalyzerMIDI_LV2
ChordAnalyzerHeadless_LV2 ChordAnalyzer_CLAP` all clean, exit 0. No new warnings:
every warning the touched translation units emit is pre-existing
(`-Wswitch-enum` on the quality helpers, `-Wsign-conversion` on the history
array and the editor's button loops, `-Wfloat-equal` in `findRoot`), and none
lands in a changed hunk.

**pluginval 1.0.4** on the freshly built artifacts, not the installed copies,
levels 1/5/7/10, both variants, all SUCCESS. It reports `Detected Inversion ...
numSteps - 9` at parameter index 8, so the count is what is declared and the
parameter order is unchanged. `./tests/run_plugin_tests.sh --plugin "Chord
Analyzer" --skip-audio`: 9 passed, 0 failed (note that it validates whatever sits
in `~/.vst3`, which is why the fresh artifacts were run separately).

## LV2

The headless variant's `detected_inversion` control port goes to maximum 8 and
gains the four new scale points, matching the JUCE choices label for label. The
JUCE-generated `dsp.ttl` for the main plugin picks the same nine scale points up
from the parameter automatically. The edited bundle parses (`rapper -i turtle -c`,
376 to 388 triples, exactly the twelve a scale point block times four adds) and
loads through lilv (`lv2info` reports the port with `Maximum: 8.000000`).
`lv2_validate` is installed here but its `sord_validate` backend is not, so
`rapper` plus a lilv load stood in for it.

The headless binary was also driven end to end through a throwaway LV2 host that
dlopens the bundle, feeds MIDI note-ons and reads the output control ports, so the
numbers a Zynthian would render are measured rather than inferred:

```
URI: https://dusk-audio.github.io/plugins/chord-analyzer-headless
D3 E3 G3 Bb3 C4 (C9/D)       root=1 quality=22 bass=3 inversion=5
F#2 C4 E4 G4 (Cadd#11/F#)    root=1 quality=1 bass=7 inversion=8
E3 C4 E4 G4 (C/E)            root=1 quality=1 bass=5 inversion=2
C4 E4 G4 (C)                 root=1 quality=1 bass=1 inversion=1
```

Against the port's scale points that reads 4th, Slash, 1st and Root.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded chord inversion detection to support root position through 6th inversion.
  * Added “Slash” detection for bass notes not included in the recognized chord.
  * Extended inversion labels and explanations across plugin formats.

* **Documentation**
  * Clarified the meaning of detected inversion values, including slash-bass results.

* **Tests**
  * Added coverage for extended chords, altered and suspended chords, omitted notes, and unmatched bass notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
