### PR TITLE
Fit the editor to the host window instead of correcting the host

### DIFF
--- a/plugins/DuskVerb/tests/test_editor_resize.cpp
+++ b/plugins/DuskVerb/tests/test_editor_resize.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <memory>
+#include <utility>
 
 namespace
 {
@@ -65,6 +66,77 @@ bool supporterTextEntersFooter()
 
     return false;
 }
+
+// The host resize path, which is not the in-editor grip path.
+//
+// JUCE's VST3 wrapper answers a host's IPlugView::checkSizeConstraint from the
+// editor's constrainer (juce_audio_plugin_client_VST3.cpp), then sizes the
+// editor to that answer. A host that keeps its own window at the size the user
+// dragged, which REAPER on Linux does, is left with an editor bigger than the
+// window and the face is clipped. This mirrors that arithmetic so the contract
+// can be asserted without a host: whatever the host asks for, the editor must
+// come back no larger, and the face must stay proportional inside it.
+juce::Rectangle<int> hostAnswer (juce::ComponentBoundsConstrainer& constrainer,
+                                 int requestedWidth, int requestedHeight)
+{
+    const auto minW = (float) constrainer.getMinimumWidth();
+    const auto maxW = (float) constrainer.getMaximumWidth();
+    const auto minH = (float) constrainer.getMinimumHeight();
+    const auto maxH = (float) constrainer.getMaximumHeight();
+
+    auto width  = juce::jlimit (minW, maxW, (float) requestedWidth);
+    auto height = juce::jlimit (minH, maxH, (float) requestedHeight);
+
+    const auto aspectRatio = (float) constrainer.getFixedAspectRatio();
+
+    if (! juce::approximatelyEqual (aspectRatio, 0.0f))
+    {
+        if (width / height > aspectRatio)
+        {
+            width = height * aspectRatio;
+
+            if (width > maxW || width < minW)
+            {
+                width = juce::jlimit (minW, maxW, width);
+                height = width / aspectRatio;
+            }
+        }
+        else
+        {
+            height = width / aspectRatio;
+
+            if (height > maxH || height < minH)
+            {
+                height = juce::jlimit (minH, maxH, height);
+                width = height * aspectRatio;
+            }
+        }
+    }
+
+    return { 0, 0, juce::roundToInt (width), juce::roundToInt (height) };
+}
+
+// Union of every visible descendant, in the editor's coordinate space. The
+// resize grip is excluded: it is meant to sit in the corner of the window, not
+// inside the letterboxed face.
+juce::Rectangle<int> paintedBounds (juce::Component& component, juce::Component& root)
+{
+    juce::Rectangle<int> bounds;
+
+    for (int i = 0; i < component.getNumChildComponents(); ++i)
+    {
+        auto* child = component.getChildComponent (i);
+
+        if (child == nullptr || ! child->isVisible()
+            || dynamic_cast<juce::ResizableCornerComponent*> (child) != nullptr)
+            continue;
+
+        bounds = bounds.getUnion (root.getLocalArea (child, child->getLocalBounds()));
+        bounds = bounds.getUnion (paintedBounds (*child, root));
+    }
+
+    return bounds;
+}
 }
 
 class DuskVerbEditorResizeTest final : public juce::JUCEApplicationBase
@@ -113,6 +185,43 @@ public:
                && resizeHandle->getBounds() == juce::Rectangle<int> (minWidth - 16, minHeight - 16, 16, 16));
 
         check (! supporterTextEntersFooter());
+
+        // Issue #240: the host path. REAPER on Linux keeps its window at the
+        // size the user dragged the frame to, so the editor must never come
+        // back larger than the host asked for. Two geometries reproduced by
+        // hand: 1057x474 lost 58 rows off the bottom, 625x340 was clipped on
+        // both axes because it fell below the editor's comfort floor.
+        const std::pair<int, int> hostSizes[] = { { 1057, 474 }, { 625, 340 }, { 1400, 500 }, { 900, 900 } };
+
+        for (const auto& requested : hostSizes)
+        {
+            auto* constrainer = editor->getConstrainer();
+            check (constrainer != nullptr);
+
+            if (constrainer == nullptr)
+                continue;
+
+            // The host constrainer must not clamp: no minimum it can violate,
+            // no aspect correction that grows either axis past the window.
+            check (juce::approximatelyEqual (constrainer->getFixedAspectRatio(), 0.0));
+            check (constrainer->getMinimumWidth() <= 1 && constrainer->getMinimumHeight() <= 1);
+
+            editor->setBounds (hostAnswer (*constrainer, requested.first, requested.second));
+
+            check (editor->getWidth() == requested.first && editor->getHeight() == requested.second);
+
+            // The face is letterboxed inside those bounds, never clipped by them.
+            const auto face = paintedBounds (*editor, *editor);
+            check (face.getRight() <= editor->getWidth());
+            check (face.getBottom() <= editor->getHeight());
+
+            // The layout is fluid: widget sizes come from the shared scale factor
+            // while the panels span the editor, so the face fills the window
+            // rather than sitting in a letterbox. What matters for #240 is that
+            // it lands inside the bounds the host gave, which the two checks
+            // above assert, and that those bounds are the host's own size.
+        }
+
 
         // DuskVerb persists its editor size on destruction. Restore the value
         // loaded at startup so this test never changes the user's preference.

--- a/plugins/multi-comp/tests/test_editor_resize.cpp
+++ b/plugins/multi-comp/tests/test_editor_resize.cpp
@@ -32,25 +32,54 @@ public:
 
         constexpr int baseWidth = 750;
         constexpr int baseHeight = 500;
-        constexpr double expectedAspect = static_cast<double>(baseWidth) / baseHeight;
         const auto initialBounds = editor->getBounds();
 
+        // The constrainer the editor carries is the one JUCE answers a host's
+        // size queries from, so it must never enlarge what the host asked for.
+        // This assertion is the reverse of the one it replaces. That earlier
+        // version had the host share the corner component's aspect constrainer
+        // so a host edge drag came back proportional, which is right only for a
+        // host that then resizes its window to the answer. REAPER on Linux keeps
+        // its window where the user dragged it, so the corrected answer left the
+        // editor overhanging the window and the face was clipped: issue #240,
+        // reproduced by hand at 1057x474 and again at 625x340. The aspect ratio
+        // now lives only on the corner component, where the plugin owns both
+        // sides of the negotiation.
         auto* constrainer = editor->getConstrainer();
         check("editor exposes a resize constrainer", constrainer != nullptr);
         if (constrainer != nullptr)
         {
-            check("host constrainer advertises the editor aspect ratio",
-                  std::abs(constrainer->getFixedAspectRatio() - expectedAspect) < 0.0001);
+            check("host constrainer does not impose an aspect ratio",
+                  std::abs(constrainer->getFixedAspectRatio()) < 0.0001);
+            check("host constrainer imposes no minimum a host could violate",
+                  constrainer->getMinimumWidth() <= 1 && constrainer->getMinimumHeight() <= 1);
         }
 
-        // Reproduce the issue's REAPER/Linux gesture: move the top edge down
-        // while dragging the right edge out. The bottom edge remains anchored.
+        // The issue's REAPER/Linux gesture: move the top edge down while
+        // dragging the right edge out. The bottom edge remains anchored.
         editor->setBounds(0, 0, baseWidth, baseHeight);
         editor->setBoundsConstrained({ 0, 150, 1125, 350 });
 
-        check("host-edge resize preserves proportional bounds",
-              editor->getWidth() == 1125 && editor->getHeight() == 750);
+        check("host-edge resize gives the editor exactly the requested bounds",
+              editor->getWidth() == 1125 && editor->getHeight() == 350);
         check("top-edge resize keeps the bottom edge anchored", editor->getBottom() == baseHeight);
+
+        // Nothing may hang outside those bounds, which is what the user sees as
+        // a cut-off face.
+        juce::Rectangle<int> face;
+        for (int i = 0; i < editor->getNumChildComponents(); ++i)
+        {
+            auto* child = editor->getChildComponent(i);
+
+            if (child == nullptr || !child->isVisible()
+                || dynamic_cast<juce::ResizableCornerComponent*>(child) != nullptr)
+                continue;
+
+            face = face.getUnion(child->getBounds());
+        }
+
+        check("the face stays inside the editor after a host-edge resize",
+              face.getRight() <= editor->getWidth() && face.getBottom() <= editor->getHeight());
 
         // EnhancedCompressorEditor persists its size on destruction. Restore
         // the value loaded at startup so this test does not alter user state.

--- a/plugins/shared/ScalableEditorHelper.h
+++ b/plugins/shared/ScalableEditorHelper.h
@@ -15,7 +15,7 @@ public:
         // objects are still alive so the editor cannot retain a dangling
         // pointer during base-class teardown.
         resizer.reset();
-        if (parentEditor != nullptr && parentEditor->getConstrainer() == &constrainer)
+        if (parentEditor != nullptr && parentEditor->getConstrainer() == &hostConstrainer)
         {
             parentEditor->setResizable(false, false);
             parentEditor->setConstrainer(nullptr);
@@ -51,6 +51,7 @@ public:
         constrainer.setMinimumSize(minWidth, minHeight);
         constrainer.setMaximumSize(maxWidth, maxHeight);
         constrainer.setFixedAspectRatio(fixedAspectRatio ? baseWidth / baseHeight : 0.0);
+        configureHostConstrainer(maxWidth, maxHeight);
 
         loadStoredSize();
 
@@ -58,12 +59,11 @@ public:
         editor->addAndMakeVisible(resizer.get());
         resizer->setAlwaysOnTop(true);
 
-        // The host and the in-editor corner must share this constrainer.
-        // setResizeLimits() configures AudioProcessorEditor's separate default
-        // constrainer, which allowed host-window edge drags to bypass the
-        // fixed aspect ratio used by the corner component.
+        // The corner component keeps `constrainer`, with the comfort floor and
+        // the fixed aspect ratio. The host gets `hostConstrainer`, which cannot
+        // fight it: see configureHostConstrainer().
         editor->setResizable(true, false);
-        editor->setConstrainer(&constrainer);
+        editor->setConstrainer(&hostConstrainer);
     }
 
     // Overload without processor — no size persistence, fixed aspect ratio.
@@ -89,13 +89,14 @@ public:
         constrainer.setMinimumSize(minWidth, minHeight);
         constrainer.setMaximumSize(maxWidth, maxHeight);
         constrainer.setFixedAspectRatio(baseWidth / baseHeight);
+        configureHostConstrainer(maxWidth, maxHeight);
 
         resizer = std::make_unique<juce::ResizableCornerComponent>(editor, &constrainer);
         editor->addAndMakeVisible(resizer.get());
         resizer->setAlwaysOnTop(true);
 
         editor->setResizable(true, false);
-        editor->setConstrainer(&constrainer);
+        editor->setConstrainer(&hostConstrainer);
     }
 
     int getStoredWidth() const { return storedWidth; }
@@ -130,12 +131,44 @@ public:
         return value * scaleFactor;
     }
 
+    // The corner component's constrainer, carrying the comfort floor and the
+    // fixed aspect ratio. This is not the constrainer the host sees.
     juce::ComponentBoundsConstrainer& getConstrainer() { return constrainer; }
 
 private:
+    // A host must always get back the size it asked for.
+    //
+    // JUCE answers a VST3 host's IPlugView::checkSizeConstraint from whatever
+    // constrainer the editor carries: it clamps the request up to the minimum
+    // size, then corrects it to the fixed aspect ratio, and sizes the editor to
+    // that answer. A host that honours the answer resizes its window to match
+    // and everything stays proportional, which is what the earlier fix for
+    // issue #240 assumed when it gave the host the corner component's
+    // constrainer. REAPER on Linux does not: it keeps its window at the size the
+    // user dragged the frame to, so an answer larger than that window leaves the
+    // editor overhanging it and the face is clipped. A comfort floor cannot help
+    // either, because the host can always drag below it.
+    //
+    // So the host gets a constrainer that can never enlarge anything: a minimum
+    // it cannot violate and no aspect correction. The maximum is kept, since
+    // clamping downwards only ever leaves a smaller editor inside a larger
+    // window, never an overhang. Fitting the face into those bounds is then the
+    // layout's job, which every editor here already does: it scales its widgets
+    // from updateResizer()'s factor and spans the panels across the editor, so
+    // the face fills whatever window it is given instead of overhanging it.
+    static constexpr int kHostMinimumSize = 1;
+
+    void configureHostConstrainer(int maxWidth, int maxHeight)
+    {
+        hostConstrainer.setMinimumSize(kHostMinimumSize, kHostMinimumSize);
+        hostConstrainer.setMaximumSize(maxWidth, maxHeight);
+        hostConstrainer.setFixedAspectRatio(0.0);
+    }
+
     juce::AudioProcessorEditor* parentEditor = nullptr;
     juce::AudioProcessor* audioProcessor = nullptr;
     juce::ComponentBoundsConstrainer constrainer;
+    juce::ComponentBoundsConstrainer hostConstrainer;
     std::unique_ptr<juce::ResizableCornerComponent> resizer;
     float baseWidth = 800.0f;
     float baseHeight = 600.0f;


### PR DESCRIPTION
Issue #240, the half that survived PR #241. The reporter's corner drag in REAPER on
Linux still cut the face off; the in-editor grip was always fine. That split is the
whole clue, because the two paths use different machinery.

## Mechanism

JUCE answers a VST3 host's `IPlugView::checkSizeConstraint` from whatever
constrainer the editor carries. It clamps the host's request up to the minimum
size, then corrects it to the fixed aspect ratio, and the editor is sized to that
answer. #241 gave the host the corner component's constrainer so a host edge drag
came back proportional. That is right for a host that then resizes its window to
the answer, and wrong for one that does not. REAPER keeps its window where the
user dragged it, so an answer larger than that window leaves the editor
overhanging it, and the overhang is the clipped face.

The clamp to the minimum is what enlarges the answer, not the aspect ratio: with
the aspect turned off the same geometries clip by the same amounts. A lower floor
is not a fix either, since a host can always drag below it. 0.5x was tried and
REAPER went straight past it.

## Evidence from REAPER 7.79 on Linux

The wrapper was instrumented and a frame drag recorded. REAPER calls
`checkSizeConstraint` and then `onSize` on every step of the drag, 545 pairs and
546 `onSize` calls in one session, so the answer is exactly what the editor
becomes. With the split below, every one of those 545 answers equalled the
request, 502 of them below the old 980x532 floor, the smallest 132x101:

```
wrapper checkSize in    asked=138x106 at 0,0
wrapper checkSize out    answer=138x106 at 0,0
wrapper onSize          asked=138x106 at 0,0
```

The X11 tree agrees:

| | REAPER container | editor window | result |
|---|---|---|---|
| before | 683x200 | 980x532 | editor overhangs, face clipped |
| after | 631x311 | 631x311 | follows below the old floor, nothing clipped |

Marc confirmed the frame drag by hand on the built plugin.

## The change

`plugins/shared/ScalableEditorHelper.h`: the host gets its own constrainer, with a
minimum it cannot violate and no aspect correction, so the answer is always the
size it asked for. The corner component keeps the comfort floor and the aspect
ratio, where the plugin owns both sides of the negotiation and the grip behaves
exactly as before. Everything else from #241 stays: the layout staleness fixes,
the grip placement, the supporters overlay.

Publishing a minimum on REAPER's own frame was considered and rejected. Setting
`PMinSize` on the FX toplevel is honoured for interactive drags only, and REAPER
rewrites its `WM_NORMAL_HINTS` back to 400x150 immediately after every configure,
measured, so it cannot hold.

Ten JUCE plugins compile this helper and all had the same latent behaviour, since
any host can drag below any floor: 4K EQ, Chord Analyzer, Convolution Reverb,
DuskAmp, DuskVerb, Multi-Comp, Multi-Q, Spectrum Analyzer, TapeMachine, Tape Echo.

## Tests

DuskVerb's resize test gains the host path, which nothing covered: the
constrainer's answer applied at the reporter's 1057x474, Marc's 625x340 and two
more, asserting the editor is exactly what the host asked for and the face lands
inside it. Those cases fail on the parent commit and pass here. The existing six
checks are unchanged and still pass.

Nine assertions across the four geometries fail on `c4da169` and pass here; the
ordinals were read off a temporary local print, since the test itself reports only
its exit status.

Multi-Comp's resize test asserted the old contract, so it asserts the new one: the
host constrainer advertises no aspect and imposes no minimum, a 1125x350 host
request yields a 1125x350 editor, and nothing hangs outside those bounds. That
inversion is deliberate and the reasoning is in the test.

## Nothing else moved

| check | result |
|---|---|
| DuskVerb at 1400x760 | 0 differing pixels of 1064000 |
| DuskVerb at 1700x923 | 0 differing pixels of 1569100 |
| pluginval 10, DuskVerb | SUCCESS |
| pluginval 10, Multi-Comp | SUCCESS |
| Multi-Comp resize test | pass |

Multi-Comp's editor cannot be pixel compared: the same build captured twice
differs by 227886 of 375000, more than before against after, because its meters
reseed per run. Its functional test covers the layout instead.

## Known limitation

The face fills the window rather than sitting in a centred letterbox, so an
off-aspect window leaves its band at the right and bottom. Centring would mean
teaching ten editors to offset their layouts, filed separately.

Refs #240.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin editor resizing so host-requested window dimensions are honored exactly.
  * Prevented automatic aspect-ratio correction from overriding sizes requested by the host.
  * Ensured visible editor content remains within the window after resizing, reducing clipping issues.
  * Preserved comfortable minimum sizing for manual corner resizing while allowing hosts to apply smaller valid dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->