### PR TITLE
Release workflow: build and run the DuskVerb editor resize test under xvfb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,7 +263,7 @@ jobs:
           .github/scripts/apt_install.sh \
             gcc-11 g++-11 cmake build-essential pkg-config \
             libasound2-dev libjack-jackd2-dev ladspa-sdk \
-            libcurl4-openssl-dev libfreetype6-dev libx11-dev \
+            libcurl4-openssl-dev libfreetype6-dev libx11-dev xvfb \
             libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev \
             libxrandr-dev libxrender-dev libwebkit2gtk-4.0-dev \
             libglu1-mesa-dev mesa-common-dev
@@ -344,8 +344,12 @@ jobs:
         shell: bash
         run: |
           cmake --build build --config ${{ env.BUILD_TYPE }} \
-            --target DuskVerbStereoImageTest DuskVerbNyquistClampTest -j"$(nproc)"
-          ctest --test-dir build -R '^DuskVerb' --output-on-failure --no-tests=error
+            --target DuskVerbStereoImageTest DuskVerbNyquistClampTest DuskVerbEditorResizeTest -j"$(nproc)"
+          # DuskVerbEditorResizeTest is a JUCE application that constructs the
+          # real editor, so it needs an X display; the runner has none, hence
+          # xvfb-run. The DSP tests do not care either way.
+          xvfb-run -a --server-args="-screen 0 1280x1024x24" \
+            ctest --test-dir build -R '^DuskVerb' --output-on-failure --no-tests=error
 
       - name: Validate plugins
         shell: bash


### PR DESCRIPTION
The duskverb-v0.7.2 release run failed in build-linux: the "DuskVerb regression tests" step builds `DuskVerbStereoImageTest` and `DuskVerbNyquistClampTest` and then runs `ctest -R '^DuskVerb'`, but 72d8e24 registered a third test, `DuskVerbEditorResize`, whose binary the step never built. ctest reported it as Not Run and failed the job, so no 0.7.2 release was published.

`DuskVerbEditorResizeTest` is a JUCE application (`START_JUCE_APPLICATION`) that constructs the real editor, so it also needs an X display, which the runner does not have.

This change:
- adds `xvfb` to the build-linux apt list (stock Ubuntu package, per the CI apt policy);
- builds `DuskVerbEditorResizeTest` alongside the two DSP tests;
- runs the ctest invocation under `xvfb-run -a`.

Validated with a manual dispatch of this workflow on the branch for DuskVerb: https://github.com/dusk-audio/dusk-audio-plugins/actions/runs/34056829934, all four build jobs green, `100% tests passed out of 3`, release job skipped as expected for a dispatch.

After this merges, the `duskverb-v0.7.2` tag needs re-pointing (or a 0.7.3) since a tag-triggered run uses the workflow at the tagged commit. Refs #240.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Linux regression testing to include editor resizing behavior.
  - Enabled automated tests that require a graphical display by running them in a virtual screen environment.
  - Standardized the virtual display configuration for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->