### PR TITLE
Scale fixed-aspect editors by the tighter axis, and make the overlay scrollbar work

### DIFF
--- a/plugins/DuskVerb/tests/test_editor_resize.cpp
+++ b/plugins/DuskVerb/tests/test_editor_resize.cpp
@@ -2,6 +2,9 @@
 
 #include "../src/PluginProcessor.h"
 #include "SupportersOverlay.h"
+#include "ScalableEditorHelper.h"
+
+#include <vector>
 
 #include <cmath>
 #include <memory>
@@ -137,6 +140,94 @@ juce::Rectangle<int> paintedBounds (juce::Component& component, juce::Component&
 
     return bounds;
 }
+// Counts pairs of visible sibling components whose bounds intersect, anywhere in
+// the tree. Some overlap is intentional (a value label drawn inside its knob's
+// bounds), so the count is only ever compared against the same editor at its
+// base size, where the layout is known good. A short window that squashes the
+// rows shows up as extra pairs on top of that baseline.
+int overlappingSiblingPairs (juce::Component& parent)
+{
+    int pairs = 0;
+    std::vector<juce::Component*> visible;
+
+    for (int i = 0; i < parent.getNumChildComponents(); ++i)
+    {
+        auto* child = parent.getChildComponent (i);
+
+        if (child != nullptr && child->isVisible()
+            && dynamic_cast<juce::ResizableCornerComponent*> (child) == nullptr)
+            visible.push_back (child);
+    }
+
+    for (size_t i = 0; i < visible.size(); ++i)
+    {
+        for (size_t j = i + 1; j < visible.size(); ++j)
+            if (visible[i]->getBounds().intersects (visible[j]->getBounds()))
+                ++pairs;
+
+        pairs += overlappingSiblingPairs (*visible[i]);
+    }
+
+    return pairs;
+}
+
+// A minimal editor whose only job is to expose the helper's scale factor, so the
+// formula can be asserted directly rather than inferred from a widget.
+class ProbeEditor final : public juce::AudioProcessorEditor
+{
+public:
+    ProbeEditor (juce::AudioProcessor& p, bool fixedAspect)
+        : juce::AudioProcessorEditor (p)
+    {
+        helper.initialize (this, 1400, 760, 700, 380, 2800, 1520);
+
+        if (! fixedAspect)
+            helper.getConstrainer().setFixedAspectRatio (0.0);
+
+        setSize (1400, 760);
+    }
+
+    void resized() override { helper.updateResizer(); }
+    float scale() const { return helper.getScaleFactor(); }
+
+private:
+    ScalableEditorHelper helper;
+};
+// Synthetic mouse events, so the overlay's handlers can be driven headlessly.
+juce::MouseEvent makeMouseEvent (juce::Component& target,
+                                 juce::Point<int> position,
+                                 juce::Point<int> downPosition,
+                                 bool wasDragged)
+{
+    return juce::MouseEvent (juce::Desktop::getInstance().getMainMouseSource(),
+                             position.toFloat(),
+                             juce::ModifierKeys::leftButtonModifier,
+                             juce::MouseInputSource::defaultPressure,
+                             juce::MouseInputSource::defaultOrientation,
+                             juce::MouseInputSource::defaultRotation,
+                             juce::MouseInputSource::defaultTiltX,
+                             juce::MouseInputSource::defaultTiltY,
+                             &target, &target,
+                             juce::Time::getCurrentTime(),
+                             downPosition.toFloat(),
+                             juce::Time::getCurrentTime(),
+                             1, wasDragged);
+}
+
+void pressAt (juce::Component& target, juce::Point<int> position)
+{
+    target.mouseDown (makeMouseEvent (target, position, position, false));
+}
+
+void dragTo (juce::Component& target, juce::Point<int> from, juce::Point<int> to)
+{
+    target.mouseDrag (makeMouseEvent (target, to, from, true));
+}
+
+void releaseAt (juce::Component& target, juce::Point<int> position)
+{
+    target.mouseUp (makeMouseEvent (target, position, position, true));
+}
 }
 
 class DuskVerbEditorResizeTest final : public juce::JUCEApplicationBase
@@ -185,6 +276,104 @@ public:
                && resizeHandle->getBounds() == juce::Rectangle<int> (minWidth - 16, minHeight - 16, 16, 16));
 
         check (! supporterTextEntersFooter());
+
+        // Issue #240 again: at a wide, short frame the reporter's face fitted its
+        // bounds but the rows were squashed into each other, knobs over labels
+        // and panel titles over the panel above, because the scale came from the
+        // width alone. An editor with a fixed aspect ratio has to take whichever
+        // axis is the tighter fit. The bounds checks above cannot see this: the
+        // face is inside the window either way.
+        {
+            editor->setBounds (0, 0, baseWidth, baseHeight);
+            const int baselinePairs = overlappingSiblingPairs (*editor);
+
+            const std::pair<int, int> squashSizes[] = { { 1445, 438 }, { 900, 900 } };
+
+            for (const auto& size : squashSizes)
+            {
+                editor->setBounds (0, 0, size.first, size.second);
+                check (overlappingSiblingPairs (*editor) <= baselinePairs);
+            }
+        }
+
+        // The scale itself, asserted on the helper rather than inferred from a
+        // widget, for both settings of the aspect flag.
+        {
+            ProbeEditor fixedAspect (processor, true);
+            fixedAspect.setBounds (0, 0, 1445, 438);
+            const float expected = juce::jmin (1445.0f / baseWidth, 438.0f / baseHeight);
+            check (std::abs (fixedAspect.scale() - expected) < 1.0e-4f);
+
+            ProbeEditor freeAspect (processor, false);
+            freeAspect.setBounds (0, 0, 1445, 438);
+            check (std::abs (freeAspect.scale() - 1445.0f / baseWidth) < 1.0e-4f);
+        }
+
+        // The supporters overlay draws a scrollbar once the list overflows. It is
+        // part of the panel, so pressing it must scroll rather than dismiss.
+        {
+            SupportersOverlay overlay ("DuskVerb", "0.7.2");
+            overlay.setActionLink ("Open crash log folder", [] {});
+            bool dismissed = false;
+            overlay.onDismiss = [&dismissed] { dismissed = true; };
+            overlay.setSize (600, 300);
+
+            juce::Image image (juce::Image::ARGB, 600, 300, true);
+            {
+                juce::Graphics graphics (image);
+                overlay.paint (graphics);
+            }
+
+            check (overlay.getMaxScrollOffset() > 0);
+
+            const auto thumb = overlay.getScrollThumbRegion();
+            check (! thumb.isEmpty());
+
+            pressAt (overlay, thumb.getCentre());
+            check (! dismissed);
+
+            const int before = overlay.getScrollOffset();
+            dragTo (overlay, thumb.getCentre(), thumb.getCentre().translated (0, thumb.getHeight()));
+            check (overlay.getScrollOffset() > before);
+            check (! dismissed);
+
+            releaseAt (overlay, thumb.getCentre());
+
+            // A press anywhere else still closes the panel.
+            pressAt (overlay, { 10, 10 });
+            check (dismissed);
+
+            // Shrink to a size that paints nothing (the panel inset leaves no
+            // width). The scrollbar regions cached by the larger paint must not
+            // survive it, or a press where the thumb used to be would take the
+            // scrollbar path and skip the dismiss.
+            const auto staleThumb  = thumb;
+            const auto staleAction = overlay.getActionHitRegion();
+            check (! staleAction.isEmpty());
+            dismissed = false;
+            overlay.setSize (60, 40);
+            {
+                juce::Image tiny (juce::Image::ARGB, 60, 40, true);
+                juce::Graphics graphics (tiny);
+                overlay.paint (graphics);
+            }
+            check (overlay.getMaxScrollOffset() == 0);
+            check (overlay.getScrollTrackRegion().isEmpty());
+            check (overlay.getActionHitRegion().isEmpty());
+            pressAt (overlay, staleThumb.getCentre());
+            check (dismissed);
+
+            // Same for the action link: its cached region must not outlive the
+            // panel, or a press there would open the log folder from a panel
+            // that is not on screen instead of closing it.
+            dismissed = false;
+            bool actionFired = false;
+            overlay.setActionLink ("Open crash log folder", [&actionFired] { actionFired = true; });
+            pressAt (overlay, staleAction.getCentre());
+            check (dismissed);
+            check (! actionFired);
+        }
+
 
         // Issue #240: the host path. REAPER on Linux keeps its window at the
         // size the user dragged the frame to, so the editor must never come

--- a/plugins/shared/ScalableEditorHelper.h
+++ b/plugins/shared/ScalableEditorHelper.h
@@ -115,8 +115,28 @@ public:
                                handleSize, handleSize);
         }
 
-        // Scale based on width only (height may vary with collapsible sections)
-        scaleFactor = static_cast<float>(parentEditor->getWidth()) / baseWidth;
+        const float widthScale = static_cast<float>(parentEditor->getWidth()) / baseWidth;
+
+        // An editor whose layout is tied to an aspect ratio has to scale by
+        // whichever axis is the tighter fit, or a window shorter than the base
+        // aspect lays the rows out at the width's scale and they overlap: knobs
+        // over their labels, panel titles over the panel above. A host can hand
+        // out any shape it likes (issue #240), so this is reachable in normal
+        // use, and it is not the same thing as being clipped, which is why the
+        // bounds checks did not see it.
+        //
+        // Editors initialised without a fixed aspect ratio grow their height
+        // independently, by opening collapsible sections, so for those the
+        // height ratio is not a scale at all and the width alone is right.
+        if (constrainer.getFixedAspectRatio() > 0.0)
+        {
+            const float heightScale = static_cast<float>(parentEditor->getHeight()) / baseHeight;
+            scaleFactor = juce::jmax(kMinimumScale, juce::jmin(widthScale, heightScale));
+        }
+        else
+        {
+            scaleFactor = juce::jmax(kMinimumScale, widthScale);
+        }
     }
 
     float getScaleFactor() const { return scaleFactor; }
@@ -157,6 +177,10 @@ private:
     // from updateResizer()'s factor and spans the panels across the editor, so
     // the face fills whatever window it is given instead of overhanging it.
     static constexpr int kHostMinimumSize = 1;
+
+    // A host may drive the editor to a degenerate size mid-drag; keep the scale
+    // positive so nothing downstream divides by zero.
+    static constexpr float kMinimumScale = 0.01f;
 
     void configureHostConstrainer(int maxWidth, int maxHeight)
     {

--- a/plugins/shared/SupportersOverlay.h
+++ b/plugins/shared/SupportersOverlay.h
@@ -52,8 +52,18 @@ public:
         const int panelWidth    = juce::jmax(0, juce::jmin(440, w - 80));
         const int panelHeight   = juce::jmax(0, juce::jmin(headerHeight + contentHeight + footerHeight, h - 60));
 
+        // Nothing to draw, and nothing for mouseDown to hit: clear the cached
+        // scrollbar state here, or a track region left over from a larger
+        // paint would still swallow a click that should dismiss the panel.
         if (panelWidth == 0 || panelHeight == 0)
+        {
+            maxScrollOffset   = 0;
+            scrollThumbTravel = 0;
+            scrollTrackRegion = juce::Rectangle<int>{};
+            scrollThumbRegion = juce::Rectangle<int>{};
+            actionHitRegion   = juce::Rectangle<int>{};
             return;
+        }
 
         auto panelBounds = juce::Rectangle<int>(
             (w - panelWidth) / 2,
@@ -146,6 +156,9 @@ public:
 
         g.restoreState();
 
+        scrollTrackRegion = juce::Rectangle<int>{};
+        scrollThumbRegion = juce::Rectangle<int>{};
+
         if (maxScrollOffset > 0 && contentBounds.getHeight() > 0)
         {
             const int trackHeight = contentBounds.getHeight();
@@ -154,6 +167,17 @@ public:
             const int thumbTravel = trackHeight - thumbHeight;
             const int thumbY = contentBounds.getY()
                              + (thumbTravel * scrollOffset / maxScrollOffset);
+
+            // Hit regions, cached for the mouse handlers. The painted bar is 3px
+            // wide, which is a hopeless click target, so the hit zone is widened
+            // to kScrollHitWidth around it. thumbTravel is kept because mouseDrag
+            // needs the same mapping the paint used, in reverse.
+            scrollTrackRegion = juce::Rectangle<int>(contentBounds.getRight() - kScrollHitWidth,
+                                                     contentBounds.getY(),
+                                                     kScrollHitWidth + 3, trackHeight);
+            scrollThumbRegion = juce::Rectangle<int>(scrollTrackRegion.getX(), thumbY,
+                                                     scrollTrackRegion.getWidth(), thumbHeight);
+            scrollThumbTravel = thumbTravel;
 
             g.setColour(juce::Colour(0x304f4f4f));
             g.fillRoundedRectangle(static_cast<float>(contentBounds.getRight() - 3),
@@ -210,13 +234,54 @@ public:
 
     void mouseDown(const juce::MouseEvent& e) override
     {
+        draggingScrollThumb = false;
+
         if (onActionClick && actionHitRegion.contains(e.getPosition()))
         {
             onActionClick();
             return;
         }
+
+        // The scrollbar is part of the panel, so a press on it scrolls and must
+        // not be read as a click outside. Before this, the bar appeared at small
+        // sizes and dismissed the panel the moment it was touched.
+        if (maxScrollOffset > 0 && scrollTrackRegion.contains(e.getPosition()))
+        {
+            if (scrollThumbRegion.contains(e.getPosition()))
+            {
+                draggingScrollThumb = true;
+                dragStartY = e.getPosition().getY();
+                dragStartOffset = scrollOffset;
+            }
+            else
+            {
+                // A press on the track above or below the thumb pages that way.
+                const int page = juce::jmax(1, scrollThumbRegion.getHeight());
+                const int direction = e.getPosition().getY() < scrollThumbRegion.getY() ? -1 : 1;
+                setScrollOffset(scrollOffset + direction * page);
+            }
+
+            return;
+        }
+
         if (onDismiss)
             onDismiss();
+    }
+
+    void mouseDrag(const juce::MouseEvent& e) override
+    {
+        if (! draggingScrollThumb || scrollThumbTravel <= 0)
+            return;
+
+        // Invert the thumb mapping from paint(): thumbY moves thumbTravel pixels
+        // over the whole of maxScrollOffset.
+        const int deltaY = e.getPosition().getY() - dragStartY;
+        setScrollOffset(dragStartOffset + (deltaY * maxScrollOffset) / scrollThumbTravel);
+    }
+
+    void mouseUp(const juce::MouseEvent&) override
+    {
+        draggingScrollThumb = false;
     }
 
     void mouseWheelMove(const juce::MouseEvent&,
@@ -227,13 +292,25 @@ public:
 
         const float direction = wheel.isReversed ? -1.0f : 1.0f;
         const int delta = juce::roundToInt(60.0f * wheel.deltaY * direction);
-        const int newOffset = juce::jlimit(0, maxScrollOffset, scrollOffset - delta);
+        setScrollOffset(scrollOffset - delta);
+    }
+
+    void setScrollOffset(int newOffset)
+    {
+        newOffset = juce::jlimit(0, maxScrollOffset, newOffset);
+
         if (newOffset != scrollOffset)
         {
             scrollOffset = newOffset;
             repaint();
         }
     }
+
+    int getScrollOffset() const { return scrollOffset; }
+    int getMaxScrollOffset() const { return maxScrollOffset; }
+    juce::Rectangle<int> getScrollThumbRegion() const { return scrollThumbRegion; }
+    juce::Rectangle<int> getScrollTrackRegion() const { return scrollTrackRegion; }
+    juce::Rectangle<int> getActionHitRegion() const { return actionHitRegion; }
 
     std::function<void()> onDismiss;
 
@@ -258,7 +335,15 @@ private:
     juce::String pluginVersion;
     juce::String actionLabel;
     std::function<void()> onActionClick;
+    static constexpr int kScrollHitWidth = 12;
+
     juce::Rectangle<int> actionHitRegion; // recomputed in paint()
+    juce::Rectangle<int> scrollTrackRegion; // recomputed in paint()
+    juce::Rectangle<int> scrollThumbRegion; // recomputed in paint()
+    int scrollThumbTravel = 0;
+    bool draggingScrollThumb = false;
+    int dragStartY = 0;
+    int dragStartOffset = 0;
     int scrollOffset = 0;
     int maxScrollOffset = 0;
 


### PR DESCRIPTION
Follow-up to #278 from the reporter's retest on #240 (DuskVerb 0.7.2 in REAPER, Linux).

## Two findings, two fixes

**Squashed layout at wide, short windows.** `ScalableEditorHelper::updateResizer()` scaled every editor from width alone, so at the reporter's 1445x438 the rows of a fixed-aspect face were laid out at scale 1.03 inside 438 px of height: knobs over labels, DAMPING and MODULATION titles overprinted. Fixed-aspect editors (Chord Analyzer, Convolution Reverb, DuskAmp, DuskVerb, Multi-Comp, TapeMachine, Tape Echo) now scale by the tighter axis, `min(w/baseW, h/baseH)`; the three that vary height with collapsible sections (4K EQ, Multi-Q, Spectrum Analyzer) keep width-only. The switch reads the grip constrainer's fixed aspect, no new state. No fixed-aspect editor derives its own scale anywhere; the only `jmin(w, h)` outside the helper is a local draw call in `AnalogLookAndFeel.cpp:616`.

**The supporters overlay dismissed on its own scrollbar.** `SupportersOverlay::mouseDown` closed the panel for any press outside the action link, including the scrollbar it paints. `paint()` now caches the track and thumb regions (12 px hit zone around the 3 px bar); a press on the thumb drags it, a press on the track pages by one thumb height, and neither dismisses. Anywhere else still closes, the wheel is unchanged.

## Tests, failing first

`plugins/DuskVerb/tests/test_editor_resize.cpp` gains a squash guard (overlapping visible sibling pairs at 1445x438 and 900x900 must not exceed the same editor at 1400x760, which is the honest baseline since value labels sit inside knob bounds by design), a direct assertion of the scale formula through a probe editor for both aspect modes, and a scrollbar block (press on the thumb does not dismiss, drag scrolls, a press elsewhere dismisses).

| half | revert only that half | exit |
|---|---|---|
| squash (helper reverted) | before | 1 |
| squash | after | 0 |
| scrollbar (hit handling disabled) | before | 1 |
| scrollbar | after | 0 |

## Controls

DuskVerb at 1400x760 and 1700x923: 0 differing pixels against the parent commit. Multi-Comp's resize test passes; its pixel diff is not usable (its meters reseed per run, the same build twice differs more than before vs after). pluginval strictness 10: SUCCESS on DuskVerb and Multi-Comp.

## In the host

On Marc's REAPER 7.79 Linux with this build, a frame drag from the upper-right corner took the FX window to 407x170 and the editor followed to 407x142 with the whole face drawn, proportional, nothing cut.

## On the minimum size

Measured this week on REAPER Linux and REAPER Windows (VM): REAPER sizes its FX window from the frame drag and never from the plugin's `checkSizeConstraint` answer, on either platform; the old strict constrainer only produced a clipped face. REAPER also rewrites its own `WM_NORMAL_HINTS` within 8 ms of any plugin write, so a window-manager floor cannot be published from the plugin either. u-he and Cherry Audio plugins behave the same way in REAPER. The in-editor corner grip remains the plugin's own floor; the frame is REAPER's.

Refs #240.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scrollbar interaction to the supporters overlay, including thumb dragging and track-based paging.
  * Scrollbar interactions now preserve the overlay instead of dismissing it.
  * Editor resizing now respects the tighter dimension for fixed-aspect layouts and remains stable at very small sizes.

* **Bug Fixes**
  * Improved scrolling behavior and clamped offsets to valid limits.
  * Prevented stale scrollbar areas from intercepting clicks after the overlay is resized.
  * Prevented excessive component overlap when editors are resized smaller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->