### PR TITLE
Dusk/daf monorepo repin

### DIFF
--- a/.github/scripts/check_fork_sources.sh
+++ b/.github/scripts/check_fork_sources.sh
@@ -1,29 +1,16 @@
 #!/usr/bin/env bash
 # Fail the build if anything would fetch framework source from upstream.
 #
-# DAF, DAF-Widgets and pugl are hard forks under dusk-audio with local patches
-# that upstream does not have. A build that pulls any of them from DISTRHO does
-# not contain those patches, and the divergence is silent: it compiles, it runs,
-# and the binary simply is not the one that was tested.
+# DAF is a hard fork under dusk-audio. Pugl and widgets are tracked trees in
+# the same checkout, so their source is covered by the single DAF revision.
 #
-# Two leaks have happened for real, and neither was a typo:
-#   - workflow `repository:` fields copied from upstream examples, which name
-#     DISTRHO because that is where upstream lives;
-#   - the `url` in the fork's own .gitmodules, which GitHub copies verbatim when
-#     a fork is created, so pugl kept pointing at DISTRHO long after the fork.
+#   ./.github/scripts/check_fork_sources.sh [daf-checkout-path]
 #
-#   ./.github/scripts/check_fork_sources.sh [daf-checkout-path] [daf-widgets-path]
-#
-# The optional arguments point at checked-out framework trees. With them the
-# guard also inspects what those trees actually are -- their origin remotes, and
-# pugl's revision against the gitlink DAF records -- rather than only the config
-# that describes a future fetch. Without them only this repository's build
-# config is scanned.
+# Without a checkout argument, only this repository's build config is scanned.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DAF_CHECKOUT="${1:-}"
-DAFWIDGETS_CHECKOUT="${2:-}"
 
 # Scan the files that decide where source comes from. Documentation may discuss
 # upstream freely, so it is deliberately out of scope.
@@ -51,24 +38,7 @@ for f in "${CONFIG_FILES[@]}"; do
     fi
 done
 
-if [ -n "$DAF_CHECKOUT" ] && [ -f "$DAF_CHECKOUT/.gitmodules" ]; then
-    if hits="$(grep -nE 'url *= *.*DISTRHO/' "$DAF_CHECKOUT/.gitmodules" || true)"; [ -n "$hits" ]; then
-        echo "FAIL  the DAF checkout's .gitmodules fetches a submodule from upstream:"
-        echo "$hits" | sed 's/^/        /'
-        echo "        fix it in dusk-audio/DAF, not here: a fork inherits this file"
-        failed=1
-    fi
-fi
-
-# Everything above reads configuration, which describes what a future fetch
-# would do. It cannot tell you what the tree in front of you was built from: a
-# checkout made before a fork was repointed keeps its old origin, and a correct
-# .gitmodules sitting next to it makes the tree look clean. So when a checkout
-# path is supplied, ask the checkout.
-# Reduce a remote URL to the "owner/repo" it names on github.com, or to nothing
-# if it names something else. Matching a substring instead accepts far too much:
-# not-dusk-audio/pugl, gitlab.com/dusk-audio/pugl and
-# github.com/attacker/mirror-dusk-audio/pugl all contain "dusk-audio/pugl".
+# Match the exact host and owner/repo, not a lookalike containing the name.
 # Twin of the function in docker/check_daf_pins.sh; keep the two in step.
 github_repo_of() {
     local url="$1" path=""
@@ -98,42 +68,30 @@ check_checkout_origin() {
     remote="$(git -C "$path" remote get-url origin 2>/dev/null || echo '(none)')"
     if [ "$(github_repo_of "$remote")" != "$expect" ]; then
         echo "FAIL  $name checkout compiles from $remote, expected github.com/$expect"
-        echo "        this is the tree being built, not a .gitmodules entry"
         failed=1
     fi
 }
 
 check_checkout_origin "DAF" "$DAF_CHECKOUT" "dusk-audio/DAF"
-check_checkout_origin "DAF-Widgets" "$DAFWIDGETS_CHECKOUT" "dusk-audio/DAF-Widgets"
 
-# pugl lives inside the DAF checkout, and its revision matters as well as its
-# origin: a submodule left at some other commit compiles source DAF does not
-# pin, which is exactly as wrong as fetching it from upstream.
 if [ -n "$DAF_CHECKOUT" ] && [ -e "$DAF_CHECKOUT/.git" ]; then
-    pugl_path="$DAF_CHECKOUT/dgl/src/pugl-upstream"
-    check_checkout_origin "pugl" "$pugl_path" "dusk-audio/pugl"
-
-    if [ -e "$pugl_path/.git" ]; then
-        pugl_pin="$(git -C "$DAF_CHECKOUT" rev-parse -q --verify HEAD:dgl/src/pugl-upstream 2>/dev/null || echo '')"
-        pugl_head="$(git -C "$pugl_path" rev-parse HEAD 2>/dev/null || echo '')"
-
-        # An empty pin with a checkout present is not "nothing to compare": it
-        # means DAF records no gitlink at that path, so whatever is sitting
-        # there is unpinned source that no revision check can vouch for.
-        # Skipping the comparison would let it through unverified.
-        if [ -z "$pugl_pin" ]; then
-            echo "FAIL  pugl checkout exists at $pugl_path, but DAF records no gitlink there"
-            echo "        nothing pins this source, so its revision cannot be verified"
+    if [ -e "$DAF_CHECKOUT/.gitmodules" ]; then
+        echo "FAIL  DAF uses submodules instead of the consolidated tree"
+        failed=1
+    fi
+    for component in dgl/src/pugl-upstream widgets; do
+        path="$DAF_CHECKOUT/$component"
+        if [ -e "$path/.git" ]; then
+            echo "FAIL  $component is a nested checkout"
             failed=1
-        elif [ -z "$pugl_head" ]; then
-            echo "FAIL  pugl checkout at $pugl_path has no readable HEAD"
+        elif [ "$(git -C "$DAF_CHECKOUT" cat-file -t "HEAD:$component" 2>/dev/null || true)" != tree ]; then
+            echo "FAIL  $component is not a tracked tree in DAF"
             failed=1
-        elif [ "$pugl_pin" != "$pugl_head" ]; then
-            echo "FAIL  pugl checkout is at ${pugl_head:0:12}, but DAF pins ${pugl_pin:0:12}"
-            echo "        run git submodule update --init --recursive in the DAF checkout"
+        elif [ -n "$(git -C "$DAF_CHECKOUT" status --porcelain -- "$component")" ]; then
+            echo "FAIL  $component differs from the DAF revision"
             failed=1
         fi
-    fi
+    done
 fi
 
 if [ "$failed" = "1" ]; then

--- a/.github/workflows/daf-au-test.yml
+++ b/.github/workflows/daf-au-test.yml
@@ -11,8 +11,7 @@ on:
       - 'tape-echo-daf-v*'
 
 env:
-  DAF_SHA: 22b8282461c5847057aa31b7f210bc9e0652366e
-  DAFWIDGETS_SHA: 487b092aa265458feb8320308a1fa36ca0901a5b
+  DAF_SHA: 64d386a8b04841aceef8c0a8d9035e8c02ce1c15
 
 jobs:
   build-au-macos:
@@ -33,16 +32,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_SHA }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_SHA }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Install Ninja
@@ -53,8 +42,7 @@ jobs:
         run: |
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF" \
-            -DDAFWIDGETS_PATH="${GITHUB_WORKSPACE}/DAF-Widgets"
+            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF"
 
       - name: Build
         working-directory: plugins/tape-echo/daf-plugin

--- a/.github/workflows/daf-au-test.yml
+++ b/.github/workflows/daf-au-test.yml
@@ -11,7 +11,7 @@ on:
       - 'tape-echo-daf-v*'
 
 env:
-  DAF_SHA: 64d386a8b04841aceef8c0a8d9035e8c02ce1c15
+  DAF_SHA: 867183d73b8fea20892eb8de49fb8c8b108c4910
 
 jobs:
   build-au-macos:

--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -66,7 +66,7 @@ on:
 # checkouts on the pinned SHAs (docker/check_daf_pins.sh) so a hand-tested build
 # is the one CI produces.
 env:
-  DAF_REF: 64d386a8b04841aceef8c0a8d9035e8c02ce1c15
+  DAF_REF: 867183d73b8fea20892eb8de49fb8c8b108c4910
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk
 

--- a/.github/workflows/daf-build.yml
+++ b/.github/workflows/daf-build.yml
@@ -66,8 +66,7 @@ on:
 # checkouts on the pinned SHAs (docker/check_daf_pins.sh) so a hand-tested build
 # is the one CI produces.
 env:
-  DAF_REF: 22b8282461c5847057aa31b7f210bc9e0652366e
-  DAFWIDGETS_REF: 487b092aa265458feb8320308a1fa36ca0901a5b
+  DAF_REF: 64d386a8b04841aceef8c0a8d9035e8c02ce1c15
   AU_TYPE: aufx
   AU_MANUFACTURER: Dusk
 
@@ -290,26 +289,14 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_REF }}
           path: DAF
-          submodules: recursive
           persist-credentials: false
 
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_REF }}
-          path: DAF-Widgets
-          submodules: recursive
-          persist-credentials: false
-
-      # Runs after the checkouts so it can inspect the trees themselves: their
-      # origin remotes and pugl's revision against the gitlink DAF records, not
-      # just the config that says where a fetch would go. Cheap, so it gates the
+      # Check the DAF origin and its tracked widget/pugl trees. This gates the
       # expensive build instead of reporting after it.
       - name: Check framework sources are our forks
         run: |
           ./.github/scripts/check_fork_sources.sh \
-            "${GITHUB_WORKSPACE}/DAF" "${GITHUB_WORKSPACE}/DAF-Widgets"
+            "${GITHUB_WORKSPACE}/DAF"
 
       - name: Install Linux dependencies
         env:
@@ -344,8 +331,7 @@ jobs:
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDUSK_DAF_INSTALL_LOCAL=OFF \
-            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF" \
-            -DDAFWIDGETS_PATH="${GITHUB_WORKSPACE}/DAF-Widgets"
+            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF"
 
       - name: Build (VST3 + CLAP + LV2)
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -571,16 +557,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_REF }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_REF }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Install Linux dependencies
@@ -606,8 +582,7 @@ jobs:
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDUSK_DAF_INSTALL_LOCAL=OFF \
-            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF" \
-            -DDAFWIDGETS_PATH="${GITHUB_WORKSPACE}/DAF-Widgets"
+            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF"
 
       - name: Build (VST3 + CLAP + LV2)
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -678,16 +653,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_REF }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_REF }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Install Ninja
@@ -701,8 +666,7 @@ jobs:
             -DDUSK_DAF_INSTALL_LOCAL=OFF \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" \
-            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF" \
-            -DDAFWIDGETS_PATH="${GITHUB_WORKSPACE}/DAF-Widgets"
+            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF"
 
       - name: Build (AU + VST3 + CLAP + LV2)
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -925,16 +889,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_REF }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_REF }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Patch DAF sources for MSVC / Windows
@@ -955,7 +909,7 @@ jobs:
           # both stay because the pin has crossed that correction in each direction once already.
           # getWidth()/getHeight() are side-effect-free getters, so the rewrite is safe whenever
           # it does match.
-          $f = "$env:GITHUB_WORKSPACE/DAF-Widgets/opengl/DearImGui.cpp"
+          $f = "$env:GITHUB_WORKSPACE/DAF/widgets/imgui/DearImGui.cpp"
           (Get-Content -Raw $f) `
             -replace 'self->getWidth\(\) \?: 640 \* scaleFactor',  'self->getWidth() ? self->getWidth() : 640 * scaleFactor' `
             -replace 'self->getHeight\(\) \?: 480 \* scaleFactor', 'self->getHeight() ? self->getHeight() : 480 * scaleFactor' `
@@ -972,8 +926,7 @@ jobs:
           cmake -B build -G "Visual Studio 17 2022" -A x64 `
             -DCMAKE_BUILD_TYPE=Release `
             -DDUSK_DAF_INSTALL_LOCAL=OFF `
-            -DDAF_PATH="$env:GITHUB_WORKSPACE/DAF" `
-            -DDAFWIDGETS_PATH="$env:GITHUB_WORKSPACE/DAF-Widgets"
+            -DDAF_PATH="$env:GITHUB_WORKSPACE/DAF"
 
       - name: Build (VST3 + CLAP)
         working-directory: ${{ env.PLUGIN_DIR }}

--- a/.github/workflows/daf-release.yml
+++ b/.github/workflows/daf-release.yml
@@ -42,7 +42,7 @@ on:
 # daf-build.yml, daf-au-test.yml and docker/build_release.sh, and re-run the
 # dispatch matrix before tagging.
 env:
-  DAF_SHA: 64d386a8b04841aceef8c0a8d9035e8c02ce1c15
+  DAF_SHA: 867183d73b8fea20892eb8de49fb8c8b108c4910
   PLUGIN_DIR: plugins/sunset-circuits/daf-plugin
   SLUG: sunset-circuits
 

--- a/.github/workflows/daf-release.yml
+++ b/.github/workflows/daf-release.yml
@@ -42,8 +42,7 @@ on:
 # daf-build.yml, daf-au-test.yml and docker/build_release.sh, and re-run the
 # dispatch matrix before tagging.
 env:
-  DAF_SHA: 22b8282461c5847057aa31b7f210bc9e0652366e
-  DAFWIDGETS_SHA: 487b092aa265458feb8320308a1fa36ca0901a5b
+  DAF_SHA: 64d386a8b04841aceef8c0a8d9035e8c02ce1c15
   PLUGIN_DIR: plugins/sunset-circuits/daf-plugin
   SLUG: sunset-circuits
 
@@ -204,16 +203,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_SHA }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_SHA }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Configure
@@ -222,8 +211,7 @@ jobs:
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDUSK_DAF_INSTALL_LOCAL=OFF \
-            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF" \
-            -DDAFWIDGETS_PATH="${GITHUB_WORKSPACE}/DAF-Widgets"
+            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF"
 
       - name: Build (VST3 + CLAP + LV2)
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -341,16 +329,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_SHA }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_SHA }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Configure
@@ -359,8 +337,7 @@ jobs:
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDUSK_DAF_INSTALL_LOCAL=OFF \
-            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF" \
-            -DDAFWIDGETS_PATH="${GITHUB_WORKSPACE}/DAF-Widgets"
+            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF"
 
       - name: Build (VST3 + CLAP + LV2)
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -416,16 +393,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_SHA }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_SHA }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Setup MSVC
@@ -473,7 +440,7 @@ jobs:
           # a C2059 buried a hundred lines into cl's output. DearImGui.cpp is the
           # only DAF-Widgets TU our plugins compile (DUSK_DAF_UI_SOURCES in
           # shared-daf/cmake/DuskDafPlugin.cmake).
-          $f = "${{ github.workspace }}/DAF-Widgets/opengl/DearImGui.cpp"
+          $f = "${{ github.workspace }}/DAF/widgets/imgui/DearImGui.cpp"
           $c = [System.IO.File]::ReadAllText($f)
           $c = $c.Replace('self->getWidth() ?: 640 * scaleFactor',  'self->getWidth() ? self->getWidth() : 640 * scaleFactor')
           $c = $c.Replace('self->getHeight() ?: 480 * scaleFactor', 'self->getHeight() ? self->getHeight() : 480 * scaleFactor')
@@ -492,8 +459,7 @@ jobs:
             -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl `
             -DCMAKE_BUILD_TYPE=Release `
             -DDUSK_DAF_INSTALL_LOCAL=OFF `
-            -DDAF_PATH="${{ github.workspace }}/DAF" `
-            -DDAFWIDGETS_PATH="${{ github.workspace }}/DAF-Widgets"
+            -DDAF_PATH="${{ github.workspace }}/DAF"
 
       - name: Build (VST3 + CLAP + LV2)
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -598,16 +564,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_SHA }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_SHA }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Install Ninja
@@ -621,8 +577,7 @@ jobs:
             -DDUSK_DAF_INSTALL_LOCAL=OFF \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="10.15" \
-            -DDAF_PATH="${{ github.workspace }}/DAF" \
-            -DDAFWIDGETS_PATH="${{ github.workspace }}/DAF-Widgets"
+            -DDAF_PATH="${{ github.workspace }}/DAF"
 
       - name: Build (VST3 + CLAP + LV2 + AU)
         working-directory: ${{ env.PLUGIN_DIR }}
@@ -803,16 +758,6 @@ jobs:
           repository: dusk-audio/DAF
           ref: ${{ env.DAF_SHA }}
           path: DAF
-          submodules: recursive
-          persist-credentials: false
-
-      - name: Checkout DAF-Widgets
-        uses: actions/checkout@v4
-        with:
-          repository: dusk-audio/DAF-Widgets
-          ref: ${{ env.DAFWIDGETS_SHA }}
-          path: DAF-Widgets
-          submodules: recursive
           persist-credentials: false
 
       - name: Configure
@@ -821,8 +766,7 @@ jobs:
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DDUSK_DAF_INSTALL_LOCAL=OFF \
-            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF" \
-            -DDAFWIDGETS_PATH="${GITHUB_WORKSPACE}/DAF-Widgets"
+            -DDAF_PATH="${GITHUB_WORKSPACE}/DAF"
 
       - name: Build (VST3 + CLAP + LV2)
         working-directory: ${{ env.PLUGIN_DIR }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,9 @@ floats locale-independently in both directions.
 
 ## Building and testing a DAF plugin
 
-DAF and DAF-Widgets are sibling checkouts of this repository (`../DAF`,
-`../DAF-Widgets`), as JUCE is. CMake finds them automatically in a normal layout;
-pass the paths explicitly only when yours differ.
+DAF is a sibling checkout of this repository (`../DAF`), as JUCE is. Its in-tree
+`widgets/` directory supplies Dear ImGui and DuskWidgets. CMake finds it
+automatically in a normal layout; pass `-DDAF_PATH=...` only when yours differs.
 
 ```bash
 cmake -S plugins/<name>/daf-plugin -B build-<name> -DCMAKE_BUILD_TYPE=Release \

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -15,11 +15,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 IMAGE_NAME="dusk-plugins-builder"
 
-# DAF / DAF-Widgets SHAs — keep in sync with daf-build.yml, daf-release.yml and daf-au-test.yml.
-# Both come from permanent dusk-audio hard forks (dusk-audio/DAF and
-# dusk-audio/DAF-Widgets); never fetch either from upstream DISTRHO.
-DAF_SHA="22b8282461c5847057aa31b7f210bc9e0652366e"
-DAFWIDGETS_SHA="487b092aa265458feb8320308a1fa36ca0901a5b"
+# DAF SHA — keep in sync with the DAF workflow pins.
+DAF_SHA="64d386a8b04841aceef8c0a8d9035e8c02ce1c15"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)
 get_plugin_target() {
@@ -67,12 +64,12 @@ is_sunset() {
 }
 
 # Build Sunset Circuits (DAF) in the container. Unlike the JUCE plugins this does
-# NOT use the top-level JUCE build graph: it clones dusk-audio/DAF (our fork) + dusk-audio/DAF-Widgets at
-# the pinned SHAs inside the container and builds plugins/sunset-circuits/daf-plugin
+# NOT use the top-level JUCE build graph: it clones dusk-audio/DAF at the pinned
+# SHA inside the container and builds plugins/sunset-circuits/daf-plugin
 # standalone (mirrors .github/workflows/daf-release.yml). Produces VST3/CLAP/LV2.
 build_sunset() {
     echo "=== Building Sunset Circuits (DAF) ==="
-    echo "Using: $CONTAINER_CMD  (DAF ${DAF_SHA:0:12}, DAF-Widgets ${DAFWIDGETS_SHA:0:12})"
+    echo "Using: $CONTAINER_CMD  (DAF ${DAF_SHA:0:12})"
 
     if ! $CONTAINER_CMD image inspect "$IMAGE_NAME" &>/dev/null; then
         echo "Building container image..."
@@ -89,16 +86,13 @@ build_sunset() {
             set -e
             export DEBIAN_FRONTEND=noninteractive
             DAF_SHA="'"$DAF_SHA"'"
-            DAFWIDGETS_SHA="'"$DAFWIDGETS_SHA"'"
 
             # DAF opengl UI deps not baked into the JUCE image.
             apt-get update
             apt-get install -y --no-install-recommends \
                 ninja-build libxext-dev libxtst-dev libglu1-mesa-dev mesa-common-dev libdbus-1-dev
 
-            # Shallow-fetch each dependency at its exact pinned SHA. Submodule
-            # failures are NOT suppressed: DAF requires its pugl submodule, and a
-            # hollow checkout must fail here, not as a confusing CMake error.
+            # Pugl and widgets are included in the pinned DAF tree.
             fetch_sha() {
                 local url="$1" sha="$2" dir="$3"
                 mkdir -p "$dir" && cd "$dir"
@@ -106,20 +100,15 @@ build_sunset() {
                 git remote add origin "$url"
                 git fetch -q --depth 1 origin "$sha"
                 git checkout -q FETCH_HEAD
-                git submodule update -q --init --recursive --depth 1
                 cd /tmp
             }
             cd /tmp
             fetch_sha https://github.com/dusk-audio/DAF.git      "$DAF_SHA"        /tmp/daf
-            fetch_sha https://github.com/dusk-audio/DAF-Widgets.git  "$DAFWIDGETS_SHA" /tmp/daf-widgets
-            test -n "$(ls -A /tmp/daf/dgl/src/pugl-upstream 2>/dev/null)" \
-                || { echo "ERROR: DAF pugl submodule missing after fetch"; exit 1; }
 
             cmake -S /src/plugins/sunset-circuits/daf-plugin -B /tmp/scbuild -G Ninja \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DDUSK_DAF_INSTALL_LOCAL=OFF \
-                -DDAF_PATH=/tmp/daf \
-                -DDAFWIDGETS_PATH=/tmp/daf-widgets
+                -DDAF_PATH=/tmp/daf
             cmake --build /tmp/scbuild \
                 --target sunset-circuits-vst3 sunset-circuits-clap sunset-circuits-lv2 \
                 -j"$(nproc)"

--- a/docker/build_release.sh
+++ b/docker/build_release.sh
@@ -16,7 +16,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 IMAGE_NAME="dusk-plugins-builder"
 
 # DAF SHA — keep in sync with the DAF workflow pins.
-DAF_SHA="64d386a8b04841aceef8c0a8d9035e8c02ce1c15"
+DAF_SHA="867183d73b8fea20892eb8de49fb8c8b108c4910"
 
 # Plugin lookup functions (compatible with bash 3.2 on macOS)
 get_plugin_target() {

--- a/docker/check_daf_pins.sh
+++ b/docker/check_daf_pins.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Compare the local DAF and DAF-Widgets checkouts against the SHAs CI builds
+# Compare the local DAF checkout against the SHA CI builds
 # with. A local build that uses different framework source than CI is a release
 # hazard: the binaries users get are not the ones that were tested by hand.
 #
 #   ./docker/check_daf_pins.sh          report only, exit 1 on drift
-#   ./docker/check_daf_pins.sh --fix    check the pinned SHAs out locally
+#   ./docker/check_daf_pins.sh --fix    check the pinned SHA out locally
 #
 # Docker release builds fetch the pins directly and are unaffected either way;
 # this is about ad-hoc local cmake builds that point DAF_PATH at a working tree.
@@ -14,7 +14,6 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$REPO_ROOT/.github/workflows/daf-build.yml"
 
 DAF_PATH="${DAF_PATH:-$REPO_ROOT/../DAF}"
-DAFWIDGETS_PATH="${DAFWIDGETS_PATH:-$REPO_ROOT/../DAF-Widgets}"
 
 FIX=0
 [ "${1:-}" = "--fix" ] && FIX=1
@@ -43,14 +42,13 @@ pin_from_workflow() {
 }
 
 DAF_PIN="$(pin_from_workflow DAF_REF)"
-DAFWIDGETS_PIN="$(pin_from_workflow DAFWIDGETS_REF)"
 
 drift=0
 
 check_one() {
     local name="$1" path="$2" pin="$3" expect_remote="$4"
 
-    if [ ! -d "$path/.git" ]; then
+    if [ ! -e "$path/.git" ]; then
         echo "MISSING  $name: no git checkout at $path"
         drift=1
         return
@@ -81,8 +79,6 @@ check_one() {
             fi
             if ! git -C "$path" checkout -q "$pin" 2>/dev/null; then
                 echo "         could not check out $pin: fetch it and re-run"
-            else
-                git -C "$path" submodule update -q --init --recursive 2>/dev/null || true
             fi
         fi
     else
@@ -97,74 +93,10 @@ check_one() {
 
 echo "CI pins (from .github/workflows/daf-build.yml):"
 echo "  DAF          $DAF_PIN"
-echo "  DAF-Widgets  $DAFWIDGETS_PIN"
 echo
 
 check_one "DAF"         "$DAF_PATH"         "$DAF_PIN"         "dusk-audio/DAF"
-check_one "DAF-Widgets" "$DAFWIDGETS_PATH"  "$DAFWIDGETS_PIN"  "dusk-audio/DAF-Widgets"
 
-# The submodule has to come from our fork too, otherwise a build still pulls
-# source from a repository we do not control.
-if [ -f "$DAF_PATH/.gitmodules" ]; then
-    pugl_url="$(git -C "$DAF_PATH" config -f .gitmodules --get submodule.dgl/src/pugl-upstream.url || echo '')"
-    if [ "$(github_repo_of "$pugl_url")" = "dusk-audio/pugl" ]; then
-        echo "OK       pugl .gitmodules: dusk-audio/pugl"
-    else
-        echo "REMOTE   pugl .gitmodules: $pugl_url, expected github.com/dusk-audio/pugl"
-        drift=1
-    fi
-fi
-
-# ...and .gitmodules only describes the next fetch. What a build actually
-# compiles is whatever sits in the working tree now, which can be a different
-# remote at a different revision: a checkout created before the fork was
-# repointed keeps its old origin forever, and .gitmodules saying the right thing
-# hides it. Check the checkout itself against the gitlink DAF records.
-PUGL_PATH="$DAF_PATH/dgl/src/pugl-upstream"
-if [ -d "$DAF_PATH/.git" ]; then
-    pugl_pin="$(git -C "$DAF_PATH" rev-parse -q --verify HEAD:dgl/src/pugl-upstream 2>/dev/null || echo '')"
-
-    if [ -z "$pugl_pin" ]; then
-        echo "MISSING  pugl checkout: DAF records no gitlink at dgl/src/pugl-upstream"
-        drift=1
-    elif [ ! -e "$PUGL_PATH/.git" ]; then
-        echo "MISSING  pugl checkout: nothing at $PUGL_PATH; run git submodule update --init --recursive"
-        drift=1
-    else
-        pugl_head="$(git -C "$PUGL_PATH" rev-parse HEAD)"
-        pugl_remote="$(git -C "$PUGL_PATH" remote get-url origin 2>/dev/null || echo '(none)')"
-        pugl_remote_wrong=0
-        pugl_sha_wrong=0
-
-        if [ "$(github_repo_of "$pugl_remote")" != "dusk-audio/pugl" ]; then
-            echo "REMOTE   pugl checkout: origin is $pugl_remote, expected github.com/dusk-audio/pugl"
-            echo "         .gitmodules is not evidence: this tree compiles from that remote"
-            drift=1
-            pugl_remote_wrong=1
-        fi
-
-        if [ "$pugl_head" != "$pugl_pin" ]; then
-            echo "DRIFT    pugl checkout: local $(echo "$pugl_head" | cut -c1-12), DAF pins $(echo "$pugl_pin" | cut -c1-12)"
-            drift=1
-            pugl_sha_wrong=1
-        elif [ "$pugl_remote_wrong" = "0" ]; then
-            echo "OK       pugl checkout: $(echo "$pugl_head" | cut -c1-12)"
-        fi
-
-        # Repair both kinds of drift, not just the revision. A submodule whose
-        # remote is stale keeps fetching from the old URL however many times it
-        # is updated, because update reads .git/config rather than .gitmodules;
-        # sync is what copies the declared URL across. So sync first, then
-        # update, whenever either half is wrong.
-        if [ "$FIX" = "1" ] && { [ "$pugl_remote_wrong" = "1" ] || [ "$pugl_sha_wrong" = "1" ]; }; then
-            echo "         syncing the submodule URL and checking out the pinned commit"
-            git -C "$DAF_PATH" submodule sync -q --recursive
-            if ! git -C "$DAF_PATH" submodule update -q --init --recursive 2>/dev/null; then
-                echo "         (URL synced; the pinned commit still needs a reachable remote)"
-            fi
-        fi
-    fi
-fi
 
 echo
 if [ "$drift" = "0" ]; then

--- a/plugins/shared-daf/THIRD_PARTY_LICENSES.md
+++ b/plugins/shared-daf/THIRD_PARTY_LICENSES.md
@@ -44,10 +44,10 @@ code. Copyright (C) 2012-2025 Filipe Coelho <falktx@falktx.com>.
 
 Copyright 2011-2022 David Robillard <d@drobilla.net> (ISC, same terms as above).
 
-## Dear ImGui (via DAF-Widgets `opengl/DearImGui`) — MIT
+## Dear ImGui (via DAF `widgets/imgui/DearImGui`) — MIT
 
-DAF-Widgets ([dusk-audio/DAF-Widgets](https://github.com/dusk-audio/DAF-Widgets)) is a
-fork of DISTRHO/DPF-Widgets by Filipe Coelho and contributors.
+DAF ([dusk-audio/DAF](https://github.com/dusk-audio/DAF)) carries the in-tree widget
+kit, forked from DPF-Widgets by Filipe Coelho and contributors.
 Dear ImGui copyright (c) 2014-2025 Omar Cornut.
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/shared-daf/cmake/DuskDafPlugin.cmake
+++ b/plugins/shared-daf/cmake/DuskDafPlugin.cmake
@@ -5,11 +5,10 @@
 # DuskDafPlugin.cmake — shared DAF wiring for Dusk Audio DAF plugins.
 #
 # include() this from a plugin's CMakeLists after project(). It locates the
-# DAF and DAF-Widgets checkouts (siblings of the repo by default, overridable
-# with -DDAF_PATH=... / -DDAFWIDGETS_PATH=...), adds DAF as a subdirectory, and
-# exposes DUSK_DAF_UI_SOURCES (the DearImGui wrapper), DUSK_DAF_WIDGET_SOURCES
+# DAF checkout (a sibling by default, overridable with -DDAF_PATH=...), adds DAF
+# as a subdirectory, and exposes DUSK_DAF_UI_SOURCES (the DearImGui wrapper), DUSK_DAF_WIDGET_SOURCES
 # (the Dusk console widget set, opt-in) and DUSK_DAF_INCLUDE_DIRS (shared-daf
-# dsp/ui + DAF-Widgets opengl) for the caller to attach. Plugins still call
+# dsp/ui + DAF widgets) for the caller to attach. Plugins still call
 # daf_add_plugin themselves so per-plugin TARGETS/FILES stay local.
 
 if(NOT DEFINED DUSK_SHARED_DAF_DIR)
@@ -20,22 +19,22 @@ set(DUSK_SHARED_DAF_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 # repo root is three levels up from plugins/<name>/daf-plugin
 set(_dusk_repo_root "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
 set(DAF_PATH        "${_dusk_repo_root}/../DAF"         CACHE PATH "Path to Dusk Audio Framework")
-set(DAFWIDGETS_PATH "${_dusk_repo_root}/../DAF-Widgets" CACHE PATH "Path to DAF-Widgets (Dear ImGui wrapper)")
+set(DAFWIDGETS_PATH "${DAF_PATH}/widgets")
 
 if(NOT EXISTS "${DAF_PATH}/CMakeLists.txt")
     message(FATAL_ERROR "DAF not found at ${DAF_PATH} — clone https://github.com/dusk-audio/DAF (our fork; do not use upstream DISTRHO/DPF) or pass -DDAF_PATH=...")
 endif()
-if(NOT EXISTS "${DAFWIDGETS_PATH}/opengl/DearImGui.cpp")
-    message(FATAL_ERROR "DAF-Widgets not found at ${DAFWIDGETS_PATH} — clone https://github.com/dusk-audio/DAF-Widgets (our fork; do not use upstream DAF) or pass -DDAFWIDGETS_PATH=...")
+if(NOT EXISTS "${DAFWIDGETS_PATH}/imgui/DearImGui.cpp")
+    message(FATAL_ERROR "DAF widgets not found at ${DAFWIDGETS_PATH} — use a DAF checkout with its in-tree widgets/ directory selected by -DDAF_PATH=...")
 endif()
 
 if(NOT TARGET daf)
     add_subdirectory("${DAF_PATH}" daf EXCLUDE_FROM_ALL)
 endif()
 
-set(DUSK_DAF_UI_SOURCES  "${DAFWIDGETS_PATH}/opengl/DearImGui.cpp")
+set(DUSK_DAF_UI_SOURCES  "${DAFWIDGETS_PATH}/imgui/DearImGui.cpp")
 
-# The Dusk console widget set (DAF-Widgets opengl/DuskWidgets.hpp): the knob with
+# The Dusk console widget set (DAF widgets/dusk/DuskWidgets.hpp): the knob with
 # its baked dome, the fader, the meters, the needle meter, the button bank and the
 # rest. Its header is not header-only, so a plugin that includes it and does not
 # compile this fails to link -- which is what dusk-audio/DAF-Widgets#6 reports.
@@ -46,13 +45,14 @@ set(DUSK_DAF_UI_SOURCES  "${DAFWIDGETS_PATH}/opengl/DearImGui.cpp")
 # lines to all six for a kit they do not call would cost build time and binary
 # size for nothing. A plugin that does draw with the kit appends this to its
 # FILES_UI next to DUSK_DAF_UI_SOURCES.
-set(DUSK_DAF_WIDGET_SOURCES "${DAFWIDGETS_PATH}/opengl/DuskWidgets.cpp")
+set(DUSK_DAF_WIDGET_SOURCES "${DAFWIDGETS_PATH}/dusk/DuskWidgets.cpp")
 
 set(DUSK_DAF_INCLUDE_DIRS
     "${DUSK_SHARED_DAF_DIR}"
     "${DUSK_SHARED_DAF_DIR}/dsp"
     "${DUSK_SHARED_DAF_DIR}/ui"
-    "${DAFWIDGETS_PATH}/opengl")
+    "${DAFWIDGETS_PATH}/imgui"
+    "${DAFWIDGETS_PATH}/dusk")
 
 # Copy the built CLAP/VST3/LV2 artefacts into the user plugin dirs after each
 # build, so hosts always load the freshly-built binary (DAF's ninja target only

--- a/tests/check_provenance_guards.sh
+++ b/tests/check_provenance_guards.sh
@@ -1,232 +1,82 @@
 #!/usr/bin/env bash
 # Copyright (C) 2026 Dusk Audio — GNU GPL v3.0 or later (see repository LICENSE).
-#
-# check_provenance_guards.sh — tests for the two framework-provenance guards.
-#
-# docker/check_daf_pins.sh and .github/scripts/check_fork_sources.sh decide
-# whether a build tree is made of the source we think it is. Both used to answer
-# that from configuration alone: workflow fields and .gitmodules. Configuration
-# describes the next fetch, not the tree in front of you, so a checkout created
-# before a fork was repointed kept its old origin and both guards approved it
-# (issue #243).
-#
-# These fixtures are throwaway git repositories, so the cases below can be built
-# exactly: a correct checkout, one on the wrong remote, one at the wrong
-# revision, and the case that motivated the issue -- a .gitmodules that names our
-# fork sitting next to a checkout that does not come from it.
-#
-# No network: remotes are set with `git remote add` and never fetched.
-
+# Local fixtures exercise origin, revision and in-tree provenance without network access.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PIN_GUARD="$REPO_ROOT/docker/check_daf_pins.sh"
-FORK_GUARD="$REPO_ROOT/.github/scripts/check_fork_sources.sh"
-
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
-
+mkdir -p "$WORK/harness/.github/scripts" "$WORK/harness/.github/workflows" "$WORK/harness/docker"
+cp "$REPO_ROOT/.github/scripts/check_fork_sources.sh" "$WORK/harness/.github/scripts/"
+cp "$REPO_ROOT/docker/check_daf_pins.sh" "$WORK/harness/docker/"
+cp "$REPO_ROOT/.github/workflows/"daf-*.yml "$WORK/harness/.github/workflows/"
+FORK_GUARD="$WORK/harness/.github/scripts/check_fork_sources.sh"
+PIN_GUARD="$WORK/harness/docker/check_daf_pins.sh"
 failures=0
 
-pass() { printf '  ok    %s\n' "$1"; }
-fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
-
 git_q() { git -c user.email=t@t -c user.name=t -c init.defaultBranch=main -c commit.gpgsign=false "$@"; }
-
-# A minimal repository with one commit and a named origin.
-make_repo() {
-    local dir="$1" origin="$2"
-    mkdir -p "$dir"
-    git_q -C "$dir" init -q
-    echo seed > "$dir/file.txt"
-    git_q -C "$dir" add file.txt
-    git_q -C "$dir" commit -qm seed
-    git_q -C "$dir" remote add origin "$origin"
-}
-
-# A DAF-shaped tree: .gitmodules for pugl, a nested pugl checkout, and a gitlink
-# recorded at whichever pugl commit is asked for. Built with update-index rather
-# than `git submodule add` so the recorded revision can disagree with the
-# checkout, which is the whole point of two of the cases.
-#   $1 dir  $2 DAF origin  $3 pugl origin  $4 gitmodules url  $5 pin=head|stale
-make_daf() {
-    local dir="$1" dafOrigin="$2" puglOrigin="$3" modulesUrl="$4" pinMode="$5"
-    make_repo "$dir" "$dafOrigin"
-
-    mkdir -p "$dir/dgl/src"
-    local pugl="$dir/dgl/src/pugl-upstream"
-    make_repo "$pugl" "$puglOrigin"
-    local puglHead stalePin
-    puglHead="$(git_q -C "$pugl" rev-parse HEAD)"
-    echo second > "$pugl/file.txt"
-    git_q -C "$pugl" commit -qam second
-    stalePin="$puglHead"                       # the first commit, now behind
-    puglHead="$(git_q -C "$pugl" rev-parse HEAD)"
-
-    cat > "$dir/.gitmodules" <<EOF
-[submodule "dgl/src/pugl-upstream"]
-	path = dgl/src/pugl-upstream
-	url = $modulesUrl
-EOF
-
-    local recorded="$puglHead"
-    [ "$pinMode" = stale ] && recorded="$stalePin"
-    git_q -C "$dir" update-index --add --cacheinfo "160000,$recorded,dgl/src/pugl-upstream"
-    git_q -C "$dir" add .gitmodules
-    git_q -C "$dir" commit -qm "record pugl"
-}
-
-# The pin guard reports on DAF and DAF-Widgets too, and those rows will always
-# read DRIFT against fixtures, since the fixture SHAs are not the CI pins. Only
-# the pugl lines are under test here, so assert on those.
-pin_guard_says() {
-    local dafPath="$1" expected="$2" label="$3"
-    local out
-    out="$(DAF_PATH="$dafPath" DAFWIDGETS_PATH="$dafPath" "$PIN_GUARD" 2>&1 || true)"
-    if printf '%s' "$out" | grep -q "$expected"; then
-        pass "$label"
+check() {
+    local label="$1" expected_status="$2" expected_text="$3" status=0 out
+    shift 3
+    out="$("$@" 2>&1)" || status=$?
+    if [ "$status" -eq "$expected_status" ] && printf '%s' "$out" | grep -q "$expected_text"; then
+        printf '  ok    %s\n' "$label"
     else
-        fail "$label -- expected a line matching: $expected"
-        printf '%s\n' "$out" | sed 's/^/        /'
+        printf '  FAIL  %s (exit %s)\n%s\n' "$label" "$status" "$out"
+        failures=$((failures + 1))
     fi
 }
 
-fork_guard_exits() {
-    local dafPath="$1" widgetsPath="$2" wantFail="$3" label="$4" expected="${5:-}"
-    local out status=0
-    out="$("$FORK_GUARD" "$dafPath" "$widgetsPath" 2>&1)" || status=$?
+mkdir -p "$WORK/daf/dgl/src/pugl-upstream" "$WORK/daf/widgets/imgui"
+git_q -C "$WORK/daf" init -q
+printf 'pugl\n' > "$WORK/daf/dgl/src/pugl-upstream/source.c"
+printf 'widgets\n' > "$WORK/daf/widgets/imgui/DearImGui.hpp"
+git_q -C "$WORK/daf" add .
+git_q -C "$WORK/daf" commit -qm 'vendor framework trees'
+git_q -C "$WORK/daf" remote add origin git@github.com:dusk-audio/DAF.git
+pin="$(git_q -C "$WORK/daf" rev-parse HEAD)"
+printf 'env:\n  DAF_REF: %s\n' "$pin" > "$WORK/harness/.github/workflows/daf-build.yml"
 
-    if [ "$wantFail" = yes ] && [ "$status" -eq 0 ]; then
-        fail "$label -- guard passed, expected failure"
-        printf '%s\n' "$out" | sed 's/^/        /'
-        return
-    fi
-    if [ "$wantFail" = no ] && [ "$status" -ne 0 ]; then
-        fail "$label -- guard failed, expected pass"
-        printf '%s\n' "$out" | sed 's/^/        /'
-        return
-    fi
-    if [ -n "$expected" ] && ! printf '%s' "$out" | grep -q "$expected"; then
-        fail "$label -- expected a line matching: $expected"
-        printf '%s\n' "$out" | sed 's/^/        /'
-        return
-    fi
-    pass "$label"
-}
+check 'fork guard accepts in-tree components' 0 'OK' "$FORK_GUARD" "$WORK/daf"
+check 'pin guard accepts the single revision' 0 'OK' env DAF_PATH="$WORK/daf" "$PIN_GUARD"
+git_q -C "$WORK/daf" worktree add -q --detach "$WORK/worktree" "$pin"
+check 'pin guard accepts a git worktree' 0 'OK' env DAF_PATH="$WORK/worktree" "$PIN_GUARD"
+check 'fork guard accepts a git worktree' 0 'OK' "$FORK_GUARD" "$WORK/worktree"
 
-echo "provenance guards"
-
-# --- 1. a correct checkout is approved ------------------------------------
-make_daf "$WORK/good" "git@github.com:dusk-audio/DAF.git" \
-         "https://github.com/dusk-audio/pugl.git" \
-         "https://github.com/dusk-audio/pugl.git" head
-make_repo "$WORK/widgets-good" "https://github.com/dusk-audio/DAF-Widgets.git"
-
-pin_guard_says "$WORK/good" "OK       pugl checkout:" "pin guard accepts a matching pugl checkout"
-fork_guard_exits "$WORK/good" "$WORK/widgets-good" no "fork guard accepts checkouts from our forks"
-
-# --- 2. wrong origin ------------------------------------------------------
-make_daf "$WORK/badremote" "git@github.com:dusk-audio/DAF.git" \
-         "https://github.com/DISTRHO/pugl.git" \
-         "https://github.com/DISTRHO/pugl.git" head
-
-pin_guard_says "$WORK/badremote" "REMOTE   pugl checkout:" "pin guard rejects a pugl checkout from upstream"
-fork_guard_exits "$WORK/badremote" "$WORK/widgets-good" yes \
-    "fork guard rejects a pugl checkout from upstream" "pugl checkout compiles from"
-
-# --- 3. wrong revision ----------------------------------------------------
-make_daf "$WORK/badsha" "git@github.com:dusk-audio/DAF.git" \
-         "https://github.com/dusk-audio/pugl.git" \
-         "https://github.com/dusk-audio/pugl.git" stale
-
-pin_guard_says "$WORK/badsha" "DRIFT    pugl checkout:" "pin guard rejects a pugl checkout at the wrong revision"
-fork_guard_exits "$WORK/badsha" "$WORK/widgets-good" yes \
-    "fork guard rejects a pugl checkout at the wrong revision" "but DAF pins"
-
-# --- 4. the case from #243: honest .gitmodules, dishonest checkout --------
-make_daf "$WORK/misleading" "git@github.com:dusk-audio/DAF.git" \
-         "https://github.com/DISTRHO/pugl.git" \
-         "https://github.com/dusk-audio/pugl.git" head
-
-pin_guard_says "$WORK/misleading" "OK       pugl .gitmodules:" \
-    "pin guard still reads .gitmodules as declared"
-pin_guard_says "$WORK/misleading" "REMOTE   pugl checkout:" \
-    "pin guard rejects an upstream checkout that .gitmodules vouches for"
-fork_guard_exits "$WORK/misleading" "$WORK/widgets-good" yes \
-    "fork guard rejects an upstream checkout that .gitmodules vouches for" \
-    "pugl checkout compiles from"
-
-# --- 5. a DAF-Widgets checkout from upstream ------------------------------
-make_repo "$WORK/widgets-bad" "https://github.com/DISTRHO/DPF-Widgets.git"
-fork_guard_exits "$WORK/good" "$WORK/widgets-bad" yes \
-    "fork guard rejects a DAF-Widgets checkout from upstream" "DAF-Widgets checkout compiles from"
-
-# --- 6. a lookalike origin ------------------------------------------------
-# The guards used to substring-match the expected "owner/repo", which accepts a
-# different account (not-dusk-audio/pugl), a different host, and a nested path
-# that merely contains the name.
-for lookalike in "https://github.com/not-dusk-audio/pugl.git" \
-                 "https://gitlab.com/dusk-audio/pugl.git" \
-                 "https://github.com/attacker/mirror-dusk-audio/pugl.git"; do
-    rm -rf "$WORK/lookalike"
-    make_daf "$WORK/lookalike" "git@github.com:dusk-audio/DAF.git" \
-             "$lookalike" "https://github.com/dusk-audio/pugl.git" head
-    pin_guard_says "$WORK/lookalike" "REMOTE   pugl checkout:" \
-        "pin guard rejects lookalike origin $lookalike"
-    fork_guard_exits "$WORK/lookalike" "$WORK/widgets-good" yes \
-        "fork guard rejects lookalike origin $lookalike" "pugl checkout compiles from"
+for remote in https://github.com/DISTRHO/DPF.git \
+              https://github.com/not-dusk-audio/DAF.git \
+              https://gitlab.com/dusk-audio/DAF.git \
+              https://github.com/attacker/mirror-dusk-audio/DAF.git; do
+    git_q -C "$WORK/daf" remote set-url origin "$remote"
+    check "fork guard rejects $remote" 1 'checkout compiles from' "$FORK_GUARD" "$WORK/daf"
+    check "pin guard rejects $remote" 1 'REMOTE' env DAF_PATH="$WORK/daf" "$PIN_GUARD"
 done
+git_q -C "$WORK/daf" remote set-url origin https://github.com/dusk-audio/DAF.git
 
-# --- 7. a pugl checkout DAF does not pin at all ---------------------------
-# An empty gitlink is not "nothing to compare": it means the source sitting
-# there is pinned by nothing, so no revision check can vouch for it.
-rm -rf "$WORK/nogitlink"
-make_repo "$WORK/nogitlink" "git@github.com:dusk-audio/DAF.git"
-mkdir -p "$WORK/nogitlink/dgl/src"
-make_repo "$WORK/nogitlink/dgl/src/pugl-upstream" "https://github.com/dusk-audio/pugl.git"
-cat > "$WORK/nogitlink/.gitmodules" <<EOF
-[submodule "dgl/src/pugl-upstream"]
-	path = dgl/src/pugl-upstream
-	url = https://github.com/dusk-audio/pugl.git
-EOF
-git_q -C "$WORK/nogitlink" add .gitmodules
-git_q -C "$WORK/nogitlink" commit -qm "gitmodules without a gitlink"
+printf 'changed\n' >> "$WORK/daf/widgets/imgui/DearImGui.hpp"
+check 'fork guard rejects modified vendored source' 1 'differs from' "$FORK_GUARD" "$WORK/daf"
+check 'pin guard rejects dirty source' 1 'DIRTY' env DAF_PATH="$WORK/daf" "$PIN_GUARD"
+git_q -C "$WORK/daf" commit -qam 'change widgets'
+check 'pin guard rejects another revision' 1 'DRIFT' env DAF_PATH="$WORK/daf" "$PIN_GUARD"
+git_q -C "$WORK/daf" reset -q --hard "$pin"
 
-fork_guard_exits "$WORK/nogitlink" "$WORK/widgets-good" yes \
-    "fork guard rejects a pugl checkout DAF records no gitlink for" "records no gitlink"
-pin_guard_says "$WORK/nogitlink" "MISSING  pugl checkout:" \
-    "pin guard reports a pugl checkout DAF records no gitlink for"
+mkdir "$WORK/daf/widgets/.git"
+check 'fork guard rejects a nested widget checkout' 1 'nested checkout' "$FORK_GUARD" "$WORK/daf"
+rmdir "$WORK/daf/widgets/.git"
+printf '[submodule "pugl"]\n' > "$WORK/daf/.gitmodules"
+check 'fork guard rejects legacy submodule configuration' 1 'submodules' "$FORK_GUARD" "$WORK/daf"
+rm "$WORK/daf/.gitmodules"
+git_q -C "$WORK/daf" rm -qr dgl/src/pugl-upstream
+git_q -C "$WORK/daf" update-index --add --cacheinfo "160000,$pin,dgl/src/pugl-upstream"
+git_q -C "$WORK/daf" commit -qm 'legacy gitlink'
+check 'fork guard rejects gitlinks instead of subtrees' 1 'tracked tree' "$FORK_GUARD" "$WORK/daf"
 
-# --- 8. --fix repairs a stale submodule remote ----------------------------
-# submodule update reads .git/config, not .gitmodules, so a submodule whose
-# recorded URL is stale keeps fetching from the old remote however often it is
-# updated. sync is what copies the declared URL across, and --fix has to run it
-# even when the revision already matches, which is the remote-only case here.
-rm -rf "$WORK/staleremote"
-make_daf "$WORK/staleremote" "git@github.com:dusk-audio/DAF.git" \
-         "https://github.com/DISTRHO/pugl.git" \
-         "https://github.com/dusk-audio/pugl.git" head
-git_q -C "$WORK/staleremote" config submodule.dgl/src/pugl-upstream.url \
-    "https://github.com/DISTRHO/pugl.git"
+check 'config-only scan still passes' 0 'OK' "$FORK_GUARD"
+printf 'repository: DISTRHO/DPF\n' >> "$WORK/harness/.github/workflows/daf-build.yml"
+check 'config-only scan rejects forbidden source' 1 'fetches framework source' "$FORK_GUARD"
 
-before="$(git_q -C "$WORK/staleremote/dgl/src/pugl-upstream" remote get-url origin)"
-DAF_PATH="$WORK/staleremote" DAFWIDGETS_PATH="$WORK/staleremote" \
-    "$PIN_GUARD" --fix > /dev/null 2>&1 || true
-after="$(git_q -C "$WORK/staleremote/dgl/src/pugl-upstream" remote get-url origin)"
-
-if [ "$before" != "$after" ] && [ "$(printf '%s' "$after" | grep -c 'dusk-audio/pugl')" = "1" ]; then
-    pass "--fix syncs a stale submodule remote to the declared URL"
-else
-    fail "--fix syncs a stale submodule remote to the declared URL -- origin went $before -> $after"
-fi
-
-# --- 9. no paths supplied: config-only scan still works -------------------
-fork_guard_exits "" "" no "fork guard still scans config alone when given no paths"
-
-echo
-if [ "$failures" = 0 ]; then
-    echo "all provenance guard tests passed"
-else
+if [ "$failures" -ne 0 ]; then
     echo "$failures provenance guard test(s) failed"
     exit 1
 fi
+echo 'all provenance guard tests passed'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release**
  * Build, test, and release workflows now use the widgets and Pugl sources bundled within the pinned DAF checkout.
  * Removed the separate DAF-Widgets checkout and configuration requirement.
  * Updated container builds and platform packaging to use the consolidated dependency layout.

* **Validation**
  * Added stricter checks to detect modified, nested, untracked, or mismatched vendored sources.

* **Documentation**
  * Updated setup instructions and third-party license information to reflect the consolidated DAF structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->